### PR TITLE
UI Tweaks #339

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,4 +17,5 @@
     "python.terminal.activateEnvInCurrentTerminal": true,
     "python.languageServer": "Jedi",
     "mypy.runUsingActiveInterpreter": true,
+    "autoDocstring.docstringFormat": "sphinx"
 }

--- a/themes/RimPy/style.qss
+++ b/themes/RimPy/style.qss
@@ -216,9 +216,7 @@ QPushButton {
     border-radius: 5px;
     min-height: 1em;
     min-width: 6em;
-    padding: 2px;
-    padding-left: 4px;
-    padding-right: 4px;
+    padding: 2px 4px;
 }
 
 QPushButton#indicator {

--- a/themes/RimPy/style.qss
+++ b/themes/RimPy/style.qss
@@ -179,6 +179,26 @@ QMenu::item:checked:selected {
 QMenu::item:checked:hover {
     background-color: #37414f;
 }
+
+/* Default Menu Bar styling. Note that this does not apply in MacOS */
+QMenuBar {
+    background-color: #19232d;
+    color: white;
+    border-radius: 3px;
+}
+
+QMenuBar::item {
+    padding: 4px 8px;
+}
+
+QMenuBar::item:selected {
+    background-color: #37414f;
+}
+
+QMenuBar::item:pressed {
+    background-color: #54687a;
+}
+
 /* Default message box style */
 QMessageBox#dialogue{
     background: #1B2838;

--- a/themes/RimPy/style.qss
+++ b/themes/RimPy/style.qss
@@ -216,7 +216,9 @@ QPushButton {
     border-radius: 5px;
     min-height: 1em;
     min-width: 6em;
-    padding: 1px;
+    padding: 2px;
+    padding-left: 4px;
+    padding-right: 4px;
 }
 
 QPushButton#indicator {

--- a/themes/RimPy/style.qss
+++ b/themes/RimPy/style.qss
@@ -44,7 +44,7 @@ QComboBox {
     border-radius: 5px;
     min-height: 1em;
     min-width: 6em;
-    padding: 1px;
+    padding: 2px 4px;
 }
 QComboBox:hover {
     background-color: #54687a;

--- a/themes/RimPy/style.qss
+++ b/themes/RimPy/style.qss
@@ -547,6 +547,9 @@ QCheckBox::indicator:unchecked {
 QCheckBox::indicator:hover {
     border: 1px solid #54687a;
 }
+QRadioButton {
+    color: white;
+}
 
 /* ===== Status panel (bottom message bar) */
 QWidget#StatusPanel {

--- a/themes/RimPy/style.qss
+++ b/themes/RimPy/style.qss
@@ -571,6 +571,22 @@ QRadioButton {
     color: white;
 }
 
+QRadioButton::indicator {
+    width: 10px;
+    height: 10px;
+    border-radius: 8px;
+    border: 3px solid #455364;
+}
+
+QRadioButton::indicator:checked {
+    background-color:#3688c3;
+}
+
+QRadioButton::indicator:unchecked {
+    background-color: #455364;
+}
+
+
 /* ===== Status panel (bottom message bar) */
 QWidget#StatusPanel {
     background-color: #455364;


### PR DESCRIPTION
Some UI tweaks related to #339

Increased padding for combo boxes.
Added styling for radio buttons for consistency with the rest of the program.
Added styling for menubar for consistency with the rest of the program on Windows. 

As a side note, should seriously consider moving away from pure white for font colors. There are guidelines for having too low contrast, but too high contrast can cause accessibility issues for some users, particularly for astigmatism and dyslexia. It's the main reason why some people use light mode when dark mode exists. I also personally find that the current colors show up kind of pixelated with such high contrast and small font size. As an example, Google uses #fafafa and GitHub uses #e6edf3.