### PR TITLE
Add ⌘-comma/⌃-comma shortcuts for opening the Settings dialog to the menu bars

### DIFF
--- a/view/menu_bar.py
+++ b/view/menu_bar.py
@@ -44,6 +44,7 @@ class MenuBar(QObject):
 
         self.settings_action = QAction("Settings…", self)
         self.settings_action.setMenuRole(QAction.MenuRole.ApplicationSpecificRole)
+        self.settings_action.setShortcut(QKeySequence("Ctrl+,"))
         self.app_menu.addAction(self.settings_action)
 
         self.app_menu.addSeparator()
@@ -120,6 +121,7 @@ class MenuBar(QObject):
         self.file_menu.addSeparator()
 
         self.settings_action = QAction("Settings…", self)
+        self.settings_action.setShortcut(QKeySequence("Ctrl+,"))
         self.file_menu.addAction(self.settings_action)
 
         self.file_menu.addSeparator()


### PR DESCRIPTION
Due to a limitation in Qt 6.6.0, the keyboard shortcut doesn't appear under the Mac's application menu. It's active and it works, but it's not shown in the menu as a valid keyboard shortcut.

<img width="315" alt="image" src="https://github.com/RimSort/RimSort/assets/8659114/5d80cb8e-6cd3-4232-9257-c93b1c23bc4b">

I'm putting this in the "better than nothing" category at this time. Ideally a future update to Qt will fix the problem without our having to change anything.

Closes #218 