### PR TITLE
MacOS: Changed Settings: user now selects .app

### DIFF
--- a/util/generic.py
+++ b/util/generic.py
@@ -78,9 +78,8 @@ def launch_game_process(game_install_path: str, args: list) -> None:
     if game_install_path:
         system_name = platform.system()
         if system_name == "Darwin":
-            executable_path = str(
-                Path(os.path.join(game_install_path, "RimWorldMac.app")).resolve()
-            )
+            # MacOS
+            executable_path = str(game_install_path)
         elif system_name == "Linux":
             # Linux
             executable_path = str(

--- a/util/mods.py
+++ b/util/mods.py
@@ -714,9 +714,6 @@ def get_game_version(game_path: str) -> str:
     """
     logger.info(f"Getting game version from Game Folder: {game_path}")
     version = ""
-    if platform.system() == "Darwin" and game_path:
-        game_path = str(Path(os.path.join(game_path, "RimWorldMac.app")).resolve())
-        logger.debug(f"Running on MacOS, generating new game path: {game_path}")
     version_file_path = str(Path(os.path.join(game_path, "Version.txt")).resolve())
     logger.debug(f"Generated Version.txt path: {version_file_path}")
     if os.path.exists(version_file_path):
@@ -790,11 +787,6 @@ def get_installed_expansions(game_path: str, game_version: str) -> Dict[str, Any
     mod_data = {}
     if game_path != "":
         logger.info(f"Getting installed expansions with game folder path: {game_path}")
-        # RimWorld folder on mac contains RimWorldMac.app which
-        # is actually a folder itself
-        if platform.system() == "Darwin" and game_path:
-            game_path = str(Path(os.path.join(game_path, "RimWorldMac.app")).resolve())
-            logger.info(f"Running on MacOS, generating new game path: {game_path}")
 
         # Get mod data
         data_path = str(Path(os.path.join(game_path, "Data")).resolve())
@@ -883,7 +875,7 @@ def get_local_mods(
             and local_path == game_path
         ):
             local_path = str(
-                Path(os.path.join(local_path, "RimWorldMac.app", "Mods")).resolve()
+                Path(os.path.join(local_path, "Mods")).resolve()
             )
             logger.info(
                 f"Running on MacOS, generating new local mods path: {local_path}"

--- a/util/mods.py
+++ b/util/mods.py
@@ -864,23 +864,6 @@ def get_local_mods(
         if game_path:
             logger.info(f"Supplementing call with game folder path: {game_path}")
 
-        # If local mods path is same as game path and we're running on a Mac,
-        # that means use the default local mods folder
-
-        system_name = platform.system()
-        if (
-            system_name == "Darwin"
-            and local_path
-            and game_path
-            and local_path == game_path
-        ):
-            local_path = str(
-                Path(os.path.join(local_path, "Mods")).resolve()
-            )
-            logger.info(
-                f"Running on MacOS, generating new local mods path: {local_path}"
-            )
-
         # Get mod data
         logger.info(f"Getting local mods from path: {local_path}")
         mod_data = parse_mod_data(local_path, "local", steam_db)

--- a/view/game_configuration_panel.py
+++ b/view/game_configuration_panel.py
@@ -1032,7 +1032,7 @@ class GameConfiguration(QObject):
         rimworld_mods_path = ""
         if system_name == "Darwin":
             rimworld_mods_path = str(
-                Path(os.path.join(os_paths[0], "RimWorldMac.app", "Mods")).resolve()
+                Path(os.path.join(os_paths[0], "Mods")).resolve()
             )
         else:
             rimworld_mods_path = str(Path(os.path.join(os_paths[0], "Mods")).resolve())
@@ -1162,11 +1162,19 @@ class GameConfiguration(QObject):
             possible_dir = self.game_folder_line.text()
             if os.path.exists(possible_dir):
                 start_dir = possible_dir
-        game_exe_folder_path = os.path.normpath(
-            show_dialogue_file(
-                mode="open_dir", caption="Select Game Folder", _dir=start_dir
+        system_name = platform.system()
+        if (system_name == "Darwin"):
+                game_exe_folder_path = os.path.normpath(
+                show_dialogue_file(
+                    mode="open", caption="Select Game App", _dir=start_dir
+                )
             )
-        )
+        else:
+            game_exe_folder_path = os.path.normpath(
+                show_dialogue_file(
+                    mode="open_dir", caption="Select Game Folder", _dir=start_dir
+                )
+            )
         logger.info(f"Selected path: {game_exe_folder_path}")
         if game_exe_folder_path and game_exe_folder_path != ".":
             logger.info(
@@ -1211,11 +1219,22 @@ class GameConfiguration(QObject):
             possible_dir = self.local_folder_line.text()
             if os.path.exists(possible_dir):
                 start_dir = possible_dir
-        local_path = os.path.normpath(
-            show_dialogue_file(
-                mode="open_dir", caption="Select Local Mods Folder", _dir=start_dir
+        
+        system_name = platform.system()
+        if (system_name == "Darwin"):
+            # On Mac it need too many hoops to jump through to select the mods dir
+            # Instead we ask the user to select the app and we append the mods dir to the path if needed
+            local_path = os.path.normpath(
+                show_dialogue_file(
+                    mode="open", caption="Select Game App", _dir=start_dir
+                )
             )
-        )
+        else:
+            local_path = os.path.normpath(
+                show_dialogue_file(
+                    mode="open_dir", caption="Select Local Mods Folder", _dir=start_dir
+                )
+            )
         logger.info(f"Selected path: {local_path}")
         if local_path and local_path != ".":
             logger.info(

--- a/view/game_configuration_panel.py
+++ b/view/game_configuration_panel.py
@@ -1183,7 +1183,7 @@ class GameConfiguration(QObject):
             if os.path.exists(possible_dir):
                 start_dir = possible_dir
         if (self.system_name == "Darwin"):
-                game_exe_folder_path = os.path.normpath(
+            game_exe_folder_path = os.path.normpath(
                 show_dialogue_file(
                     mode="open", caption="Select Game App", _dir=start_dir
                 )


### PR DESCRIPTION
Fixes issue [#171](https://github.com/RimSort/RimSort/issues/171) by having users select their .app instead of asking for a folder and then assuming the app name, which causes crashes if the app was not named "RimWorldMac.app"

**May cause crashes to users on MacOS with old version settings**
If it does: delete ~/Library/Application Support/RimSort/settings.json or run:
`rm ~/Library/Application\ Support/RimSort/settings.json` in terminal

