### PR TITLE
[FIX] bugfix for missing loadAfter/loadBefore warnings on the UI

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,5 +17,6 @@
         "--enable=W0611", "--enable=W0614"
     ],
     "python.terminal.activateEnvironment": true,
-    "search.maxResults": 100000
+    "search.maxResults": 100000,
+    "python.formatting.provider": "black"
 }

--- a/sub_view/active_mods_panel.py
+++ b/sub_view/active_mods_panel.py
@@ -252,8 +252,11 @@ class ActiveModList(QWidget):
                     # Only if explict_bool = True then we show error
                     if load_this_before[1]:
                         # Note: we cannot use uuid_to_index.get(load_this_before) as 0 is falsy but valid
-                        if load_this_before[0] in uuid_to_index:
-                            if current_mod_index <= uuid_to_index[load_this_before[0]]:
+                        if load_this_before[0] in packageId_to_uuid:
+                            if (
+                                current_mod_index
+                                <= uuid_to_index[packageId_to_uuid[load_this_before[0]]]
+                            ):
                                 package_id_to_errors[uuid][
                                     "load_before_violations"
                                 ].add(load_this_before[0])
@@ -268,8 +271,11 @@ class ActiveModList(QWidget):
                         )
                     # Only if explict_bool = True then we show error
                     if load_this_after[1]:
-                        if load_this_after[0] in uuid_to_index:
-                            if current_mod_index >= uuid_to_index[load_this_after[0]]:
+                        if load_this_after[0] in packageId_to_uuid:
+                            if (
+                                current_mod_index
+                                >= uuid_to_index[packageId_to_uuid[load_this_after[0]]]
+                            ):
                                 package_id_to_errors[uuid]["load_after_violations"].add(
                                     load_this_after[0]
                                 )


### PR DESCRIPTION
### Notes

There's a bug where `loadAfter` and `loadBefore` violations aren't showing in the UI as warning/error labels (on individual mod cells and also on the warnings/error summary). This was due to code looking in a `uuid`-keyed dict for mods with package IDs. I've made a small fix so we're looking in the right place.

### Testing

Manual testing and verification through running RimSort locally and dragging around mods