### PR TITLE
[436] adding shortcuts for opening useful directories

### DIFF
--- a/app/controllers/menu_bar_controller.py
+++ b/app/controllers/menu_bar_controller.py
@@ -75,6 +75,22 @@ class MenuBarController(QObject):
             EventBus().do_upload_rimworld_log
         )
 
+        self.menu_bar.open_app_directory_action.triggered.connect(
+            EventBus().do_open_app_directory
+        )
+
+        self.menu_bar.open_settings_directory_action.triggered.connect(
+            EventBus().do_open_settings_directory
+        )
+
+        self.menu_bar.open_rimsort_logs_directory_action.triggered.connect(
+            EventBus().do_open_rimsort_logs_directory
+        )
+
+        self.menu_bar.open_rimworld_logs_directory_action.triggered.connect(
+            EventBus().do_open_rimworld_logs_directory
+        )
+
         # Edit menu
 
         self.menu_bar.cut_action.triggered.connect(self._on_menu_bar_cut_triggered)

--- a/app/utils/event_bus.py
+++ b/app/utils/event_bus.py
@@ -31,6 +31,12 @@ class EventBus(QObject):
     do_export_mod_list_to_clipboard = Signal()
     do_export_mod_list_to_rentry = Signal()
 
+    # Shortcuts submenu signals
+    do_open_app_directory = Signal()
+    do_open_settings_directory = Signal()
+    do_open_rimsort_logs_directory = Signal()
+    do_open_rimworld_logs_directory = Signal()
+
     # Edit Menu bar signals
     do_rule_editor = Signal()
 

--- a/app/utils/steam/steamworks/wrapper.py
+++ b/app/utils/steam/steamworks/wrapper.py
@@ -15,6 +15,7 @@ if "__compiled__" not in globals():
     sys.path.append(str((Path(getcwd()) / "submodules" / "SteamworksPy")))
 
 from steamworks import STEAMWORKS
+
 from app.utils.generic import launch_game_process
 
 

--- a/app/views/menu_bar.py
+++ b/app/views/menu_bar.py
@@ -1,4 +1,5 @@
 from typing import Optional
+
 from PySide6.QtCore import QObject
 from PySide6.QtGui import QAction, QKeySequence
 from PySide6.QtWidgets import QMenu, QMenuBar
@@ -31,6 +32,10 @@ class MenuBar(QObject):
         self.upload_rimsort_log_action: QAction
         self.upload_rimsort_old_log_action: QAction
         self.upload_rimworld_log_action: QAction
+        self.open_app_directory_action: QAction
+        self.open_settings_directory_action: QAction
+        self.open_rimsort_logs_directory_action: QAction
+        self.open_rimworld_logs_directory_action: QAction
         self.cut_action: QAction
         self.copy_action: QAction
         self.paste_action: QAction
@@ -53,6 +58,7 @@ class MenuBar(QObject):
         self.import_submenu: QMenu
         self.export_submenu: QMenu
         self.upload_submenu: QMenu
+        self.shortcuts_submenu: QMenu
         self.instances_submenu: QMenu
 
         self._create_menu_bar()
@@ -112,7 +118,6 @@ class MenuBar(QObject):
         self.import_from_workshop_collection_action = self._add_action(
             self.import_submenu, "From Workshop collection"
         )
-        file_menu.addSeparator()
         self.export_submenu = QMenu("Export")
         file_menu.addMenu(self.export_submenu)
         self.export_to_clipboard_action = self._add_action(
@@ -132,6 +137,21 @@ class MenuBar(QObject):
         )
         self.upload_rimworld_log_action = self._add_action(
             self.upload_submenu, "RimWorld Player.log"
+        )
+        file_menu.addSeparator()
+        self.shortcuts_submenu = QMenu("Shortcuts")
+        file_menu.addMenu(self.shortcuts_submenu)
+        self.open_app_directory_action = self._add_action(
+            self.shortcuts_submenu, "Open RimSort Directory"
+        )
+        self.open_settings_directory_action = self._add_action(
+            self.shortcuts_submenu, "Open RimSort User Files"
+        )
+        self.open_rimsort_logs_directory_action = self._add_action(
+            self.shortcuts_submenu, "Open RimSort Logs Directory"
+        )
+        self.open_rimworld_logs_directory_action = self._add_action(
+            self.shortcuts_submenu, "Open RimWorld Logs Directory"
         )
         if SystemInfo().operating_system != SystemInfo.OperatingSystem.MACOS:
             file_menu.addSeparator()

--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -1,12 +1,12 @@
 import json
 import os
 from enum import Enum
+from errno import ENOTEMPTY
 from functools import partial
 from pathlib import Path
 from shutil import copy2, copytree, rmtree
 from traceback import format_exc
 from typing import List, Optional
-from errno import ENOTEMPTY
 
 from loguru import logger
 from PySide6.QtCore import QEvent, QModelIndex, QObject, QRectF, QSize, Qt, Signal
@@ -1291,7 +1291,7 @@ class ModListWidget(QListWidget):
                                         )
                                         pass
                                     except OSError as e:
-                                        if os.name == 'nt':
+                                        if os.name == "nt":
                                             error_code = e.winerror
                                         else:
                                             error_code = e.errno
@@ -1299,7 +1299,7 @@ class ModListWidget(QListWidget):
                                             warning_text = "Mod directory was not empty. Please close all programs accessing files or subfolders in the directory (including your file manager) and try again."
                                         else:
                                             warning_text = "An OSError occurred while deleting mod."
-                                        
+
                                         logger.warning(
                                             f"Unable to delete mod located at the path: {mod_metadata['path']}"
                                         )


### PR DESCRIPTION
Changes for https://github.com/RimSort/RimSort/issues/436
Adds four new menu buttons, under `File -> Shortcuts`
- Open the app directory (where RimSort is)
- Open the directory RimSort keeps settings files in (and DB and instances)
- Open the RimSort logs directory
- Open the RimWorld logs directory

Did not add shortcuts for the following because they're easily reachable via settings panel:
- SteamCMD
- Steam Workshop Mods folders
- Local Mods folder
- Game mod folder

Tested on Windows and Mac