### PR TITLE
Updated .gitignore for PyCharm IDE users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,7 +157,7 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
 
 # venv
 bin/

--- a/.gitignore
+++ b/.gitignore
@@ -168,7 +168,6 @@ pyvenv.cfg
 data/DEBUG
 .DS_Store
 test*
-*.xml
 *_AppIDQuery*
 /steamworks
 SteamworksPy.dylib


### PR DESCRIPTION
- Uncommented previously commented-out `.idea/` line to ignore PyCharm user-specific IDE config files
- Removed `*.xml` line which is no longer necessary now that `.idea/` is ignored