### PR TITLE
Add Optional Settings to "Use Mods Dependency Rules For Sorting"

### DIFF
--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -599,6 +599,10 @@ class SettingsController(QObject):
         elif self.settings.sorting_algorithm == SortMethod.TOPOLOGICAL:
             self.settings_dialog.sorting_topological_radio.setChecked(True)
 
+        # Use dependencies for sorting checkbox
+        if self.settings.use_dependency_for_sorting:
+            (self.settings_dialog.use_dependency_for_sorting_checkbox.setChecked(True))
+
         # Set dependencies checkbox
         self.settings_dialog.check_deps_checkbox.setChecked(
             self.settings.check_dependencies_on_sort
@@ -800,6 +804,11 @@ class SettingsController(QObject):
             self.settings.sorting_algorithm = SortMethod.ALPHABETICAL
         elif self.settings_dialog.sorting_topological_radio.isChecked():
             self.settings.sorting_algorithm = SortMethod.TOPOLOGICAL
+
+        # Use dependencies for sorting checkbox
+        self.settings.use_dependency_for_sorting = (
+            self.settings_dialog.use_dependency_for_sorting_checkbox.isChecked()
+        )
 
         # Set dependencies checkbox
         self.settings.check_dependencies_on_sort = (

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -67,6 +67,7 @@ class Settings(QObject):
         self.check_dependencies_on_sort: bool = (
             True  # Whether to check for missing dependencies when sorting
         )
+        self.use_dependency_for_sorting: bool = False
 
         # DB Builder
         self.db_builder_include: str = "all_mods"

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -468,6 +468,15 @@ class SettingsDialog(QDialog):
         self.sorting_topological_radio = QRadioButton("Topologically")
         sort_group_box_layout.addWidget(self.sorting_topological_radio)
 
+        # Use dependencies for sorting checkbox
+        self.use_dependency_for_sorting_checkbox = QCheckBox(
+            "Use dependency rules for sorting."
+        )
+        self.use_dependency_for_sorting_checkbox.setToolTip(
+            "If enabled, Mods will be sorted such that dependencies are loaded before the dependent mod."
+        )
+        sort_group_box_layout.addWidget(self.use_dependency_for_sorting_checkbox)
+
         # Dependencies group
         deps_group_box = QGroupBox("Sort Dependencies")
         tab_layout.addWidget(deps_group_box)


### PR DESCRIPTION
- [x] Add setting to use Mods Dependency in the About file as Sorting Rule

- [ ] when enabled uses dependencies (mod required) to load_before the mod having it as a dependency in about.xml

![Screenshot 2024-07-14 055405](https://github.com/user-attachments/assets/eb63f89a-3efd-458d-a1ae-fa2dd25930e9)
