### PR TITLE
Implement lazy loading for `ModListItemInner`

### DIFF
--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -302,7 +302,9 @@ class MainContent(QObject):
             iml.setFocus()
             if not iml.selectedIndexes():
                 iml.setCurrentRow(self.___get_relative_middle(iml))
-            self.__mod_list_slot(iml.selectedItems()[0].data(Qt.UserRole))
+            data = iml.selectedItems()[0].data(Qt.UserRole)
+            uuid = data["uuid"]
+            self.__mod_list_slot(uuid)
 
         elif key == "Return" or key == "Space" or key == "DoubleClick":
             # TODO: graphical bug where if you hold down the key, items are
@@ -314,7 +316,9 @@ class MainContent(QObject):
 
                 # Remove items from current list
                 for item in items_to_move:
-                    aml.uuids.remove(item.data(Qt.UserRole))
+                    data = item.data(Qt.UserRole)
+                    uuid = data["uuid"]
+                    aml.uuids.remove(uuid)
                     aml.takeItem(aml.row(item))
                 if aml.count():
                     if aml.count() == first_selected:
@@ -353,7 +357,9 @@ class MainContent(QObject):
             aml.setFocus()
             if not aml.selectedIndexes():
                 aml.setCurrentRow(self.___get_relative_middle(aml))
-            self.__mod_list_slot(aml.selectedItems()[0].data(Qt.UserRole))
+            data = aml.selectedItems()[0].data(Qt.UserRole)
+            uuid = data["uuid"]
+            self.__mod_list_slot(uuid)
 
         elif key == "Return" or key == "Space" or key == "DoubleClick":
             # TODO: graphical bug where if you hold down the key, items are
@@ -365,7 +371,9 @@ class MainContent(QObject):
 
                 # Remove items from current list
                 for item in items_to_move:
-                    iml.uuids.remove(item.data(Qt.UserRole))
+                    data = item.data(Qt.UserRole)
+                    uuid = data["uuid"]
+                    iml.uuids.remove(uuid)
                     iml.takeItem(iml.row(item))
                 if iml.count():
                     if iml.count() == first_selected:

--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -517,9 +517,7 @@ class ModListWidget(QListWidget):
                 self.uuids.insert(idx, uuid)
         # Update list signal
         self.list_update_signal.emit("drop")
-        logger.debug(
-            "List update signal emitted after rows dropped (n=%s)", self.count()
-        )
+        logger.debug(f"List update signal emitted after rows dropped [{self.count()}]")
 
     def eventFilter(self, source_object: QObject, event: QEvent) -> None:
         """
@@ -1407,7 +1405,7 @@ class ModListWidget(QListWidget):
             # Update list with the number of items
             self.list_update_signal.emit(str(self.count()))
             logger.debug(
-                "List update signal emitted after rows inserted (n=%s)", self.count()
+                f"List update signal emitted after rows inserted [{self.count()}]"
             )
 
     def handle_rows_removed(self, parent: QModelIndex, first: int, last: int) -> None:
@@ -1434,7 +1432,7 @@ class ModListWidget(QListWidget):
             # Update list with the number of items
             self.list_update_signal.emit(str(self.count()))
             logger.debug(
-                "List update signal emitted after rows removed (n=%s)", self.count()
+                f"List update signal emitted after rows removed [{self.count()}]"
             )
 
     def get_item_widget_at_index(self, idx: int) -> Optional[ModListItemInner]:


### PR DESCRIPTION
This introduces a functional "lazy-loading" for `ModListItemInner`

While unmeasured by me, you can observe a significant improvement in performance inside the app. Item widgets will not be created unless their parent items are visible.

Additional support has been added for search filter support as well