### PR TITLE
[306] Fix expansion disabling

### DIFF
--- a/app/utils/schema.py
+++ b/app/utils/schema.py
@@ -7,8 +7,7 @@ from app.views.dialogue import show_warning
 
 
 def generate_rimworld_mods_list(
-    game_version: str,
-    packageids: list[str],
+    game_version: str, packageids: list[str], dlc_ids: list[str] = RIMWORLD_PACKAGE_IDS
 ) -> dict[str, Any]:
     """
     Generate the default Rimworld mods list
@@ -22,7 +21,7 @@ def generate_rimworld_mods_list(
             "knownExpansions": {
                 "li": [
                     packageid
-                    for packageid in packageids
+                    for packageid in dlc_ids
                     if packageid.lower() in RIMWORLD_PACKAGE_IDS
                     and packageid.lower() != "ludeon.rimworld"
                 ],


### PR DESCRIPTION
Closes #306

Patch to fix expansion disabling functionality by making it such that by default, the generate_rimworld_mods_list function handles dlc_ids/known expansions separately from packageids as a whole. In prior behavior, removing expansions from the active list also removed from knownexpansions. However, RimWorld would then forcibly add the expansion packageid into knownexpansions and the modlist.

This means that by default, the knownexpansions field of modconfig.xml will have all expansions that RimSort knows about, regardless if the user owns them, has then enabled or disabled, or if the game version predates that expansion.

Based on my testing, this behavior is fine and handled by the game. There appears to be no negative effects if knownexpansions contains packageids that the user does not own, does not exist (Ie. complete garbage string), does not have installed, or has disabled. 