### PR TITLE
[QOL] Improving functionality clicking on mods

### DIFF
--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -482,7 +482,8 @@ class ModListWidget(QListWidget):
         self.setSelectionMode(QAbstractItemView.SelectionMode.ExtendedSelection)
 
         # When an item is clicked, display the mod information
-        self.currentItemChanged.connect(self.mod_clicked)
+        self.currentItemChanged.connect(self.mod_changed_to)
+        self.itemClicked.connect(self.mod_clicked)
 
         # When an item is double clicked, move it to the opposite list
         self.itemDoubleClicked.connect(self.mod_double_clicked)
@@ -1448,10 +1449,21 @@ class ModListWidget(QListWidget):
             (self.itemWidget(self.item(i)), self.item(i)) for i in range(self.count())
         ]
 
-    def mod_clicked(self, current: QListWidgetItem, previous: QListWidgetItem) -> None:
+    def mod_changed_to(self, current: QListWidgetItem, previous: QListWidgetItem) -> None:
         """
         Method to handle clicking on a row or navigating between rows with
         the keyboard. Look up the mod's data by uuid
+        """
+        if current is not None:
+            self.mod_info_signal.emit(current.data(Qt.UserRole))
+
+    def mod_clicked(self, current: QListWidgetItem) -> None:
+        """
+        Method to handle clicking on a row. Necessary because `mod_changed_to` does not
+        properly handle clicking on a previous selected item after clicking on an item
+        in another list. For example, clicking on item 1 in the inactive list, then on item 2
+        in the active list, then back to item 1 in the inactive list-- this method makes
+        it so that mod info is updated as expected.
         """
         if current is not None:
             self.mod_info_signal.emit(current.data(Qt.UserRole))


### PR DESCRIPTION
There is currently an edge case where if you click back and forth between the same two mods, one on the inactive mods panel and one on the active mods panel, the ModInfo panel does not update accordingly. This is because we're currently using the `currentItemChanged` hook and technically the item does not change in the context of a single mod panel. So, I'm adding the `itemClicked` hook to account for this edge case.

Technically, this means when you click an item the ModInfo panel is actually updated twice, but the work done during a single update is minimal so I think this is worth the QoL improvement.