### PR TITLE
Fix passing run_args on run

### DIFF
--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -377,7 +377,7 @@ class Settings(QObject):
         EventBus().settings_have_changed.emit()
 
     @property
-    def instances(self) -> Dict[str, Dict[str, str]]:
+    def instances(self) -> Dict[str, Dict[str, str | list[str]]]:
         return self._instances
 
     @instances.setter

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -3249,9 +3249,13 @@ class MainContent(QObject):
         game_install_path = Path(
             self.settings_controller.settings.instances[current_instance]["game_folder"]
         )
-        run_args = [
-            self.settings_controller.settings.instances[current_instance]["run_args"]
-        ]
+        # Run args is inconsistent and is sometimes a string and sometimes a list
+        run_args: list[str] | str = self.settings_controller.settings.instances[
+            current_instance
+        ]["run_args"]
+
+        run_args = [run_args] if isinstance(run_args, str) else run_args
+
         steam_client_integration = self.settings_controller.settings.instances[
             current_instance
         ].get("steam_client_integration", False)


### PR DESCRIPTION
Making handling of run_args agnostic as to if it is a string or list

"run_args" in the settings controller seems to be sometimes a string and sometimes a list of strings. Will likely fix the consistency later on through the metadata rework but for now this ensures agnostic handling. 