### PR TITLE
Fix open_url_browser function which malfunctions on macOS under Python 3.9

### DIFF
--- a/util/generic.py
+++ b/util/generic.py
@@ -156,10 +156,8 @@ def open_url_browser(url: str) -> None:
     """
     Open the url of a mod of a url in a user's default web browser
     """
-    browser = webbrowser.get().name
-    logger.info(f"USER ACTION: Opening mod url {url} in " + f"{browser}")
-    webbrowser.open_new_tab(url)
-
+    logger.info(f"USER ACTION: Opening mod url {url}")
+    webbrowser.open(url)
 
 def platform_specific_open(path: str) -> None:
     """

--- a/util/generic.py
+++ b/util/generic.py
@@ -154,9 +154,9 @@ def launch_game_process(game_install_path: str, args: list) -> None:
 
 def open_url_browser(url: str) -> None:
     """
-    Open the url of a mod of a url in a user's default web browser
+    Open a url in a user's default web browser
     """
-    logger.info(f"USER ACTION: Opening mod url {url}")
+    logger.info(f"USER ACTION: Opening url {url}")
     webbrowser.open(url)
 
 def platform_specific_open(path: str) -> None:


### PR DESCRIPTION
On the Mac, under Python 3.9, the method call `webbrowser.get().name` fails with an OS-level error:

```
>>> import webbrowser
>>> webbrowser.get().name
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'MacOSXOSAScript' object has no attribute 'name'
```

This problem goes away under Python 3.11, but I think a better fix would be to remove the call entirely, as on the Mac it just returns `"default"` and on Windows it returns an empty string. So it's kind of pointless.

This PR removes the `webbrowser.get().name` call entirely and rewords the docstring and log message text to be generic. Now it works identically on macOS and Windows.