### PR TITLE
Remove console param from build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,7 +150,6 @@ jobs:
         with:
           nuitka-version: main
           script-name: app/__main__.py
-          disable-console: true
           onefile: false
           static-libpython: auto
           product-version: >-


### PR DESCRIPTION
- Remove console param from build action such that it defaults to whatever is set in __main__.py