### PR TITLE
Set the default sorting algorithm to be Topological

### DIFF
--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -44,7 +44,7 @@ class Settings(QObject):
         self.database_expiry: int = 604800  # 7 days
 
         # Sorting
-        self.sorting_algorithm: SortMethod = SortMethod.ALPHABETICAL
+        self.sorting_algorithm: SortMethod = SortMethod.TOPOLOGICAL
 
         # DB Builder
         self.db_builder_include: str = "all_mods"


### PR DESCRIPTION
Sets the default sorting algorithm to be Topological instead of Alphabetical. This change has been in discussion for a while.

The reason for making this change is twofold. Currently, Alphabetical is bugged in the sense that it does not respect certain rules when sorting. Additionally, topological as an algorithm makes more sense and is easier to maintain.

The downside is that alphabetical has been the norm for a long time. The result of this is that there may be alphabetical based sorting results that incidentally solved load order issues, but are not explicitly defined in about.xml or the community rules database. To be clear, this is not a flaw of the sorting algorithm itself. These are flaws in the rules defined that were missed.

To be clear, if someone has used RimSort already, and has a valid settings file, they will not experience any change. Only freshly new users as well as those that reset their settings to default will notice a change.