### PR TITLE
add dependencies label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,12 +5,7 @@ documentation 📚:
 DevOps 💻:
   - changed-files:
       - any-glob-to-any-file:
-          [
-            ".github/**",
-            "distribute.py",
-            "requirements*.txt",
-            "rimsort.nuitka-package.config.yml",
-          ]
+          [".github/**", "distribute.py", "rimsort.nuitka-package.config.yml"]
 
 macOS 🍏:
   - changed-files:
@@ -23,3 +18,7 @@ Linux🐧:
 Windows 🪟:
   - changed-files:
       - any-glob-to-any-file: ["**/*.dll"]
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file: ["requirements*.txt"]


### PR DESCRIPTION
Add auto label for dependencies label based on "requirements*.txt" glob.
Remove "requirements*.txt" glob from DevOps label.