### PR TITLE
Obfuscate user in paths

### DIFF
--- a/app/utils/obfuscate_message.py
+++ b/app/utils/obfuscate_message.py
@@ -1,0 +1,41 @@
+"""
+This module is to be used with loguru to remove potentially sensitive information such as the user's name.
+"""
+
+import re
+
+
+def obfuscate_message(message: str, anonymize_path: bool = True) -> str:
+    """
+    Obfuscate the message such that it does not reveal user information.
+
+    The message may contain a path, in which case the path will be anonymized.
+
+    Args:
+        message: The message to obfuscate.
+        anonymize_path: Whether to anonymize the path in the message.
+
+    Returns:
+        The obfuscated message.
+    """
+    if anonymize_path:
+        message = _anonymize_path(message)
+
+    return message
+
+
+def _anonymize_path(message: str) -> str:
+    """
+    Anonymize the path in the message such that
+    it does not reveal user information such as usernames.
+
+    The input message may or may not contain a path at all.
+
+    OS agnostic.
+    """
+    # Windows - Only remove the username, keep the drive letter
+    message = message = re.sub(r"([A-Z]:\\Users\\)[^\\]+\\", r"\1...\\", message)
+    # Linux - Only remove the username
+    message = re.sub(r"/home/[^/]+/", r"/home/../", message)
+    
+    return message

--- a/app/utils/obfuscate_message.py
+++ b/app/utils/obfuscate_message.py
@@ -36,6 +36,6 @@ def _anonymize_path(message: str) -> str:
     # Windows - Only remove the username, keep the drive letter
     message = message = re.sub(r"([A-Z]:\\Users\\)[^\\]+\\", r"\1...\\", message)
     # Linux - Only remove the username
-    message = re.sub(r"/home/[^/]+/", r"/home/../", message)
+    message = re.sub(r"/home/[^/]+/", r"/home/.../", message)
     
     return message

--- a/requirements_develop.txt
+++ b/requirements_develop.txt
@@ -6,3 +6,4 @@ types-requests
 types-toposort
 types-xmltodict
 lxml-stubs
+pytest

--- a/tests/utils/test_obfuscate_message.py
+++ b/tests/utils/test_obfuscate_message.py
@@ -19,7 +19,7 @@ def test__anonymize_path_windows_path_only() -> None:
 
 def test__anonymize_path_linux_path_only() -> None:
     message = "/home/user/Documents/file.txt"
-    expected = "/home/../Documents/file.txt"
+    expected = "/home/.../Documents/file.txt"
     assert _anonymize_path(message) == expected
 
     message = "/home/abc/Documents/file.txt"
@@ -37,9 +37,9 @@ def test__anonymize_path_windows_mixed_message() -> None:
 
 def test__anonymize_path_linux_mixed_message() -> None:
     message = "/home/user/Documents/file.txt: error"
-    expected = "/home/../Documents/file.txt: error"
+    expected = "/home/.../Documents/file.txt: error"
     assert _anonymize_path(message) == expected
 
     message = "Error!!! at: /home/user/Documents/file.txt"
-    expected = "Error!!! at: /home/../Documents/file.txt"
+    expected = "Error!!! at: /home/.../Documents/file.txt"
     assert _anonymize_path(message) == expected

--- a/tests/utils/test_obfuscate_message.py
+++ b/tests/utils/test_obfuscate_message.py
@@ -1,0 +1,45 @@
+from app.utils.obfuscate_message import _anonymize_path
+
+
+def test__anonymize_path_windows_path_only() -> None:
+    message = r"C:\Users\user\Documents\file.txt"
+    expected = r"C:\Users\...\Documents\file.txt"
+    assert _anonymize_path(message) == expected
+
+    message = r"C:\Users\abc\Documents\file.txt"
+    assert _anonymize_path(message) == expected
+
+    message = r"D:\Users\user\Documents\file.txt"
+    expected = r"D:\Users\...\Documents\file.txt"
+    assert _anonymize_path(message) == expected
+
+    message = r"D:\Users\abc\Documents\file.txt"
+    assert _anonymize_path(message) == expected
+
+
+def test__anonymize_path_linux_path_only() -> None:
+    message = "/home/user/Documents/file.txt"
+    expected = "/home/../Documents/file.txt"
+    assert _anonymize_path(message) == expected
+
+    message = "/home/abc/Documents/file.txt"
+    assert _anonymize_path(message) == expected
+
+
+def test__anonymize_path_windows_mixed_message() -> None:
+    message = "C:\\Users\\user\\Documents\\file.txt: error"
+    expected = "C:\\Users\\...\\Documents\\file.txt: error"
+    assert _anonymize_path(message) == expected
+
+    message = "Error!!! at: C:\\Users\\user\\Documents\\file.txt"
+    expected = "Error!!! at: C:\\Users\\...\\Documents\\file.txt"
+    assert _anonymize_path(message) == expected
+
+def test__anonymize_path_linux_mixed_message() -> None:
+    message = "/home/user/Documents/file.txt: error"
+    expected = "/home/../Documents/file.txt: error"
+    assert _anonymize_path(message) == expected
+
+    message = "Error!!! at: /home/user/Documents/file.txt"
+    expected = "Error!!! at: /home/../Documents/file.txt"
+    assert _anonymize_path(message) == expected


### PR DESCRIPTION
This PR implements #427

It uses a regular expression to try to find the user in a path and replaces it with '...'

I've included some pytests.
Works for both Windows and Unix, though I've only tested on a Windows (NTFS) system. Pytests include unix style paths. It is drive agnostic.

There may be some edge cases, but this should catch the username in 99% of cases. Note that if someone names a folder other than the user folder their name, there isn't much that can be done there.

It does not filter out unix sudo paths since those are all the same as far as I know and there is no identifying info.

This PR also adds pytest as a develop dependency