### PR TITLE
(minor) Enable Theme Support

### DIFF
--- a/app/controllers/app_controller.py
+++ b/app/controllers/app_controller.py
@@ -6,6 +6,7 @@ from PySide6.QtWidgets import QApplication
 
 from app.controllers.main_window_controller import MainWindowController
 from app.controllers.settings_controller import SettingsController
+from app.controllers.theme_controller import ThemeController
 from app.models.settings import Settings
 from app.utils.app_info import AppInfo
 from app.utils.constants import DEFAULT_USER_RULES
@@ -21,31 +22,43 @@ class AppController(QObject):
         super().__init__()
 
         self.app = QApplication(sys.argv)
-
-        self.app.setStyle("Fusion")
-
-        self.app.setStyleSheet(  # Add style sheet for styling layouts and widgets
-            (
-                AppInfo().application_folder / "themes" / "RimPy" / "style.qss"
-            ).read_text()
-        )
         self.app.setWindowIcon(GUIInfo().app_icon)
 
-        # One-time initialization of userRules.json
+        self.initialize_user_rules()
+        self.initialize_settings()
+        self.initialize_theme_controller()
+        self.initialize_steamcmd_interface()
+        self.initialize_metadata_manager()
+        self.initialize_main_window()
+
+        self.app.setStyle("Fusion")
+        self.theme_controller.apply_selected_theme(
+            self.settings.enable_themes,
+            self.settings.theme_name,
+        )
+
+    def initialize_user_rules(self) -> None:
+        """Initializes userRules.json if it does not exist."""
         user_rules_path = AppInfo().databases_folder / "userRules.json"
         if not user_rules_path.exists():
             initial_rules_db = DEFAULT_USER_RULES
             with open(user_rules_path, "w", encoding="utf-8") as output:
                 json.dump(initial_rules_db, output, indent=4)
 
-        # Instantiate the settings model, view and controller
+    def initialize_settings(self) -> None:
+        """Initializes the settings model, view, and controller."""
         self.settings = Settings()
         self.settings_dialog = SettingsDialog()
         self.settings_controller = SettingsController(
             model=self.settings, view=self.settings_dialog
         )
 
-        # Initialize SteamcmdInterface
+    def initialize_theme_controller(self) -> None:
+        """Initializes the ThemeController."""
+        self.theme_controller = ThemeController()
+
+    def initialize_steamcmd_interface(self) -> None:
+        """Initializes the SteamcmdInterface."""
         self.steamcmd_wrapper = SteamcmdInterface.instance(
             self.settings_controller.settings.instances[
                 self.settings_controller.settings.current_instance
@@ -53,22 +66,27 @@ class AppController(QObject):
             self.settings_controller.settings.steamcmd_validate_downloads,
         )
 
-        # Initialize the MetadataManager
+    def initialize_metadata_manager(self) -> None:
+        """Initializes the MetadataManager."""
         self.metadata_manager = MetadataManager.instance(
             settings_controller=self.settings_controller
         )
 
-        # Instantiate the main window and its controller
+    def initialize_main_window(self) -> None:
+        """Initializes the main window and its controller."""
         self.main_window = MainWindow(settings_controller=self.settings_controller)
         self.main_window_controller = MainWindowController(self.main_window)
 
     def run(self) -> int:
+        """Runs the main application loop after initializing the main window."""
         self.main_window.show()
         self.main_window.initialize_content(is_initial=True)
         return self.app.exec()
 
     def shutdown_watchdog(self) -> None:
+        """Initiates the shutdown procedure for the watchdog."""
         self.main_window.shutdown_watchdog()
 
     def quit(self) -> None:
+        """Exits the application."""
         self.app.quit()

--- a/app/controllers/theme_controller.py
+++ b/app/controllers/theme_controller.py
@@ -1,0 +1,207 @@
+from pathlib import Path
+from typing import Optional
+
+from loguru import logger
+from PySide6.QtWidgets import QApplication, QComboBox
+
+from app.models.settings import Settings
+from app.utils.app_info import AppInfo
+from app.views import dialogue
+from app.views.settings_dialog import SettingsDialog
+
+
+class ThemeController:
+    def __init__(self, default_theme: str = "RimPy") -> None:
+        """Initialize the ThemeController with a default theme.
+
+        Args:
+            default_theme (str): The name of the default theme. Defaults to "RimPy".
+        """
+        self.app_info = AppInfo()
+        self.app_instance = QApplication.instance()
+        logger.info("Initializing ThemeController")
+        self.default_theme = default_theme
+        self.themes = self._get_supported_themes()
+        logger.info(f"Supported themes: {self.themes}")
+        self.theme_stylesheets_folder = [
+            self.app_info.theme_storage_folder,
+            self.app_info.theme_data_folder,
+        ]
+
+    def _get_supported_themes(self) -> set[str]:
+        """Retrieves a set of supported themes from the theme data and storage folders."""
+        theme_data_folders = self._get_theme_names_from_folder(
+            self.app_info.theme_data_folder
+        )
+        theme_storage_folders = self._get_theme_names_from_folder(
+            self.app_info.theme_storage_folder
+        )
+        supported_themes = theme_data_folders | theme_storage_folders
+        logger.info(f"Supported themes retrieved: {supported_themes}")
+        logger.debug(
+            f"Checking theme folders: {[self.app_info.theme_data_folder, self.app_info.theme_storage_folder]}"
+        )
+        return supported_themes
+
+    def _get_theme_names_from_folder(self, folder: Path) -> set[str]:
+        """Helper method to get theme names from a specified folder.
+
+        Args:
+            folder (Path): The folder to search for themes.
+
+        Returns:
+            set[str]: A set of theme names found in the folder.
+        """
+        supported_themes = set()
+        if folder.exists():
+            for subfolder in folder.iterdir():
+                if subfolder.is_dir() and (subfolder / "style.qss").exists():
+                    supported_themes.add(subfolder.name)
+                    logger.info(
+                        f"Found theme with stylesheet in {folder}: {subfolder.name}"
+                    )
+        else:
+            logger.warning(f"Folder does not exist: {folder}")
+        return supported_themes
+
+    def load_theme(self, theme_name: str) -> Optional[str]:
+        """Load the specified theme.
+
+        Args:
+            theme_name (str): The name of the theme to load.
+
+        Returns:
+            Optional[str]: The stylesheet content if loaded successfully, None otherwise.
+        """
+        if not theme_name:
+            logger.error("Attempted to load an empty theme name")
+            return None
+
+        if theme_name in self.themes:
+            logger.info(f"Loading theme: {theme_name}")
+            stylesheet_path = self.get_theme_stylesheet_path(theme_name)
+            if stylesheet_path:
+                try:
+                    with open(stylesheet_path, "r") as f:
+                        return f.read()
+                except Exception as e:
+                    logger.error(f"Error loading theme: {e}")
+        else:
+            logger.error(f"Attempted to load unsupported theme: {theme_name}")
+
+        # Fallback to default theme
+        if theme_name != self.default_theme:
+            logger.info(f"Falling back to default theme: {self.default_theme}")
+            return self.load_theme(self.default_theme)
+        return None
+
+    def get_theme_stylesheet_path(self, theme_name: str) -> Optional[Path]:
+        """Returns the path to the stylesheet for the specified theme.
+
+        Args:
+            theme_name (str): The name of the theme.
+
+        Returns:
+            Optional[Path]: The path to the stylesheet if found, None otherwise.
+        """
+        logger.info(f"Searching for stylesheet for theme: {theme_name}")
+        for folder in self.theme_stylesheets_folder:
+            potential_path = folder / theme_name / "style.qss"
+            logger.debug(f"Checking for stylesheet at: {potential_path}")
+            if potential_path.exists():
+                logger.info(
+                    f"Found stylesheet for theme '{theme_name}' at: {potential_path}"
+                )
+                return potential_path
+        logger.error(f"Stylesheet path does not exist for theme '{theme_name}'")
+        dialogue.show_warning(
+            title="Theme path Error",
+            text=f"Stylesheet path does not exist for theme '{theme_name}' Resetting to default theme '{self.default_theme}'.",
+        )
+        return None
+
+    def apply_selected_theme(
+        self, enable_themes: bool, selected_theme_name: str
+    ) -> None:
+        """Apply the selected theme without restarting the application.
+
+        Args:
+            enable_themes (bool): Flag to enable themes.
+            selected_theme_name (str): The name of the theme to apply.
+        """
+        if not isinstance(self.app_instance, QApplication):
+            logger.warning("Application instance is not a QApplication.")
+            return
+
+        if enable_themes:
+            stylesheet = self.load_theme(selected_theme_name)
+            if stylesheet:
+                self.app_instance.setStyleSheet(stylesheet)
+                logger.info(f"Applied theme: {selected_theme_name}")
+            else:
+                logger.warning(
+                    f"Failed to apply theme: {selected_theme_name},"
+                    f"Resetting to default theme: {self.default_theme}"
+                )
+                dialogue.show_warning(
+                    title="Theme Error",
+                    text=f"Failed to apply theme: {selected_theme_name},"
+                    f"Resetting to default theme: {self.default_theme}",
+                )
+                self.reset_to_default_theme()
+        else:
+            # If themes are disabled, Set Fusion theme
+            self.set_fusion_theme()
+
+    def reset_to_default_theme(self) -> None:
+        """Reset the application to the default theme."""
+        if isinstance(self.app_instance, QApplication):
+            logger.info("Resetting to default theme")
+            stylesheet = self.load_theme(self.default_theme)
+            if stylesheet:
+                self.app_instance.setStyleSheet(stylesheet)
+            else:
+                logger.error(f"Failed to load default theme: {self.default_theme}")
+
+    def set_fusion_theme(self) -> None:
+        """Applies when themes are disabled."""
+        if isinstance(self.app_instance, QApplication):
+            logger.info("Themes disabled, setting Fusion theme")
+            self.app_instance.setStyleSheet("")  # Clear any existing stylesheets
+            self.app_instance.setStyle("Fusion")
+
+    def populate_themes_combobox(self, combobox: QComboBox) -> None:
+        """Populate the themes combobox with available themes."""
+        combobox.clear()
+        available_themes = list(self._get_supported_themes())
+        combobox.addItems(available_themes)
+
+    def setup_theme_dialog(
+        self, settings_dialog: "SettingsDialog", settings: "Settings"
+    ) -> None:
+        """
+        Set up the settings dialog with current settings.
+        Reloading settings is required since ThemeController will reset to RimPy if the theme is invalid.
+        """
+        settings_dialog.enable_themes_checkbox.setChecked(settings.enable_themes)
+        if settings.enable_themes:
+            # Set the current theme in the combobox
+            current_theme_name = settings.theme_name
+            current_index = settings_dialog.themes_combobox.findText(current_theme_name)
+            if current_index != -1:
+                settings_dialog.themes_combobox.setCurrentIndex(current_index)
+            else:
+                # Fallback to default theme
+                default_theme = self.default_theme
+                logger.warning(
+                    f"Resetting to '{default_theme}' theme due to missing or invalid theme: {current_theme_name}"
+                )
+                settings.theme_name = default_theme
+                current_index = settings_dialog.themes_combobox.findText(default_theme)
+                settings.save()
+                self.apply_selected_theme(settings.enable_themes, default_theme)
+        else:
+            self.set_fusion_theme()
+            logger.info(
+                "Themes disabled, setting Fusion theme. Please enable themes to apply a theme."
+            )

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -63,6 +63,10 @@ class Settings(QObject):
         self.todds_dry_run: bool = False
         self.todds_overwrite: bool = False
 
+        # Theme
+        self.enable_themes: bool = True
+        self.theme_name: str = "RimPy"
+
         # Advanced
         self.debug_logging_enabled: bool = False
         self.watchdog_toggle: bool = True

--- a/app/utils/app_info.py
+++ b/app/utils/app_info.py
@@ -81,6 +81,7 @@ class AppInfo:
 
         self._databases_folder: Path = self._app_storage_folder / "dbs"
         self._saved_modlists_folder: Path = self._app_storage_folder / "modlists"
+        self._theme_storage_folder: Path = self._app_storage_folder / "themes"
         self._theme_data_folder: Path = self._application_folder / "themes"
         self._settings_file: Path = self._app_storage_folder / "settings.json"
 
@@ -91,6 +92,7 @@ class AppInfo:
         self._saved_modlists_folder.mkdir(parents=True, exist_ok=True)
 
         self._databases_folder.mkdir(parents=True, exist_ok=True)
+        self._theme_storage_folder.mkdir(parents=True, exist_ok=True)
 
         self._is_initialized: bool = True
 
@@ -185,9 +187,16 @@ class AppInfo:
     @property
     def theme_data_folder(self) -> Path:
         """
-        Get the path to the folder where application-specific data is stored.
+        Get the path to the folder where application Themes / Stylesheets are stored.
         """
         return self._theme_data_folder
+
+    @property
+    def theme_storage_folder(self) -> Path:
+        """
+        Get the path to the user folder where Themes / Stylesheets are stored.
+        """
+        return self._theme_storage_folder
 
     @property
     def databases_folder(self) -> Path:

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -32,7 +32,7 @@ class SettingsDialog(QDialog):
 
         self.setWindowTitle("Settings")
         self.setObjectName("settingsPanel")
-        self.resize(800, 600)
+        self.resize(900, 600)
 
         main_layout = QVBoxLayout()
         self.setLayout(main_layout)
@@ -48,6 +48,7 @@ class SettingsDialog(QDialog):
         self._do_db_builder_tab()
         self._do_steamcmd_tab()
         self._do_todds_tab()
+        self._do_themes_tab()
         self._do_advanced_tab()
 
         # Bottom buttons layout
@@ -686,6 +687,62 @@ class SettingsDialog(QDialog):
         )
         group_layout.addWidget(self.todds_overwrite_checkbox)
 
+    def _do_themes_tab(self) -> None:
+        tab = QWidget()
+        self.tab_widget.addTab(tab, "Theme")
+
+        tab_layout = QVBoxLayout(tab)
+        tab_layout.setAlignment(Qt.AlignmentFlag.AlignTop)
+
+        group_box = QGroupBox()
+        tab_layout.addWidget(group_box)
+
+        group_layout = QHBoxLayout()
+        group_box.setLayout(group_layout)
+        group_box.setFont(GUIInfo().emphasis_font)
+
+        self.enable_themes_checkbox = QCheckBox(
+            "Enable to use theme / stylesheet instead of system Theme"
+        )
+        self.enable_themes_checkbox.setToolTip(
+            "To add your own theme / stylesheet \n\n"
+            "1) Create a new-folder in 'themes' folder in your 'RimSort' config folder \n"
+            "2) Using the default 'RimPy' theme copy it to the folder you created \n"
+            "3) Edit the copied 'style.qss' as per your imagination \n"
+            "4) Start 'RimSort' and select your theme from dropdown \n"
+            "5) Click 'ok' to save settings and apply the selected theme \n\n"
+            "NOTE \n"
+            "Name of folder will be used as name of the theme and any invalid theme will be ignored \n"
+        )
+        group_layout.addWidget(self.enable_themes_checkbox)
+
+        self.themes_combobox = QComboBox()
+        self.themes_combobox.setSizePolicy(
+            QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred
+        )
+        group_layout.addWidget(self.themes_combobox)
+
+        self.theme_location_open_button = QToolButton()
+        self.theme_location_open_button.setText("Open Theme Location")
+        group_layout.addWidget(self.theme_location_open_button)
+
+        if self.enable_themes_checkbox.isChecked():
+            self.enable_themes_checkbox.stateChanged.connect(
+                self.connect_populate_themes_combobox
+            )
+        else:
+            self.themes_combobox.clear()
+
+    def connect_populate_themes_combobox(self) -> None:
+        """Populate the themes combobox with available themes."""
+        from app.controllers.theme_controller import ThemeController
+
+        if self.enable_themes_checkbox.isChecked():
+            theme_controller = ThemeController()
+            theme_controller.populate_themes_combobox
+        else:
+            self.themes_combobox.clear()
+
     def _do_advanced_tab(self) -> None:
         tab = QWidget()
         self.tab_widget.addTab(tab, "Advanced")
@@ -713,7 +770,9 @@ class SettingsDialog(QDialog):
         self.mod_type_filter_checkbox = QCheckBox("Enable mod type filter")
         group_layout.addWidget(self.mod_type_filter_checkbox)
 
-        self.hide_invalid_mods_when_filtering_checkbox = QCheckBox("Hide invalid mods when filtering")
+        self.hide_invalid_mods_when_filtering_checkbox = QCheckBox(
+            "Hide invalid mods when filtering"
+        )
         group_layout.addWidget(self.hide_invalid_mods_when_filtering_checkbox)
 
         self.show_duplicate_mods_warning_checkbox = QCheckBox(
@@ -843,6 +902,7 @@ class SettingsDialog(QDialog):
         if index and index != -1:
             self.tab_widget.setCurrentIndex(index)
 
-    def showEvent(self, event: QShowEvent) -> None:
-        super().showEvent(event)
+    def showEvent(self, arg__1: QShowEvent) -> None:
+        """Using arg__1 instead of event to avoid name conflict"""
+        super().showEvent(arg__1)
         self.global_ok_button.setFocus()

--- a/themes/Modern/style.qss
+++ b/themes/Modern/style.qss
@@ -1,0 +1,612 @@
+/* 
+Theme: Modern Theme
+- Primary Background: #101820
+- Secondary Background: #121c24
+- Tertiary Background: #1a2a34
+- Quaternary Background: #1f2e38
+- Primary Accent: #2b4a6f
+- Secondary Accent: #2d6aa3
+- Tertiary Accent: #2e3a4f
+- Quaternary Accent: #354a52
+- Primary Text: #3b4a64
+- Secondary Text: #4a5a7a
+- Tertiary Text: #55698b
+- White: #d6e0f3
+- Highlight: #888888
+- Subtext: #bfbfbf
+- Detail: #cdd0e1
+*/
+/* ======== General styling ======= */
+/* Styling for MultiButton */
+MultiButton QPushButton {
+    border-top-right-radius: 0px;
+    border-bottom-right-radius: 0px;
+}
+MultiButton QComboBox {
+    border-top-right-radius: 0px;
+    border-bottom-right-radius: 0px;
+    padding: 0px;
+}
+MultiButton QToolButton {
+    border-top-left-radius: 0px;
+    border-bottom-left-radius: 0px;
+    max-height: 1em;
+}
+MultiButton QToolButton::menu-indicator {
+    image: none;
+}
+/* Styling for combo boxes */
+QComboBox {
+    color: #d6e0f3;
+    background-color: #3b4a64;
+    border-style: solid;
+    border-width: 0px;
+    border-radius: 5px;
+    min-height: 1em;
+    min-width: 6em;
+    padding: 2px 4px;
+}
+QComboBox:hover {
+    background-color: #4a5a7a;
+}
+/* Padding effect for QComboBox */
+QComboBox#padInternal {
+    padding-left: 25px;
+}
+QComboBox::drop-down#MainUI {
+    width: 0;
+    height: 0;
+}
+QComboBox::drop-down#MissingModsUI {
+    border-style: solid;
+}
+QComboBox QAbstractItemView {
+    background-color: #4a5a7a;
+    color: #d6e0f3;
+    selection-background-color: #3b4a64;
+    selection-color: #d6e0f3;
+}
+/* Horizontal line for use as a spacer */
+QFrame#horizontalLine {
+    background-color: #d6e0f3;
+}
+/* Default input box style */
+QInputDialog{
+    background: #121c24;
+}
+/* TODO: Possibly redundant and can be deprecated */
+QInputDialog#dialogue{
+    background: #121c24;
+}
+/* Styling for labels */
+QLabel {
+    color: #d6e0f3;
+}
+/* Bold style header */
+QLabel#summaryHeader {
+    color: #d6e0f3;
+    font-weight: bold;
+}
+/* LoadingAnimation text label */
+QLabel#loadingAnimationString {
+    font-size: 18 px;
+}
+/* Metadata value labels + text */
+QLabel#summaryLabel {
+    color: #d6e0f3;
+    font-weight: 500;
+}
+QLabel#summaryValue {
+    color: #d6e0f3;
+}
+QLabel#summaryValueInvalid {
+    color: red;
+}
+/* Styling for line edit widgets */
+QLineEdit {
+    color: #bfbfbf;
+    background-color: #101820;
+    border-style: solid;
+    border-color: #3b4a64;
+    border-width: 1px;
+    border-radius: 3px;
+}
+QLineEdit:disabled {
+    color: #888888;
+    background-color: #1f2e38;
+}
+/* Styling for list widgets (mod list and rule editor lists) */
+QListWidget {
+    background-color: #101820;
+    border-style: solid;
+    border-color: #3b4a64;
+    border-width: 1px;
+    border-radius: 3px;
+    padding-right: 5px;
+}
+QListWidget::item {
+    border: 0px;
+    /* padding-right: 20px; */
+    margin-right: 12px;
+}
+
+/* Styling for a selected mod item */
+QListWidget::item:selected:!active {
+    background: #2e3a4f;
+}
+QListWidget::item:selected:active {
+    background: #4a5a7a;
+}
+QListWidget::item:hover {
+    background: #1f2e38;
+}
+/* Default context menu style */
+QMenu {
+    background-color: #101820;
+    border: 1px solid #3b4a64;
+    padding: 4px;
+}
+QMenu::item {
+    background-color: transparent;
+    color: #d6e0f3;
+    padding: 8px 16px;
+}
+QMenu::item:selected {
+    background-color: #4a5a7a;
+}
+QMenu::separator {
+    height: 1px;
+    background-color: #3b4a64;
+    margin: 4px 0;
+}
+QMenu::indicator {
+    width: 13px;
+    height: 13px;
+}
+QMenu::icon {
+    margin-right: 8px;
+}
+QMenu::item:disabled {
+    color: #888888;
+}
+QMenu::item:disabled:selected {
+    background-color: transparent;
+}
+QMenu::item:selected:disabled {
+    color: #888888;
+}
+QMenu::item:hover {
+    background-color: #2e3a4f;
+}
+QMenu::item:checked {
+    background-color: #4a5a7a;
+}
+QMenu::item:checked:selected {
+    background-color: #4a5a7a;
+}
+QMenu::item:checked:hover {
+    background-color: #2e3a4f;
+}
+
+/* Default Menu Bar styling. Note that this does not apply in MacOS */
+QMenuBar {
+    background-color: #101820;
+    color: #d6e0f3;
+    border-radius: 3px;
+}
+
+QMenuBar::item {
+    padding: 4px 8px;
+}
+
+QMenuBar::item:selected {
+    background-color: #2e3a4f;
+}
+
+QMenuBar::item:pressed {
+    background-color: #4a5a7a;
+}
+
+/* Default message box style */
+QMessageBox#dialogue{
+    background: #121c24;
+}
+QWidget#dialogue {
+    background: #121c24;
+}
+/* Styling for progress bars */
+QProgressBar {
+    border: 1px solid #3b4a64;
+    border-radius: 5px;
+    background-color: #101820;
+    color: #d6e0f3;
+    text-align: center;
+}
+QProgressBar::chunk#default {
+    background-color: #55698b;
+    width: 10px;
+}
+QProgressBar::chunk#warn {
+    background-color: yellow;
+}
+QProgressBar::chunk#critical {
+    background-color: orange;
+}
+QProgressBar::chunk#emergency {
+    background-color: red;
+}
+QProgressBar::chunk#warn {
+    background-color: green;
+}
+/* Styling for push buttons */
+QPushButton {
+    color: #d6e0f3;
+    background-color: #3b4a64;
+    border-style: solid;
+    border-width: 0px;
+    border-radius: 5px;
+    min-height: 1em;
+    min-width: 6em;
+    padding: 2px 4px;
+}
+
+QPushButton#indicator {
+    background-color: #4a5a7a;
+}
+QPushButton:hover {
+    background-color: #4a5a7a;
+}
+QPushButton:pressed {
+    background-color: #354a52;
+    border-style: inset;
+}
+QPushButton#LeftButton {
+    margin-right: 4px;
+}
+QPushButton#RightButton {
+    margin-left: 4px;
+}
+/* Default style for QTabWidget */
+QTabWidget {
+    background-color: #101820; /* Primary background */
+    border: 1px solid #3b4a64; /* Panel borders */
+}
+
+QTabWidget::pane {
+    border: 1px solid #3b4a64; /* Panel borders */
+    border-radius: 3px; /* Consistent with your other styles */
+    padding: 4px; /* Content padding inside the tabs */
+}
+
+QTabWidget::tab-bar {
+    alignment: center; /* Center-align the tabs */
+    background-color: #101820; /* Optional: Tab bar background color */
+}
+
+/* Styling for individual tab buttons */
+QTabBar::tab {
+    background-color: #3b4a64; /* Normal button color */
+    color: #d6e0f3; /* Text color */
+    border: 1px solid #3b4a64; /* Normal border color */
+    border-bottom-color: #101820; /* Border color for active tab */
+    border-top-left-radius: 3px; /* Consistent with your button styles */
+    border-top-right-radius: 3px; /* Consistent with your button styles */
+    min-width: 6em; /* Minimum width for tabs */
+    padding: 4px; /* Padding inside tabs */
+}
+
+QTabBar::tab:selected {
+    background-color: #4a5a7a; /* Button hover color for selected tab */
+    color: #d6e0f3;
+    border-bottom: 1px solid #101820; /* Hide bottom border for selected tab */
+}
+
+QTabBar::tab:!selected {
+    background-color: #2e3a4f; /* Different style for unselected tabs */
+    margin-top: 2px; /* Unselected tabs are slight lower than the selected one */
+}
+
+QTabBar::tab:!selected:hover {
+    background-color: #4a5a7a; /* Button hover color */
+}
+
+QTabBar::tab:disabled {
+    color: #888888; /* Text color for disabled tabs */
+}
+/* Default style for tooltips */
+QToolTip {
+    border-style: none;
+    background: #2b4a6f;
+    color: #d6e0f3;
+}
+/* Default style for vertical scrollbars */
+QScrollBar:vertical {
+    border: 1px solid #3b4a64;
+    border-radius: 5px;
+    background: #101820;
+    width: 10px;
+    margin: 20px 0px 20px 0px;
+}
+QScrollBar::handle:vertical {
+    background: #55698b;
+    border: 0px solid #3b4a64;
+    border-radius: 4px;
+    min-height: 10px;
+}
+QScrollBar::handle:vertical:hover {
+    background: #2b4a6f;
+}
+QScrollBar::add-line:vertical {
+    height: 10px;
+    background: #3b4a64;
+    subcontrol-position: bottom;
+    subcontrol-origin: margin;
+    margin-bottom: 5px;
+    border: 0px;
+    border-radius: 5px;
+}
+QScrollBar::add-line:vertical:hover {
+    background: #cdd0e1;
+}
+QScrollBar::sub-line:vertical {
+    height: 10px;
+    background: #3b4a64;
+    subcontrol-position: top;
+    subcontrol-origin: margin;
+    margin-top: 5px;
+    border-radius: 5px;
+}
+QScrollBar::sub-line:vertical:hover {
+    background: #cdd0e1;
+}
+QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical {
+    background: none;
+}
+QScrollBar:horizontal {
+    height: 0px;
+}
+/* Used in conjunction with proxy_style.py for drag-drop styling */
+QStyle::PE_IndicatorItemViewItemDrop {
+    color: #d6e0f3;
+}
+/* Style for table view with sortable columns */
+QHeaderView {
+    background-color: #3b4a64;
+    color: #d6e0f3;
+}
+QHeaderView::section {
+    background-color: #3b4a64;
+    color: #d6e0f3;
+    padding: 4px;
+    border-radius: 0px;
+}
+QHeaderView::section:horizontal:hover, 
+QHeaderView::section:vertical:hover {
+    background-color: #4a5a7a;
+}
+/* QTableView specific styling */
+QTableView {
+    gridline-color: #3b4a64;
+    background-color: #101820;
+    color: #d6e0f3;
+    alternate-background-color: #1a2a34;
+    selection-background-color: #4a5a7a;
+    selection-color: #d6e0f3;
+}
+/* Styling for table view cells */
+QTableView::item {
+    padding: 4px;
+    color: #d6e0f3;
+    gridline-color: #3b4a64;
+    background-color: #101820;
+}
+QTableView::item:hover {
+    background-color: #2e3a4f;
+}
+QTableView::item:disabled {
+    color: #888888;
+}
+QTableView::item:selected {
+    background-color: #4a5a7a;
+}
+/* Styling for table corner button */
+QTableView QTableCornerButton::section {
+    background-color: #3b4a64;
+    color: #d6e0f3;
+}
+QTableView QTableCornerButton::section:hover {
+    background-color: #4a5a7a;
+}
+QTableView::indicator {
+    width: 13px;
+    height: 13px;
+}
+QTableView::indicator:checked {
+    background: #2d6aa3;
+}
+QTableView::indicator:unchecked {
+    background: #3b4a64;
+}
+/* Styling for tool buttons */
+QToolButton {
+    background-color: #3b4a64;
+    border-style: solid;
+    border-width: 0px;
+    border-radius: 5px;
+    color: #d6e0f3;
+    padding: 1px;
+}
+QToolButton:hover {
+    background-color: #4a5a7a;
+}
+QToolButton:pressed {
+    background-color: #354a52;
+    border-style: inset;
+}
+QToolButton:disabled {
+    color: #888888;
+}
+
+/* ===== Browser (util/steam/browser.py) ===== */
+QWidget#browserPanel {
+    background-color: #101820;
+}
+QLabel#browserPaneldownloader_label {
+    color: #d6e0f3;
+}
+
+/* ======= MainWindow (view/main_content_panel.py) ======= */
+QMainWindow {
+    background-color: #101820;
+}
+QWidget#MainPanel {
+    border-style: solid;
+    border-color: #3b4a64;
+    border-width: 1px;
+    border-radius: 3px;
+    margin: 7px; /* Space between frame and app edge */
+}
+/* Styling for the mod item text */
+QLabel#ListItemLabel {
+    color: #d6e0f3;
+}
+QLabel#ListItemLabelFiltered { 
+    color: grey; 
+}
+QLabel#ListItemLabelInvalid {
+    color: red;
+}
+/* Styling for the errors summary frame */
+QWidget#errorFrame { /* Outer-most encapsulator */
+    background-color: #101820;
+    border-style: solid;
+    border-color: #3b4a64;
+    border-width: 1px;
+    border-radius: 3px;
+}
+
+/* ===== GameConfiguration (view/game_configuration_panel.py) ===== */
+QLabel#gameVersion {
+    color: #d6e0f3;
+    margin-right: 4px;
+}
+
+/* ===== Mod info panel (sub_view/mod_info_panel.py) ===== */
+/* Outer-most encapsulator */
+/* Contains QScrollArea for mod description */
+QWidget#descriptionWidget {
+    background-color: #101820;
+    border-style: solid;
+    border-color: #3b4a64;
+    border-width: 1px;
+    border-radius: 3px;
+    padding: 2px; /* The sharp corner of the text box clips out */
+    padding-right: 5px;
+    color: #d6e0f3;
+}
+/* Text, minus scroll bar */
+QWidget#descriptionContent { 
+    background-color: #101820;
+    padding-right: 10px; /* Make some distance between text and scroll bar */
+}
+/* Description text itself */
+QLabel#descriptionLabel { 
+    color: #d6e0f3;
+    background-color: #101820;
+    margin-right: 3px;
+}
+
+/* ===== Missing mods prompt (window/missing_mods_panel.py) ===== */
+QWidget#missingModsPanel{
+    background-color: #121c24;
+}
+/*
+QHeaderView#missingModPanelTableView {
+    background-color: #121c24;
+    color: #d6e0f3;
+}*/
+QComboBox#missing_mods_variant_cb{
+    background-color: #121c24;
+    color: #d6e0f3;
+    border-radius: 0;
+}
+
+/* ===== RuleEditor (window/rule_editor_panel.py) ===== */
+QWidget#RuleEditor {
+    border-style: solid;
+    border-color: #3b4a64;
+    border-width: 1px;
+    border-radius: 3px;
+    margin: 7px; /* Space between frame and app edge */
+    background-color: #101820;
+}
+
+/* ===== RunnerPanel (window/runner_panel.py) ===== */
+QWidget#RunnerPanel {
+    border-style: solid;
+    border-color: #3b4a64;
+    border-width: 1px;
+    border-radius: 3px;
+    margin: 7px; /* Space between frame and app edge */
+    background-color: #101820;
+}
+QPlainTextEdit#RunnerPanelText {
+    background-color: #1a2a34;
+    color: #d6e0f3;
+}
+
+/* ===== Settings (window/settings_panel.py) ===== */
+QDialog#settingsPanel {
+    background-color: #101820;
+}
+QCheckBox#summaryValue {
+    color: #d6e0f3;
+}
+QCheckBox {
+    padding: 2px;
+    color: #d6e0f3;
+}
+QCheckBox::indicator {
+    width: 13px;
+    height: 13px;
+    border: 1px solid #3b4a64;
+    border-radius: 3px;
+    background-color: #101820;
+}
+QCheckBox::indicator:checked {
+    background-color: #2d6aa3;
+}
+QCheckBox::indicator:unchecked {
+    background-color: #3b4a64;
+}
+QCheckBox::indicator:hover {
+    border: 1px solid #4a5a7a;
+}
+QRadioButton {
+    color: #d6e0f3;
+}
+
+QRadioButton::indicator {
+    width: 10px;
+    height: 10px;
+    border-radius: 8px;
+    border: 3px solid #3b4a64;
+}
+
+QRadioButton::indicator:checked {
+    background-color:#2d6aa3;
+}
+
+QRadioButton::indicator:unchecked {
+    background-color: #3b4a64;
+}
+
+
+/* ===== Status panel (bottom message bar) */
+QWidget#StatusPanel {
+    background-color: #3b4a64;
+}
+QLabel#StatusLabel {
+    color: #d6e0f3;
+    background-color: #3b4a64;
+}

--- a/themes/Nature/style.qss
+++ b/themes/Nature/style.qss
@@ -1,0 +1,612 @@
+/* 
+Theme: Nature Theme
+- Primary Background: #2e3d2f
+- Secondary Background: #3a4b3a
+- Tertiary Background: #4a5b4a
+- Quaternary Background: #5a6b5a
+- Primary Accent: #6b8e23
+- Secondary Accent: #8fbc8f
+- Tertiary Accent: #556b2f
+- Quaternary Accent: #2e8b57
+- Primary Text: #dcdcdc
+- Secondary Text: #c0c0c0
+- Tertiary Text: #a9a9a9
+- White: #ffffff
+- Highlight: #ffd700
+- Subtext: #f0e68c
+- Detail: #eee8aa
+*/
+/* ======== General styling ======= */
+/* Styling for MultiButton */
+MultiButton QPushButton {
+    border-top-right-radius: 0px;
+    border-bottom-right-radius: 0px;
+}
+MultiButton QComboBox {
+    border-top-right-radius: 0px;
+    border-bottom-right-radius: 0px;
+    padding: 0px;
+}
+MultiButton QToolButton {
+    border-top-left-radius: 0px;
+    border-bottom-left-radius: 0px;
+    max-height: 1em;
+}
+MultiButton QToolButton::menu-indicator {
+    image: none;
+}
+/* Styling for combo boxes */
+QComboBox {
+    color: #ffffff;
+    background-color: #4a5b4a;
+    border-style: solid;
+    border-width: 0px;
+    border-radius: 5px;
+    min-height: 1em;
+    min-width: 6em;
+    padding: 2px 4px;
+}
+QComboBox:hover {
+    background-color: #5a6b5a;
+}
+/* Padding effect for QComboBox */
+QComboBox#padInternal {
+    padding-left: 25px;
+}
+QComboBox::drop-down#MainUI {
+    width: 0;
+    height: 0;
+}
+QComboBox::drop-down#MissingModsUI {
+    border-style: solid;
+}
+QComboBox QAbstractItemView {
+    background-color: #5a6b5a;
+    color: #ffffff;
+    selection-background-color: #4a5b4a;
+    selection-color: #ffffff;
+}
+/* Horizontal line for use as a spacer */
+QFrame#horizontalLine {
+    background-color: #ffffff;
+}
+/* Default input box style */
+QInputDialog{
+    background: #3a4b3a;
+}
+/* TODO: Possibly redundant and can be deprecated */
+QInputDialog#dialogue{
+    background: #3a4b3a;
+}
+/* Styling for labels */
+QLabel {
+    color: #ffffff;
+}
+/* Bold style header */
+QLabel#summaryHeader {
+    color: #ffffff;
+    font-weight: bold;
+}
+/* LoadingAnimation text label */
+QLabel#loadingAnimationString {
+    font-size: 18 px;
+}
+/* Metadata value labels + text */
+QLabel#summaryLabel {
+    color: #ffffff;
+    font-weight: 500;
+}
+QLabel#summaryValue {
+    color: #ffffff;
+}
+QLabel#summaryValueInvalid {
+    color: red;
+}
+/* Styling for line edit widgets */
+QLineEdit {
+    color: #f0e68c;
+    background-color: #2e3d2f;
+    border-style: solid;
+    border-color: #4a5b4a;
+    border-width: 1px;
+    border-radius: 3px;
+}
+QLineEdit:disabled {
+    color: #a9a9a9;
+    background-color: #5a6b5a;
+}
+/* Styling for list widgets (mod list and rule editor lists) */
+QListWidget {
+    background-color: #2e3d2f;
+    border-style: solid;
+    border-color: #4a5b4a;
+    border-width: 1px;
+    border-radius: 3px;
+    padding-right: 5px;
+}
+QListWidget::item {
+    border: 0px;
+    /* padding-right: 20px; */
+    margin-right: 12px;
+}
+
+/* Styling for a selected mod item */
+QListWidget::item:selected:!active {
+    background: #556b2f;
+}
+QListWidget::item:selected:active {
+    background: #5a6b5a;
+}
+QListWidget::item:hover {
+    background: #3a4b3a;
+}
+/* Default context menu style */
+QMenu {
+    background-color: #2e3d2f;
+    border: 1px solid #4a5b4a;
+    padding: 4px;
+}
+QMenu::item {
+    background-color: transparent;
+    color: #ffffff;
+    padding: 8px 16px;
+}
+QMenu::item:selected {
+    background-color: #5a6b5a;
+}
+QMenu::separator {
+    height: 1px;
+    background-color: #4a5b4a;
+    margin: 4px 0;
+}
+QMenu::indicator {
+    width: 13px;
+    height: 13px;
+}
+QMenu::icon {
+    margin-right: 8px;
+}
+QMenu::item:disabled {
+    color: #a9a9a9;
+}
+QMenu::item:disabled:selected {
+    background-color: transparent;
+}
+QMenu::item:selected:disabled {
+    color: #a9a9a9;
+}
+QMenu::item:hover {
+    background-color: #556b2f;
+}
+QMenu::item:checked {
+    background-color: #5a6b5a;
+}
+QMenu::item:checked:selected {
+    background-color: #5a6b5a;
+}
+QMenu::item:checked:hover {
+    background-color: #556b2f;
+}
+
+/* Default Menu Bar styling. Note that this does not apply in MacOS */
+QMenuBar {
+    background-color: #2e3d2f;
+    color: #ffffff;
+    border-radius: 3px;
+}
+
+QMenuBar::item {
+    padding: 4px 8px;
+}
+
+QMenuBar::item:selected {
+    background-color: #556b2f;
+}
+
+QMenuBar::item:pressed {
+    background-color: #5a6b5a;
+}
+
+/* Default message box style */
+QMessageBox#dialogue{
+    background: #3a4b3a;
+}
+QWidget#dialogue {
+    background: #3a4b3a;
+}
+/* Styling for progress bars */
+QProgressBar {
+    border: 1px solid #4a5b4a;
+    border-radius: 5px;
+    background-color: #2e3d2f;
+    color: #ffffff;
+    text-align: center;
+}
+QProgressBar::chunk#default {
+    background-color: #8fbc8f;
+    width: 10px;
+}
+QProgressBar::chunk#warn {
+    background-color: yellow;
+}
+QProgressBar::chunk#critical {
+    background-color: orange;
+}
+QProgressBar::chunk#emergency {
+    background-color: red;
+}
+QProgressBar::chunk#warn {
+    background-color: green;
+}
+/* Styling for push buttons */
+QPushButton {
+    color: #ffffff;
+    background-color: #4a5b4a;
+    border-style: solid;
+    border-width: 0px;
+    border-radius: 5px;
+    min-height: 1em;
+    min-width: 6em;
+    padding: 2px 4px;
+}
+
+QPushButton#indicator {
+    background-color: #5a6b5a;
+}
+QPushButton:hover {
+    background-color: #5a6b5a;
+}
+QPushButton:pressed {
+    background-color: #2e8b57;
+    border-style: inset;
+}
+QPushButton#LeftButton {
+    margin-right: 4px;
+}
+QPushButton#RightButton {
+    margin-left: 4px;
+}
+/* Default style for QTabWidget */
+QTabWidget {
+    background-color: #2e3d2f; /* Primary background */
+    border: 1px solid #4a5b4a; /* Panel borders */
+}
+
+QTabWidget::pane {
+    border: 1px solid #4a5b4a; /* Panel borders */
+    border-radius: 3px; /* Consistent with your other styles */
+    padding: 4px; /* Content padding inside the tabs */
+}
+
+QTabWidget::tab-bar {
+    alignment: center; /* Center-align the tabs */
+    background-color: #2e3d2f; /* Optional: Tab bar background color */
+}
+
+/* Styling for individual tab buttons */
+QTabBar::tab {
+    background-color: #4a5b4a; /* Normal button color */
+    color: #ffffff; /* Text color */
+    border: 1px solid #4a5b4a; /* Normal border color */
+    border-bottom-color: #2e3d2f; /* Border color for active tab */
+    border-top-left-radius: 3px; /* Consistent with your button styles */
+    border-top-right-radius: 3px; /* Consistent with your button styles */
+    min-width: 6em; /* Minimum width for tabs */
+    padding: 4px; /* Padding inside tabs */
+}
+
+QTabBar::tab:selected {
+    background-color: #5a6b5a; /* Button hover color for selected tab */
+    color: #ffffff;
+    border-bottom: 1px solid #2e3d2f; /* Hide bottom border for selected tab */
+}
+
+QTabBar::tab:!selected {
+    background-color: #556b2f; /* Different style for unselected tabs */
+    margin-top: 2px; /* Unselected tabs are slight lower than the selected one */
+}
+
+QTabBar::tab:!selected:hover {
+    background-color: #5a6b5a; /* Button hover color */
+}
+
+QTabBar::tab:disabled {
+    color: #a9a9a9; /* Text color for disabled tabs */
+}
+/* Default style for tooltips */
+QToolTip {
+    border-style: none;
+    background: #6b8e23;
+    color: #ffffff;
+}
+/* Default style for vertical scrollbars */
+QScrollBar:vertical {
+    border: 1px solid #4a5b4a;
+    border-radius: 5px;
+    background: #2e3d2f;
+    width: 10px;
+    margin: 20px 0px 20px 0px;
+}
+QScrollBar::handle:vertical {
+    background: #8fbc8f;
+    border: 0px solid #4a5b4a;
+    border-radius: 4px;
+    min-height: 10px;
+}
+QScrollBar::handle:vertical:hover {
+    background: #6b8e23;
+}
+QScrollBar::add-line:vertical {
+    height: 10px;
+    background: #4a5b4a;
+    subcontrol-position: bottom;
+    subcontrol-origin: margin;
+    margin-bottom: 5px;
+    border: 0px;
+    border-radius: 5px;
+}
+QScrollBar::add-line:vertical:hover {
+    background: #eee8aa;
+}
+QScrollBar::sub-line:vertical {
+    height: 10px;
+    background: #4a5b4a;
+    subcontrol-position: top;
+    subcontrol-origin: margin;
+    margin-top: 5px;
+    border-radius: 5px;
+}
+QScrollBar::sub-line:vertical:hover {
+    background: #eee8aa;
+}
+QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical {
+    background: none;
+}
+QScrollBar:horizontal {
+    height: 0px;
+}
+/* Used in conjunction with proxy_style.py for drag-drop styling */
+QStyle::PE_IndicatorItemViewItemDrop {
+    color: #ffffff;
+}
+/* Style for table view with sortable columns */
+QHeaderView {
+    background-color: #4a5b4a;
+    color: #ffffff;
+}
+QHeaderView::section {
+    background-color: #4a5b4a;
+    color: #ffffff;
+    padding: 4px;
+    border-radius: 0px;
+}
+QHeaderView::section:horizontal:hover, 
+QHeaderView::section:vertical:hover {
+    background-color: #5a6b5a;
+}
+/* QTableView specific styling */
+QTableView {
+    gridline-color: #4a5b4a;
+    background-color: #2e3d2f;
+    color: #ffffff;
+    alternate-background-color: #3a4b3a;
+    selection-background-color: #5a6b5a;
+    selection-color: #ffffff;
+}
+/* Styling for table view cells */
+QTableView::item {
+    padding: 4px;
+    color: #ffffff;
+    gridline-color: #4a5b4a;
+    background-color: #2e3d2f;
+}
+QTableView::item:hover {
+    background-color: #556b2f;
+}
+QTableView::item:disabled {
+    color: #a9a9a9;
+}
+QTableView::item:selected {
+    background-color: #5a6b5a;
+}
+/* Styling for table corner button */
+QTableView QTableCornerButton::section {
+    background-color: #4a5b4a;
+    color: #ffffff;
+}
+QTableView QTableCornerButton::section:hover {
+    background-color: #5a6b5a;
+}
+QTableView::indicator {
+    width: 13px;
+    height: 13px;
+}
+QTableView::indicator:checked {
+    background: #2e8b57;
+}
+QTableView::indicator:unchecked {
+    background: #4a5b4a;
+}
+/* Styling for tool buttons */
+QToolButton {
+    background-color: #4a5b4a;
+    border-style: solid;
+    border-width: 0px;
+    border-radius: 5px;
+    color: #ffffff;
+    padding: 1px;
+}
+QToolButton:hover {
+    background-color: #5a6b5a;
+}
+QToolButton:pressed {
+    background-color: #2e8b57;
+    border-style: inset;
+}
+QToolButton:disabled {
+    color: #a9a9a9;
+}
+
+/* ===== Browser (util/steam/browser.py) ===== */
+QWidget#browserPanel {
+    background-color: #2e3d2f;
+}
+QLabel#browserPaneldownloader_label {
+    color: #ffffff;
+}
+
+/* ======= MainWindow (view/main_content_panel.py) ======= */
+QMainWindow {
+    background-color: #2e3d2f;
+}
+QWidget#MainPanel {
+    border-style: solid;
+    border-color: #4a5b4a;
+    border-width: 1px;
+    border-radius: 3px;
+    margin: 7px; /* Space between frame and app edge */
+}
+/* Styling for the mod item text */
+QLabel#ListItemLabel {
+    color: #ffffff;
+}
+QLabel#ListItemLabelFiltered { 
+    color: #c0c0c0; 
+}
+QLabel#ListItemLabelInvalid {
+    color: #e06c75;
+}
+/* Styling for the errors summary frame */
+QWidget#errorFrame { /* Outer-most encapsulator */
+    background-color: #2e3d2f;
+    border-style: solid;
+    border-color: #4a5b4a;
+    border-width: 1px;
+    border-radius: 3px;
+}
+
+/* ===== GameConfiguration (view/game_configuration_panel.py) ===== */
+QLabel#gameVersion {
+    color: #ffffff;
+    margin-right: 4px;
+}
+
+/* ===== Mod info panel (sub_view/mod_info_panel.py) ===== */
+/* Outer-most encapsulator */
+/* Contains QScrollArea for mod description */
+QWidget#descriptionWidget {
+    background-color: #2e3d2f;
+    border-style: solid;
+    border-color: #4a5b4a;
+    border-width: 1px;
+    border-radius: 3px;
+    padding: 2px; /* The sharp corner of the text box clips out */
+    padding-right: 5px;
+    color: #ffffff;
+}
+/* Text, minus scroll bar */
+QWidget#descriptionContent { 
+    background-color: #2e3d2f;
+    padding-right: 10px; /* Make some distance between text and scroll bar */
+}
+/* Description text itself */
+QLabel#descriptionLabel { 
+    color: #ffffff;
+    background-color: #2e3d2f;
+    margin-right: 3px;
+}
+
+/* ===== Missing mods prompt (window/missing_mods_panel.py) ===== */
+QWidget#missingModsPanel{
+    background-color: #3a4b3a;
+}
+/*
+QHeaderView#missingModPanelTableView {
+    background-color: #1B2838;
+    color: #e6edf3;
+}*/
+QComboBox#missing_mods_variant_cb{
+    background-color: #3a4b3a;
+    color: #ffffff;
+    border-radius: 0;
+}
+
+/* ===== RuleEditor (window/rule_editor_panel.py) ===== */
+QWidget#RuleEditor {
+    border-style: solid;
+    border-color: #4a5b4a;
+    border-width: 1px;
+    border-radius: 3px;
+    margin: 7px; /* Space between frame and app edge */
+    background-color: #2e3d2f;
+}
+
+/* ===== RunnerPanel (window/runner_panel.py) ===== */
+QWidget#RunnerPanel {
+    border-style: solid;
+    border-color: #4a5b4a;
+    border-width: 1px;
+    border-radius: 3px;
+    margin: 7px; /* Space between frame and app edge */
+    background-color: #2e3d2f;
+}
+QPlainTextEdit#RunnerPanelText {
+    background-color: #4a5b4a;
+    color: #ffffff;
+}
+
+/* ===== Settings (window/settings_panel.py) ===== */
+QDialog#settingsPanel {
+    background-color: #2e3d2f;
+}
+QCheckBox#summaryValue {
+    color: #ffffff;
+}
+QCheckBox {
+    padding: 2px;
+    color: #ffffff;
+}
+QCheckBox::indicator {
+    width: 13px;
+    height: 13px;
+    border: 1px solid #4a5b4a;
+    border-radius: 3px;
+    background-color: #2e3d2f;
+}
+QCheckBox::indicator:checked {
+    background-color: #8fbc8f;
+}
+QCheckBox::indicator:unchecked {
+    background-color: #4a5b4a;
+}
+QCheckBox::indicator:hover {
+    border: 1px solid #5a6b5a;
+}
+QRadioButton {
+    color: #ffffff;
+}
+
+QRadioButton::indicator {
+    width: 10px;
+    height: 10px;
+    border-radius: 8px;
+    border: 3px solid #4a5b4a;
+}
+
+QRadioButton::indicator:checked {
+    background-color:#8fbc8f;
+}
+
+QRadioButton::indicator:unchecked {
+    background-color: #4a5b4a;
+}
+
+
+/* ===== Status panel (bottom message bar) */
+QWidget#StatusPanel {
+    background-color: #4a5b4a;
+}
+QLabel#StatusLabel {
+    color: #ffffff;
+    background-color: #4a5b4a;
+}

--- a/themes/SunSet/style.qss
+++ b/themes/SunSet/style.qss
@@ -1,0 +1,612 @@
+/* 
+Theme: SunSet Theme
+- Primary Background: #2e1a1a
+- Secondary Background: #3a2a2a
+- Tertiary Background: #4a3a3a
+- Quaternary Background: #5a4a4a
+- Primary Accent: #ff4500
+- Secondary Accent: #ff6347
+- Tertiary Accent: #ff7f50
+- Quaternary Accent: #ffa07a
+- Primary Text: #ffd700
+- Secondary Text: #ffa500
+- Tertiary Text: #ff8c00
+- White: #ffffff
+- Highlight: #ffdab9
+- Subtext: #ffe4b5
+- Detail: #ffebcd
+*/
+/* ======== General styling ======= */
+/* Styling for MultiButton */
+MultiButton QPushButton {
+    border-top-right-radius: 0px;
+    border-bottom-right-radius: 0px;
+}
+MultiButton QComboBox {
+    border-top-right-radius: 0px;
+    border-bottom-right-radius: 0px;
+    padding: 0px;
+}
+MultiButton QToolButton {
+    border-top-left-radius: 0px;
+    border-bottom-left-radius: 0px;
+    max-height: 1em;
+}
+MultiButton QToolButton::menu-indicator {
+    image: none;
+}
+/* Styling for combo boxes */
+QComboBox {
+    color: #ffffff;
+    background-color: #4a3a3a;
+    border-style: solid;
+    border-width: 0px;
+    border-radius: 5px;
+    min-height: 1em;
+    min-width: 6em;
+    padding: 2px 4px;
+}
+QComboBox:hover {
+    background-color: #5a4a4a;
+}
+/* Padding effect for QComboBox */
+QComboBox#padInternal {
+    padding-left: 25px;
+}
+QComboBox::drop-down#MainUI {
+    width: 0;
+    height: 0;
+}
+QComboBox::drop-down#MissingModsUI {
+    border-style: solid;
+}
+QComboBox QAbstractItemView {
+    background-color: #5a4a4a;
+    color: #ffffff;
+    selection-background-color: #4a3a3a;
+    selection-color: #ffffff;
+}
+/* Horizontal line for use as a spacer */
+QFrame#horizontalLine {
+    background-color: #ffffff;
+}
+/* Default input box style */
+QInputDialog{
+    background: #3a2a2a;
+}
+/* TODO: Possibly redundant and can be deprecated */
+QInputDialog#dialogue{
+    background: #3a2a2a;
+}
+/* Styling for labels */
+QLabel {
+    color: #ffffff;
+}
+/* Bold style header */
+QLabel#summaryHeader {
+    color: #ffffff;
+    font-weight: bold;
+}
+/* LoadingAnimation text label */
+QLabel#loadingAnimationString {
+    font-size: 18 px;
+}
+/* Metadata value labels + text */
+QLabel#summaryLabel {
+    color: #ffffff;
+    font-weight: 500;
+}
+QLabel#summaryValue {
+    color: #ffffff;
+}
+QLabel#summaryValueInvalid {
+    color: red;
+}
+/* Styling for line edit widgets */
+QLineEdit {
+    color: #ffe4b5;
+    background-color: #2e1a1a;
+    border-style: solid;
+    border-color: #4a3a3a;
+    border-width: 1px;
+    border-radius: 3px;
+}
+QLineEdit:disabled {
+    color: #ff8c00;
+    background-color: #5a4a4a;
+}
+/* Styling for list widgets (mod list and rule editor lists) */
+QListWidget {
+    background-color: #2e1a1a;
+    border-style: solid;
+    border-color: #4a3a3a;
+    border-width: 1px;
+    border-radius: 3px;
+    padding-right: 5px;
+}
+QListWidget::item {
+    border: 0px;
+    /* padding-right: 20px; */
+    margin-right: 12px;
+}
+
+/* Styling for a selected mod item */
+QListWidget::item:selected:!active {
+    background: #ff7f50;
+}
+QListWidget::item:selected:active {
+    background: #5a4a4a;
+}
+QListWidget::item:hover {
+    background: #3a2a2a;
+}
+/* Default context menu style */
+QMenu {
+    background-color: #2e1a1a;
+    border: 1px solid #4a3a3a;
+    padding: 4px;
+}
+QMenu::item {
+    background-color: transparent;
+    color: #ffffff;
+    padding: 8px 16px;
+}
+QMenu::item:selected {
+    background-color: #5a4a4a;
+}
+QMenu::separator {
+    height: 1px;
+    background-color: #4a3a3a;
+    margin: 4px 0;
+}
+QMenu::indicator {
+    width: 13px;
+    height: 13px;
+}
+QMenu::icon {
+    margin-right: 8px;
+}
+QMenu::item:disabled {
+    color: #ff8c00;
+}
+QMenu::item:disabled:selected {
+    background-color: transparent;
+}
+QMenu::item:selected:disabled {
+    color: #ff8c00;
+}
+QMenu::item:hover {
+    background-color: #ff7f50;
+}
+QMenu::item:checked {
+    background-color: #5a4a4a;
+}
+QMenu::item:checked:selected {
+    background-color: #5a4a4a;
+}
+QMenu::item:checked:hover {
+    background-color: #ff7f50;
+}
+
+/* Default Menu Bar styling. Note that this does not apply in MacOS */
+QMenuBar {
+    background-color: #2e1a1a;
+    color: #ffffff;
+    border-radius: 3px;
+}
+
+QMenuBar::item {
+    padding: 4px 8px;
+}
+
+QMenuBar::item:selected {
+    background-color: #ff7f50;
+}
+
+QMenuBar::item:pressed {
+    background-color: #5a4a4a;
+}
+
+/* Default message box style */
+QMessageBox#dialogue{
+    background: #3a2a2a;
+}
+QWidget#dialogue {
+    background: #3a2a2a;
+}
+/* Styling for progress bars */
+QProgressBar {
+    border: 1px solid #4a3a3a;
+    border-radius: 5px;
+    background-color: #2e1a1a;
+    color: #ffffff;
+    text-align: center;
+}
+QProgressBar::chunk#default {
+    background-color: #ff6347;
+    width: 10px;
+}
+QProgressBar::chunk#warn {
+    background-color: yellow;
+}
+QProgressBar::chunk#critical {
+    background-color: orange;
+}
+QProgressBar::chunk#emergency {
+    background-color: red;
+}
+QProgressBar::chunk#warn {
+    background-color: green;
+}
+/* Styling for push buttons */
+QPushButton {
+    color: #ffffff;
+    background-color: #4a3a3a;
+    border-style: solid;
+    border-width: 0px;
+    border-radius: 5px;
+    min-height: 1em;
+    min-width: 6em;
+    padding: 2px 4px;
+}
+
+QPushButton#indicator {
+    background-color: #5a4a4a;
+}
+QPushButton:hover {
+    background-color: #5a4a4a;
+}
+QPushButton:pressed {
+    background-color: #ffa07a;
+    border-style: inset;
+}
+QPushButton#LeftButton {
+    margin-right: 4px;
+}
+QPushButton#RightButton {
+    margin-left: 4px;
+}
+/* Default style for QTabWidget */
+QTabWidget {
+    background-color: #2e1a1a; /* Primary background */
+    border: 1px solid #4a3a3a; /* Panel borders */
+}
+
+QTabWidget::pane {
+    border: 1px solid #4a3a3a; /* Panel borders */
+    border-radius: 3px; /* Consistent with your other styles */
+    padding: 4px; /* Content padding inside the tabs */
+}
+
+QTabWidget::tab-bar {
+    alignment: center; /* Center-align the tabs */
+    background-color: #2e1a1a; /* Optional: Tab bar background color */
+}
+
+/* Styling for individual tab buttons */
+QTabBar::tab {
+    background-color: #4a3a3a; /* Normal button color */
+    color: #ffffff; /* Text color */
+    border: 1px solid #4a3a3a; /* Normal border color */
+    border-bottom-color: #2e1a1a; /* Border color for active tab */
+    border-top-left-radius: 3px; /* Consistent with your button styles */
+    border-top-right-radius: 3px; /* Consistent with your button styles */
+    min-width: 6em; /* Minimum width for tabs */
+    padding: 4px; /* Padding inside tabs */
+}
+
+QTabBar::tab:selected {
+    background-color: #5a4a4a; /* Button hover color for selected tab */
+    color: #ffffff;
+    border-bottom: 1px solid #2e1a1a; /* Hide bottom border for selected tab */
+}
+
+QTabBar::tab:!selected {
+    background-color: #ff7f50; /* Different style for unselected tabs */
+    margin-top: 2px; /* Unselected tabs are slight lower than the selected one */
+}
+
+QTabBar::tab:!selected:hover {
+    background-color: #5a4a4a; /* Button hover color */
+}
+
+QTabBar::tab:disabled {
+    color: #ff8c00; /* Text color for disabled tabs */
+}
+/* Default style for tooltips */
+QToolTip {
+    border-style: none;
+    background: #ff4500;
+    color: #ffffff;
+}
+/* Default style for vertical scrollbars */
+QScrollBar:vertical {
+    border: 1px solid #4a3a3a;
+    border-radius: 5px;
+    background: #2e1a1a;
+    width: 10px;
+    margin: 20px 0px 20px 0px;
+}
+QScrollBar::handle:vertical {
+    background: #ff6347;
+    border: 0px solid #4a3a3a;
+    border-radius: 4px;
+    min-height: 10px;
+}
+QScrollBar::handle:vertical:hover {
+    background: #ff4500;
+}
+QScrollBar::add-line:vertical {
+    height: 10px;
+    background: #4a3a3a;
+    subcontrol-position: bottom;
+    subcontrol-origin: margin;
+    margin-bottom: 5px;
+    border: 0px;
+    border-radius: 5px;
+}
+QScrollBar::add-line:vertical:hover {
+    background: #ffebcd;
+}
+QScrollBar::sub-line:vertical {
+    height: 10px;
+    background: #4a3a3a;
+    subcontrol-position: top;
+    subcontrol-origin: margin;
+    margin-top: 5px;
+    border-radius: 5px;
+}
+QScrollBar::sub-line:vertical:hover {
+    background: #ffebcd;
+}
+QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical {
+    background: none;
+}
+QScrollBar:horizontal {
+    height: 0px;
+}
+/* Used in conjunction with proxy_style.py for drag-drop styling */
+QStyle::PE_IndicatorItemViewItemDrop {
+    color: #ffffff;
+}
+/* Style for table view with sortable columns */
+QHeaderView {
+    background-color: #4a3a3a;
+    color: #ffffff;
+}
+QHeaderView::section {
+    background-color: #4a3a3a;
+    color: #ffffff;
+    padding: 4px;
+    border-radius: 0px;
+}
+QHeaderView::section:horizontal:hover, 
+QHeaderView::section:vertical:hover {
+    background-color: #5a4a4a;
+}
+/* QTableView specific styling */
+QTableView {
+    gridline-color: #4a3a3a;
+    background-color: #2e1a1a;
+    color: #ffffff;
+    alternate-background-color: #3a2a2a;
+    selection-background-color: #5a4a4a;
+    selection-color: #ffffff;
+}
+/* Styling for table view cells */
+QTableView::item {
+    padding: 4px;
+    color: #ffffff;
+    gridline-color: #4a3a3a;
+    background-color: #2e1a1a;
+}
+QTableView::item:hover {
+    background-color: #ff7f50;
+}
+QTableView::item:disabled {
+    color: #ff8c00;
+}
+QTableView::item:selected {
+    background-color: #5a4a4a;
+}
+/* Styling for table corner button */
+QTableView QTableCornerButton::section {
+    background-color: #4a3a3a;
+    color: #ffffff;
+}
+QTableView QTableCornerButton::section:hover {
+    background-color: #5a4a4a;
+}
+QTableView::indicator {
+    width: 13px;
+    height: 13px;
+}
+QTableView::indicator:checked {
+    background: #ff6347;
+}
+QTableView::indicator:unchecked {
+    background: #4a3a3a;
+}
+/* Styling for tool buttons */
+QToolButton {
+    background-color: #4a3a3a;
+    border-style: solid;
+    border-width: 0px;
+    border-radius: 5px;
+    color: #ffffff;
+    padding: 1px;
+}
+QToolButton:hover {
+    background-color: #5a4a4a;
+}
+QToolButton:pressed {
+    background-color: #ffa07a;
+    border-style: inset;
+}
+QToolButton:disabled {
+    color: #ff8c00;
+}
+
+/* ===== Browser (util/steam/browser.py) ===== */
+QWidget#browserPanel {
+    background-color: #2e1a1a;
+}
+QLabel#browserPaneldownloader_label {
+    color: #ffffff;
+}
+
+/* ======= MainWindow (view/main_content_panel.py) ======= */
+QMainWindow {
+    background-color: #2e1a1a;
+}
+QWidget#MainPanel {
+    border-style: solid;
+    border-color: #4a3a3a;
+    border-width: 1px;
+    border-radius: 3px;
+    margin: 7px; /* Space between frame and app edge */
+}
+/* Styling for the mod item text */
+QLabel#ListItemLabel {
+    color: #ffffff;
+}
+QLabel#ListItemLabelFiltered { 
+    color: #ffa500; 
+}
+QLabel#ListItemLabelInvalid {
+    color: #ff4500;
+}
+/* Styling for the errors summary frame */
+QWidget#errorFrame { /* Outer-most encapsulator */
+    background-color: #2e1a1a;
+    border-style: solid;
+    border-color: #4a3a3a;
+    border-width: 1px;
+    border-radius: 3px;
+}
+
+/* ===== GameConfiguration (view/game_configuration_panel.py) ===== */
+QLabel#gameVersion {
+    color: #ffffff;
+    margin-right: 4px;
+}
+
+/* ===== Mod info panel (sub_view/mod_info_panel.py) ===== */
+/* Outer-most encapsulator */
+/* Contains QScrollArea for mod description */
+QWidget#descriptionWidget {
+    background-color: #2e1a1a;
+    border-style: solid;
+    border-color: #4a3a3a;
+    border-width: 1px;
+    border-radius: 3px;
+    padding: 2px; /* The sharp corner of the text box clips out */
+    padding-right: 5px;
+    color: #ffffff;
+}
+/* Text, minus scroll bar */
+QWidget#descriptionContent { 
+    background-color: #2e1a1a;
+    padding-right: 10px; /* Make some distance between text and scroll bar */
+}
+/* Description text itself */
+QLabel#descriptionLabel { 
+    color: #ffffff;
+    background-color: #2e1a1a;
+    margin-right: 3px;
+}
+
+/* ===== Missing mods prompt (window/missing_mods_panel.py) ===== */
+QWidget#missingModsPanel{
+    background-color: #3a2a2a;
+}
+/*
+QHeaderView#missingModPanelTableView {
+    background-color: #3a2a2a;
+    color: #ffffff;
+}*/
+QComboBox#missing_mods_variant_cb{
+    background-color: #3a2a2a;
+    color: #ffffff;
+    border-radius: 0;
+}
+
+/* ===== RuleEditor (window/rule_editor_panel.py) ===== */
+QWidget#RuleEditor {
+    border-style: solid;
+    border-color: #4a3a3a;
+    border-width: 1px;
+    border-radius: 3px;
+    margin: 7px; /* Space between frame and app edge */
+    background-color: #2e1a1a;
+}
+
+/* ===== RunnerPanel (window/runner_panel.py) ===== */
+QWidget#RunnerPanel {
+    border-style: solid;
+    border-color: #4a3a3a;
+    border-width: 1px;
+    border-radius: 3px;
+    margin: 7px; /* Space between frame and app edge */
+    background-color: #2e1a1a;
+}
+QPlainTextEdit#RunnerPanelText {
+    background-color: #4a3a3a;
+    color: #ffffff;
+}
+
+/* ===== Settings (window/settings_panel.py) ===== */
+QDialog#settingsPanel {
+    background-color: #2e1a1a;
+}
+QCheckBox#summaryValue {
+    color: #ffffff;
+}
+QCheckBox {
+    padding: 2px;
+    color: #ffffff;
+}
+QCheckBox::indicator {
+    width: 13px;
+    height: 13px;
+    border: 1px solid #4a3a3a;
+    border-radius: 3px;
+    background-color: #2e1a1a;
+}
+QCheckBox::indicator:checked {
+    background-color: #ff6347;
+}
+QCheckBox::indicator:unchecked {
+    background-color: #4a3a3a;
+}
+QCheckBox::indicator:hover {
+    border: 1px solid #5a4a4a;
+}
+QRadioButton {
+    color: #ffffff;
+}
+
+QRadioButton::indicator {
+    width: 10px;
+    height: 10px;
+    border-radius: 8px;
+    border: 3px solid #4a3a3a;
+}
+
+QRadioButton::indicator:checked {
+    background-color:#ff6347;
+}
+
+QRadioButton::indicator:unchecked {
+    background-color: #4a3a3a;
+}
+
+
+/* ===== Status panel (bottom message bar) */
+QWidget#StatusPanel {
+    background-color: #4a3a3a;
+}
+QLabel#StatusLabel {
+    color: #ffffff;
+    background-color: #4a3a3a;
+}

--- a/themes/Wood/style.qss
+++ b/themes/Wood/style.qss
@@ -1,0 +1,606 @@
+/* 
+Theme: Wood Theme
+- Primary Background: #3b2f2f
+- Secondary Background: #4a3a3a
+- Tertiary Background: #5a4a4a
+- Quaternary Background: #6a5a5a
+- Primary Accent: #8b4513
+- Secondary Accent: #a0522d
+- Tertiary Accent: #d2691e
+- Quaternary Accent: #cd853f
+- Primary Text: #deb887
+- Secondary Text: #f4a460
+- Tertiary Text: #d2b48c
+- White: #ffffff
+- Highlight: #ffdead
+- Subtext: #ffe4c4
+- Detail: #ffebcd
+*/
+/* ======== General styling ======= */
+/* Styling for MultiButton */
+MultiButton QPushButton {
+    border-top-right-radius: 0px;
+    border-bottom-right-radius: 0px;
+}
+MultiButton QComboBox {
+    border-top-right-radius: 0px;
+    border-bottom-right-radius: 0px;
+    padding: 0px;
+}
+MultiButton QToolButton {
+    border-top-left-radius: 0px;
+    border-bottom-left-radius: 0px;
+    max-height: 1em;
+}
+MultiButton QToolButton::menu-indicator {
+    image: none;
+}
+/* Styling for combo boxes */
+QComboBox {
+    color: #ffffff;
+    background-color: #5a4a4a;
+    border-style: solid;
+    border-width: 0px;
+    border-radius: 5px;
+    min-height: 1em;
+    min-width: 6em;
+    padding: 2px 4px;
+}
+QComboBox:hover {
+    background-color: #6a5a5a;
+}
+/* Padding effect for QComboBox */
+QComboBox#padInternal {
+    padding-left: 25px;
+}
+QComboBox::drop-down#MainUI {
+    width: 0;
+    height: 0;
+}
+QComboBox::drop-down#MissingModsUI {
+    border-style: solid;
+}
+QComboBox QAbstractItemView {
+    background-color: #6a5a5a;
+    color: #ffffff;
+    selection-background-color: #5a4a4a;
+    selection-color: #ffffff;
+}
+/* Horizontal line for use as a spacer */
+QFrame#horizontalLine {
+    background-color: #ffffff;
+}
+/* Default input box style */
+QInputDialog{
+    background: #ffe4b5;
+}
+/* TODO: Possibly redundant and can be deprecated */
+QInputDialog#dialogue{
+    background: #ffe4b5;
+}
+/* Styling for labels */
+QLabel {
+    color: #ffffff;
+}
+/* Bold style header */
+QLabel#summaryHeader {
+    color: #ffffff;
+    font-weight: bold;
+}
+/* LoadingAnimation text label */
+QLabel#loadingAnimationString {
+    font-size: 18 px;
+}
+/* Metadata value labels + text */
+QLabel#summaryLabel {
+    color: #ffffff;
+    font-weight: 500;
+}
+QLabel#summaryValue {
+    color: #ffffff;
+}
+QLabel#summaryValueInvalid {
+    color: red;
+}
+/* Styling for line edit widgets */
+QLineEdit {
+    color: #ffe4c4;
+    background-color: #3b2f2f;
+    border-style: solid;
+    border-color: #5a4a4a;
+    border-width: 1px;
+    border-radius: 3px;
+}
+QLineEdit:disabled {
+    color: #d2b48c;
+    background-color: #6a5a5a;
+}
+/* Styling for list widgets (mod list and rule editor lists) */
+QListWidget {
+    background-color: #3b2f2f;
+    border-style: solid;
+    border-color: #5a4a4a;
+    border-width: 1px;
+    border-radius: 3px;
+    padding-right: 5px;
+}
+QListWidget::item {
+    border: 0px;
+    /* padding-right: 20px; */
+    margin-right: 12px;
+}
+
+/* Styling for a selected mod item */
+QListWidget::item:selected:!active {
+    background: #d2691e;
+}
+QListWidget::item:selected:active {
+    background: #6a5a5a;
+}
+QListWidget::item:hover {
+    background: #4a3a3a;
+}
+/* Default context menu style */
+QMenu {
+    background-color: #3b2f2f;
+    border: 1px solid #5a4a4a;
+    padding: 4px;
+}
+QMenu::item {
+    background-color: transparent;
+    color: #ffffff;
+    padding: 8px 16px;
+}
+QMenu::item:selected {
+    background-color: #6a5a5a;
+}
+QMenu::separator {
+    height: 1px;
+    background-color: #5a4a4a;
+    margin: 4px 0;
+}
+QMenu::indicator {
+    width: 13px;
+    height: 13px;
+}
+QMenu::icon {
+    margin-right: 8px;
+}
+QMenu::item:disabled {
+    color: #d2b48c;
+}
+QMenu::item:disabled:selected {
+    background-color: transparent;
+}
+QMenu::item:selected:disabled {
+    color: #d2b48c;
+}
+QMenu::item:hover {
+    background-color: #d2691e;
+}
+QMenu::item:checked {
+    background-color: #6a5a5a;
+}
+QMenu::item:checked:selected {
+    background-color: #6a5a5a;
+}
+QMenu::item:checked:hover {
+    background-color: #d2691e;
+}
+
+/* Default Menu Bar styling. Note that this does not apply in MacOS */
+QMenuBar {
+    background-color: #3b2f2f;
+    color: #ffffff;
+    border-radius: 3px;
+}
+
+QMenuBar::item {
+    padding: 4px 8px;
+}
+
+QMenuBar::item:selected {
+    background-color: #d2691e;
+}
+
+QMenuBar::item:pressed {
+    background-color: #6a5a5a;
+}
+
+/* Default message box style */
+QMessageBox#dialogue{
+    background: #ffe4b5;
+}
+QWidget#dialogue {
+    background: #ffe4b5;
+}
+/* Styling for progress bars */
+QProgressBar {
+    border: 1px solid #5a4a4a;
+    border-radius: 5px;
+    background-color: #3b2f2f;
+    color: #ffffff;
+    text-align: center;
+}
+QProgressBar::chunk#default {
+    background-color: #a0522d;
+    width: 10px;
+}
+QProgressBar::chunk#warn {
+    background-color: yellow;
+}
+QProgressBar::chunk#critical {
+    background-color: orange;
+}
+QProgressBar::chunk#emergency {
+    background-color: red;
+}
+QProgressBar::chunk#warn {
+    background-color: green;
+}
+/* Styling for push buttons */
+QPushButton {
+    color: #ffffff;
+    background-color: #5a4a4a;
+    border-style: solid;
+    border-width: 0px;
+    border-radius: 5px;
+    min-height: 1em;
+    min-width: 6em;
+    padding: 2px 4px;
+}
+
+QPushButton#indicator {
+    background-color: #6a5a5a;
+}
+QPushButton:hover {
+    background-color: #6a5a5a;
+}
+QPushButton:pressed {
+    background-color: #cd853f;
+    border-style: inset;
+}
+QPushButton#LeftButton {
+    margin-right: 4px;
+}
+QPushButton#RightButton {
+    margin-left: 4px;
+}
+/* Default style for QTabWidget */
+QTabWidget {
+    background-color: #3b2f2f; /* Primary background */
+    border: 1px solid #5a4a4a; /* Panel borders */
+}
+
+QTabWidget::pane {
+    border: 1px solid #5a4a4a; /* Panel borders */
+    border-radius: 3px; /* Consistent with your other styles */
+    padding: 4px; /* Content padding inside the tabs */
+}
+
+QTabWidget::tab-bar {
+    alignment: center; /* Center-align the tabs */
+    background-color: #3b2f2f; /* Optional: Tab bar background color */
+}
+
+/* Styling for individual tab buttons */
+QTabBar::tab {
+    background-color: #5a4a4a; /* Normal button color */
+    color: #ffffff; /* Text color */
+    border: 1px solid #5a4a4a; /* Normal border color */
+    border-bottom-color: #3b2f2f; /* Border color for active tab */
+    border-top-left-radius: 3px; /* Consistent with your button styles */
+    border-top-right-radius: 3px; /* Consistent with your button styles */
+    min-width: 6em; /* Minimum width for tabs */
+    padding: 4px; /* Padding inside tabs */
+}
+
+QTabBar::tab:selected {
+    background-color: #6a5a5a; /* Button hover color for selected tab */
+    color: #ffffff;
+    border-bottom: 1px solid #3b2f2f; /* Hide bottom border for selected tab */
+}
+
+QTabBar::tab:!selected {
+    background-color: #d2691e; /* Different style for unselected tabs */
+    margin-top: 2px; /* Unselected tabs are slight lower than the selected one */
+}
+
+QTabBar::tab:!selected:hover {
+    background-color: #6a5a5a; /* Button hover color */
+}
+
+QTabBar::tab:disabled {
+    color: #d2b48c; /* Text color for disabled tabs */
+}
+/* Default style for tooltips */
+QToolTip {
+    border-style: none;
+    background: #8b4513;
+    color: #ffffff;
+}
+/* Default style for vertical scrollbars */
+QScrollBar:vertical {
+    border: 1px solid #5a4a4a;
+    border-radius: 5px;
+    background: #3b2f2f;
+    width: 10px;
+    margin: 20px 0px 20px 0px;
+}
+QScrollBar::handle:vertical {
+    background: #a0522d;
+    border: 0px solid #5a4a4a;
+    border-radius: 4px;
+    min-height: 10px;
+}
+QScrollBar::handle:vertical:hover {
+    background: #8b4513;
+}
+QScrollBar::add-line:vertical {
+    height: 10px;
+    background: #5a4a4a;
+    subcontrol-position: bottom;
+    subcontrol-origin: margin;
+    margin-bottom: 5px;
+    border: 0px;
+    border-radius: 5px;
+}
+QScrollBar::add-line:vertical:hover {
+    background: #ffebcd;
+}
+QScrollBar::sub-line:vertical {
+    height: 10px;
+    background: #5a4a4a;
+    subcontrol-position: top;
+    subcontrol-origin: margin;
+    margin-top: 5px;
+    border-radius: 5px;
+}
+QScrollBar::sub-line:vertical:hover {
+    background: #ffebcd;
+}
+QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical {
+    background: none;
+}
+QScrollBar:horizontal {
+    height: 0px;
+}
+/* Used in conjunction with proxy_style.py for drag-drop styling */
+QStyle::PE_IndicatorItemViewItemDrop {
+    color: #ffffff;
+}
+/* Style for table view with sortable columns */
+QHeaderView {
+    background-color: #5a4a4a;
+    color: #ffffff;
+}
+QHeaderView::section {
+    background-color: #5a4a4a;
+    color: #ffffff;
+    padding: 4px;
+    border-radius: 0px;
+}
+QHeaderView::section:horizontal:hover, 
+QHeaderView::section:vertical:hover {
+    background-color: #6a5a5a;
+}
+/* QTableView specific styling */
+QTableView {
+    gridline-color: #5a4a4a;
+    background-color: #3b2f2f;
+    color: #ffffff;
+    alternate-background-color: #4a3a3a;
+    selection-background-color: #6a5a5a;
+    selection-color: #ffffff;
+}
+/* Styling for table view cells */
+QTableView::item {
+    padding: 4px;
+    color: #ffffff;
+    gridline-color: #5a4a4a;
+    background-color: #3b2f2f;
+}
+QTableView::item:hover {
+    background-color: #d2691e;
+}
+QTableView::item:disabled {
+    color: #d2b48c;
+}
+QTableView::item:selected {
+    background-color: #6a5a5a;
+}
+/* Styling for table corner button */
+QTableView QTableCornerButton::section {
+    background-color: #5a4a4a;
+    color: #ffffff;
+}
+QTableView QTableCornerButton::section:hover {
+    background-color: #6a5a5a;
+}
+QTableView::indicator {
+    width: 13px;
+    height: 13px;
+}
+QTableView::indicator:checked {
+    background: #a0522d;
+}
+QTableView::indicator:unchecked {
+    background: #5a4a4a;
+}
+/* Styling for tool buttons */
+QToolButton {
+    background-color: #5a4a4a;
+    border-style: solid;
+    border-width: 0px;
+    border-radius: 5px;
+    color: #ffffff;
+    padding: 1px;
+}
+QToolButton:hover {
+    background-color: #6a5a5a;
+}
+QToolButton:pressed {
+    background-color: #cd853f;
+    border-style: inset;
+}
+QToolButton:disabled {
+    color: #d2b48c;
+}
+
+/* ===== Browser (util/steam/browser.py) ===== */
+QWidget#browserPanel {
+    background-color: #3b2f2f;
+}
+QLabel#browserPaneldownloader_label {
+    color: #ffffff;
+}
+
+/* ======= MainWindow (view/main_content_panel.py) ======= */
+QMainWindow {
+    background-color: #3b2f2f;
+}
+QWidget#MainPanel {
+    border-style: solid;
+    border-color: #5a4a4a;
+    border-width: 1px;
+    border-radius: 3px;
+    margin: 7px; /* Space between frame and app edge */
+}
+/* Styling for the mod item text */
+QLabel#ListItemLabel {
+    color: #ffffff;
+}
+QLabel#ListItemLabelFiltered { 
+    color: #f4a460; 
+}
+QLabel#ListItemLabelInvalid {
+    color: #ff4500;
+}
+/* Styling for the errors summary frame */
+QWidget#errorFrame { /* Outer-most encapsulator */
+    background-color: #3b2f2f;
+    border-style: solid;
+    border-color: #5a4a4a;
+    border-width: 1px;
+    border-radius: 3px;
+}
+
+/* ===== GameConfiguration (view/game_configuration_panel.py) ===== */
+QLabel#gameVersion {
+    color: #ffffff;
+    margin-right: 4px;
+}
+
+/* ===== Mod info panel (sub_view/mod_info_panel.py) ===== */
+/* Outer-most encapsulator */
+/* Contains QScrollArea for mod description */
+QWidget#descriptionWidget {
+    background-color: #3b2f2f;
+    border-style: solid;
+    border-color: #5a4a4a;
+    border-width: 1px;
+    border-radius: 3px;
+    padding: 2px; /* The sharp corner of the text box clips out */
+    padding-right: 5px;
+    color: #ffffff;
+}
+/* Text, minus scroll bar */
+QWidget#descriptionContent { 
+    background-color: #3b2f2f;
+    padding-right: 10px; /* Make some distance between text and scroll bar */
+}
+/* Description text itself */
+QLabel#descriptionLabel { 
+    color: #ffffff;
+    background-color: #3b2f2f;
+    margin-right: 3px;
+}
+
+/* ===== Missing mods prompt (window/missing_mods_panel.py) ===== */
+QWidget#missingModsPanel{
+    background-color: #4a3a3a;
+}
+QComboBox#missing_mods_variant_cb{
+    background-color: #4a3a3a;
+    color: #ffffff;
+    border-radius: 0;
+}
+
+/* ===== RuleEditor (window/rule_editor_panel.py) ===== */
+QWidget#RuleEditor {
+    border-style: solid;
+    border-color: #5a4a4a;
+    border-width: 1px;
+    border-radius: 3px;
+    margin: 7px; /* Space between frame and app edge */
+    background-color: #3b2f2f;
+}
+
+/* ===== RunnerPanel (window/runner_panel.py) ===== */
+QWidget#RunnerPanel {
+    border-style: solid;
+    border-color: #5a4a4a;
+    border-width: 1px;
+    border-radius: 3px;
+    margin: 7px; /* Space between frame and app edge */
+    background-color: #3b2f2f;
+}
+QPlainTextEdit#RunnerPanelText {
+    background-color: #5a4a4a;
+    color: #ffffff;
+}
+
+/* ===== Settings (window/settings_panel.py) ===== */
+QDialog#settingsPanel {
+    background-color: #3b2f2f;
+}
+QCheckBox#summaryValue {
+    color: #ffffff;
+}
+QCheckBox {
+    padding: 2px;
+    color: #ffffff;
+}
+QCheckBox::indicator {
+    width: 13px;
+    height: 13px;
+    border: 1px solid #5a4a4a;
+    border-radius: 3px;
+    background-color: #3b2f2f;
+}
+QCheckBox::indicator:checked {
+    background-color: #a0522d;
+}
+QCheckBox::indicator:unchecked {
+    background-color: #5a4a4a;
+}
+QCheckBox::indicator:hover {
+    border: 1px solid #6a5a5a;
+}
+QRadioButton {
+    color: #ffffff;
+}
+
+QRadioButton::indicator {
+    width: 10px;
+    height: 10px;
+    border-radius: 8px;
+    border: 3px solid #5a4a4a;
+}
+
+QRadioButton::indicator:checked {
+    background-color:#a0522d;
+}
+
+QRadioButton::indicator:unchecked {
+    background-color: #5a4a4a;
+}
+
+/* ===== Status panel (bottom message bar) */
+QWidget#StatusPanel {
+    background-color: #5a4a4a;
+}
+QLabel#StatusLabel {
+    color: #ffffff;
+    background-color: #5a4a4a;
+}


### PR DESCRIPTION
- [x] Option to disable stylesheet to use OS/System Theme (current theme "fusion")
- [x] Added Theme Controller
- [x] Added Button to open theme folder location
- [x] Users can add new Themes (stylesheet)
- [x] Added New Themes

How to add your own Themes (stylesheet)
1) Create a new folder in "themes" folder in your RimSort Config Folder
2) Using the default RimPy Theme As Refrence create your own style.qss file in the folder you created
3) Start RimSort and Select your theme from the Dropdown
4) Save settings to apply the Theme
"Note: The Name of Folder will be used as Name of the Theme / Invalid Themes will be ignored

- [x]  Users can contribute to add new Themes by just adding it to "themes" folder in  "application_folder"  and create a pull request 

![image](https://github.com/user-attachments/assets/59a0f998-ff96-4300-8bb9-266a27a6ac00)
