### PR TITLE
Do not Prosses if Git Does not exists

### DIFF
--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -2249,6 +2249,11 @@ class MainContent(QObject):
         Handles possible existing repo, and prompts (re)download of repo
         Otherwise it just clones the repo and notifies user
         """
+        # Check if git is installed
+        if not GIT_EXISTS:
+            self._do_notify_no_git()
+            return
+
         if (
             repo_url
             and repo_url != ""


### PR DESCRIPTION
fix
Error:
Traceback (most recent call last):
  File "C:\Users\Nossea\DOWNLO~1\RIMSOR~1\RimSort\app\views\main_content_panel.py", line 2294, in _do_clone_repo_to_path
NameError: name 'Repo' is not defined

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Users\Nossea\DOWNLO~1\RIMSOR~1\RimSort\app\views\main_content_panel.py", line 3186, in _on_do_download_steam_workshop_db_from_github
  File "C:\Users\Nossea\DOWNLO~1\RIMSOR~1\RimSort\app\views\main_content_panel.py", line 2300, in _do_clone_repo_to_path
NameError: name 'GitCommandError' is not defined