### PR TITLE
Refactor app_info.py initialization

### DIFF
--- a/app/__main__.py
+++ b/app/__main__.py
@@ -33,19 +33,10 @@ from typing import Optional, Type
 import loguru
 from loguru import logger
 
+from app.controllers.app_controller import AppController
+from app.models.dialogue import show_fatal_error
 from app.utils.app_info import AppInfo
 from app.utils.obfuscate_message import obfuscate_message
-
-# One-time initialization of AppInfo class (this must be done in __main__ so we can use __file__)
-# Initialize as early as possible!
-# When the application is frozen, __file__ should be the same when we are __process_main__.
-# This should be the same relative path as the initial __file__ in __main__, i.e. on Win11:
-# __file__ is [C:\Users\Tristin\RimSort\build\__MAIN~1.DIS\__main__.py] when __main__ and __process_main__
-
-# TODO: Fix this so that this cursed import order is not required.
-AppInfo(main_file=__file__)
-
-from app.controllers.app_controller import AppController
 
 SYSTEM = platform.system()
 # Watchdog conditionals
@@ -62,9 +53,6 @@ elif SYSTEM == "Windows":
     # This is a stub if it's ever even needed...
     # I still can't figure out why it won't log at all on Windows...?
     # getLogger("").setLevel(WARNING)
-
-# TODO: Fix this so that this cursed import order is not required
-from app.models.dialogue import show_fatal_error
 
 
 def handle_exception(

--- a/app/utils/app_info.py
+++ b/app/utils/app_info.py
@@ -1,3 +1,4 @@
+import sys
 from pathlib import Path
 from typing import Optional
 
@@ -13,14 +14,13 @@ class AppInfo:
     using the `platformdirs` package, ensuring platform-specific conventions are adhered to.
 
     Examples:
-        >>> app_info = AppInfo(__file__)
         >>> print(app_info.app_name)
         >>> print(app_info.app_storage_folder)
     """
 
     _instance: Optional["AppInfo"] = None
 
-    def __new__(cls, main_file: Optional[str] = None) -> "AppInfo":
+    def __new__(cls) -> "AppInfo":
         """
         Create a new instance or return the existing singleton instance of the `AppInfo` class.
         """
@@ -28,21 +28,20 @@ class AppInfo:
             cls._instance = super(AppInfo, cls).__new__(cls)
         return cls._instance
 
-    def __init__(self, main_file: Optional[str] = None) -> None:
+    def __init__(self) -> None:
         """
         Initialize the `AppInfo` instance, setting application metadata and determining important directories.
 
-        Args:
-            main_file (Optional[str]): Path to the main application file (i.e., __file__ from __main__).
-
         Raises:
-            ValueError: If `main_file` is not provided during the first initialization.
+            Exception: If the main file path cannot be determined.
         """
         if hasattr(self, "_is_initialized") and self._is_initialized:
             return
 
+        main_file = sys.modules["__main__"].__file__
+
         if main_file is None:
-            raise ValueError("AppInfo must be initialized once with __file__.")
+            raise Exception("Unable to get the main file path.")
 
         # Need to go one up if we are running from source
         self._application_folder = (


### PR DESCRIPTION
Refactors the app_info.py initialization process such that it no longer takes a main_file arg. Instead, it looks up the `__main__` module and gets the correct file path to later get the application folder. This makes it such that the app_info singleton can be initialized at any time and by any module. As a consequence, it does not need to have special handling in app.__main__, resolving the long-standing import order issues.