### PR TITLE
[418] support mod replacements

### DIFF
--- a/app/controllers/app_controller.py
+++ b/app/controllers/app_controller.py
@@ -25,7 +25,7 @@ class AppController(QObject):
 
         self.app.setStyleSheet(  # Add style sheet for styling layouts and widgets
             (
-                (AppInfo().application_folder / "themes" / "RimPy" / "style.qss")
+                AppInfo().application_folder / "themes" / "RimPy" / "style.qss"
             ).read_text()
         )
 

--- a/app/sort/dependencies.py
+++ b/app/sort/dependencies.py
@@ -71,7 +71,7 @@ def gen_rev_deps_graph(
 
 
 def gen_tier_one_deps_graph(
-    dependencies_graph: dict[str, set[str]]
+    dependencies_graph: dict[str, set[str]],
 ) -> tuple[dict[str, set[str]], set[str]]:
     # Below is a list of mods determined to be "tier one", in the sense that they
     # should be loaded first before any other regular mod. Tier one mods will have specific

--- a/app/utils/constants.py
+++ b/app/utils/constants.py
@@ -95,3 +95,4 @@ SEARCH_DATA_SOURCE_FILTER_INDEXES = [
     "csharp",
     "xml",
 ]
+KNOWN_MOD_REPLACEMENTS = {"brrainz.harmony": {"zetrith.prepatcher"}}

--- a/app/utils/rentry/wrapper.py
+++ b/app/utils/rentry/wrapper.py
@@ -103,9 +103,9 @@ class RentryImport:
         """
         Initialize the Rentry Import instance.
         """
-        self.package_ids: list[str] = (
-            []
-        )  # Initialize an empty list to store package_ids
+        self.package_ids: list[
+            str
+        ] = []  # Initialize an empty list to store package_ids
         self.input_dialog()  # Call the input_dialog method to set up the UI
 
     def input_dialog(self):

--- a/app/utils/steam/steamworks/wrapper.py
+++ b/app/utils/steam/steamworks/wrapper.py
@@ -179,9 +179,7 @@ class SteamworksAppDependenciesQuery:
             callbacks=True, callbacks_total=len(self.pfid_or_pfids), _libs=self._libs
         )
         if not steamworks_interface.steam_not_running:  # Skip if True
-            while (
-                not steamworks_interface.steamworks.loaded()
-            ):  # Ensure that Steamworks API is initialized before attempting any instruction
+            while not steamworks_interface.steamworks.loaded():  # Ensure that Steamworks API is initialized before attempting any instruction
                 break
             else:
                 for pfid in self.pfid_or_pfids:
@@ -276,9 +274,7 @@ class SteamworksSubscriptionHandler:
             callbacks=True, callbacks_total=callbacks_total, _libs=self._libs
         )
         if not steamworks_interface.steam_not_running:  # Skip if True
-            while (
-                not steamworks_interface.steamworks.loaded()
-            ):  # Ensure that Steamworks API is initialized before attempting any instruction
+            while not steamworks_interface.steamworks.loaded():  # Ensure that Steamworks API is initialized before attempting any instruction
                 break
             else:
                 if self.action == "resubscribe":

--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -41,7 +41,10 @@ from app.models.dialogue import (
     show_warning,
 )
 from app.utils.app_info import AppInfo
-from app.utils.constants import SEARCH_DATA_SOURCE_FILTER_INDEXES
+from app.utils.constants import (
+    KNOWN_MOD_REPLACEMENTS,
+    SEARCH_DATA_SOURCE_FILTER_INDEXES,
+)
 from app.utils.event_bus import EventBus
 from app.utils.generic import (
     copy_to_clipboard_safely,
@@ -1704,11 +1707,16 @@ class ModListWidget(QListWidget):
                 and mod_data.get("packageid")
                 and mod_data["packageid"] not in self.ignore_warning_list
             ):
-                # Check dependencies
+                # Check dependencies (and replacements for dependencies)
+                # Note: dependency replacements are NOT assumed to be subject
+                # to the same load order rules as the orignal mods!
                 mod_errors["missing_dependencies"] = {
                     dep
                     for dep in mod_data.get("dependencies", [])
                     if dep not in package_ids_set
+                    and not self._has_replacement(
+                        mod_data["packageid"], dep, package_ids_set
+                    )
                 }
 
                 # Check incompatibilities
@@ -1798,6 +1806,21 @@ class ModListWidget(QListWidget):
             current_item.setData(Qt.ItemDataRole.UserRole, current_item_data)
         logger.info(f"Finished recalculating {self.list_type} list errors")
         return total_error_text, total_warning_text, num_errors, num_warnings
+
+    def _has_replacement(
+        self, package_id: str, dep: str, package_ids_set: set[str]
+    ) -> bool:
+        # Get a list of mods that can replace this mod
+        replacements = KNOWN_MOD_REPLACEMENTS.get(dep, set())
+        # Return true if any of the above mods (replacements) are in the mod list
+        # If no replacements exist for dep, returns false
+        for replacement in replacements:
+            if replacement in package_ids_set:
+                logger.debug(
+                    f"Missing dependency [{dep}] for [{package_id}] replaced with [{replacement}]"
+                )
+                return True
+        return False
 
     def recreate_mod_list_and_sort(
         self,


### PR DESCRIPTION
An initial solution for supporting mod replacements, e.g. Prepatcher can be substituted for Harmony. The solution maintains a dictionary in `constants.py` that maps mods to a list of replacement mods. During warning/error calculation, if mod A depends on mod B but mod B doesn't exist in the mod list, we check if any of mod B's replacements exist in the mod list (note: specific to active or inactive, not both). This way, having Prepatcher but not Harmony will not show warnings for all the mods that depend on Harmony.

NOTE: this change does NOT enforce load order for mod replacements. i.e. if mod A, through some load order rules, would end up being loaded somewhere between some other mods, but we replace it with mod B, there is no guarantee that mod B will be loaded in the same spot; mod B will be loaded according to its own load order rules. The main reason for doing this is because I'm not sure we can assume (at this point) that mod replacements will always be intended to function identically-ish to the mod they are "replacing". E.g. mod A could be replaced by mod B but mod A could just be a subset of mod B's features, and mod B might have its own load order rules dependent on its own features.

Testing: I have a mod list using both Prepatcher and Harmony. Taking out Harmony results in X warnings before this change. After this change, taking out Harmony results in no additional warnings, but taking out both Harmony and Prepatcher results in the same X warnings.

Note: this change is intended to be community-friendly, so anyone can create a PR to add to the constants dict. The following comment on Discord could be a good second contender:
> The male ratkin mod hasn't been updated to require the official version of the ratkin mod since the 1.5 update (its asking for the outdated fork)