### PR TITLE
Add graceful error handling for sorting algorithm not implemented

### DIFF
--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -1148,12 +1148,25 @@ class MainContent(QObject):
 
         # Get the current order of active mods list
         current_order = self.mods_panel.active_mods_list.uuids.copy()
-
-        sorter = Sorter(
-            self.settings_controller.settings.sorting_algorithm,
-            active_package_ids=active_package_ids,
-            active_uuids=set(self.mods_panel.active_mods_list.uuids),
-        )
+        try:
+            sorter = Sorter(
+                self.settings_controller.settings.sorting_algorithm,
+                active_package_ids=active_package_ids,
+                active_uuids=set(self.mods_panel.active_mods_list.uuids),
+            )
+        except NotImplementedError as e:
+            dialogue.show_warning(
+                title="Sorting algorithm not implemented",
+                text="The selected sorting algorithm is not implemented",
+                information=(
+                    "This may be caused by malformed settings or improper migration between versions or different mod manager. "
+                    "Try resetting your settings, selecting a different sorting algorithm, or "
+                    "deleting your settings file. If the issue persists, please report it the developers."
+                ),
+                details=str(e),
+            )
+            logger.error(f"Sort failed. Sorting algorithm not implemented: {e}")
+            return
 
         success, new_order = sorter.sort()
 


### PR DESCRIPTION
Adds graceful error handling for when sorting algorithm not implemented error. Warns the user with a warning dialogue instead of a fatal crash when RimSort doesn't recognize the sorting method that has been selected. The dialogue describes some potential avenues of mitigation. Mitigation is not done automatically to provide greater user control.

This is particularly useful for improper migration between versions, or from other mod managers like RimPy that happen to use the same settings file and location.

![image](https://github.com/user-attachments/assets/3c0651a3-beab-4bcf-98b4-7c827d7cd552)

