### PR TITLE
Temporarily force windows console as workaround Nuitka bug 3019

### DIFF
--- a/app/__main__.py
+++ b/app/__main__.py
@@ -3,7 +3,7 @@
 # nuitka-project: --assume-yes-for-downloads
 # nuitka-project: --output-filename=RimSort
 # nuitka-project: --output-dir={MAIN_DIRECTORY}/../build/
-# nuitka-project: --disable-console
+# nuitka-project: --windows-console-mode=force
 # nuitka-project: --noinclude-default-mode=error
 # nuitka-project: --include-package=steamworks
 # nuitka-project: --user-package-configuration-file={MAIN_DIRECTORY}/../rimsort.nuitka-package.config.yml

--- a/distribute.py
+++ b/distribute.py
@@ -550,7 +550,7 @@ def main() -> None:
             )
         if args.dev:
             print("In dev mode, enabling console in build")
-            _NUITKA_CMD.append("--enable-console")
+            _NUITKA_CMD.append("--windows-console-mode=force")
 
         print("Building RimSort application with Nuitka...")
         freeze_application()


### PR DESCRIPTION
Temporarily tell Nuitka to force enable the console on Windows. This is a temporary workaround for Nuitka issue 3019 so we can avoid downgrading Nuitka and messing with the Nuitka action.