### PR TITLE
Artifact attestation

### DIFF
--- a/.github/workflows/auto_build.yml
+++ b/.github/workflows/auto_build.yml
@@ -14,6 +14,8 @@ on:
       - "distribute.py"
       - "requirements*.txt"
 
+permissions: {}
+
 jobs:
   pre-build:
     uses: ./.github/workflows/get_version_info.yml

--- a/.github/workflows/auto_build.yml
+++ b/.github/workflows/auto_build.yml
@@ -25,6 +25,8 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      attestations: write
+      packages: write
     uses: ./.github/workflows/build.yml
     with:
       version_format: ${{ needs.pre-build.outputs.version_format }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,26 +36,31 @@ jobs:
             arch: "i386"
             env:
               BUILD_OUTPUT: "__main__.app"
+              Executable: "RimSort"
           - os: macos-latest
             platform: "Darwin"
             arch: "arm"
             env:
               BUILD_OUTPUT: "__main__.app"
+              Executable: "RimSort"
           - os: ubuntu-22.04
             platform: "Ubuntu-22.04"
             arch: "x86_64"
             env:
               BUILD_OUTPUT: "__main__.dist"
+              Executable: "RimSort"
           - os: ubuntu-24.04
             platform: "Ubuntu-24.04"
             arch: "x86_64"
             env:
               BUILD_OUTPUT: "__main__.dist"
+              Executable: "RimSort"
           - os: windows-latest
             platform: "Windows"
             arch: "x86_64"
             env:
               BUILD_OUTPUT: "__main__.dist"
+              Executable: "RimSort.exe"
     steps:
       - name: Check-out repository
         uses: actions/checkout@main
@@ -169,6 +174,16 @@ jobs:
         uses: actions/attest-build-provenance@v1.1.2
         with:
           subject-path: ./build/${{ steps.filename.outputs.FILENAME }}.tar
+
+      - name: Find Executable and save to attest
+        id: find_executable
+        run: |
+          find . -name "${{ matrix.env.Executable }}" -exec echo "EXECUTABLE={}" \; >> "$GITHUB_OUTPUT"
+
+      - name: Generate executable attestations
+        uses: actions/attest-build-provenance@v1.1.2
+        with:
+          subject-path: ${{ steps.find_executable.outputs.EXECUTABLE }}
 
         # Upload folder as artifact
       - name: Upload folder as artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,7 +178,7 @@ jobs:
       - name: Find Executable
         id: find_executable
         run: |
-          executable=(find . -name "${{ matrix.env.Executable }}")
+          executable=$(find . -name "${{ matrix.env.Executable }}")
           echo "EXECUTABLE=$executable" >> "$GITHUB_OUTPUT"
 
       - name: Generate executable attestations

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,6 +168,7 @@ jobs:
           executable=$(find . -name "${{ matrix.env.Executable }}")
           echo "EXECUTABLE=$executable" >> "$GITHUB_OUTPUT"
           echo "Executable found at $executable"
+        shell: bash
 
       - name: Generate executable attestations
         uses: actions/attest-build-provenance@v1.1.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,8 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      attestations: write
+      packages: write
 
     runs-on: ${{ matrix.os }}
     strategy:
@@ -162,6 +164,11 @@ jobs:
           tar -cvf "${{ steps.filename.outputs.FILENAME }}.tar" "output" 
           rm -rf "output"
         shell: bash
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1.1.2
+        with:
+          subject-path: ./build/${{ steps.filename.outputs.FILENAME }}.tar
 
         # Upload folder as artifact
       - name: Upload folder as artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,10 +175,11 @@ jobs:
         with:
           subject-path: ./build/${{ steps.filename.outputs.FILENAME }}.tar
 
-      - name: Find Executable and save to attest
+      - name: Find Executable
         id: find_executable
         run: |
-          find . -name "${{ matrix.env.Executable }}" -exec echo "EXECUTABLE={}" \; >> "$GITHUB_OUTPUT"
+          executable=(find . -name "${{ matrix.env.Executable }}")
+          echo "EXECUTABLE=$executable" >> "$GITHUB_OUTPUT"
 
       - name: Generate executable attestations
         uses: actions/attest-build-provenance@v1.1.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,13 +36,13 @@ jobs:
             arch: "i386"
             env:
               BUILD_OUTPUT: "__main__.app"
-              Executable: "RimSort"
+              Executable: RimSort
           - os: macos-latest
             platform: "Darwin"
             arch: "arm"
             env:
               BUILD_OUTPUT: "__main__.app"
-              Executable: "RimSort"
+              Executable: RimSort
           - os: ubuntu-22.04
             platform: "Ubuntu-22.04"
             arch: "x86_64"
@@ -54,13 +54,13 @@ jobs:
             arch: "x86_64"
             env:
               BUILD_OUTPUT: "__main__.dist"
-              Executable: "RimSort"
+              Executable: RimSort
           - os: windows-latest
             platform: "Windows"
             arch: "x86_64"
             env:
               BUILD_OUTPUT: "__main__.dist"
-              Executable: "RimSort.exe"
+              Executable: RimSort.exe
     steps:
       - name: Check-out repository
         uses: actions/checkout@main
@@ -180,6 +180,7 @@ jobs:
         run: |
           executable=$(find . -name "${{ matrix.env.Executable }}")
           echo "EXECUTABLE=$executable" >> "$GITHUB_OUTPUT"
+          echo "Executable found at $executable"
 
       - name: Generate executable attestations
         uses: actions/attest-build-provenance@v1.1.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,6 +162,18 @@ jobs:
           echo "FILENAME=$FILENAME" >> "$GITHUB_OUTPUT"
         shell: bash
 
+      - name: Find Executable
+        id: find_executable
+        run: |
+          executable=$(find . -name "${{ matrix.env.Executable }}")
+          echo "EXECUTABLE=$executable" >> "$GITHUB_OUTPUT"
+          echo "Executable found at $executable"
+
+      - name: Generate executable attestations
+        uses: actions/attest-build-provenance@v1.1.2
+        with:
+          subject-path: ${{ steps.find_executable.outputs.EXECUTABLE }}
+
       - name: Rename new build
         run: |
           cd build
@@ -174,18 +186,6 @@ jobs:
         uses: actions/attest-build-provenance@v1.1.2
         with:
           subject-path: ./build/${{ steps.filename.outputs.FILENAME }}.tar
-
-      - name: Find Executable
-        id: find_executable
-        run: |
-          executable=$(find . -name "${{ matrix.env.Executable }}")
-          echo "EXECUTABLE=$executable" >> "$GITHUB_OUTPUT"
-          echo "Executable found at $executable"
-
-      - name: Generate executable attestations
-        uses: actions/attest-build-provenance@v1.1.2
-        with:
-          subject-path: ${{ steps.find_executable.outputs.EXECUTABLE }}
 
         # Upload folder as artifact
       - name: Upload folder as artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,7 +148,7 @@ jobs:
             ${{ steps.sem_version.outputs.minor }}.
             ${{ steps.sem_version.outputs.patch }}.
             ${{ steps.sem_version.outputs.increment }}
-          file-description: "An open source RimWorld mod manager."
+          file-description: "RimSort"
           include-data-files: |
             version.xml=version.xml
         env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,5 +46,5 @@ jobs:
           VALIDATE_VALIDATE_NATURAL_LANGUAGE: true
           # Linter not up to date
           GITHUB_ACTIONS_COMMAND_ARGS: |
-            '-ignore ''"ubuntu-24.04" is unknown'''
-            '-ignore ''unknown permission scope "attestations"'''
+            -ignore '"ubuntu-24.04" is unknown'
+            -ignore 'unknown permission scope "attestations"'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
 
       - name: Super-linter
-        uses: super-linter/super-linter@v6.5.0 # x-release-please-version
+        uses: super-linter/super-linter@v6.5.1 # x-release-please-version
         env:
           # To report GitHub Actions status checks
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -46,3 +46,4 @@ jobs:
           VALIDATE_VALIDATE_NATURAL_LANGUAGE: true
           # Linter not up to date
           GITHUB_ACTIONS_COMMAND_ARGS: '--ignore ''"ubuntu-24.04" is unknown'''
+          GITHUB_ACTIONS_COMMAND_ARGS: '--ignore ''unknown permission scope "attestations"'''

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,6 +45,6 @@ jobs:
           VALIDATE_MARKDOWN: true
           VALIDATE_VALIDATE_NATURAL_LANGUAGE: true
           # Linter not up to date
-          GITHUB_ACTIONS_COMMAND_ARGS: |
+          GITHUB_ACTIONS_COMMAND_ARGS: >-
             -ignore 'unknown permission scope "attestations"'
             -ignore '"ubuntu-24.04" is unknown'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,5 +46,5 @@ jobs:
           VALIDATE_VALIDATE_NATURAL_LANGUAGE: true
           # Linter not up to date
           GITHUB_ACTIONS_COMMAND_ARGS: |
-            -ignore '"ubuntu-24.04" is unknown'
             -ignore 'unknown permission scope "attestations"'
+            -ignore '"ubuntu-24.04" is unknown'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,5 +45,6 @@ jobs:
           VALIDATE_MARKDOWN: true
           VALIDATE_VALIDATE_NATURAL_LANGUAGE: true
           # Linter not up to date
-          GITHUB_ACTIONS_COMMAND_ARGS: '--ignore ''"ubuntu-24.04" is unknown'''
-          GITHUB_ACTIONS_COMMAND_ARGS: '--ignore ''unknown permission scope "attestations"'''
+          GITHUB_ACTIONS_COMMAND_ARGS: |
+            '--ignore ''"ubuntu-24.04" is unknown'''
+            '--ignore ''unknown permission scope "attestations"'''

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,5 +46,5 @@ jobs:
           VALIDATE_VALIDATE_NATURAL_LANGUAGE: true
           # Linter not up to date
           GITHUB_ACTIONS_COMMAND_ARGS: |
-            '--ignore ''"ubuntu-24.04" is unknown'''
-            '--ignore ''unknown permission scope "attestations"'''
+            '-ignore ''"ubuntu-24.04" is unknown'''
+            '-ignore ''unknown permission scope "attestations"'''

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,8 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      attestations: write
+      packages: write
     uses: ./.github/workflows/build.yml
     with:
       version_format: ${{ needs.pre-build.outputs.version_format }}

--- a/distribute.py
+++ b/distribute.py
@@ -545,7 +545,7 @@ def main() -> None:
             version = "".join(args.product_version.split())
             _NUITKA_CMD.extend(
                 [
-                    "--file-description=An open source RimWorld mod manager.",
+                    "--file-description=RimSort",
                     f"--product-version={version}",
                 ]
             )


### PR DESCRIPTION
Add GitHub attestation to the build pipeline for the executable and the zipped artifact.

Includes bump to the linter version and also a temporary ignore for the GitHub Actions linter to ignore not recognizing the attestations permission.