### PR TITLE
Graceful fail if exception when validating mods list

### DIFF
--- a/app/utils/schema.py
+++ b/app/utils/schema.py
@@ -76,7 +76,8 @@ def validate_rimworld_mods_list(
         show_warning(
             title="Unable to read data",
             text=("RimSort was unable to read the supplied mods list."),
-            information="The supplied mods list may be missing or invalid.",
+            information="The supplied mods list may be missing or invalid. "
+            + "If you just (re)installed RimWorld, you may need to run it once to generate the mods list.",
             details=str(e),
         )
     else:

--- a/app/utils/schema.py
+++ b/app/utils/schema.py
@@ -40,38 +40,52 @@ def validate_rimworld_mods_list(
     :return: True if the ModsConfig is in the expected format, otherwise False.
     """
     logger.debug("Validating RimWorld mods list")
-    # RimWorld Config/ModsConfig.xml format
-    if mods_config_data.get("ModsConfigData", {}).get("activeMods", {}).get("li", {}):
-        logger.info("Validated XML formatting (RimWorld Config/ModsConfig.xml)")
-        active_mods = mods_config_data["ModsConfigData"]["activeMods"]["li"]
-        if isinstance(active_mods, list):
-            return active_mods
-        elif isinstance(active_mods, str):
-            return [active_mods]
-    # RimWorld .rws XML save file format
-    elif (
-        mods_config_data.get("savegame", {})
-        .get("meta", {})
-        .get("modIds", {})
-        .get("li", {})
-    ):
-        logger.info("Validated XML formatting (RimWorld .rws savegame)")
-        return mods_config_data["savegame"]["meta"]["modIds"]["li"]
-    # RimWorld .rws XML file format
-    elif (
-        mods_config_data.get("savedModList", {})
-        .get("meta", {})
-        .get("modIds", {})
-        .get("li", {})
-    ):
-        logger.info("Validated XML formatting (RimWorld .rml modlist)")
-        return mods_config_data["savedModList"]["meta"]["modIds"]["li"]
+    try:
+        # RimWorld Config/ModsConfig.xml format
+        if (
+            mods_config_data.get("ModsConfigData", {})
+            .get("activeMods", {})
+            .get("li", {})
+        ):
+            logger.info("Validated XML formatting (RimWorld Config/ModsConfig.xml)")
+            active_mods = mods_config_data["ModsConfigData"]["activeMods"]["li"]
+            if isinstance(active_mods, list):
+                return active_mods
+            elif isinstance(active_mods, str):
+                return [active_mods]
+        # RimWorld .rws XML save file format
+        elif (
+            mods_config_data.get("savegame", {})
+            .get("meta", {})
+            .get("modIds", {})
+            .get("li", {})
+        ):
+            logger.info("Validated XML formatting (RimWorld .rws savegame)")
+            return mods_config_data["savegame"]["meta"]["modIds"]["li"]
+        # RimWorld .rws XML file format
+        elif (
+            mods_config_data.get("savedModList", {})
+            .get("meta", {})
+            .get("modIds", {})
+            .get("li", {})
+        ):
+            logger.info("Validated XML formatting (RimWorld .rml modlist)")
+            return mods_config_data["savedModList"]["meta"]["modIds"]["li"]
+    except Exception as e:
+        logger.error(f"Error trying to validate data: {e}")
+        show_warning(
+            title="Unable to read data",
+            text=("RimSort was unable to read the supplied mods list."),
+            information="The supplied mods list may be missing or invalid.",
+            details=str(e),
+        )
+    else:
+        logger.error(f"Invalid format: {mods_config_data}")
+        show_warning(
+            title="Unable to read data",
+            text=(
+                "RimSort was unable to read the supplied mods list because it may be invalid or missing."
+            ),
+        )
 
-    logger.error(f"Invalid format: {mods_config_data}")
-    show_warning(
-        title="Unable to read data",
-        text=(
-            "RimSort was unable to read the supplied mods list because it may be invalid or missing."
-        ),
-    )
     return ["Ludeon.RimWorld"]


### PR DESCRIPTION
Graceful fail if exception, such as if the mods_config_data is None for some reason, when validating mod lists. 

Gives a warning to the user instead of a vague hard crash that is difficult to self diagnose.