### PR TITLE
fix repo is not defined crash

### DIFF
--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -2167,7 +2167,7 @@ class MainContent(QObject):
             logger.debug("USER ACTION: cancelled input!")
             return
 
-    def _do_cleanup_gitpython(self, repo: Repo) -> None:
+    def _do_cleanup_gitpython(self, repo: "Repo") -> None:
         # Cleanup GitPython
         collect()
         repo.git.clear_cache()


### PR DESCRIPTION
Patch to fix 'Repo' is not defined crash when Git is not installed.