### PR TITLE
Refactor application to rely on UUIDs, optimizations

### DIFF
--- a/model/mod_list.py
+++ b/model/mod_list.py
@@ -835,7 +835,11 @@ class ModListWidget(QListWidget):
                         for source_item in selected_items:
                             if type(source_item) is QListWidgetItem:
                                 source_widget = self.itemWidget(source_item)
-                                widget_json_data = source_widget.json_data
+                                widget_json_data = (
+                                    MetadataManager.instance().all_mods_compiled[
+                                        source_widget.uuid
+                                    ]
+                                )
                                 if not widget_json_data[
                                     "data_source"  # Disallow Official Expansions
                                 ] == "expansion" or not widget_json_data[
@@ -861,7 +865,11 @@ class ModListWidget(QListWidget):
                         for source_item in selected_items:
                             if type(source_item) is QListWidgetItem:
                                 source_widget = self.itemWidget(source_item)
-                                widget_json_data = source_widget.json_data
+                                widget_json_data = (
+                                    MetadataManager.instance().all_mods_compiled[
+                                        source_widget.uuid
+                                    ]
+                                )
                                 if not widget_json_data[
                                     "data_source"  # Disallow Official Expansions
                                 ] == "expansion" or not widget_json_data[
@@ -880,7 +888,9 @@ class ModListWidget(QListWidget):
                     if type(source_item) is QListWidgetItem:
                         source_widget = self.itemWidget(source_item)
                         # Retrieve metadata
-                        widget_json_data = source_widget.json_data
+                        widget_json_data = MetadataManager.instance().all_mods_compiled[
+                            source_widget.uuid
+                        ]
                         mod_data_source = widget_json_data.get("data_source")
                         mod_path = widget_json_data["path"]
                         # Toggle warning action

--- a/model/mod_list.py
+++ b/model/mod_list.py
@@ -143,7 +143,7 @@ class ModListWidget(QListWidget):
 
         # This set is used to keep track of mods that have been loaded
         # into widgets. Used for an optimization strategy for `handle_rows_inserted`
-        self.uuids = set()
+        self.uuids = list()
         self.ignore_warning_list = []
         logger.debug("Finished ModListWidget initialization")
 
@@ -973,7 +973,8 @@ class ModListWidget(QListWidget):
             return super().keyPressEvent(e)
 
     def handle_other_list_row_added(self, uuid: str) -> None:
-        self.uuids.discard(uuid)
+        if uuid in self.uuids:
+            self.uuids.remove(uuid)
 
     def handle_rows_inserted(self, parent: QModelIndex, first: int, last: int) -> None:
         """
@@ -1036,7 +1037,7 @@ class ModListWidget(QListWidget):
                 widget.main_label.style().polish(widget.main_label)
                 item.setSizeHint(widget.sizeHint())
                 self.setItemWidget(item, widget)
-                self.uuids.add(uuid)
+                self.uuids.insert(idx, uuid)
                 self.item_added_signal.emit(uuid)
 
         if len(self.uuids) == self.count():
@@ -1096,7 +1097,7 @@ class ModListWidget(QListWidget):
         self.setUpdatesEnabled(False)
         # Clear list
         self.clear()
-        self.uuids = set()
+        self.uuids = list()
         if uuids:  # Insert data...
             for uuid_key in uuids:
                 list_item = QListWidgetItem(self)

--- a/model/mod_list.py
+++ b/model/mod_list.py
@@ -148,9 +148,23 @@ class ModListWidget(QListWidget):
         logger.debug("Finished ModListWidget initialization")
 
     def dropEvent(self, event: QDropEvent) -> None:
-        ret = super().dropEvent(event)
+        super().dropEvent(event)
+        # Get the drop action
+        drop_action = event.dropAction()
+        # Check if the drop action is MoveAction
+        if drop_action == Qt.MoveAction:
+            # Get the new indexes of the dropped items
+            new_indexes = [index.row() for index in self.selectedIndexes()]
+            # Get the UUIDs of the dropped items
+            uuids = [item.data(Qt.UserRole) for item in self.selectedItems()]
+            # Insert the UUIDs at the respective new indexes
+            for idx, uuid in zip(new_indexes, uuids):
+                if uuid in self.uuids:  # Remove the uuid if it exists in the list
+                    self.uuids.remove(uuid)
+                # Reinsert uuid at it's new index
+                self.uuids.insert(idx, uuid)
+        # Update list signal
         self.list_update_signal.emit("drop")
-        return ret
 
     def eventFilter(self, source_object: QObject, event: QEvent) -> None:
         """

--- a/sort/alphabetical_sort.py
+++ b/sort/alphabetical_sort.py
@@ -1,17 +1,27 @@
 from logger_tt import logger
 from typing import Any
 
+from util.metadata import MetadataManager
+
 
 def do_alphabetical_sort(
-    dependency_graph: dict[str, set[str]], active_mods_json: dict[str, Any]
-) -> dict[str, Any]:
+    dependency_graph: dict[str, set[str]], active_mods_uuids: set[str]
+) -> set[str]:
     logger.info(f"Starting Alphabetical sort for {len(dependency_graph)} mods")
     # Get an alphabetized list of dependencies
     active_mods_id_to_name = dict(
-        (v["packageid"], v["name"]) for v in active_mods_json.values()
+        (
+            MetadataManager.instance().all_mods_compiled[uuid]["packageid"],
+            MetadataManager.instance().all_mods_compiled[uuid]["name"],
+        )
+        for uuid in active_mods_uuids
     )
     active_mods_packageid_to_uuid = dict(
-        (v["packageid"], v["uuid"]) for v in active_mods_json.values()
+        (
+            MetadataManager.instance().all_mods_compiled[uuid]["packageid"],
+            uuid,
+        )
+        for uuid in active_mods_uuids
     )
     active_mods_alphabetized = sorted(
         active_mods_id_to_name.items(), key=lambda x: x[1], reverse=False
@@ -37,15 +47,15 @@ def do_alphabetical_sort(
                 mods_load_order,
                 dependency_graph,
                 package_id,
-                active_mods_json,
+                active_mods_uuids,
                 index_just_appended,
             )
 
-    reordered = {}
+    reordered = set()
     for package_id in mods_load_order:
         if package_id in active_mods_packageid_to_uuid:
             mod_uuid = active_mods_packageid_to_uuid[package_id]
-            reordered[mod_uuid] = active_mods_json[mod_uuid]
+            reordered.add(mod_uuid)
     logger.info(f"Finished Alphabetical sort with {len(reordered)} mods")
     return reordered
 
@@ -54,17 +64,21 @@ def recursively_force_insert(
     mods_load_order: list[str],
     dependency_graph: dict[str, set[str]],
     package_id: str,
-    active_mods_json: dict[str, Any],
+    active_mods_uuids: set[str],
     index_just_appended: int,
 ) -> None:
     # Get the reverse alphabetized list (by name) of the current mod's dependencies
     deps_of_package = dependency_graph[package_id]
     deps_id_to_name = {}
     for dependency_id in deps_of_package:
-        for uuid, mod_data in active_mods_json.items():
-            mod_package_id = mod_data["packageid"]
+        for uuid in active_mods_uuids:
+            mod_package_id = MetadataManager.instance().all_mods_compiled[uuid][
+                "packageid"
+            ]
             if dependency_id == mod_package_id:
-                deps_id_to_name[dependency_id] = active_mods_json[uuid]["name"]
+                deps_id_to_name[
+                    dependency_id
+                ] = MetadataManager.instance().all_mods_compiled[uuid]["name"]
     deps_of_package_alphabetized = sorted(
         deps_id_to_name.items(), key=lambda x: x[1], reverse=True
     )
@@ -100,6 +114,6 @@ def recursively_force_insert(
                 mods_load_order,
                 dependency_graph,
                 dep_id,
-                active_mods_json,
+                active_mods_uuids,
                 new_idx,
             )

--- a/sort/alphabetical_sort.py
+++ b/sort/alphabetical_sort.py
@@ -1,12 +1,12 @@
 from logger_tt import logger
-from typing import Any
+from typing import Any, List
 
 from util.metadata import MetadataManager
 
 
 def do_alphabetical_sort(
     dependency_graph: dict[str, set[str]], active_mods_uuids: set[str]
-) -> set[str]:
+) -> List[str]:
     logger.info(f"Starting Alphabetical sort for {len(dependency_graph)} mods")
     # Get an alphabetized list of dependencies
     active_mods_id_to_name = dict(
@@ -51,11 +51,11 @@ def do_alphabetical_sort(
                 index_just_appended,
             )
 
-    reordered = set()
+    reordered = list()
     for package_id in mods_load_order:
         if package_id in active_mods_packageid_to_uuid:
             mod_uuid = active_mods_packageid_to_uuid[package_id]
-            reordered.add(mod_uuid)
+            reordered.append(mod_uuid)
     logger.info(f"Finished Alphabetical sort with {len(reordered)} mods")
     return reordered
 

--- a/sort/topo_sort.py
+++ b/sort/topo_sort.py
@@ -1,5 +1,5 @@
 from logger_tt import logger
-from typing import Any
+from typing import Any, List
 
 from toposort import toposort
 
@@ -8,14 +8,14 @@ from util.metadata import MetadataManager
 
 def do_topo_sort(
     dependency_graph: dict[str, set[str]], active_mods_uuids: set[str]
-) -> set[str]:
+) -> List[str]:
     """
     Sort mods using the topological sort algorithm. For each
     topological level, sort the mods alphabetically.
     """
     logger.info(f"Initializing toposort for {len(dependency_graph)} mods")
     sorted_dependencies = toposort(dependency_graph)
-    reordered = set()
+    reordered = list()
     active_mods_packageid_to_uuid = dict(
         (MetadataManager.instance().all_mods_compiled[uuid]["packageid"], uuid)
         for uuid in active_mods_uuids
@@ -34,6 +34,6 @@ def do_topo_sort(
         )
         # Add into reordered set
         for sorted_mod_uuid in sorted_temp_mod_set:
-            reordered.add(sorted_mod_uuid)
+            reordered.append(sorted_mod_uuid)
     logger.info(f"Finished Toposort sort with {len(reordered)} mods")
     return reordered

--- a/sort/topo_sort.py
+++ b/sort/topo_sort.py
@@ -3,37 +3,37 @@ from typing import Any
 
 from toposort import toposort
 
+from util.metadata import MetadataManager
+
 
 def do_topo_sort(
-    dependency_graph: dict[str, set[str]], active_mods_json: dict[str, Any]
-) -> dict[str, Any]:
+    dependency_graph: dict[str, set[str]], active_mods_uuids: set[str]
+) -> set[str]:
     """
     Sort mods using the topological sort algorithm. For each
     topological level, sort the mods alphabetically.
     """
     logger.info(f"Initializing toposort for {len(dependency_graph)} mods")
     sorted_dependencies = toposort(dependency_graph)
-    alphabetized_dependencies_w_data = {}
+    reordered = set()
     active_mods_packageid_to_uuid = dict(
-        (v["packageid"], v["uuid"]) for v in active_mods_json.values()
+        (MetadataManager.instance().all_mods_compiled[uuid]["packageid"], uuid)
+        for uuid in active_mods_uuids
     )
     for level in sorted_dependencies:
-        temp_mod_dict = {}
+        temp_mod_set = set()
         for package_id in level:
             if package_id in active_mods_packageid_to_uuid:
                 mod_uuid = active_mods_packageid_to_uuid[package_id]
-                temp_mod_dict[mod_uuid] = active_mods_json[mod_uuid]
+                temp_mod_set.add(mod_uuid)
         # Sort packages in this topological level by name
-        sorted_temp_mod_dict = sorted(
-            temp_mod_dict.items(), key=lambda x: x[1]["name"], reverse=False
+        sorted_temp_mod_set = sorted(
+            temp_mod_set,
+            key=lambda uuid: MetadataManager.instance().all_mods_compiled[uuid]["name"],
+            reverse=False,
         )
-        # sorted_mod is tuple of (uuid, json_data)
-        # Add into reordered_active_mods_data (dicts are ordered now)
-        for sorted_mod in sorted_temp_mod_dict:
-            alphabetized_dependencies_w_data[sorted_mod[0]] = active_mods_json[
-                sorted_mod[0]
-            ]
-    logger.info(
-        f"Finished Toposort sort with {len(alphabetized_dependencies_w_data)} mods"
-    )
-    return alphabetized_dependencies_w_data
+        # Add into reordered set
+        for sorted_mod_uuid in sorted_temp_mod_set:
+            reordered.add(sorted_mod_uuid)
+    logger.info(f"Finished Toposort sort with {len(reordered)} mods")
+    return reordered

--- a/sub_view/inactive_mods_panel.py
+++ b/sub_view/inactive_mods_panel.py
@@ -18,6 +18,7 @@ from controller.settings_controller import SettingsController
 from model.mod_list import ModListWidget
 from model.mod_list_item import ModListItemInner
 from util.constants import SEARCH_DATA_SOURCE_FILTER_INDEXES
+from util.metadata import MetadataManager
 
 
 class InactiveModList:
@@ -177,8 +178,15 @@ class InactiveModList:
         for widget, item in wni:
             if (
                 pattern
-                and widget.json_data.get(search_filter)
-                and not pattern.lower() in str(widget.json_data[search_filter]).lower()
+                and MetadataManager.instance()
+                .all_mods_compiled[widget.uuid]
+                .get(search_filter)
+                and not pattern.lower()
+                in str(
+                    MetadataManager.instance()
+                    .all_mods_compiled[widget.uuid]
+                    .get(search_filter)
+                ).lower()
             ):
                 if self.inactive_mods_search_filter_state:
                     item.setHidden(True)

--- a/util/metadata.py
+++ b/util/metadata.py
@@ -1657,8 +1657,8 @@ def add_load_rule_to_mod(
 
 
 def get_active_inactive_mods(
-    config_path: str, all_mods: Dict[str, Any]
-) -> Tuple[Dict[str, Any], Dict[str, Any], Dict[str, Any], list]:
+    config_path: str,
+) -> Tuple[list[str], list[str], Dict[str, Any], list]:
     """
     Given a path to the ModsConfig.xml folder and a complete list of
     mods (including base game and DLC) and their dependencies,
@@ -1670,8 +1670,10 @@ def get_active_inactive_mods(
     :return: a Tuple which contains the active mods dict, inactive mods dict,
     duplicate mods dict, and missing mods list
     """
-    active_mods: dict[str, Any] = {}
-    inactive_mods: dict[str, Any] = {}
+    all_mods = MetadataManager.instance().all_mods_compiled
+
+    active_mods_uuids: list[str] = []
+    inactive_mods_uuids: list[str] = []
     duplicate_mods = {}
     duplicates_processed = []
     missing_mods = []
@@ -1691,7 +1693,7 @@ def get_active_inactive_mods(
         logger.error(
             f"Unable to get active mods from config with read data: {mod_data}"
         )
-        return active_mods, inactive_mods, duplicate_mods, missing_mods
+        return active_mods_uuids, inactive_mods, duplicate_mods, missing_mods
     # Parse the ModsConfig.xml data
     for package_id in mod_data["ModsConfigData"]["activeMods"][
         "li"
@@ -1719,6 +1721,7 @@ def get_active_inactive_mods(
             else ["expansion", "local", "workshop"]
         )
         # Loop through all mods
+        logger.info("Generating active mod list")
         for uuid, metadata in all_mods.items():
             metadata_package_id = metadata["packageid"]
             metadata_path = metadata["path"]
@@ -1732,7 +1735,7 @@ def get_active_inactive_mods(
                 # Add non-duplicates to active mods
                 if target_id not in duplicate_mods.keys():
                     populated_mods.append(target_id)
-                    active_mods[uuid] = metadata
+                    active_mods_uuids.append(uuid)
                 else:  # Otherwise, duplicate needs calculated
                     if (
                         target_id in duplicates_processed
@@ -1755,62 +1758,31 @@ def get_active_inactive_mods(
                         source_paths_sorted = natsorted(paths_to_uuid.keys())
                         if source_paths_sorted:  # If we have paths returned
                             # If we are here, we've found our calculated duplicate, log and use this mod
-                            duplicate_mod_metadata = all_mods[
-                                paths_to_uuid[source_paths_sorted[0]]
-                            ]
                             logger.debug(
-                                f"Using duplicate {source} mod for {target_id}: {duplicate_mod_metadata['path']}"
+                                f"Using duplicate {source} mod for {target_id}: {all_mods[paths_to_uuid[source_paths_sorted[0]]]['path']}"
                             )
                             populated_mods.append(target_id)
                             duplicates_processed.append(target_id)
-                            active_mods[
-                                duplicate_mod_metadata["uuid"]
-                            ] = duplicate_mod_metadata
+                            active_mods_uuids.append(duplicate_uuid)
                             break
                         else:  # Skip this source priority if no paths
                             logger.debug(f"No paths returned for {source}")
                             continue
     # Calculate missing mods from the difference
     missing_mods = list(set(to_populate) - set(populated_mods))
-    logger.debug(f"Generated active mods dict with {len(active_mods)} mods")
+    logger.debug(f"Generated active mods dict with {len(active_mods_uuids)} mods")
     # Get the inactive mods by subtracting active mods from workshop + expansions
-    inactive_mods = get_inactive_mods(all_mods, active_mods)
-    logger.info(f"# active mods: {len(active_mods)}")
-    logger.info(f"# inactive mods: {len(inactive_mods)}")
+    logger.info("Generating inactive mod list")
+    inactive_mods_uuids = [
+        uuid
+        for uuid in MetadataManager.instance().all_mods_compiled.keys()
+        if uuid not in active_mods_uuids
+    ]
+    logger.info(f"# active mods: {len(active_mods_uuids)}")
+    logger.info(f"# inactive mods: {len(inactive_mods_uuids)}")
     logger.info(f"# duplicate mods: {len(duplicate_mods)}")
     logger.info(f"# missing mods: {len(missing_mods)}")
-    return active_mods, inactive_mods, duplicate_mods, missing_mods
-
-
-def get_inactive_mods(
-    all_mods: Dict[str, Any],
-    active_mods: Dict[str, Any],
-) -> Dict[str, Any]:
-    """
-    Generate a list of inactive mods by cross-referencing the list of
-    installed workshop mods with the active mods and known expansions.
-
-    Move the first local instance of any duplicate found alphabetically
-    ascending by filename to the active mods list; and the rest of the dupes
-    to the inactive mods list. TODO this is not accurate
-
-    :param all_mods: dict of workshop mods and expansions
-    :param active_mods: dict of active mods
-    :param duplicate_mods: dict keyed with packageids to list of dupe uuids
-    :return: a dict for inactive mods
-    """
-    logger.info("Generating inactive mod list")
-    inactive_mods = all_mods.copy()
-
-    # Remove active_mods uuids from inactive_mods in a more efficient way using dict comprehension
-    inactive_mods = {
-        mod_uuid: mod_data
-        for mod_uuid, mod_data in inactive_mods.items()
-        if mod_uuid not in active_mods
-    }
-
-    logger.info("Finished generating inactive mods list")
-    return inactive_mods
+    return active_mods_uuids, inactive_mods_uuids, duplicate_mods, missing_mods
 
 
 def log_deps_order_info(all_mods) -> None:

--- a/util/metadata.py
+++ b/util/metadata.py
@@ -326,9 +326,9 @@ class MetadataManager(QObject):
             """
             workshop_acf_data = acf_to_dict(appworkshop_acf_path)
             workshop_mods_pfid_to_uuid = {
-                v["publishedfileid"]: v["uuid"]
-                for v in workshop_mods.values()
-                if v.get("publishedfileid")
+                metadata["publishedfileid"]: uuid
+                for uuid, metadata in workshop_mods.items()
+                if metadata.get("publishedfileid")
             }
             # Reference needed information from appworkshop_294100.acf
             workshop_item_details = workshop_acf_data["AppWorkshop"][
@@ -1347,8 +1347,6 @@ class ModParser(QRunnable):
                         os.path.getmtime(directory)
                     )
                     mod_metadata["path"] = directory
-                    # Track source & uuid in case metadata becomes detached
-                    mod_metadata["uuid"] = uuid
                     logger.debug(
                         f"Finished editing XML mod content, adding final content to larger list: {mod_metadata}"
                     )

--- a/view/main_content_panel.py
+++ b/view/main_content_panel.py
@@ -1251,8 +1251,8 @@ class MainContent(QObject):
         combined_mods = {}
         for uuid in (
             reordered_tier_one_sorted
-            | reordered_tier_two_sorted
-            | reordered_tier_three_sorted
+            + reordered_tier_two_sorted
+            + reordered_tier_three_sorted
         ):
             combined_mods[uuid] = self.metadata_manager.all_mods_compiled[uuid]
 
@@ -1265,8 +1265,8 @@ class MainContent(QObject):
                 if uuid
                 not in set(
                     reordered_tier_one_sorted
-                    | reordered_tier_two_sorted
-                    | reordered_tier_three_sorted
+                    + reordered_tier_two_sorted
+                    + reordered_tier_three_sorted
                 )
             },
         )

--- a/view/main_content_panel.py
+++ b/view/main_content_panel.py
@@ -1112,36 +1112,38 @@ class MainContent(QObject):
             self.inactive_mods_panel.inactive_mods_filter_data_source_icons
         )
         self.inactive_mods_panel.clear_inactive_mods_search()
-
         # Metadata to insert
         active_mods_uuids = []
         inactive_mods_uuids = []
         logger.info("Clearing mods from active mod list")
-        # Metadata from official modules, stored so they can be inserted in proper order
-        for uuid, mod_data in self.metadata_manager.all_mods_compiled.items():
-            if mod_data["data_source"] == "expansion":
-                if (
-                    mod_data["packageid"]
-                    == RIMWORLD_DLC_METADATA["294100"]["packageid"]
-                ):
-                    active_mods_uuids.append(uuid)
-                elif (
-                    mod_data["packageid"]
-                    == RIMWORLD_DLC_METADATA["1149640"]["packageid"]
-                ):
-                    active_mods_uuids.append(uuid)
-                elif (
-                    mod_data["packageid"]
-                    == RIMWORLD_DLC_METADATA["1392840"]["packageid"]
-                ):
-                    active_mods_uuids.append(uuid)
-                elif (
-                    mod_data["packageid"]
-                    == RIMWORLD_DLC_METADATA["1826140"]["packageid"]
-                ):
-                    active_mods_uuids.append(uuid)
-            else:
-                inactive_mods_uuids.append(uuid)
+        # Define the order of the DLC package IDs
+        package_id_order = [
+            RIMWORLD_DLC_METADATA["294100"]["packageid"],
+            RIMWORLD_DLC_METADATA["1149640"]["packageid"],
+            RIMWORLD_DLC_METADATA["1392840"]["packageid"],
+            RIMWORLD_DLC_METADATA["1826140"]["packageid"],
+        ]
+        # Create a set of all package IDs from mod_data
+        package_ids_set = set(
+            mod_data["packageid"]
+            for mod_data in self.metadata_manager.all_mods_compiled.values()
+        )
+        # Iterate over the DLC package IDs in the correct order
+        for package_id in package_id_order:
+            if package_id in package_ids_set:
+                # Append the UUIDs to active_mods_uuids if the package ID exists in mod_data
+                active_mods_uuids.extend(
+                    uuid
+                    for uuid, mod_data in self.metadata_manager.all_mods_compiled.items()
+                    if mod_data["data_source"] == "expansion"
+                    and mod_data["packageid"] == package_id
+                )
+        # Append the remaining UUIDs to inactive_mods_uuids
+        inactive_mods_uuids.extend(
+            uuid
+            for uuid in self.metadata_manager.all_mods_compiled.keys()
+            if uuid not in active_mods_uuids
+        )
         self.__insert_data_into_lists(active_mods_uuids, inactive_mods_uuids)
 
     def _do_sort(self) -> None:

--- a/view/main_content_panel.py
+++ b/view/main_content_panel.py
@@ -307,7 +307,7 @@ class MainContent(QObject):
                 # Remove items from current list
                 for item in items_to_move:
                     aml.takeItem(aml.row(item))
-                    aml.uuids.discard(item.data(Qt.UserRole))
+                    aml.uuids.remove(item.data(Qt.UserRole))
                 if aml.count():
                     if aml.count() == first_selected:
                         aml.setCurrentRow(aml.count() - 1)
@@ -358,7 +358,7 @@ class MainContent(QObject):
                 # Remove items from current list
                 for item in items_to_move:
                     iml.takeItem(iml.row(item))
-                    iml.uuids.discard(item.data(Qt.UserRole))
+                    iml.uuids.remove(item.data(Qt.UserRole))
                 if iml.count():
                     if iml.count() == first_selected:
                         iml.setCurrentRow(iml.count() - 1)


### PR DESCRIPTION
With this PR, the app will no longer store metadata inside mods list items. We rely on an ordered list of UUIDs to be utilized with MetadataManager for metadata-related interactions.

**Following functionality is affected with this PR:**

- General mods list interactions (e.g., moving mods between lists)
- Clearing mods
- Restoring mods
- Sorting mod list
- Saving mod list
- todds optimize without active mods target checked
- Export mod list to XML
- Export mod list to clipboard
- Share mod list via Rentry
- Recalculate active mods list errors/warnings