### PR TITLE
Fix and Improve Assembly Detection

### DIFF
--- a/app/utils/metadata.py
+++ b/app/utils/metadata.py
@@ -1329,29 +1329,44 @@ class ModParser(QRunnable):
                             f"https://steamcommunity.com/sharedfiles/filedetails/?id={pfid}"
                         )
                     # If a mod contains C# assemblies, we want to tag the mod
-                    assemblies_path = str((directory_path / "Assemblies"))
-                    if os.path.exists(assemblies_path):
-                        if any(
-                            filename.endswith((".dll", ".DLL"))
-                            for filename in os.listdir(assemblies_path)
-                        ):
-                            mod_metadata["csharp"] = True
+                    assemblies_path = str(directory_path / "Assemblies")
+                    # Check if the 'Assemblies' directory exists and is a directory
+                    if os.path.exists(assemblies_path) and os.path.isdir(
+                        assemblies_path
+                    ):
+                        try:
+                            # Check if there are any .dll files in the 'Assemblies' directory
+                            if any(
+                                filename.endswith((".dll", ".DLL"))
+                                for filename in os.listdir(assemblies_path)
+                            ):
+                                mod_metadata["csharp"] = (
+                                    True  # Tag the mod as containing C# code
+                                )
+                        except Exception as e:
+                            logger.error(
+                                f"Failed to list directory {assemblies_path}: {e}"
+                            )
                     else:
+                        # If no 'Assemblies' directory in the main folder, check in subfolders
+                        logger.debug("Checking subfolders for C# assemblies")
                         subfolder_paths = [
-                            str((directory_path / folder))
+                            str(directory_path / folder)
                             for folder in os.listdir(directory)
-                            if os.path.isdir(str((directory_path / folder)))
+                            if os.path.isdir(str(directory_path / folder))
                         ]
                         for subfolder_path in subfolder_paths:
-                            assemblies_path = str(
-                                os.path.join(Path(subfolder_path) / "Assemblies")
-                            )
+                            assemblies_path = str(Path(subfolder_path) / "Assemblies")
+                            # Check if the 'Assemblies' directory exists in the subfolder
                             if os.path.exists(assemblies_path):
+                                # Check if there are any .dll files in this 'Assemblies' directory
                                 if any(
                                     filename.endswith((".dll", ".DLL"))
                                     for filename in os.listdir(assemblies_path)
                                 ):
-                                    mod_metadata["csharp"] = True
+                                    mod_metadata["csharp"] = (
+                                        True  # Tag the mod as containing C# code
+                                    )
                     # data_source will be used with setIcon later
                     mod_metadata["data_source"] = intent
                     mod_metadata["folder"] = directory_name


### PR DESCRIPTION
Fixes issues with mods which have assemblies .dll or file in the root dir

i had encountered the below issue

[ERROR][2024-04-14 13:35:24][14492][Dummy-10][metadata][run][1486] : NotADirectoryError: [WinError 267] The directory name is invalid: 'G:\\Games\\RimWorld\\Mods\\2916253559\\Assemblies'
Traceback (most recent call last):
  File "E:\Github\RimSort_Main\app\utils\metadata.py", line 1480, in run
    mod_metadata = self.__parse_mod_data(
                   ^^^^^^^^^^^^^^^^^^^^^^
  File "E:\Github\RimSort_Main\app\utils\metadata.py", line 1336, in __parse_mod_data
    for filename in os.listdir(assemblies_path)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
NotADirectoryError: [WinError 267] The directory name is invalid: 'G:\\Games\\RimWorld\\Mods\\2916253559\\Assemblies'
