### PR TITLE
Refactor menu bar

### DIFF
--- a/app/controllers/menu_bar_controller.py
+++ b/app/controllers/menu_bar_controller.py
@@ -21,17 +21,18 @@ class MenuBarController(QObject):
 
         self.menu_bar.quit_action.triggered.connect(QApplication.instance().quit)
 
-        self.menu_bar.check_for_updates_action.triggered.connect(
-            EventBus().do_check_for_application_update.emit
-        )
+        # TODO: updates not implemented yet
+        # self.menu_bar.check_for_updates_action.triggered.connect(
+        #     EventBus().do_check_for_application_update.emit
+        # )
 
-        self.menu_bar.check_for_updates_on_startup_action.toggled.connect(
-            self._on_menu_bar_check_for_updates_on_startup_triggered
-        )
+        # self.menu_bar.check_for_updates_on_startup_action.toggled.connect(
+        #     self._on_menu_bar_check_for_updates_on_startup_triggered
+        # )
 
-        self.menu_bar.check_for_updates_on_startup_action.setChecked(
-            self.settings_controller.settings.check_for_update_startup
-        )
+        # self.menu_bar.check_for_updates_on_startup_action.setChecked(
+        #     self.settings_controller.settings.check_for_update_startup
+        # )
 
         self.menu_bar.settings_action.triggered.connect(
             self.settings_controller.show_settings_dialog

--- a/app/views/menu_bar.py
+++ b/app/views/menu_bar.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from PySide6.QtCore import QObject
 from PySide6.QtGui import QAction, QKeySequence
 from PySide6.QtWidgets import QMenu, QMenuBar
@@ -7,234 +8,254 @@ from app.utils.system_info import SystemInfo
 
 class MenuBar(QObject):
     def __init__(self, menu_bar: QMenuBar) -> None:
+        """
+        Initialize the MenuBar object.
+
+        Args:
+            menu_bar (QMenuBar): The menu bar to which the menus and actions will be added.
+        """
         super().__init__()
 
-        self.menu_bar = menu_bar
+        self.menu_bar: QMenuBar = menu_bar
 
-        # Menu bars are different on macOS
+        # Declare actions and submenus as class variables
+        # to be used by menu_bar_controller
+        self.settings_action: QAction
+        self.quit_action: QAction
+        self.open_mod_list_action: QAction
+        self.save_mod_list_action: QAction
+        self.import_from_rentry_action: QAction
+        self.import_from_workshop_collection_action: QAction
+        self.export_to_clipboard_action: QAction
+        self.export_to_rentry_action: QAction
+        self.upload_rimsort_log_action: QAction
+        self.upload_rimsort_old_log_action: QAction
+        self.upload_rimworld_log_action: QAction
+        self.cut_action: QAction
+        self.copy_action: QAction
+        self.paste_action: QAction
+        self.rule_editor_action: QAction
+        self.add_git_mod_action: QAction
+        self.browse_workshop_action: QAction
+        self.update_workshop_mods_action: QAction
+        self.backup_instance_action: QAction
+        self.restore_instance_action: QAction
+        self.clone_instance_action: QAction
+        self.create_instance_action: QAction
+        self.delete_instance_action: QAction
+        self.optimize_textures_action: QAction
+        self.delete_dds_textures_action: QAction
+        self.wiki_action: QAction
+        self.check_for_updates_action: QAction
+        self.check_for_updates_on_startup_action: QAction
+        self.validate_steam_client_action: QAction
+
+        self.import_submenu: QMenu
+        self.export_submenu: QMenu
+        self.upload_submenu: QMenu
+        self.instances_submenu: QMenu
+
+        self._create_menu_bar()
+
+    def _add_action(
+        self,
+        menu: QMenu,
+        title: str,
+        shortcut: Optional[str] = None,
+        checkable: bool = False,
+        role: Optional[QAction.MenuRole] = None,
+    ) -> QAction:
+        """
+        Add an action to a menu.
+
+        Args:
+            menu (QMenu): The menu to which the action will be added.
+            title (str): The title of the action.
+            shortcut (Optional[str], optional): The keyboard shortcut for the action. Defaults to None.
+            checkable (bool, optional): Whether the action is checkable. Defaults to False.
+            role (Optional[QAction.MenuRole], optional): The menu role of the action. Defaults to None.
+
+        Returns:
+            QAction: The created action.
+        """
+        action = QAction(title, self)
+        if shortcut:
+            action.setShortcut(QKeySequence(shortcut))
+        if checkable:
+            action.setCheckable(True)
+        if role:
+            action.setMenuRole(role)
+        menu.addAction(action)
+        return action
+
+    def _create_file_menu(self) -> QMenu:
+        """
+        Create the "File" menu and add its actions and submenus.
+
+        Returns:
+            QMenu: The created "File" menu.
+        """
+        file_menu = self.menu_bar.addMenu("File")
+        self.open_mod_list_action = self._add_action(
+            file_menu, "Open Mod List…", "Ctrl+O"
+        )
+        file_menu.addSeparator()
+        self.save_mod_list_action = self._add_action(
+            file_menu, "Save Mod List As…", "Ctrl+Shift+S"
+        )
+        file_menu.addSeparator()
+        self.import_submenu = QMenu("Import")
+        file_menu.addMenu(self.import_submenu)
+        self.import_from_rentry_action = self._add_action(
+            self.import_submenu, "From Rentry.co"
+        )
+        self.import_from_workshop_collection_action = self._add_action(
+            self.import_submenu, "From Workshop collection"
+        )
+        file_menu.addSeparator()
+        self.export_submenu = QMenu("Export")
+        file_menu.addMenu(self.export_submenu)
+        self.export_to_clipboard_action = self._add_action(
+            self.export_submenu, "To Clipboard…"
+        )
+        self.export_to_rentry_action = self._add_action(
+            self.export_submenu, "To Rentry.co…"
+        )
+        file_menu.addSeparator()
+        self.upload_submenu = QMenu("Upload Log")
+        file_menu.addMenu(self.upload_submenu)
+        self.upload_rimsort_log_action = self._add_action(
+            self.upload_submenu, "RimSort.log"
+        )
+        self.upload_rimsort_old_log_action = self._add_action(
+            self.upload_submenu, "RimSort.old.log"
+        )
+        self.upload_rimworld_log_action = self._add_action(
+            self.upload_submenu, "RimWorld Player.log"
+        )
+        if SystemInfo().operating_system != SystemInfo.OperatingSystem.MACOS:
+            file_menu.addSeparator()
+            self.settings_action = self._add_action(file_menu, "Settings…", "Ctrl+,")
+            file_menu.addSeparator()
+            self.quit_action = self._add_action(file_menu, "Exit", "Ctrl+Q")
+        return file_menu
+
+    def _create_edit_menu(self) -> QMenu:
+        """
+        Create the "Edit" menu and add its actions.
+
+        Returns:
+            QMenu: The created "Edit" menu.
+        """
+        edit_menu = self.menu_bar.addMenu("Edit")
+        self.cut_action = self._add_action(edit_menu, "Cut", "Ctrl+X")
+        self.copy_action = self._add_action(edit_menu, "Copy", "Ctrl+C")
+        self.paste_action = self._add_action(edit_menu, "Paste", "Ctrl+V")
+        edit_menu.addSeparator()
+        self.rule_editor_action = self._add_action(edit_menu, "Rule Editor…")
+        return edit_menu
+
+    def _create_download_menu(self) -> QMenu:
+        """
+        Create the "Download" menu and add its actions.
+
+        Returns:
+            QMenu: The created "Download" menu.
+        """
+        download_menu = self.menu_bar.addMenu("Download")
+        self.add_git_mod_action = self._add_action(download_menu, "Add Git Mod")
+        download_menu.addSeparator()
+        self.browse_workshop_action = self._add_action(download_menu, "Browse Workshop")
+        self.update_workshop_mods_action = self._add_action(
+            download_menu, "Update Workshop Mods"
+        )
+        return download_menu
+
+    def _create_instances_menu(self) -> QMenu:
+        """
+        Create the "Instances" menu and add its actions and submenus.
+
+        Returns:
+            QMenu: The created "Instances" menu.
+        """
+        instances_menu = self.menu_bar.addMenu("Instances")
+        self.instances_submenu = QMenu('Current: "Default"')
+        instances_menu.addMenu(self.instances_submenu)
+        instances_menu.addSeparator()
+        self.backup_instance_action = self._add_action(
+            instances_menu, "Backup Instance…"
+        )
+        self.restore_instance_action = self._add_action(
+            instances_menu, "Restore Instance…"
+        )
+        instances_menu.addSeparator()
+        self.clone_instance_action = self._add_action(instances_menu, "Clone Instance…")
+        self.create_instance_action = self._add_action(
+            instances_menu, "Create Instance…"
+        )
+        self.delete_instance_action = self._add_action(
+            instances_menu, "Delete Instance…"
+        )
+        return instances_menu
+
+    def _create_texture_menu(self) -> QMenu:
+        """
+        Create the "Textures" menu and add its actions.
+
+        Returns:
+            QMenu: The created "Textures" menu.
+        """
+        texture_menu = self.menu_bar.addMenu("Textures")
+        self.optimize_textures_action = self._add_action(
+            texture_menu, "Optimize Textures"
+        )
+        texture_menu.addSeparator()
+        self.delete_dds_textures_action = self._add_action(
+            texture_menu, "Delete .dds Textures"
+        )
+        return texture_menu
+
+    def _create_help_menu(self) -> QMenu:
+        """
+        Create the "Help" menu and add its actions.
+
+        Returns:
+            QMenu: The created "Help" menu.
+        """
+        help_menu = self.menu_bar.addMenu("Help")
+        self.wiki_action = self._add_action(help_menu, "RimSort Wiki…")
+        help_menu.addSeparator()
+        # TODO: updates not implemented yet
+        # self.check_for_updates_action = self._add_action(
+        #     help_menu, "Check for Updates…"
+        # )
+        # self.check_for_updates_on_startup_action = self._add_action(
+        #     help_menu, "Check for Updates on Startup", checkable=True
+        # )
+        # help_menu.addSeparator()
+        self.validate_steam_client_action = self._add_action(
+            help_menu, "Validate Steam Client mods"
+        )
+        return help_menu
+
+    def _create_menu_bar(self) -> None:
+        """
+        Create the menu bar. On macOS, include the app menu.
+        """
         if SystemInfo().operating_system == SystemInfo.OperatingSystem.MACOS:
-            self._do_menu_bar_macos()
-        else:
-            self._do_menu_bar_non_macos()
-
-    def _do_menu_bar_macos(self) -> None:
-        # Application menu (macOS only)
-        self.app_menu = self.menu_bar.addMenu(
-            "AppName"
-        )  # This title is ignored on macOS
-        self.check_for_updates_action = QAction("Check for Updates…", self)
-        self.check_for_updates_action.setMenuRole(
-            QAction.MenuRole.ApplicationSpecificRole
-        )
-        self.app_menu.addAction(self.check_for_updates_action)
-        self.check_for_updates_on_startup_action = QAction(
-            "Check for Updates on Startup", self
-        )
-        self.check_for_updates_on_startup_action.setCheckable(True)
-        self.check_for_updates_on_startup_action.setMenuRole(
-            QAction.MenuRole.ApplicationSpecificRole
-        )
-        self.app_menu.addAction(self.check_for_updates_on_startup_action)
-        separator = QAction(self)
-        separator.setSeparator(True)
-        separator.setMenuRole(QAction.MenuRole.ApplicationSpecificRole)
-        self.app_menu.addAction(separator)
-        self.settings_action = QAction("Settings…", self)
-        self.settings_action.setMenuRole(QAction.MenuRole.ApplicationSpecificRole)
-        self.settings_action.setShortcut(QKeySequence("Ctrl+,"))
-        self.app_menu.addAction(self.settings_action)
-        self.app_menu.addSeparator()
-        self.quit_action = QAction("Quit", self)
-        self.app_menu.addAction(self.quit_action)
-        # File menu
-        self.file_menu = self.menu_bar.addMenu("File")
-        self.open_mod_list_action = QAction("Open Mod List…", self)
-        self.open_mod_list_action.setShortcut(QKeySequence("Ctrl+O"))
-        self.file_menu.addAction(self.open_mod_list_action)
-        self.file_menu.addSeparator()
-        self.save_mod_list_action = QAction("Save Mod List As…", self)
-        self.save_mod_list_action.setShortcut(QKeySequence("Ctrl+Shift+S"))
-        self.file_menu.addAction(self.save_mod_list_action)
-        self.file_menu.addSeparator()
-        self.import_submenu = QMenu("Import")
-        self.file_menu.addMenu(self.import_submenu)
-        self.import_from_rentry_action = QAction("From Rentry.co", self)
-        self.import_submenu.addAction(self.import_from_rentry_action)
-        self.import_from_workshop_collection_action = QAction(
-            "From Workshop collection", self
-        )
-        self.import_submenu.addAction(self.import_from_workshop_collection_action)
-        self.file_menu.addSeparator()
-        self.export_submenu = QMenu("Export")
-        self.file_menu.addMenu(self.export_submenu)
-        self.export_to_clipboard_action = QAction("To Clipboard…", self)
-        self.export_submenu.addAction(self.export_to_clipboard_action)
-        self.export_to_rentry_action = QAction("To Rentry.co…", self)
-        self.export_submenu.addAction(self.export_to_rentry_action)
-        self.file_menu.addSeparator()
-        self.upload_submenu = QMenu("Upload Log")
-        self.file_menu.addMenu(self.upload_submenu)
-        self.upload_rimsort_log_action = QAction("RimSort.log", self)
-        self.upload_submenu.addAction(self.upload_rimsort_log_action)
-        self.upload_rimsort_old_log_action = QAction("RimSort.old.log", self)
-        self.upload_submenu.addAction(self.upload_rimsort_old_log_action)
-        self.upload_rimworld_log_action = QAction("RimWorld.log", self)
-        self.upload_submenu.addAction(self.upload_rimworld_log_action)
-        # Edit menu
-        self.edit_menu = self.menu_bar.addMenu("Edit")
-        self.cut_action = QAction("Cut", self)
-        self.cut_action.setShortcut(QKeySequence("Ctrl+X"))
-        self.edit_menu.addAction(self.cut_action)
-        self.copy_action = QAction("Copy", self)
-        self.copy_action.setShortcut(QKeySequence("Ctrl+C"))
-        self.edit_menu.addAction(self.copy_action)
-        self.paste_action = QAction("Paste", self)
-        self.paste_action.setShortcut(QKeySequence("Ctrl+V"))
-        self.edit_menu.addAction(self.paste_action)
-        self.edit_menu.addSeparator()
-        self.rule_editor_action = QAction("Rule Editor…", self)
-        self.edit_menu.addAction(self.rule_editor_action)
-        # Download menu
-        self.download_menu = self.menu_bar.addMenu("Download")
-        self.add_git_mod_action = QAction("Add Git Mod", self)
-        self.download_menu.addAction(self.add_git_mod_action)
-        self.download_menu.addSeparator()
-        self.browse_workshop_action = QAction("Browse Workshop", self)
-        self.download_menu.addAction(self.browse_workshop_action)
-        self.update_workshop_mods_action = QAction("Update Workshop Mods", self)
-        self.download_menu.addAction(self.update_workshop_mods_action)
-        # Instances menu
-        self.instances_menu = self.menu_bar.addMenu("Instances")
-        self.instances_submenu = QMenu('Current: "Default"')
-        self.backup_instance_action = QAction("Backup Instance…", self)
-        self.restore_instance_action = QAction("Restore Instance…", self)
-        self.clone_instance_action = QAction("Clone Instance…", self)
-        self.create_instance_action = QAction("Create Instance…", self)
-        self.delete_instance_action = QAction("Delete Instance…", self)
-        self.instances_menu.addMenu(self.instances_submenu)
-        self.instances_menu.addSeparator()
-        self.instances_menu.addAction(self.backup_instance_action)
-        self.instances_menu.addAction(self.restore_instance_action)
-        self.instances_menu.addSeparator()
-        self.instances_menu.addAction(self.clone_instance_action)
-        self.instances_menu.addAction(self.create_instance_action)
-        self.instances_menu.addAction(self.delete_instance_action)
-        # Textures menu
-        self.texture_menu = self.menu_bar.addMenu("Textures")
-        self.optimize_textures_action = QAction("Optimize Textures", self)
-        self.texture_menu.addAction(self.optimize_textures_action)
-        self.texture_menu.addSeparator()
-        self.delete_dds_textures_action = QAction("Delete .dds Textures", self)
-        self.texture_menu.addAction(self.delete_dds_textures_action)
-        # Help menu
-        self.help_menu = self.menu_bar.addMenu("Help")
-        self.wiki_action = QAction("RimSort Wiki…", self)
-        self.help_menu.addAction(self.wiki_action)
-        self.help_menu.addSeparator()
-        self.validate_steam_client_action = QAction("Validate Steam Client mods", self)
-        self.help_menu.addAction(self.validate_steam_client_action)
-
-    def _do_menu_bar_non_macos(self) -> None:
-        # File menu
-        self.file_menu = self.menu_bar.addMenu("File")
-        self.open_mod_list_action = QAction("Open Mod List…", self)
-        self.open_mod_list_action.setShortcut(QKeySequence("Ctrl+O"))
-        self.file_menu.addAction(self.open_mod_list_action)
-        self.file_menu.addSeparator()
-        self.save_mod_list_action = QAction("Save Mod List As…", self)
-        self.save_mod_list_action.setShortcut(QKeySequence("Ctrl+Shift+S"))
-        self.file_menu.addAction(self.save_mod_list_action)
-        self.file_menu.addSeparator()
-        self.import_submenu = QMenu("Import")
-        self.file_menu.addMenu(self.import_submenu)
-        self.import_from_rentry_action = QAction("From Rentry.co", self)
-        self.import_submenu.addAction(self.import_from_rentry_action)
-        self.import_from_workshop_collection_action = QAction(
-            "From Workshop collection", self
-        )
-        self.import_submenu.addAction(self.import_from_workshop_collection_action)
-        self.file_menu.addSeparator()
-        self.export_submenu = QMenu("Export")
-        self.file_menu.addMenu(self.export_submenu)
-        self.export_to_clipboard_action = QAction("To Clipboard…", self)
-        self.export_submenu.addAction(self.export_to_clipboard_action)
-        self.export_to_rentry_action = QAction("To Rentry.co…", self)
-        self.export_submenu.addAction(self.export_to_rentry_action)
-        self.file_menu.addSeparator()
-        self.upload_submenu = QMenu("Upload Log")
-        self.file_menu.addMenu(self.upload_submenu)
-        self.upload_rimsort_log_action = QAction("RimSort.log", self)
-        self.upload_submenu.addAction(self.upload_rimsort_log_action)
-        self.upload_rimsort_old_log_action = QAction("RimSort.old.log", self)
-        self.upload_submenu.addAction(self.upload_rimsort_old_log_action)
-        self.upload_rimworld_log_action = QAction("RimWorld Player.log", self)
-        self.upload_submenu.addAction(self.upload_rimworld_log_action)
-        self.file_menu.addSeparator()
-        self.settings_action = QAction("Settings…", self)
-        self.settings_action.setShortcut(QKeySequence("Ctrl+,"))
-        self.file_menu.addAction(self.settings_action)
-        self.file_menu.addSeparator()
-        self.quit_action = QAction("Exit", self)
-        self.quit_action.setShortcut(QKeySequence("Ctrl+Q"))
-        self.file_menu.addAction(self.quit_action)
-        # Edit menu
-        self.edit_menu = self.menu_bar.addMenu("Edit")
-        self.cut_action = QAction("Cut", self)
-        self.cut_action.setShortcut(QKeySequence("Ctrl+X"))
-        self.edit_menu.addAction(self.cut_action)
-        self.copy_action = QAction("Copy", self)
-        self.copy_action.setShortcut(QKeySequence("Ctrl+C"))
-        self.edit_menu.addAction(self.copy_action)
-        self.paste_action = QAction("Paste", self)
-        self.paste_action.setShortcut(QKeySequence("Ctrl+V"))
-        self.edit_menu.addAction(self.paste_action)
-        self.edit_menu.addSeparator()
-        self.rule_editor_action = QAction("Rule Editor…", self)
-        self.edit_menu.addAction(self.rule_editor_action)
-        # Download menu
-        self.file_menu = self.menu_bar.addMenu("Download")
-        self.add_git_mod_action = QAction("Add Git Mod", self)
-        self.file_menu.addAction(self.add_git_mod_action)
-        self.file_menu.addSeparator()
-        self.browse_workshop_action = QAction("Browse Workshop", self)
-        self.file_menu.addAction(self.browse_workshop_action)
-        self.update_workshop_mods_action = QAction("Update Workshop Mods", self)
-        self.file_menu.addAction(self.update_workshop_mods_action)
-        # Instances menu
-        self.instances_menu = self.menu_bar.addMenu("Instances")
-        self.instances_submenu = QMenu('Current: "Default"')
-        self.backup_instance_action = QAction("Backup Instance…", self)
-        self.restore_instance_action = QAction("Restore Instance…", self)
-        self.clone_instance_action = QAction("Clone Instance…", self)
-        self.create_instance_action = QAction("Create Instance…", self)
-        self.delete_instance_action = QAction("Delete Instance…", self)
-        self.instances_menu.addMenu(self.instances_submenu)
-        self.instances_menu.addSeparator()
-        self.instances_menu.addAction(self.backup_instance_action)
-        self.instances_menu.addAction(self.restore_instance_action)
-        self.instances_menu.addSeparator()
-        self.instances_menu.addAction(self.clone_instance_action)
-        self.instances_menu.addAction(self.create_instance_action)
-        self.instances_menu.addAction(self.delete_instance_action)
-        # Textures menu
-        self.file_menu = self.menu_bar.addMenu("Textures")
-        self.optimize_textures_action = QAction("Optimize Textures", self)
-        self.file_menu.addAction(self.optimize_textures_action)
-        self.file_menu.addSeparator()
-        self.delete_dds_textures_action = QAction("Delete .dds Textures", self)
-        self.file_menu.addAction(self.delete_dds_textures_action)
-        # Help menu
-        self.help_menu = self.menu_bar.addMenu("Help")
-        self.wiki_action = QAction("RimSort Wiki…", self)
-        self.help_menu.addAction(self.wiki_action)
-        self.help_menu.addSeparator()
-        self.check_for_updates_action = QAction("Check for Updates…", self)
-        self.help_menu.addAction(self.check_for_updates_action)
-        self.check_for_updates_on_startup_action = QAction(
-            "Check for Updates on Startup", self
-        )
-        self.check_for_updates_on_startup_action.setCheckable(True)
-        self.help_menu.addAction(self.check_for_updates_on_startup_action)
-        self.help_menu.addSeparator()
-        self.validate_steam_client_action = QAction("Validate Steam Client mods", self)
-        self.help_menu.addAction(self.validate_steam_client_action)
+            app_menu = self.menu_bar.addMenu("AppName")
+            app_menu.addSeparator()
+            self.settings_action = self._add_action(
+                app_menu,
+                "Settings...",
+                shortcut="Ctrl+,",
+                role=QAction.MenuRole.ApplicationSpecificRole,
+            )
+            app_menu.addSeparator()
+            self.quit_action = self._add_action(app_menu, "Quit")
+        self._create_file_menu()
+        self._create_edit_menu()
+        self._create_download_menu()
+        self._create_instances_menu()
+        self._create_texture_menu()
+        self._create_help_menu()


### PR DESCRIPTION
Refactored `menu_bar.py`
- individual menus are separated into their own method
- single menu creation method for both mac and non-mac
- settings and quit actions are on the App menu for mac and on the File menu for non-mac
- on mac, moved update stuff to Help menu to be consistent with non-mac

Tested on Mac and Windows