### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,22 +1,22 @@
 bs4==0.0.1
 GitPython==3.1.31
-imageio==2.27.0
 loguru==0.7.2
 lxml==4.9.3
-mypy==1.2.0
-natsort==8.3.1
-nuitka==1.5.6
-platformdirs==3.11.0
+mypy==1.7.1
+natsort==8.4.0
+nuitka==1.9.1
+platformdirs==4.0.0
 PyGithub==1.58.2
 pyperclip==1.8.2
-PySide6==6.4.3; sys_platform == 'darwin' and platform_machine == 'x86_64'
-PySide6==6.4.3; sys_platform == 'darwin' and platform_machine == 'arm64'
-PySide6==6.4.3; sys_platform == 'linux'
-PySide6==6.4.3; sys_platform == 'win32'
+PySide6
+PySide6==6.6.0; sys_platform == 'darwin' and platform_machine == 'x86_64'
+PySide6==6.6.0; sys_platform == 'darwin' and platform_machine == 'arm64'
+PySide6==6.6.0; sys_platform == 'linux'
+PySide6==6.6.0; sys_platform == 'win32'
 pytz==2023.3
-requests==2.28.2
+requests==2.31.0
 steam==1.4.4
-toposort==1.9
+toposort==1.10
 xmltodict==0.13.0
 watchdog==3.0.0
-psutil==5.9.5
+psutil==5.9.6


### PR DESCRIPTION
- Updated requirements.txt to bring the following packages up to their current versions as of this writing:
  - mypy
  - natsort
  - nuitka
  - platformdirs
  - PySide6
  - requests
  - toposort
  - psutil
- Removed imageio as it was not being used anywhere in the application

This configuration builds successfully against Python 3.11.