### PR TITLE
Use Dependency in mods as Sorting rule

### DIFF
--- a/app/sort/topo_sort.py
+++ b/app/sort/topo_sort.py
@@ -32,19 +32,13 @@ def do_topo_sort(
         for uuid in active_mods_uuids
     )
     for level in sorted_dependencies:
-        temp_mod_set = set()
+        sorted_mod_set = set()
         for package_id in level:
             if package_id in active_mods_packageid_to_uuid:
                 mod_uuid = active_mods_packageid_to_uuid[package_id]
-                temp_mod_set.add(mod_uuid)
-        # Sort packages in this topological level by name
-        sorted_temp_mod_set = sorted(
-            temp_mod_set,
-            key=lambda uuid: metadata_manager.internal_local_metadata[uuid]["name"],
-            reverse=False,
-        )
+                sorted_mod_set.add(mod_uuid)
         # Add into reordered set
-        for sorted_mod_uuid in sorted_temp_mod_set:
+        for sorted_mod_uuid in sorted_mod_set:
             reordered.append(sorted_mod_uuid)
     logger.info(f"Finished Toposort sort with {len(reordered)} mods")
     return reordered

--- a/app/utils/metadata.py
+++ b/app/utils/metadata.py
@@ -612,6 +612,29 @@ class MetadataManager(QObject):
                         dependencies,
                         self.internal_local_metadata,
                     )
+                    # Cleanup Dependencies so that it can be used as load order rules
+                    load_dependencies = (
+                        str(dependencies)
+                        .lower()
+                        .split(",")[0]
+                        .replace("{'packageid': '", "")
+                        .replace("[{'packageid' :", "")
+                        .replace("displayname': '", "")
+                        .replace("[", "")
+                        .replace("'", "")
+                        .replace("{", "")
+                        .replace("}", "")
+                        .replace("li:", "")
+                    )
+                    logger.debug(load_dependencies)
+                    add_load_rule_to_mod(
+                        self.internal_local_metadata[uuid],
+                        load_dependencies,
+                        "loadTheseBefore",
+                        "loadTheseAfter",
+                        self.internal_local_metadata,
+                        self.packageid_to_uuids,
+                    )
 
             if self.internal_local_metadata[uuid].get("moddependenciesbyversion"):
                 major, minor = self.game_version.split(".")[
@@ -634,6 +657,29 @@ class MetadataManager(QObject):
                                 self.internal_local_metadata[uuid],
                                 dependencies_by_ver["li"],
                                 self.internal_local_metadata,
+                            )
+                            # Cleanup Dependencies so that it can be used as load order rules
+                            load_dependencies_by_ver = (
+                                str(dependencies_by_ver["li"])
+                                .lower()
+                                .split(",")[0]
+                                .replace("{'packageid': '", "")
+                                .replace("[{'packageid' :", "")
+                                .replace("displayname': '", "")
+                                .replace("[", "")
+                                .replace("'", "")
+                                .replace("{", "")
+                                .replace("}", "")
+                                .replace("li:", "")
+                            )
+                            logger.debug(load_dependencies_by_ver)
+                            add_load_rule_to_mod(
+                                self.internal_local_metadata[uuid],
+                                load_dependencies_by_ver,
+                                "loadTheseBefore",
+                                "loadTheseAfter",
+                                self.internal_local_metadata,
+                                self.packageid_to_uuids,
                             )
                         else:
                             logger.warning(


### PR DESCRIPTION
1) Use Mod Dependencies as a sorting order rule
2) Avoid Sorting packages in topological level by name

The above changes fixes a lot of sorting related issues as well as help in properly sorting mods