### PR TITLE
Change "Save Mod List…" menu item to "Save Mod List As…"

### DIFF
--- a/view/menu_bar.py
+++ b/view/menu_bar.py
@@ -59,8 +59,8 @@ class MenuBar(QObject):
 
         self.file_menu.addSeparator()
 
-        self.save_mod_list_action = QAction("Save Mod List…", self)
-        self.save_mod_list_action.setShortcut(QKeySequence("Ctrl+S"))
+        self.save_mod_list_action = QAction("Save Mod List As…", self)
+        self.save_mod_list_action.setShortcut(QKeySequence("Ctrl+Shift+S"))
         self.file_menu.addAction(self.save_mod_list_action)
 
         self.file_menu.addSeparator()
@@ -102,8 +102,8 @@ class MenuBar(QObject):
 
         self.file_menu.addSeparator()
 
-        self.save_mod_list_action = QAction("Save Mod List…", self)
-        self.save_mod_list_action.setShortcut(QKeySequence("Ctrl+S"))
+        self.save_mod_list_action = QAction("Save Mod List As…", self)
+        self.save_mod_list_action.setShortcut(QKeySequence("Ctrl+Shift+S"))
         self.file_menu.addAction(self.save_mod_list_action)
 
         self.file_menu.addSeparator()


### PR DESCRIPTION
Also change the shortcut ⌃S / ⌘S to ⇧⌃S / ⇧⌘S, as is standard for a "Save As…" menu item.

This change will keep the menu bar "Save" item (write to a user-specified XML file) from overlapping with the main window's "Save" button (write to RimWorld's `ModsConfig.xml` file).

![image](https://github.com/RimSort/RimSort/assets/8659114/b2b23e76-3e06-438c-8571-feda47ec9307)

<img width="294" alt="image" src="https://github.com/RimSort/RimSort/assets/8659114/558695dc-a0dd-471a-9d55-265ced533592">
