### PR TITLE
[Hotfix] RimSort is not starting on MacOS

### DIFF
--- a/app/views/menu_bar.py
+++ b/app/views/menu_bar.py
@@ -96,6 +96,9 @@ class MenuBar(QObject):
         self.upload_rimsort_log_action = QAction("RimSort.log", self)
         self.upload_submenu.addAction(self.upload_rimsort_log_action)
 
+        self.upload_rimsort_old_log_action = QAction("RimSort.old.log", self)
+        self.upload_submenu.addAction(self.upload_rimsort_old_log_action)
+
         self.upload_rimworld_log_action = QAction("RimWorld.log", self)
         self.upload_submenu.addAction(self.upload_rimworld_log_action)
 


### PR DESCRIPTION
RimSort on MacOS is not starting because `upload_rimsort_old_log_action` is not properly instantiated upon MenuBar creation for MacOS.
