### PR TITLE
Add main window buttons for primary app functions

### DIFF
--- a/controller/app_controller.py
+++ b/controller/app_controller.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from PySide6.QtCore import QObject
 from PySide6.QtWidgets import QApplication
 
+from controller.main_window_controller import MainWindowController
 from util.app_info import AppInfo
 from util.constants import DEFAULT_USER_RULES
 from util.system_info import SystemInfo
@@ -38,13 +39,13 @@ class AppController(QObject):
             with open(user_rules_path, "w", encoding="utf-8") as output:
                 json.dump(initial_rules_db, output, indent=4)
 
-        # Instantiate and show the main window
+        # Instantiate the main window and its controller
         self.main_window = MainWindow()
-        self.main_window.show()
-        self.main_window.initialize_content()
+        self.main_window_controller = MainWindowController(self.main_window)
 
     def run(self) -> int:
         self.main_window.show()
+        self.main_window.initialize_content()
         return self.app.exec()
 
     def shutdown_watchdog(self) -> None:

--- a/controller/app_controller.py
+++ b/controller/app_controller.py
@@ -7,10 +7,14 @@ from PySide6.QtCore import QObject
 from PySide6.QtWidgets import QApplication
 
 from controller.main_window_controller import MainWindowController
+from controller.settings_controller import SettingsController
+from model.settings import Settings
 from util.app_info import AppInfo
 from util.constants import DEFAULT_USER_RULES
+from util.metadata import MetadataManager
 from util.system_info import SystemInfo
 from view.main_window import MainWindow
+from view.settings_dialog import SettingsDialog
 
 
 class AppController(QObject):
@@ -26,11 +30,11 @@ class AppController(QObject):
         elif SystemInfo().operating_system == SystemInfo.OperatingSystem.MACOS:
             self.app.setStyle("macOS")
 
-        self.app.setStyleSheet(  # Add style sheet for styling layouts and widgets
-            Path(
-                os.path.join(AppInfo().application_folder, "themes/RimPy/style.qss")
-            ).read_text()
-        )
+        # self.app.setStyleSheet(  # Add style sheet for styling layouts and widgets
+        #     Path(
+        #         os.path.join(AppInfo().application_folder, "themes/RimPy/style.qss")
+        #     ).read_text()
+        # )
 
         # One-time initialization of userRules.json
         user_rules_path = AppInfo().databases_folder / "userRules.json"
@@ -39,8 +43,20 @@ class AppController(QObject):
             with open(user_rules_path, "w", encoding="utf-8") as output:
                 json.dump(initial_rules_db, output, indent=4)
 
+        # Instantiate the settings model, view and controller
+        self.settings = Settings()
+        self.settings_dialog = SettingsDialog()
+        self.settings_controller = SettingsController(
+            model=self.settings, view=self.settings_dialog
+        )
+
+        # Initialize the MetadataManager
+        self.metadata_manager = MetadataManager.instance(
+            settings_controller=self.settings_controller
+        )
+
         # Instantiate the main window and its controller
-        self.main_window = MainWindow()
+        self.main_window = MainWindow(settings_controller=self.settings_controller)
         self.main_window_controller = MainWindowController(self.main_window)
 
     def run(self) -> int:

--- a/controller/app_controller.py
+++ b/controller/app_controller.py
@@ -30,11 +30,11 @@ class AppController(QObject):
         elif SystemInfo().operating_system == SystemInfo.OperatingSystem.MACOS:
             self.app.setStyle("macOS")
 
-        # self.app.setStyleSheet(  # Add style sheet for styling layouts and widgets
-        #     Path(
-        #         os.path.join(AppInfo().application_folder, "themes/RimPy/style.qss")
-        #     ).read_text()
-        # )
+        self.app.setStyleSheet(  # Add style sheet for styling layouts and widgets
+            Path(
+                os.path.join(AppInfo().application_folder, "themes/RimPy/style.qss")
+            ).read_text()
+        )
 
         # One-time initialization of userRules.json
         user_rules_path = AppInfo().databases_folder / "userRules.json"

--- a/controller/main_window_controller.py
+++ b/controller/main_window_controller.py
@@ -11,6 +11,10 @@ class MainWindowController(QObject):
 
         self.main_window = view
 
+        self.main_window.refresh_button.clicked.connect(
+            EventBus().do_refresh_mods_lists.emit
+        )
+
         EventBus().refresh_started.connect(self._on_refresh_started)
         EventBus().refresh_finished.connect(self._on_refresh_finished)
 

--- a/controller/main_window_controller.py
+++ b/controller/main_window_controller.py
@@ -11,6 +11,13 @@ class MainWindowController(QObject):
 
         self.main_window = view
 
+        EventBus().do_refresh_button_set_default.connect(
+            self._on_do_refresh_button_set_default
+        )
+        EventBus().do_refresh_button_unset_default.connect(
+            self._on_do_refresh_button_unset_default
+        )
+
         EventBus().do_save_button_set_default.connect(
             self._on_do_save_button_set_default
         )
@@ -36,12 +43,36 @@ class MainWindowController(QObject):
         EventBus().refresh_finished.connect(self._on_refresh_finished)
 
     @Slot()
+    def _on_do_refresh_button_set_default(self) -> None:
+        self.main_window.refresh_button.setDefault(True)
+        self.main_window.clear_button.setDefault(False)
+        self.main_window.sort_button.setDefault(False)
+        self.main_window.save_button.setDefault(False)
+        self.main_window.run_button.setDefault(False)
+
+    @Slot()
+    def _on_do_refresh_button_unset_default(self) -> None:
+        self.main_window.refresh_button.setDefault(False)
+        self.main_window.clear_button.setDefault(False)
+        self.main_window.sort_button.setDefault(False)
+        self.main_window.save_button.setDefault(False)
+        self.main_window.run_button.setDefault(False)
+
+    @Slot()
     def _on_do_save_button_set_default(self) -> None:
+        self.main_window.refresh_button.setDefault(False)
+        self.main_window.clear_button.setDefault(False)
+        self.main_window.sort_button.setDefault(False)
         self.main_window.save_button.setDefault(True)
+        self.main_window.run_button.setDefault(False)
 
     @Slot()
     def _on_do_save_button_unset_default(self) -> None:
+        self.main_window.refresh_button.setDefault(False)
+        self.main_window.clear_button.setDefault(False)
+        self.main_window.sort_button.setDefault(False)
         self.main_window.save_button.setDefault(False)
+        self.main_window.run_button.setDefault(False)
 
     @Slot()
     def _on_refresh_started(self) -> None:

--- a/controller/main_window_controller.py
+++ b/controller/main_window_controller.py
@@ -1,5 +1,6 @@
-from PySide6.QtCore import QObject
+from PySide6.QtCore import QObject, Slot
 
+from util.event_bus import EventBus
 from view.main_window import MainWindow
 
 
@@ -8,3 +9,15 @@ class MainWindowController(QObject):
         super().__init__()
 
         self.main_window = view
+
+        EventBus().do_set_main_window_widgets_enabled.connect(
+            self._on_do_set_main_window_widgets_enabled
+        )
+
+    @Slot(bool)
+    def _on_do_set_main_window_widgets_enabled(self, enabled: bool) -> None:
+        self.main_window.refresh_button.setEnabled(enabled)
+        self.main_window.clear_button.setEnabled(enabled)
+        self.main_window.sort_button.setEnabled(enabled)
+        self.main_window.save_button.setEnabled(enabled)
+        self.main_window.run_button.setEnabled(enabled)

--- a/controller/main_window_controller.py
+++ b/controller/main_window_controller.py
@@ -1,0 +1,10 @@
+from PySide6.QtCore import QObject
+
+from view.main_window import MainWindow
+
+
+class MainWindowController(QObject):
+    def __init__(self, view: MainWindow) -> None:
+        super().__init__()
+
+        self.main_window = view

--- a/controller/main_window_controller.py
+++ b/controller/main_window_controller.py
@@ -11,6 +11,13 @@ class MainWindowController(QObject):
 
         self.main_window = view
 
+        EventBus().do_save_button_set_default.connect(
+            self._on_do_save_button_set_default
+        )
+        EventBus().do_save_button_unset_default.connect(
+            self._on_do_save_button_unset_default
+        )
+
         self.main_window.refresh_button.clicked.connect(
             EventBus().do_refresh_mods_lists.emit
         )
@@ -27,6 +34,14 @@ class MainWindowController(QObject):
 
         EventBus().refresh_started.connect(self._on_refresh_started)
         EventBus().refresh_finished.connect(self._on_refresh_finished)
+
+    @Slot()
+    def _on_do_save_button_set_default(self) -> None:
+        self.main_window.save_button.setDefault(True)
+
+    @Slot()
+    def _on_do_save_button_unset_default(self) -> None:
+        self.main_window.save_button.setDefault(False)
 
     @Slot()
     def _on_refresh_started(self) -> None:

--- a/controller/main_window_controller.py
+++ b/controller/main_window_controller.py
@@ -17,6 +17,9 @@ class MainWindowController(QObject):
         self.main_window.clear_button.clicked.connect(
             EventBus().do_clear_active_mods_list.emit
         )
+        self.main_window.sort_button.clicked.connect(
+            EventBus().do_sort_active_mods_list.emit
+        )
 
         EventBus().refresh_started.connect(self._on_refresh_started)
         EventBus().refresh_finished.connect(self._on_refresh_finished)

--- a/controller/main_window_controller.py
+++ b/controller/main_window_controller.py
@@ -1,6 +1,7 @@
 from PySide6.QtCore import QObject, Slot
 
 from util.event_bus import EventBus
+from util.metadata import MetadataManager
 from view.main_window import MainWindow
 
 
@@ -10,14 +11,25 @@ class MainWindowController(QObject):
 
         self.main_window = view
 
-        EventBus().do_set_main_window_widgets_enabled.connect(
-            self._on_do_set_main_window_widgets_enabled
-        )
+        EventBus().refresh_started.connect(self._on_refresh_started)
+        EventBus().refresh_finished.connect(self._on_refresh_finished)
 
-    @Slot(bool)
-    def _on_do_set_main_window_widgets_enabled(self, enabled: bool) -> None:
-        self.main_window.refresh_button.setEnabled(enabled)
-        self.main_window.clear_button.setEnabled(enabled)
-        self.main_window.sort_button.setEnabled(enabled)
-        self.main_window.save_button.setEnabled(enabled)
-        self.main_window.run_button.setEnabled(enabled)
+    @Slot()
+    def _on_refresh_started(self) -> None:
+        self.main_window.refresh_button.setEnabled(False)
+        self.main_window.clear_button.setEnabled(False)
+        self.main_window.sort_button.setEnabled(False)
+        self.main_window.save_button.setEnabled(False)
+        self.main_window.run_button.setEnabled(False)
+
+    @Slot()
+    def _on_refresh_finished(self) -> None:
+        self.main_window.refresh_button.setEnabled(True)
+        self.main_window.clear_button.setEnabled(True)
+        self.main_window.sort_button.setEnabled(True)
+        self.main_window.save_button.setEnabled(True)
+        self.main_window.run_button.setEnabled(True)
+
+        self.main_window.game_version_label.setText(
+            "RimWorld version " + MetadataManager.instance().game_version
+        )

--- a/controller/main_window_controller.py
+++ b/controller/main_window_controller.py
@@ -23,6 +23,7 @@ class MainWindowController(QObject):
         self.main_window.save_button.clicked.connect(
             EventBus().do_save_active_mods_list.emit
         )
+        self.main_window.run_button.clicked.connect(EventBus().do_run_game.emit)
 
         EventBus().refresh_started.connect(self._on_refresh_started)
         EventBus().refresh_finished.connect(self._on_refresh_finished)

--- a/controller/main_window_controller.py
+++ b/controller/main_window_controller.py
@@ -14,6 +14,9 @@ class MainWindowController(QObject):
         self.main_window.refresh_button.clicked.connect(
             EventBus().do_refresh_mods_lists.emit
         )
+        self.main_window.clear_button.clicked.connect(
+            EventBus().do_clear_active_mods_list.emit
+        )
 
         EventBus().refresh_started.connect(self._on_refresh_started)
         EventBus().refresh_finished.connect(self._on_refresh_finished)

--- a/controller/main_window_controller.py
+++ b/controller/main_window_controller.py
@@ -20,6 +20,9 @@ class MainWindowController(QObject):
         self.main_window.sort_button.clicked.connect(
             EventBus().do_sort_active_mods_list.emit
         )
+        self.main_window.save_button.clicked.connect(
+            EventBus().do_save_active_mods_list.emit
+        )
 
         EventBus().refresh_started.connect(self._on_refresh_started)
         EventBus().refresh_finished.connect(self._on_refresh_finished)

--- a/controller/menu_bar_controller.py
+++ b/controller/menu_bar_controller.py
@@ -66,6 +66,11 @@ class MenuBarController(QObject):
 
         self.menu_bar.wiki_action.triggered.connect(self._on_menu_bar_wiki_triggered)
 
+        # External signals
+
+        EventBus().refresh_started.connect(self._on_refresh_started)
+        EventBus().refresh_finished.connect(self._on_refresh_finished)
+
     @Slot()
     def _on_menu_bar_check_for_updates_on_startup_triggered(self) -> None:
         is_checked = self.menu_bar.check_for_updates_on_startup_action.isChecked()
@@ -99,3 +104,19 @@ class MenuBarController(QObject):
     @Slot()
     def _on_menu_bar_wiki_triggered(self) -> None:
         open_url_browser("https://github.com/RimSort/RimSort/wiki")
+
+    @Slot()
+    def _on_refresh_started(self) -> None:
+        """
+        Disable all menus in the menu bar.
+        """
+        for action in self.menu_bar.menu_bar.actions():
+            action.setEnabled(False)
+
+    @Slot()
+    def _on_refresh_finished(self) -> None:
+        """
+        Enable all menus in the menu bar.
+        """
+        for action in self.menu_bar.menu_bar.actions():
+            action.setEnabled(True)

--- a/util/event_bus.py
+++ b/util/event_bus.py
@@ -44,6 +44,9 @@ class EventBus(QObject):
     do_install_steamcmd = Signal()
 
     # MainWindow signals
+    do_save_button_set_default = Signal()
+    do_save_button_unset_default = Signal()
+
     do_refresh_mods_lists = Signal()
     do_clear_active_mods_list = Signal()
     do_sort_active_mods_list = Signal()

--- a/util/event_bus.py
+++ b/util/event_bus.py
@@ -47,6 +47,7 @@ class EventBus(QObject):
     do_refresh_mods_lists = Signal()
     do_clear_active_mods_list = Signal()
     do_sort_active_mods_list = Signal()
+    do_save_active_mods_list = Signal()
 
     refresh_started = Signal()
     refresh_finished = Signal()

--- a/util/event_bus.py
+++ b/util/event_bus.py
@@ -44,6 +44,9 @@ class EventBus(QObject):
     do_install_steamcmd = Signal()
 
     # MainWindow signals
+    do_refresh_button_set_default = Signal()
+    do_refresh_button_unset_default = Signal()
+
     do_save_button_set_default = Signal()
     do_save_button_unset_default = Signal()
 

--- a/util/event_bus.py
+++ b/util/event_bus.py
@@ -20,15 +20,17 @@ class EventBus(QObject):
 
     _instance = None
 
-    # Application-scope signals
-    settings_have_changed = Signal()
-
+    # Menu bar signals
     do_check_for_application_update = Signal()
     do_open_mod_list = Signal()
     do_save_mod_list_as = Signal()
     do_export_mod_list_to_clipboard = Signal()
     do_export_mod_list_to_rentry = Signal()
 
+    # Settings signals
+    settings_have_changed = Signal()
+
+    # SettingsDialog signals
     do_download_community_rules_db_from_github = Signal()
     do_download_steam_workshop_db_from_github = Signal()
     do_upload_log = Signal()
@@ -40,6 +42,9 @@ class EventBus(QObject):
     do_import_acf = Signal()
     do_delete_acf = Signal()
     do_install_steamcmd = Signal()
+
+    # MainWindow signals
+    do_set_main_window_widgets_enabled = Signal(bool)
 
     def __new__(cls) -> "EventBus":
         """

--- a/util/event_bus.py
+++ b/util/event_bus.py
@@ -48,6 +48,7 @@ class EventBus(QObject):
     do_clear_active_mods_list = Signal()
     do_sort_active_mods_list = Signal()
     do_save_active_mods_list = Signal()
+    do_run_game = Signal()
 
     refresh_started = Signal()
     refresh_finished = Signal()

--- a/util/event_bus.py
+++ b/util/event_bus.py
@@ -46,6 +46,7 @@ class EventBus(QObject):
     # MainWindow signals
     do_refresh_mods_lists = Signal()
     do_clear_active_mods_list = Signal()
+    do_sort_active_mods_list = Signal()
 
     refresh_started = Signal()
     refresh_finished = Signal()

--- a/util/event_bus.py
+++ b/util/event_bus.py
@@ -43,6 +43,9 @@ class EventBus(QObject):
     do_delete_acf = Signal()
     do_install_steamcmd = Signal()
 
+    # MainWindow signals
+    do_refresh_mods_lists = Signal()
+
     refresh_started = Signal()
     refresh_finished = Signal()
 

--- a/util/event_bus.py
+++ b/util/event_bus.py
@@ -45,6 +45,7 @@ class EventBus(QObject):
 
     # MainWindow signals
     do_refresh_mods_lists = Signal()
+    do_clear_active_mods_list = Signal()
 
     refresh_started = Signal()
     refresh_finished = Signal()

--- a/util/event_bus.py
+++ b/util/event_bus.py
@@ -43,8 +43,8 @@ class EventBus(QObject):
     do_delete_acf = Signal()
     do_install_steamcmd = Signal()
 
-    # MainWindow signals
-    do_set_main_window_widgets_enabled = Signal(bool)
+    refresh_started = Signal()
+    refresh_finished = Signal()
 
     def __new__(cls) -> "EventBus":
         """

--- a/view/main_content_panel.py
+++ b/view/main_content_panel.py
@@ -171,6 +171,7 @@ class MainContent(QObject):
             EventBus().do_clear_active_mods_list.connect(self._do_clear)
             EventBus().do_sort_active_mods_list.connect(self._do_sort)
             EventBus().do_save_active_mods_list.connect(self._do_save)
+            EventBus().do_run_game.connect(self._do_run_game)
 
             # INITIALIZE WIDGETS
             # Initialize Steam(CMD) integraations

--- a/view/main_content_panel.py
+++ b/view/main_content_panel.py
@@ -996,9 +996,10 @@ class MainContent(QObject):
         loading_animation_text_label = None
         # Hide the info panel widgets
         self.mod_info_panel.info_panel_frame.hide()
-        # Disable widgets
-        for widget in QApplication.instance().allWidgets():
-            widget.setEnabled(False)
+
+        # Disable MainWindow widgets
+        EventBus().do_set_main_window_widgets_enabled.emit(False)
+
         # Encapsulate mod parsing inside a nice lil animation
         loading_animation = LoadingAnimation(
             gif_path=gif_path,
@@ -1019,9 +1020,10 @@ class MainContent(QObject):
         if text:
             self.mod_info_panel.panel.removeWidget(loading_animation_text_label)
             loading_animation_text_label.close()
-        # Enable widgets
-        for widget in QApplication.instance().allWidgets():
-            widget.setEnabled(True)
+
+        # Re-enable MainWindow widgets
+        EventBus().do_set_main_window_widgets_enabled.emit(True)
+
         # Show the info panel widgets
         self.mod_info_panel.info_panel_frame.show()
         logger.debug(f"Returning {type(data)}")

--- a/view/main_content_panel.py
+++ b/view/main_content_panel.py
@@ -177,9 +177,7 @@ class MainContent(QObject):
             )
 
             # Initialize MetadataManager
-            self.metadata_manager = MetadataManager.instance(
-                settings_controller=self.settings_controller
-            )
+            self.metadata_manager = MetadataManager.instance()
             self.metadata_manager.update_game_configuration_signal.connect(
                 self.__update_game_configuration
             )

--- a/view/main_content_panel.py
+++ b/view/main_content_panel.py
@@ -170,6 +170,7 @@ class MainContent(QObject):
             EventBus().do_refresh_mods_lists.connect(self._do_refresh)
             EventBus().do_clear_active_mods_list.connect(self._do_clear)
             EventBus().do_sort_active_mods_list.connect(self._do_sort)
+            EventBus().do_save_active_mods_list.connect(self._do_save)
 
             # INITIALIZE WIDGETS
             # Initialize Steam(CMD) integraations
@@ -3129,3 +3130,15 @@ class MainContent(QObject):
     @Slot()
     def _on_do_build_steam_workshop_database(self) -> None:
         self._do_build_database_thread()
+
+    @Slot()
+    def _do_run_game(self) -> None:
+        self._do_steamworks_api_call(
+            [
+                "launch_game_process",
+                [
+                    self.settings_controller.settings.game_folder,
+                    self.settings_controller.settings.run_args,
+                ],
+            ]
+        )

--- a/view/main_content_panel.py
+++ b/view/main_content_panel.py
@@ -169,6 +169,7 @@ class MainContent(QObject):
 
             EventBus().do_refresh_mods_lists.connect(self._do_refresh)
             EventBus().do_clear_active_mods_list.connect(self._do_clear)
+            EventBus().do_sort_active_mods_list.connect(self._do_sort)
 
             # INITIALIZE WIDGETS
             # Initialize Steam(CMD) integraations

--- a/view/main_content_panel.py
+++ b/view/main_content_panel.py
@@ -167,6 +167,8 @@ class MainContent(QObject):
             )
             EventBus().do_install_steamcmd.connect(self._do_setup_steamcmd)
 
+            EventBus().do_refresh_mods_lists.connect(self._do_refresh)
+
             # INITIALIZE WIDGETS
             # Initialize Steam(CMD) integraations
             self.steam_browser = SteamcmdDownloader = None

--- a/view/main_content_panel.py
+++ b/view/main_content_panel.py
@@ -225,8 +225,8 @@ class MainContent(QObject):
                 self.actions_slot
             )  # Settings
             self.active_mods_panel.list_updated_signal.connect(
-                self.__do_save_animation
-            )  # Save btn animation
+                EventBus().do_save_button_set_default.emit
+            )
             self.active_mods_panel.active_mods_list.key_press_signal.connect(
                 self.__handle_active_mod_key_press
             )
@@ -1691,15 +1691,7 @@ class MainContent(QObject):
         else:
             logger.error("Could not save active mods")
         # Stop the save button from blinking if it is blinking
-        if self.actions_panel.save_button_flashing_animation.isActive():
-            self.actions_panel.save_button_flashing_animation.stop()
-            self.actions_panel.save_button.setObjectName("")
-            self.actions_panel.save_button.style().unpolish(
-                self.actions_panel.save_button
-            )
-            self.actions_panel.save_button.style().polish(
-                self.actions_panel.save_button
-            )
+        EventBus().do_save_button_unset_default.emit()
         logger.info("Finished saving active mods")
 
     def __do_save_animation(self) -> None:

--- a/view/main_content_panel.py
+++ b/view/main_content_panel.py
@@ -225,8 +225,8 @@ class MainContent(QObject):
                 self.actions_slot
             )  # Settings
             self.active_mods_panel.list_updated_signal.connect(
-                EventBus().do_save_button_set_default.emit
-            )
+                self.__do_save_button_set_default
+            )  # Save btn animation
             self.active_mods_panel.active_mods_list.key_press_signal.connect(
                 self.__handle_active_mod_key_press
             )
@@ -1036,26 +1036,7 @@ class MainContent(QObject):
         # If we are refreshing cache from user action
         if not is_initial:
             self.active_mods_panel.list_updated = False
-            # Stop the refresh button from blinking if it is blinking
-            if self.actions_panel.refresh_button_flashing_animation.isActive():
-                self.actions_panel.refresh_button_flashing_animation.stop()
-                self.actions_panel.refresh_button.setObjectName("")
-                self.actions_panel.refresh_button.style().unpolish(
-                    self.actions_panel.refresh_button
-                )
-                self.actions_panel.refresh_button.style().polish(
-                    self.actions_panel.refresh_button
-                )
-            # Stop the save button from blinking if it is blinking
-            if self.actions_panel.save_button_flashing_animation.isActive():
-                self.actions_panel.save_button_flashing_animation.stop()
-                self.actions_panel.save_button.setObjectName("")
-                self.actions_panel.save_button.style().unpolish(
-                    self.actions_panel.save_button
-                )
-                self.actions_panel.save_button.style().polish(
-                    self.actions_panel.save_button
-                )
+            EventBus().do_refresh_button_unset_default.emit()
             self.active_mods_panel.active_mods_filter_data_source_index = len(
                 self.active_mods_panel.active_mods_filter_data_source_icons
             )
@@ -1125,13 +1106,9 @@ class MainContent(QObject):
         )
         EventBus().refresh_finished.emit()
 
-    def _do_refresh_animation(self, path: str) -> None:
+    def _do_refresh_button_set_default(self, path: str) -> None:
         logger.debug(f"File change detected: {path}")
-        if not self.actions_panel.refresh_button_flashing_animation.isActive():
-            logger.debug("Starting refresh button animation")
-            self.actions_panel.refresh_button_flashing_animation.start(
-                500
-            )  # blink every 500 milliseconds
+        EventBus().do_refresh_button_set_default.emit()
 
     def _do_clear(self) -> None:
         """
@@ -1715,16 +1692,13 @@ class MainContent(QObject):
         EventBus().do_save_button_unset_default.emit()
         logger.info("Finished saving active mods")
 
-    def __do_save_animation(self) -> None:
+    def __do_save_button_set_default(self) -> None:
         logger.debug("Active mods list updated")
         if (
             self.active_mods_panel.list_updated  # This will only evaluate True if this is initialization, or _do_refresh()
             and not self.actions_panel.save_button_flashing_animation.isActive()  # No need to re-enable if it's already blinking
         ):
-            logger.debug("Starting save button animation")
-            self.actions_panel.save_button_flashing_animation.start(
-                500
-            )  # Blink every 500 milliseconds
+            EventBus().do_save_button_set_default.emit()
 
     def _do_restore(self) -> None:
         """

--- a/view/main_content_panel.py
+++ b/view/main_content_panel.py
@@ -994,10 +994,6 @@ class MainContent(QObject):
         loading_animation_text_label = None
         # Hide the info panel widgets
         self.mod_info_panel.info_panel_frame.hide()
-
-        # Disable MainWindow widgets
-        EventBus().do_set_main_window_widgets_enabled.emit(False)
-
         # Encapsulate mod parsing inside a nice lil animation
         loading_animation = LoadingAnimation(
             gif_path=gif_path,
@@ -1018,10 +1014,6 @@ class MainContent(QObject):
         if text:
             self.mod_info_panel.panel.removeWidget(loading_animation_text_label)
             loading_animation_text_label.close()
-
-        # Re-enable MainWindow widgets
-        EventBus().do_set_main_window_widgets_enabled.emit(True)
-
         # Show the info panel widgets
         self.mod_info_panel.info_panel_frame.show()
         logger.debug(f"Returning {type(data)}")
@@ -1033,6 +1025,7 @@ class MainContent(QObject):
         """
         Refresh expensive calculations & repopulate lists with that refreshed data
         """
+        EventBus().refresh_started.emit()
         # If we are refreshing cache from user action
         if not is_initial:
             self.active_mods_panel.list_updated = False
@@ -1123,6 +1116,7 @@ class MainContent(QObject):
         self.active_mods_panel.steam_package_id_to_name = (
             self.metadata_manager.info_from_steam_package_id_to_name
         )
+        EventBus().refresh_finished.emit()
 
     def _do_refresh_animation(self, path: str) -> None:
         logger.debug(f"File change detected: {path}")

--- a/view/main_content_panel.py
+++ b/view/main_content_panel.py
@@ -168,6 +168,7 @@ class MainContent(QObject):
             EventBus().do_install_steamcmd.connect(self._do_setup_steamcmd)
 
             EventBus().do_refresh_mods_lists.connect(self._do_refresh)
+            EventBus().do_clear_active_mods_list.connect(self._do_clear)
 
             # INITIALIZE WIDGETS
             # Initialize Steam(CMD) integraations

--- a/view/main_window.py
+++ b/view/main_window.py
@@ -38,7 +38,9 @@ class MainWindow(QMainWindow):
     Subclass QMainWindow to customize the main application window.
     """
 
-    def __init__(self, debug_mode: bool = False) -> None:
+    def __init__(
+        self, settings_controller: SettingsController, debug_mode: bool = False
+    ) -> None:
         """
         Initialize the main application window. Construct the layout,
         add the three main views, and set up relevant signals and slots.
@@ -46,12 +48,7 @@ class MainWindow(QMainWindow):
         logger.info("Initializing MainWindow")
         super(MainWindow, self).__init__()
 
-        # Instantiate the settings model and controller
-        self.settings = Settings()
-        self.settings_dialog = SettingsDialog()
-        self.settings_controller = SettingsController(
-            model=self.settings, view=self.settings_dialog
-        )
+        self.settings_controller = settings_controller
 
         # Create the main application window
         self.DEBUG_MODE = debug_mode

--- a/view/main_window.py
+++ b/view/main_window.py
@@ -3,7 +3,14 @@ from typing import Optional
 
 from PySide6.QtCore import QSize
 from PySide6.QtGui import QShowEvent
-from PySide6.QtWidgets import QMainWindow, QVBoxLayout, QWidget
+from PySide6.QtWidgets import (
+    QMainWindow,
+    QVBoxLayout,
+    QWidget,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+)
 from loguru import logger
 from watchdog.observers.api import BaseObserver
 
@@ -11,6 +18,7 @@ from controller.menu_bar_controller import MenuBarController
 from controller.settings_controller import SettingsController
 from model.settings import Settings
 from util.app_info import AppInfo
+from util.gui_info import GUIInfo
 from util.system_info import SystemInfo
 from util.watchdog import RSFileSystemEventHandler
 from view.game_configuration_panel import GameConfiguration
@@ -97,6 +105,39 @@ class MainWindow(QMainWindow):
 
         # Arrange all panels vertically on the main window layout
         app_layout.addWidget(self.main_content_panel.main_layout_frame)
+
+        button_layout = QHBoxLayout()
+        button_layout.setContentsMargins(12, 12, 12, 12)
+        button_layout.setSpacing(12)
+        app_layout.addLayout(button_layout)
+
+        version_string = QLabel("RimWorld version " + "TBD")
+        version_string.setFont(GUIInfo().smaller_font)
+        version_string.setEnabled(False)
+        button_layout.addWidget(version_string)
+
+        button_layout.addStretch()
+
+        self.refresh_button = QPushButton("Refresh")
+        self.refresh_button.setMinimumWidth(100)
+        button_layout.addWidget(self.refresh_button)
+
+        self.clear_button = QPushButton("Clear")
+        self.clear_button.setMinimumWidth(100)
+        button_layout.addWidget(self.clear_button)
+
+        self.sort_button = QPushButton("Sort")
+        self.sort_button.setMinimumWidth(100)
+        button_layout.addWidget(self.sort_button)
+
+        self.save_button = QPushButton("Save")
+        self.save_button.setMinimumWidth(100)
+        button_layout.addWidget(self.save_button)
+
+        self.run_button = QPushButton("Run Game")
+        self.run_button.setMinimumWidth(100)
+        button_layout.addWidget(self.run_button)
+
         app_layout.addWidget(self.bottom_panel.frame)
 
         # Display all items

--- a/view/main_window.py
+++ b/view/main_window.py
@@ -197,7 +197,7 @@ class MainWindow(QMainWindow):
             )
         # Connect watchdog to our refresh button animation
         self.watchdog_event_handler.file_changes_signal.connect(
-            self.main_content_panel._do_refresh_animation
+            self.main_content_panel._do_refresh_button_set_default
         )
         # Connect main content signal so it can stop watchdog
         self.main_content_panel.stop_watchdog_signal.connect(self.shutdown_watchdog)

--- a/view/main_window.py
+++ b/view/main_window.py
@@ -16,7 +16,6 @@ from watchdog.observers.api import BaseObserver
 
 from controller.menu_bar_controller import MenuBarController
 from controller.settings_controller import SettingsController
-from model.settings import Settings
 from util.app_info import AppInfo
 from util.gui_info import GUIInfo
 from util.system_info import SystemInfo
@@ -24,7 +23,6 @@ from util.watchdog import RSFileSystemEventHandler
 from view.game_configuration_panel import GameConfiguration
 from view.main_content_panel import MainContent
 from view.menu_bar import MenuBar
-from view.settings_dialog import SettingsDialog
 from view.status_panel import Status
 
 if SystemInfo().operating_system == SystemInfo.OperatingSystem.WINDOWS:
@@ -108,10 +106,10 @@ class MainWindow(QMainWindow):
         button_layout.setSpacing(12)
         app_layout.addLayout(button_layout)
 
-        version_string = QLabel("RimWorld version " + "TBD")
-        version_string.setFont(GUIInfo().smaller_font)
-        version_string.setEnabled(False)
-        button_layout.addWidget(version_string)
+        self.game_version_label = QLabel()
+        self.game_version_label.setFont(GUIInfo().smaller_font)
+        self.game_version_label.setEnabled(False)
+        button_layout.addWidget(self.game_version_label)
 
         button_layout.addStretch()
 


### PR DESCRIPTION
The following buttons have been added to the main window:

- Refresh
- Clear
- Sort
- Save
- Run Game

These buttons are all wired up to the appropriate methods in MainContent through the event bus.

Also _free gratis_ we now show the game version as a disabled label widget in the bottom left corner of the main window.

<img width="1264" alt="image" src="https://github.com/RimSort/RimSort/assets/8659114/37f653bd-c827-433a-9c91-9aa3bd324f5f">