### PR TITLE
Change deprecated extend-select to lint.extend-select

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ indent-width = 4
 
 # Assume Python 3.11
 target-version = "py311"
-extend-select = ["I"]
+lint.extend-select = ["I"]
 
 [tool.pytest.ini_options]
 addopts = [


### PR DESCRIPTION
Fixes a deprecation warning with Ruff