### PR TITLE
Add a basic menu bar to the app

### DIFF
--- a/RimSort.py
+++ b/RimSort.py
@@ -15,6 +15,9 @@ from logging import getLogger, WARNING
 from PySide6.QtCore import QSize, QTimer
 from PySide6.QtWidgets import QApplication, QMainWindow, QVBoxLayout, QWidget
 
+from controller.menu_bar_controller import MenuBarController
+from view.menu_bar import MenuBar
+
 SYSTEM = platform.system()
 # Watchdog conditionals
 if SYSTEM == "Darwin":
@@ -110,6 +113,9 @@ class MainWindow(QMainWindow):
         widget = QWidget()
         widget.setLayout(app_layout)
         self.setCentralWidget(widget)
+
+        self.menu_bar = MenuBar(menu_bar=self.menuBar())
+        self.menu_bar_controller = MenuBarController(view=self.menu_bar)
 
         logger.debug("Finished MainWindow initialization")
 

--- a/controller/menu_bar_controller.py
+++ b/controller/menu_bar_controller.py
@@ -1,0 +1,109 @@
+from PySide6.QtCore import QObject, Slot
+from PySide6.QtWidgets import QApplication, QLineEdit, QTextEdit, QPlainTextEdit
+
+from util.generic import open_url_browser
+from view.game_configuration_panel import GameConfiguration
+from view.main_content_panel import MainContent
+from view.menu_bar import MenuBar
+
+
+class MenuBarController(QObject):
+    def __init__(
+        self,
+        view: MenuBar,
+    ) -> None:
+        super().__init__()
+
+        self.menu_bar = view
+
+        # Application menu
+
+        self.menu_bar.quit_action.triggered.connect(QApplication.instance().quit)
+
+        self.menu_bar.check_for_updates_action.triggered.connect(
+            self._on_menu_bar_check_for_updates_triggered
+        )
+
+        self.menu_bar.settings_action.triggered.connect(
+            GameConfiguration.instance()._open_settings_panel
+        )
+
+        # File menu
+
+        self.menu_bar.open_mod_list_action.triggered.connect(
+            self._on_menu_bar_open_mod_list_triggered
+        )
+
+        self.menu_bar.save_mod_list_action.triggered.connect(
+            self._on_menu_bar_save_mod_list_triggered
+        )
+
+        self.menu_bar.export_to_clipboard_action.triggered.connect(
+            self._on_menu_bar_export_to_clipboard_triggered
+        )
+
+        self.menu_bar.export_to_rentry_action.triggered.connect(
+            self._on_menu_bar_export_to_rentry_triggered
+        )
+
+        # Edit menu
+
+        self.menu_bar.cut_action.triggered.connect(self._on_menu_bar_cut_triggered)
+
+        self.menu_bar.copy_action.triggered.connect(self._on_menu_bar_copy_triggered)
+
+        self.menu_bar.paste_action.triggered.connect(self._on_menu_bar_paste_triggered)
+
+        # Help menu
+
+        self.menu_bar.wiki_action.triggered.connect(self._on_menu_bar_wiki_triggered)
+
+    @Slot()
+    def _on_menu_bar_check_for_updates_triggered(self) -> None:
+        GameConfiguration.instance().configuration_signal.emit("check_for_update")
+
+    @Slot()
+    def _on_menu_bar_open_mod_list_triggered(self) -> None:
+        MainContent.instance().actions_panel.actions_signal.emit("import_list_file_xml")
+
+    @Slot()
+    def _on_menu_bar_save_mod_list_triggered(self) -> None:
+        MainContent.instance().actions_panel.actions_signal.emit("export_list_file_xml")
+
+    @Slot()
+    def _on_menu_bar_export_to_clipboard_triggered(self) -> None:
+        MainContent.instance().actions_panel.actions_signal.emit(
+            "export_list_clipboard"
+        )
+
+    @Slot()
+    def _on_menu_bar_export_to_rentry_triggered(self) -> None:
+        MainContent.instance().actions_panel.actions_signal.emit("upload_list_rentry")
+
+    @Slot()
+    def _on_menu_bar_cut_triggered(self) -> None:
+        app_instance = QApplication.instance()
+        if isinstance(app_instance, QApplication):
+            focused_widget = app_instance.focusWidget()
+            if isinstance(focused_widget, (QLineEdit, QTextEdit, QPlainTextEdit)):
+                focused_widget.cut()
+
+    @Slot()
+    def _on_menu_bar_copy_triggered(self) -> None:
+        app_instance = QApplication.instance()
+        if isinstance(app_instance, QApplication):
+            focused_widget = app_instance.focusWidget()
+            if isinstance(focused_widget, (QLineEdit, QTextEdit, QPlainTextEdit)):
+                focused_widget.copy()
+
+    @Slot()
+    def _on_menu_bar_paste_triggered(self) -> None:
+        app_instance = QApplication.instance()
+        if isinstance(app_instance, QApplication):
+            focused_widget = app_instance.focusWidget()
+            if isinstance(focused_widget, (QLineEdit, QTextEdit, QPlainTextEdit)):
+                focused_widget.paste()
+
+    @Slot()
+    def _on_menu_bar_wiki_triggered(self) -> None:
+        open_url_browser("https://github.com/RimSort/RimSort/wiki")

--- a/controller/menu_bar_controller.py
+++ b/controller/menu_bar_controller.py
@@ -1,6 +1,7 @@
 from PySide6.QtCore import QObject, Slot
 from PySide6.QtWidgets import QApplication, QLineEdit, QTextEdit, QPlainTextEdit
 
+from controller.settings_controller import SettingsController
 from util.generic import open_url_browser
 from view.game_configuration_panel import GameConfiguration
 from view.main_content_panel import MainContent
@@ -8,13 +9,11 @@ from view.menu_bar import MenuBar
 
 
 class MenuBarController(QObject):
-    def __init__(
-        self,
-        view: MenuBar,
-    ) -> None:
+    def __init__(self, view: MenuBar, settings_controller: SettingsController) -> None:
         super().__init__()
 
         self.menu_bar = view
+        self.settings_controller = settings_controller
 
         # Application menu
 
@@ -22,6 +21,14 @@ class MenuBarController(QObject):
 
         self.menu_bar.check_for_updates_action.triggered.connect(
             self._on_menu_bar_check_for_updates_triggered
+        )
+
+        self.menu_bar.check_for_updates_on_startup_action.toggled.connect(
+            self._on_menu_bar_check_for_updates_on_startup_triggered
+        )
+
+        self.menu_bar.check_for_updates_on_startup_action.setChecked(
+            self.settings_controller.settings.check_for_updates_on_startup
         )
 
         self.menu_bar.settings_action.triggered.connect(
@@ -61,6 +68,14 @@ class MenuBarController(QObject):
     @Slot()
     def _on_menu_bar_check_for_updates_triggered(self) -> None:
         GameConfiguration.instance().configuration_signal.emit("check_for_update")
+
+    @Slot()
+    def _on_menu_bar_check_for_updates_on_startup_triggered(self) -> None:
+        is_checked = self.menu_bar.check_for_updates_on_startup_action.isChecked()
+        self.settings_controller.settings.check_for_updates_on_startup = is_checked
+        GameConfiguration.instance()._update_persistent_storage(
+            settings={"check_for_update_startup": is_checked}
+        )
 
     @Slot()
     def _on_menu_bar_open_mod_list_triggered(self) -> None:

--- a/controller/settings_controller.py
+++ b/controller/settings_controller.py
@@ -1,0 +1,11 @@
+from PySide6.QtCore import QObject
+
+from model.settings import Settings
+
+
+class SettingsController(QObject):
+    def __init__(self, model: Settings) -> None:
+        super().__init__()
+
+        self.settings = model
+

--- a/model/settings.py
+++ b/model/settings.py
@@ -1,0 +1,16 @@
+from PySide6.QtCore import QObject, Signal
+
+
+class Settings(QObject):
+    def __init__(self) -> None:
+        super().__init__()
+
+        self._check_for_updates_on_startup = False
+
+    @property
+    def check_for_updates_on_startup(self) -> bool:
+        return self._check_for_updates_on_startup
+
+    @check_for_updates_on_startup.setter
+    def check_for_updates_on_startup(self, value: bool) -> None:
+        self._check_for_updates_on_startup = value

--- a/util/system_info.py
+++ b/util/system_info.py
@@ -1,0 +1,126 @@
+import platform
+from enum import Enum, unique, auto
+from typing import Optional
+
+
+class SystemInfo:
+    """
+    A singleton class that provides information about the system's operating system and architecture.
+
+    Attributes:
+        _instance: The singleton instance of the `SystemInfo` class.
+        _operating_system: The detected operating system.
+        _architecture: The detected system architecture.
+
+    Examples:
+        >>> info = SystemInfo()
+        >>> print(info.operating_system)
+        >>> print(info.architecture)
+    """
+
+    _instance: Optional["SystemInfo"] = None
+    _operating_system: Optional["SystemInfo.OperatingSystem"] = None
+    _architecture: Optional["SystemInfo.Architecture"] = None
+
+    @unique
+    class OperatingSystem(Enum):
+        """
+        An enumeration representing the possible operating systems.
+
+        Attributes:
+            WINDOWS: Represents the Windows OS.
+            LINUX: Represents the Linux OS.
+            MACOS: Represents the macOS.
+        """
+
+        WINDOWS = auto()
+        LINUX = auto()
+        MACOS = auto()
+
+    @unique
+    class Architecture(Enum):
+        """
+        An enumeration representing the possible system architectures.
+
+        Attributes:
+            X86: Represents the x86 architecture (32-bit).
+            X64: Represents the x64 architecture (64-bit).
+            ARM64: Represents the ARM64 architecture.
+        """
+
+        X86 = auto()
+        X64 = auto()
+        ARM64 = auto()
+
+    def __new__(cls) -> "SystemInfo":
+        """
+        Create a new instance or return the existing singleton instance of the `SystemInfo` class.
+        """
+        if not cls._instance:
+            cls._instance = super(SystemInfo, cls).__new__(cls)
+        return cls._instance
+
+    def __init__(self) -> None:
+        """
+        Initialize the `SystemInfo` instance by detecting the operating system and architecture.
+        """
+        if hasattr(self, "_is_initialized") and self._is_initialized:
+            return
+
+        if platform.system() in ["Windows"]:
+            self._operating_system = SystemInfo.OperatingSystem.WINDOWS
+        elif platform.system() in ["Linux"]:
+            self._operating_system = SystemInfo.OperatingSystem.LINUX
+        elif platform.system() in ["Darwin"]:
+            self._operating_system = SystemInfo.OperatingSystem.MACOS
+        else:
+            raise UnsupportedOperatingSystemError(
+                f"Unsupported operating system detected: {platform.system()}."
+            )
+
+        if platform.machine() in ["x86_64", "AMD64"]:
+            self._architecture = SystemInfo.Architecture.X64
+        elif platform.machine() in ["arm64", "aarch64"]:
+            self._architecture = SystemInfo.Architecture.ARM64
+        else:
+            raise UnsupportedArchitectureError(
+                f"Unsupported architecture detected: {platform.machine()}."
+            )
+
+        self._is_initialized: bool = True
+
+    @property
+    def operating_system(self) -> Optional["SystemInfo.OperatingSystem"]:
+        """
+        Get the detected operating system.
+
+        Returns:
+            The detected operating system as an instance of `SystemInfo.OperatingSystem`.
+        """
+        return self._operating_system
+
+    @property
+    def architecture(self) -> Optional["SystemInfo.Architecture"]:
+        """
+        Get the detected system architecture.
+
+        Returns:
+            The detected architecture as an instance of `SystemInfo.Architecture`.
+        """
+        return self._architecture
+
+
+class UnsupportedOperatingSystemError(Exception):
+    """
+    Exception raised when an unsupported operating system is detected.
+    """
+
+    pass
+
+
+class UnsupportedArchitectureError(Exception):
+    """
+    Exception raised when an unsupported system architecture is detected.
+    """
+
+    pass

--- a/view/game_configuration_panel.py
+++ b/view/game_configuration_panel.py
@@ -23,6 +23,7 @@ from PySide6.QtWidgets import (
     QVBoxLayout,
 )
 
+from controller.settings_controller import SettingsController
 from model.dialogue import *
 from model.multibutton import MultiButton
 from util.constants import DEFAULT_SETTINGS, DEFAULT_USER_RULES
@@ -52,13 +53,20 @@ class GameConfiguration(QObject):
             cls._instance = super(GameConfiguration, cls).__new__(cls)
         return cls._instance
 
-    def __init__(self, RIMSORT_VERSION: str, DEBUG_MODE=None) -> None:
+    def __init__(
+        self,
+        RIMSORT_VERSION: str,
+        settings_controller: SettingsController = None,
+        DEBUG_MODE=None,
+    ) -> None:
         """
         Initialize the game configuration.
         """
         if not hasattr(self, "initialized"):
             super(GameConfiguration, self).__init__()
             logger.debug("Initializing GameConfiguration")
+
+            self.settings_controller = settings_controller
 
             self.debug_mode = DEBUG_MODE
             self.rimsort_version = RIMSORT_VERSION
@@ -639,7 +647,7 @@ class GameConfiguration(QObject):
 
             # Update check
             if settings_data.get("check_for_update_startup"):
-                self.check_for_updates_action.setChecked(
+                self.settings_controller.settings.check_for_updates_on_startup = (
                     settings_data["check_for_update_startup"]
                 )
 

--- a/view/game_configuration_panel.py
+++ b/view/game_configuration_panel.py
@@ -192,28 +192,6 @@ class GameConfiguration(QObject):
             self.game_version_line.setDisabled(True)
             self.game_version_line.setPlaceholderText("Unknown")
             self.game_version_line.setReadOnly(True)
-            # check for update btn
-            self.check_for_updates_action = QAction("Check for update on startup")
-            self.check_for_updates_action.setCheckable(True)
-            self.check_for_updates_button = MultiButton(
-                main_action="Check for update",
-                main_action_tooltip="Use menu to enable this check on startup",
-                context_menu_content=[self.check_for_updates_action],
-            )
-            self.check_for_updates_button.main_action.clicked.connect(
-                partial(self.configuration_signal.emit, "check_for_update")
-            )
-            self.check_for_updates_button.setObjectName("RightButton")
-            self.check_for_updates_button.setContextMenuPolicy(Qt.CustomContextMenu)
-            self.client_settings_button = QPushButton("Settings")
-            self.client_settings_button.clicked.connect(self._open_settings_panel)
-            self.client_settings_button.setObjectName("LeftButton")
-            # wiki btn
-            self.wiki_button = QPushButton("Wiki")
-            self.wiki_button.clicked.connect(
-                partial(open_url_browser, "https://github.com/RimSort/RimSort/wiki")
-            )
-            self.wiki_button.setObjectName("RightButton")
             # folder paths
             # game folder
             if self.system_name == "Darwin":
@@ -384,9 +362,6 @@ class GameConfiguration(QObject):
             self.client_settings_row.addWidget(self.hide_show_folder_rows_button)
             self.client_settings_row.addWidget(self.game_version_label)
             self.client_settings_row.addWidget(self.game_version_line)
-            self.client_settings_row.addWidget(self.check_for_updates_button)
-            self.client_settings_row.addWidget(self.client_settings_button)
-            self.client_settings_row.addWidget(self.wiki_button)
 
             self.game_folder_row.addWidget(self.game_folder_open_button)
             self.game_folder_row.addWidget(self.game_folder_line)
@@ -436,7 +411,6 @@ class GameConfiguration(QObject):
             self._initialize_storage()
 
             # SIGNALS AND SLOTS
-            self.check_for_updates_action.toggled.connect(self._check_updates_toggle)
             self.game_folder_line.textChanged.connect(
                 partial(self.__handle_line_edit, line="game")
             )

--- a/view/menu_bar.py
+++ b/view/menu_bar.py
@@ -1,0 +1,139 @@
+from PySide6.QtCore import QObject
+from PySide6.QtGui import QAction, QKeySequence
+from PySide6.QtWidgets import QMenuBar, QMenu
+
+from util.system_info import SystemInfo
+
+
+class MenuBar(QObject):
+    def __init__(self, menu_bar: QMenuBar) -> None:
+        super().__init__()
+
+        self.menu_bar = menu_bar
+
+        # Menu bars are different on macOS
+        if SystemInfo().operating_system == SystemInfo.OperatingSystem.MACOS:
+            self._do_menu_bar_macos()
+        else:
+            self._do_menu_bar_non_macos()
+
+    def _do_menu_bar_macos(self) -> None:
+        app_menu = self.menu_bar.addMenu("AppName")  # This title is ignored on macOS
+
+        self.check_for_updates_action = QAction("Check for Updates…", self)
+        self.check_for_updates_action.setMenuRole(
+            QAction.MenuRole.ApplicationSpecificRole
+        )
+        app_menu.addAction(self.check_for_updates_action)
+
+        app_menu.addSeparator()
+
+        self.settings_action = QAction("Settings…", self)
+        self.settings_action.setMenuRole(QAction.MenuRole.ApplicationSpecificRole)
+        app_menu.addAction(self.settings_action)
+
+        app_menu.addSeparator()
+
+        self.quit_action = QAction("Quit", self)
+        app_menu.addAction(self.quit_action)
+
+        self.file_menu = self.menu_bar.addMenu("File")
+
+        self.open_mod_list_action = QAction("Open Mod List…", self)
+        self.open_mod_list_action.setShortcut(QKeySequence("Ctrl+O"))
+        self.file_menu.addAction(self.open_mod_list_action)
+
+        self.file_menu.addSeparator()
+
+        self.save_mod_list_action = QAction("Save Mod List…", self)
+        self.save_mod_list_action.setShortcut(QKeySequence("Ctrl+S"))
+        self.file_menu.addAction(self.save_mod_list_action)
+
+        self.file_menu.addSeparator()
+
+        self.export_submenu = QMenu("Export")
+        self.file_menu.addMenu(self.export_submenu)
+
+        self.export_to_clipboard_action = QAction("To Clipboard…", self)
+        self.export_submenu.addAction(self.export_to_clipboard_action)
+
+        self.export_to_rentry_action = QAction("To Rentry.co…", self)
+        self.export_submenu.addAction(self.export_to_rentry_action)
+
+        self.edit_menu = self.menu_bar.addMenu("Edit")
+
+        self.cut_action = QAction("Cut", self)
+        self.cut_action.setShortcut(QKeySequence("Ctrl+X"))
+        self.edit_menu.addAction(self.cut_action)
+
+        self.copy_action = QAction("Copy", self)
+        self.copy_action.setShortcut(QKeySequence("Ctrl+C"))
+        self.edit_menu.addAction(self.copy_action)
+
+        self.paste_action = QAction("Paste", self)
+        self.paste_action.setShortcut(QKeySequence("Ctrl+V"))
+        self.edit_menu.addAction(self.paste_action)
+
+        self.help_menu = self.menu_bar.addMenu("Help")
+
+        self.wiki_action = QAction(f"RimSort Wiki…", self)
+        self.help_menu.addAction(self.wiki_action)
+
+    def _do_menu_bar_non_macos(self) -> None:
+        self.file_menu = self.menu_bar.addMenu("File")
+
+        self.open_mod_list_action = QAction("Open Mod List…", self)
+        self.open_mod_list_action.setShortcut(QKeySequence("Ctrl+O"))
+        self.file_menu.addAction(self.open_mod_list_action)
+
+        self.file_menu.addSeparator()
+
+        self.save_mod_list_action = QAction("Save Mod List…", self)
+        self.save_mod_list_action.setShortcut(QKeySequence("Ctrl+S"))
+        self.file_menu.addAction(self.save_mod_list_action)
+
+        self.file_menu.addSeparator()
+
+        self.export_submenu = QMenu("Export")
+        self.file_menu.addMenu(self.export_submenu)
+
+        self.export_to_clipboard_action = QAction("To Clipboard…", self)
+        self.export_submenu.addAction(self.export_to_clipboard_action)
+
+        self.export_to_rentry_action = QAction("To Rentry.co…", self)
+        self.export_submenu.addAction(self.export_to_rentry_action)
+
+        self.file_menu.addSeparator()
+
+        self.settings_action = QAction("Settings…", self)
+        self.file_menu.addAction(self.settings_action)
+
+        self.file_menu.addSeparator()
+
+        self.quit_action = QAction("Exit", self)
+        self.quit_action.setShortcut(QKeySequence("Ctrl+Q"))
+        self.file_menu.addAction(self.quit_action)
+
+        self.edit_menu = self.menu_bar.addMenu("Edit")
+
+        self.cut_action = QAction("Cut", self)
+        self.cut_action.setShortcut(QKeySequence("Ctrl+X"))
+        self.edit_menu.addAction(self.cut_action)
+
+        self.copy_action = QAction("Copy", self)
+        self.copy_action.setShortcut(QKeySequence("Ctrl+C"))
+        self.edit_menu.addAction(self.copy_action)
+
+        self.paste_action = QAction("Paste", self)
+        self.paste_action.setShortcut(QKeySequence("Ctrl+V"))
+        self.edit_menu.addAction(self.paste_action)
+
+        self.help_menu = self.menu_bar.addMenu("Help")
+
+        self.wiki_action = QAction(f"RimSort Wiki…", self)
+        self.help_menu.addAction(self.wiki_action)
+
+        self.help_menu.addSeparator()
+
+        self.check_for_updates_action = QAction("Check for Updates…", self)
+        self.help_menu.addAction(self.check_for_updates_action)

--- a/view/menu_bar.py
+++ b/view/menu_bar.py
@@ -18,24 +18,35 @@ class MenuBar(QObject):
             self._do_menu_bar_non_macos()
 
     def _do_menu_bar_macos(self) -> None:
-        app_menu = self.menu_bar.addMenu("AppName")  # This title is ignored on macOS
+        self.app_menu = self.menu_bar.addMenu(
+            "AppName"
+        )  # This title is ignored on macOS
 
         self.check_for_updates_action = QAction("Check for Updates…", self)
         self.check_for_updates_action.setMenuRole(
             QAction.MenuRole.ApplicationSpecificRole
         )
-        app_menu.addAction(self.check_for_updates_action)
+        self.app_menu.addAction(self.check_for_updates_action)
 
-        app_menu.addSeparator()
+        self.check_for_updates_on_startup_action = QAction(
+            "Check for Updates on Startup", self
+        )
+        self.check_for_updates_on_startup_action.setCheckable(True)
+        self.check_for_updates_on_startup_action.setMenuRole(
+            QAction.MenuRole.ApplicationSpecificRole
+        )
+        self.app_menu.addAction(self.check_for_updates_on_startup_action)
+
+        self.app_menu.addSeparator()
 
         self.settings_action = QAction("Settings…", self)
         self.settings_action.setMenuRole(QAction.MenuRole.ApplicationSpecificRole)
-        app_menu.addAction(self.settings_action)
+        self.app_menu.addAction(self.settings_action)
 
-        app_menu.addSeparator()
+        self.app_menu.addSeparator()
 
         self.quit_action = QAction("Quit", self)
-        app_menu.addAction(self.quit_action)
+        self.app_menu.addAction(self.quit_action)
 
         self.file_menu = self.menu_bar.addMenu("File")
 
@@ -137,3 +148,12 @@ class MenuBar(QObject):
 
         self.check_for_updates_action = QAction("Check for Updates…", self)
         self.help_menu.addAction(self.check_for_updates_action)
+
+        self.check_for_updates_on_startup_action = QAction(
+            "Check for Updates on Startup", self
+        )
+        self.check_for_updates_on_startup_action.setCheckable(True)
+        self.check_for_updates_on_startup_action.setMenuRole(
+            QAction.MenuRole.ApplicationSpecificRole
+        )
+        self.help_menu.addAction(self.check_for_updates_on_startup_action)


### PR DESCRIPTION
- Add a view class with different menu bars for macOS and non-macOS users
- Add a controller class to handle the menu bar's signals
- Implement view and controller as members of MainWindow
- Add a SystemInfo class to neatly distinguish between operating systems and architectures (used for the conditional logic in the MenuBar view class)