### PR TITLE
Clean up RimSort.py

### DIFF
--- a/RimSort.py
+++ b/RimSort.py
@@ -1,40 +1,32 @@
 import sys
 
-from multiprocessing import current_process, freeze_support, set_start_method
+from multiprocessing import freeze_support, set_start_method
 
 import os
 from pathlib import Path
 import platform
-from requests.exceptions import HTTPError
 from tempfile import gettempdir
 import traceback
-from typing import Any, Optional
 
-from logger_tt import handlers, logger, setup_logging
+from logger_tt import logger, setup_logging
 from logging import getLogger, WARNING
-from PySide6.QtCore import QSize, QTimer
-from PySide6.QtWidgets import QApplication, QMainWindow, QVBoxLayout, QWidget
+from PySide6.QtWidgets import QApplication
 
-from controller.menu_bar_controller import MenuBarController
-from controller.settings_controller import SettingsController
-from model.settings import Settings
 from util.app_info import AppInfo
-from view.menu_bar import MenuBar
+from view.main_window import MainWindow
 
 SYSTEM = platform.system()
 # Watchdog conditionals
 if SYSTEM == "Darwin":
-    from watchdog.observers import Observer
 
     # Comment to see logging for watchdog handler on Darwin
     getLogger("watchdog.observers.fsevents").setLevel(WARNING)
 elif SYSTEM == "Linux":
-    from watchdog.observers import Observer
 
     # Comment to see logging for watchdog handler on Linux
     getLogger("watchdog.observers.inotify_buffer").setLevel(WARNING)
 elif SYSTEM == "Windows":
-    from watchdog.observers.polling import PollingObserver
+    pass
 
     # Comment to see logging for watchdog handler on Windows
     # This is a stub if it's ever even needed...
@@ -43,185 +35,6 @@ elif SYSTEM == "Windows":
 
 from model.dialogue import show_fatal_error
 from util.proxy_style import ProxyStyle
-from util.watchdog import RSFileSystemEventHandler
-from view.game_configuration_panel import GameConfiguration
-from view.main_content_panel import MainContent
-from view.status_panel import Status
-
-
-class MainWindow(QMainWindow):
-    """
-    Subclass QMainWindow to customize the main application window.
-    """
-
-    def __init__(self, DEBUG_MODE=None) -> None:
-        """
-        Initialize the main application window. Construct the layout,
-        add the three main views, and set up relevant signals and slots.
-        """
-        logger.info("Initializing MainWindow")
-        super(MainWindow, self).__init__()
-
-        # Instantiate the settings model and controller
-        self.settings = Settings()
-        self.settings_controller = SettingsController(model=self.settings)
-
-        # Create the main application window
-        self.DEBUG_MODE = DEBUG_MODE
-        self.init = None  # Content initialization should only fire on startup. Otherwise, this is handled by Refresh button
-        self.version_string = "Alpha-v1.0.6.2-hf"
-
-        # Check for SHA and append to version string if found
-        sha_file = str(Path(os.path.join(data_path, "SHA")).resolve())
-        if os.path.exists(sha_file):
-            with open(sha_file, encoding="utf-8") as f:
-                sha = f.read().strip()
-            self.version_string += f" [Edge {sha}]"
-
-        # Watchdog
-        self.watchdog_event_handler = None
-        self.watchdog_observer = None
-
-        # Setup the window
-        self.setWindowTitle(f"RimSort {self.version_string}")
-        self.setMinimumSize(QSize(1024, 768))
-
-        # Create the window layout
-        app_layout = QVBoxLayout()
-        app_layout.setContentsMargins(0, 0, 0, 0)  # Space from main layout to border
-        app_layout.setSpacing(0)  # Space between widgets
-
-        # Create various panels on the application GUI
-        self.game_configuration = GameConfiguration.instance(
-            DEBUG_MODE=DEBUG_MODE,
-            settings_controller=self.settings_controller,
-            RIMSORT_VERSION=self.version_string,
-        )
-        self.main_content_panel = MainContent(
-            settings_controller=self.settings_controller
-        )
-        self.bottom_panel = Status()
-
-        # Connect the game configuration actions signals to Status panel to display fading action text
-        self.game_configuration.configuration_signal.connect(
-            self.bottom_panel.actions_slot
-        )
-        self.game_configuration.settings_panel.actions_signal.connect(
-            self.bottom_panel.actions_slot
-        )
-        # Connect the actions_signal to Status panel to display fading action text
-        self.main_content_panel.actions_panel.actions_signal.connect(
-            self.bottom_panel.actions_slot
-        )
-        self.main_content_panel.status_signal.connect(self.bottom_panel.actions_slot)
-
-        # Arrange all panels vertically on the main window layout
-        app_layout.addLayout(self.game_configuration.panel)
-        app_layout.addWidget(self.main_content_panel.main_layout_frame)
-        app_layout.addWidget(self.bottom_panel.frame)
-
-        # Display all items
-        widget = QWidget()
-        widget.setLayout(app_layout)
-        self.setCentralWidget(widget)
-
-        self.menu_bar = MenuBar(menu_bar=self.menuBar())
-        self.menu_bar_controller = MenuBarController(
-            view=self.menu_bar, settings_controller=self.settings_controller
-        )
-
-        logger.debug("Finished MainWindow initialization")
-
-    def showEvent(self, event) -> None:
-        # Call the original showEvent handler
-        super().showEvent(event)
-        if not self.init:
-            # HIDE/SHOW FOLDER ROWS BASED ON PREFERENCE
-            if self.settings_controller.settings.show_folder_rows:
-                self.game_configuration.hide_show_folder_rows_button.setText(
-                    "Hide paths"
-                )
-            else:
-                self.game_configuration.hide_show_folder_rows_button.setText(
-                    "Show paths"
-                )
-            # set visibility
-            self.game_configuration.game_folder_frame.setVisible(
-                self.settings_controller.settings.show_folder_rows
-            )
-            self.game_configuration.config_folder_frame.setVisible(
-                self.settings_controller.settings.show_folder_rows
-            )
-            self.game_configuration.local_folder_frame.setVisible(
-                self.settings_controller.settings.show_folder_rows
-            )
-            self.game_configuration.workshop_folder_frame.setVisible(
-                self.settings_controller.settings.show_folder_rows
-            )
-
-    def __initialize_content(self) -> None:
-        self.init = True
-
-        # IF CHECK FOR UPDATE ON STARTUP...
-        if self.settings_controller.settings.check_for_update_startup:
-            self.main_content_panel.actions_slot("check_for_update")
-
-        # REFRESH CONFIGURED METADATA
-        self.main_content_panel._do_refresh(is_initial=True)
-
-        # CHECK USER PREFERENCE FOR WATCHDOG
-        if self.settings_controller.settings.watchdog_toggle:
-            # Setup watchdog
-            self.__initialize_watchdog()
-
-    def __initialize_watchdog(self) -> None:
-        logger.info("Initializing watchdog FS Observer")
-        # INITIALIZE WATCHDOG - WE WAIT TO START UNTIL DONE PARSING MOD LIST
-        game_folder_path = self.game_configuration.game_folder_line.text()
-        local_folder_path = self.game_configuration.local_folder_line.text()
-        workshop_folder_path = self.game_configuration.workshop_folder_line.text()
-        self.watchdog_event_handler = RSFileSystemEventHandler()
-        if SYSTEM == "Windows":
-            self.watchdog_observer = PollingObserver()
-        else:
-            self.watchdog_observer = Observer()
-        if game_folder_path and game_folder_path != "":
-            self.watchdog_observer.schedule(
-                self.watchdog_event_handler,
-                game_folder_path,
-                # recursive=True,
-            )
-        if local_folder_path and local_folder_path != "":
-            self.watchdog_observer.schedule(
-                self.watchdog_event_handler,
-                local_folder_path,
-                # recursive=True,
-            )
-        if workshop_folder_path and workshop_folder_path != "":
-            self.watchdog_observer.schedule(
-                self.watchdog_event_handler,
-                workshop_folder_path,
-                # recursive=True,
-            )
-        # Connect watchdog to our refresh button animation
-        self.watchdog_event_handler.file_changes_signal.connect(
-            self.main_content_panel._do_refresh_animation
-        )
-        # Connect main content signal so it can stop watchdog
-        self.main_content_panel.stop_watchdog_signal.connect(self.__shutdown_watchdog)
-        # Start watchdog
-        try:
-            self.watchdog_observer.start()
-        except Exception as e:
-            logger.warning(
-                f"Unable to initialize watchdog Observer due to exception: {e.__class__.__name__}"
-            )
-
-    def __shutdown_watchdog(self) -> None:
-        if self.watchdog_observer and self.watchdog_observer.is_alive():
-            self.watchdog_observer.stop()
-            self.watchdog_observer.join()
-            self.watchdog_observer = None
 
 
 def handle_exception(exc_type, exc_value, exc_traceback):

--- a/RimSort.py
+++ b/RimSort.py
@@ -7,6 +7,8 @@ from pathlib import Path
 import platform
 from tempfile import gettempdir
 import traceback
+from types import TracebackType
+from typing import Type, Optional
 
 from logger_tt import logger, setup_logging
 from logging import getLogger, WARNING
@@ -18,11 +20,9 @@ from view.main_window import MainWindow
 SYSTEM = platform.system()
 # Watchdog conditionals
 if SYSTEM == "Darwin":
-
     # Comment to see logging for watchdog handler on Darwin
     getLogger("watchdog.observers.fsevents").setLevel(WARNING)
 elif SYSTEM == "Linux":
-
     # Comment to see logging for watchdog handler on Linux
     getLogger("watchdog.observers.inotify_buffer").setLevel(WARNING)
 elif SYSTEM == "Windows":
@@ -37,7 +37,11 @@ from model.dialogue import show_fatal_error
 from util.proxy_style import ProxyStyle
 
 
-def handle_exception(exc_type, exc_value, exc_traceback):
+def handle_exception(
+    exc_type: Type[BaseException],
+    exc_value: BaseException,
+    exc_traceback: Optional[TracebackType],
+) -> None:
     """
     This function is called (through excepthook) when the main application
     loop encounters an uncaught exception. When this happens, the error is
@@ -93,7 +97,7 @@ def main_thread() -> None:
     except Exception as e:
         # Catch exceptions during initial application instantiation
         # Uncaught exceptions during the application loop are caught with excepthook
-        if e is SystemExit:
+        if isinstance(e, SystemExit):
             logger.warning("Exiting application")
         elif (
             e.__class__.__name__ == "HTTPError" or e.__class__.__name__ == "SSLError"

--- a/RimSort.py
+++ b/RimSort.py
@@ -1,18 +1,16 @@
-import sys
-
-from multiprocessing import freeze_support, set_start_method
-
 import os
-from pathlib import Path
 import platform
-from tempfile import gettempdir
+import sys
 import traceback
+from logging import getLogger, WARNING
+from multiprocessing import freeze_support, set_start_method
+from pathlib import Path
+from tempfile import gettempdir
 from types import TracebackType
 from typing import Type, Optional
 
-from logger_tt import handlers, logger, setup_logging
-from logging import getLogger, WARNING
 from PySide6.QtWidgets import QApplication
+from logger_tt import handlers, logger, setup_logging
 
 from util.app_info import AppInfo
 from view.main_window import MainWindow

--- a/RimSort.py
+++ b/RimSort.py
@@ -85,7 +85,7 @@ def main_thread() -> None:
             ).read_text()
         )
         # Create the main window
-        window = MainWindow(DEBUG_MODE=DEBUG_MODE)
+        window = MainWindow(debug_mode=DEBUG_MODE)
         logger.info("Showing MainWindow")
         window.show()
         window.__initialize_content()

--- a/RimSort.py
+++ b/RimSort.py
@@ -10,7 +10,7 @@ import traceback
 from types import TracebackType
 from typing import Type, Optional
 
-from logger_tt import logger, setup_logging
+from logger_tt import handlers, logger, setup_logging
 from logging import getLogger, WARNING
 from PySide6.QtWidgets import QApplication
 

--- a/RimSort.py
+++ b/RimSort.py
@@ -104,11 +104,13 @@ def main_thread() -> None:
             e.__class__.__name__ == "HTTPError" or e.__class__.__name__ == "SSLError"
         ):  # requests.exceptions.HTTPError OR urllib3.exceptions.SSLError
             stacktrace = traceback.format_exc()
+            # If an HTTPError from steam/urllib3 module(s) somehow is uncaught,
+            # try to remove the Steam API key from the stacktrace
             pattern = "&key="
             stacktrace = stacktrace[
                 : len(stacktrace)
                 - (len(stacktrace) - (stacktrace.find(pattern) + len(pattern)))
-            ]  # If an HTTPError from steam/urllib3 module(s) somehow is uncaught, try to remove the Steam API key from the stacktrace
+            ]
         else:
             stacktrace = traceback.format_exc()
         logger.error(

--- a/RimSort.py
+++ b/RimSort.py
@@ -97,6 +97,7 @@ def main_thread() -> None:
     except Exception as e:
         # Catch exceptions during initial application instantiation
         # Uncaught exceptions during the application loop are caught with excepthook
+        stacktrace: str = ""
         if isinstance(e, SystemExit):
             logger.warning("Exiting application")
         elif (

--- a/RimSort.py
+++ b/RimSort.py
@@ -120,7 +120,7 @@ def main_thread() -> None:
         if "window" in locals():
             try:
                 logger.debug("Stopping watchdog...")
-                window.__shutdown_watchdog()
+                window.shutdown_watchdog()
             except:
                 stacktrace = traceback.format_exc()
                 logger.warning(

--- a/RimSort.py
+++ b/RimSort.py
@@ -92,7 +92,7 @@ def main_thread() -> None:
         window = MainWindow(debug_mode=DEBUG_MODE)
         logger.info("Showing MainWindow")
         window.show()
-        window.__initialize_content()
+        window.initialize_content()
         app.exec()
     except Exception as e:
         # Catch exceptions during initial application instantiation

--- a/util/app_info.py
+++ b/util/app_info.py
@@ -58,6 +58,10 @@ class AppInfo:
         self._user_data_folder = Path(platform_dirs.user_data_dir)
         self._user_log_folder = Path(platform_dirs.user_log_dir)
 
+        # Derive some secondary directory paths
+
+        self._app_data_folder = self._application_folder / "data"
+
         # Make sure important directories exist
 
         self._user_data_folder.mkdir(parents=True, exist_ok=True)
@@ -128,3 +132,10 @@ class AppInfo:
             Path: The path to the user-specific log folder.
         """
         return self._user_log_folder
+
+    @property
+    def app_data_folder(self) -> Path:
+        """
+        Get the path to the folder where application-specific data is stored.
+        """
+        return self._app_data_folder

--- a/view/main_window.py
+++ b/view/main_window.py
@@ -132,7 +132,7 @@ class MainWindow(QMainWindow):
                 self.settings_controller.settings.show_folder_rows
             )
 
-    def __initialize_content(self) -> None:
+    def initialize_content(self) -> None:
         self.init = True
 
         # IF CHECK FOR UPDATE ON STARTUP...

--- a/view/main_window.py
+++ b/view/main_window.py
@@ -5,9 +5,7 @@ from PySide6.QtCore import QSize
 from PySide6.QtGui import QShowEvent
 from PySide6.QtWidgets import QMainWindow, QVBoxLayout, QWidget
 from logger_tt import logger
-from watchdog.observers import Observer
 from watchdog.observers.api import BaseObserver
-from watchdog.observers.polling import PollingObserver
 
 from controller.menu_bar_controller import MenuBarController
 from controller.settings_controller import SettingsController
@@ -19,6 +17,11 @@ from view.game_configuration_panel import GameConfiguration
 from view.main_content_panel import MainContent
 from view.menu_bar import MenuBar
 from view.status_panel import Status
+
+if SystemInfo().operating_system == SystemInfo.OperatingSystem.WINDOWS:
+    from watchdog.observers.polling import PollingObserver
+else:
+    from watchdog.observers import Observer
 
 
 class MainWindow(QMainWindow):

--- a/view/main_window.py
+++ b/view/main_window.py
@@ -1,0 +1,194 @@
+import os
+from pathlib import Path
+
+from PySide6.QtCore import QSize
+from PySide6.QtWidgets import QMainWindow, QVBoxLayout, QWidget
+from logger_tt import logger
+from watchdog.observers import Observer
+from watchdog.observers.polling import PollingObserver
+
+from controller.menu_bar_controller import MenuBarController
+from controller.settings_controller import SettingsController
+from model.settings import Settings
+from util.app_info import AppInfo
+from util.system_info import SystemInfo
+from util.watchdog import RSFileSystemEventHandler
+from view.game_configuration_panel import GameConfiguration
+from view.main_content_panel import MainContent
+from view.menu_bar import MenuBar
+from view.status_panel import Status
+
+
+class MainWindow(QMainWindow):
+    """
+    Subclass QMainWindow to customize the main application window.
+    """
+
+    def __init__(self, DEBUG_MODE=None) -> None:
+        """
+        Initialize the main application window. Construct the layout,
+        add the three main views, and set up relevant signals and slots.
+        """
+        logger.info("Initializing MainWindow")
+        super(MainWindow, self).__init__()
+
+        # Instantiate the settings model and controller
+        self.settings = Settings()
+        self.settings_controller = SettingsController(model=self.settings)
+
+        # Create the main application window
+        self.DEBUG_MODE = DEBUG_MODE
+        self.init = None  # Content initialization should only fire on startup. Otherwise, this is handled by Refresh button
+        self.version_string = "Alpha-v1.0.6.2-hf"
+
+        # Check for SHA and append to version string if found
+        sha_file = str(AppInfo().app_data_folder / "SHA")
+        if os.path.exists(sha_file):
+            with open(sha_file, encoding="utf-8") as f:
+                sha = f.read().strip()
+            self.version_string += f" [Edge {sha}]"
+
+        # Watchdog
+        self.watchdog_event_handler = None
+        self.watchdog_observer = None
+
+        # Setup the window
+        self.setWindowTitle(f"RimSort {self.version_string}")
+        self.setMinimumSize(QSize(1024, 768))
+
+        # Create the window layout
+        app_layout = QVBoxLayout()
+        app_layout.setContentsMargins(0, 0, 0, 0)  # Space from main layout to border
+        app_layout.setSpacing(0)  # Space between widgets
+
+        # Create various panels on the application GUI
+        self.game_configuration = GameConfiguration.instance(
+            DEBUG_MODE=DEBUG_MODE,
+            settings_controller=self.settings_controller,
+            RIMSORT_VERSION=self.version_string,
+        )
+        self.main_content_panel = MainContent(
+            settings_controller=self.settings_controller
+        )
+        self.bottom_panel = Status()
+
+        # Connect the game configuration actions signals to Status panel to display fading action text
+        self.game_configuration.configuration_signal.connect(
+            self.bottom_panel.actions_slot
+        )
+        self.game_configuration.settings_panel.actions_signal.connect(
+            self.bottom_panel.actions_slot
+        )
+        # Connect the actions_signal to Status panel to display fading action text
+        self.main_content_panel.actions_panel.actions_signal.connect(
+            self.bottom_panel.actions_slot
+        )
+        self.main_content_panel.status_signal.connect(self.bottom_panel.actions_slot)
+
+        # Arrange all panels vertically on the main window layout
+        app_layout.addLayout(self.game_configuration.panel)
+        app_layout.addWidget(self.main_content_panel.main_layout_frame)
+        app_layout.addWidget(self.bottom_panel.frame)
+
+        # Display all items
+        widget = QWidget()
+        widget.setLayout(app_layout)
+        self.setCentralWidget(widget)
+
+        self.menu_bar = MenuBar(menu_bar=self.menuBar())
+        self.menu_bar_controller = MenuBarController(
+            view=self.menu_bar, settings_controller=self.settings_controller
+        )
+
+        logger.debug("Finished MainWindow initialization")
+
+    def showEvent(self, event) -> None:
+        # Call the original showEvent handler
+        super().showEvent(event)
+        if not self.init:
+            # HIDE/SHOW FOLDER ROWS BASED ON PREFERENCE
+            if self.settings_controller.settings.show_folder_rows:
+                self.game_configuration.hide_show_folder_rows_button.setText(
+                    "Hide paths"
+                )
+            else:
+                self.game_configuration.hide_show_folder_rows_button.setText(
+                    "Show paths"
+                )
+            # set visibility
+            self.game_configuration.game_folder_frame.setVisible(
+                self.settings_controller.settings.show_folder_rows
+            )
+            self.game_configuration.config_folder_frame.setVisible(
+                self.settings_controller.settings.show_folder_rows
+            )
+            self.game_configuration.local_folder_frame.setVisible(
+                self.settings_controller.settings.show_folder_rows
+            )
+            self.game_configuration.workshop_folder_frame.setVisible(
+                self.settings_controller.settings.show_folder_rows
+            )
+
+    def __initialize_content(self) -> None:
+        self.init = True
+
+        # IF CHECK FOR UPDATE ON STARTUP...
+        if self.settings_controller.settings.check_for_update_startup:
+            self.main_content_panel.actions_slot("check_for_update")
+
+        # REFRESH CONFIGURED METADATA
+        self.main_content_panel._do_refresh(is_initial=True)
+
+        # CHECK USER PREFERENCE FOR WATCHDOG
+        if self.settings_controller.settings.watchdog_toggle:
+            # Setup watchdog
+            self.__initialize_watchdog()
+
+    def __initialize_watchdog(self) -> None:
+        logger.info("Initializing watchdog FS Observer")
+        # INITIALIZE WATCHDOG - WE WAIT TO START UNTIL DONE PARSING MOD LIST
+        game_folder_path = self.game_configuration.game_folder_line.text()
+        local_folder_path = self.game_configuration.local_folder_line.text()
+        workshop_folder_path = self.game_configuration.workshop_folder_line.text()
+        self.watchdog_event_handler = RSFileSystemEventHandler()
+        if SystemInfo().operating_system == SystemInfo.OperatingSystem.WINDOWS:
+            self.watchdog_observer = PollingObserver()
+        else:
+            self.watchdog_observer = Observer()
+        if game_folder_path and game_folder_path != "":
+            self.watchdog_observer.schedule(
+                self.watchdog_event_handler,
+                game_folder_path,
+                # recursive=True,
+            )
+        if local_folder_path and local_folder_path != "":
+            self.watchdog_observer.schedule(
+                self.watchdog_event_handler,
+                local_folder_path,
+                # recursive=True,
+            )
+        if workshop_folder_path and workshop_folder_path != "":
+            self.watchdog_observer.schedule(
+                self.watchdog_event_handler,
+                workshop_folder_path,
+                # recursive=True,
+            )
+        # Connect watchdog to our refresh button animation
+        self.watchdog_event_handler.file_changes_signal.connect(
+            self.main_content_panel._do_refresh_animation
+        )
+        # Connect main content signal so it can stop watchdog
+        self.main_content_panel.stop_watchdog_signal.connect(self.__shutdown_watchdog)
+        # Start watchdog
+        try:
+            self.watchdog_observer.start()
+        except Exception as e:
+            logger.warning(
+                f"Unable to initialize watchdog Observer due to exception: {e.__class__.__name__}"
+            )
+
+    def __shutdown_watchdog(self) -> None:
+        if self.watchdog_observer and self.watchdog_observer.is_alive():
+            self.watchdog_observer.stop()
+            self.watchdog_observer.join()
+            self.watchdog_observer = None

--- a/view/main_window.py
+++ b/view/main_window.py
@@ -1,10 +1,12 @@
 import os
-from pathlib import Path
+from typing import Optional
 
 from PySide6.QtCore import QSize
+from PySide6.QtGui import QShowEvent
 from PySide6.QtWidgets import QMainWindow, QVBoxLayout, QWidget
 from logger_tt import logger
 from watchdog.observers import Observer
+from watchdog.observers.api import BaseObserver
 from watchdog.observers.polling import PollingObserver
 
 from controller.menu_bar_controller import MenuBarController
@@ -24,7 +26,7 @@ class MainWindow(QMainWindow):
     Subclass QMainWindow to customize the main application window.
     """
 
-    def __init__(self, DEBUG_MODE=None) -> None:
+    def __init__(self, debug_mode: bool = False) -> None:
         """
         Initialize the main application window. Construct the layout,
         add the three main views, and set up relevant signals and slots.
@@ -37,8 +39,9 @@ class MainWindow(QMainWindow):
         self.settings_controller = SettingsController(model=self.settings)
 
         # Create the main application window
-        self.DEBUG_MODE = DEBUG_MODE
-        self.init = None  # Content initialization should only fire on startup. Otherwise, this is handled by Refresh button
+        self.DEBUG_MODE = debug_mode
+        # Content initialization should only fire on startup. Otherwise, this is handled by Refresh button
+        self.init: bool = False
         self.version_string = "Alpha-v1.0.6.2-hf"
 
         # Check for SHA and append to version string if found
@@ -49,10 +52,10 @@ class MainWindow(QMainWindow):
             self.version_string += f" [Edge {sha}]"
 
         # Watchdog
-        self.watchdog_event_handler = None
-        self.watchdog_observer = None
+        self.watchdog_event_handler: Optional[RSFileSystemEventHandler] = None
+        self.watchdog_observer: Optional[BaseObserver] = None
 
-        # Setup the window
+        # Set up the window
         self.setWindowTitle(f"RimSort {self.version_string}")
         self.setMinimumSize(QSize(1024, 768))
 
@@ -63,7 +66,7 @@ class MainWindow(QMainWindow):
 
         # Create various panels on the application GUI
         self.game_configuration = GameConfiguration.instance(
-            DEBUG_MODE=DEBUG_MODE,
+            DEBUG_MODE=debug_mode,
             settings_controller=self.settings_controller,
             RIMSORT_VERSION=self.version_string,
         )
@@ -102,7 +105,7 @@ class MainWindow(QMainWindow):
 
         logger.debug("Finished MainWindow initialization")
 
-    def showEvent(self, event) -> None:
+    def showEvent(self, event: QShowEvent) -> None:
         # Call the original showEvent handler
         super().showEvent(event)
         if not self.init:

--- a/view/main_window.py
+++ b/view/main_window.py
@@ -181,7 +181,7 @@ class MainWindow(QMainWindow):
             self.main_content_panel._do_refresh_animation
         )
         # Connect main content signal so it can stop watchdog
-        self.main_content_panel.stop_watchdog_signal.connect(self.__shutdown_watchdog)
+        self.main_content_panel.stop_watchdog_signal.connect(self.shutdown_watchdog)
         # Start watchdog
         try:
             self.watchdog_observer.start()
@@ -190,7 +190,7 @@ class MainWindow(QMainWindow):
                 f"Unable to initialize watchdog Observer due to exception: {e.__class__.__name__}"
             )
 
-    def __shutdown_watchdog(self) -> None:
+    def shutdown_watchdog(self) -> None:
         if self.watchdog_observer and self.watchdog_observer.is_alive():
             self.watchdog_observer.stop()
             self.watchdog_observer.join()


### PR DESCRIPTION
- added an app_data_folder property to AppInfo that points to the `data` folder location
- refactored `MainWindow` into its own Python module and out of `RimSort.py`
- renamed some previously private methods in `MainWindow` to public methods because they're being called outside the class
- `RimSort.py` and `main_window.py` now both pass mypy, which the exception of `logger_tt` lacking type stubs

Tested on macOS 14 and Windows 11.