### PR TITLE
[477] fix rule editor equivalence check bug

### DIFF
--- a/app/windows/rule_editor_panel.py
+++ b/app/windows/rule_editor_panel.py
@@ -483,9 +483,9 @@ class RuleEditor(QWidget):
                     )  # Get the item in column 4 (index 3)
                     # Search table for rows that match.
                     if (
-                        (packageid_value and rule_data in packageid_value.text())
-                        and (rule_source_value and mode[0] in rule_source_value.text())
-                        and (rule_type_value and mode[1] in rule_type_value.text())
+                        (packageid_value and rule_data == packageid_value.text())
+                        and (rule_source_value and mode[0] == rule_source_value.text())
+                        and (rule_type_value and mode[1] == rule_type_value.text())
                     ):
                         show_warning(
                             title="Duplicate rule",


### PR DESCRIPTION
Addressing https://github.com/RimSort/RimSort/issues/477

Checking for duplicate rules is incorrectly using substring check rather than equivalence check, resulting in cases where mods with package ids sharing substrings are marked as duplicate. Fixing so we're checking for string equivalence.

Example case: add WMBP More Vanilla Biomes `carolusclen.dlc.wmbp.mvb` first, and then WMBP Alpha Biomes `carolusclen.dlc.wmbp`. This is fixed through this PR. Genuine duplicate rules are still detected.