### PR TITLE
[562] Fixed clearing list in mod downloader

### DIFF
--- a/app/utils/steam/browser.py
+++ b/app/utils/steam/browser.py
@@ -290,8 +290,8 @@ class SteamBrowser(QWidget):
 
     def _clear_downloader_list(self) -> None:
         self.downloader_list.clear()
-        self.downloader_list_mods_tracking = []
-        self.downloader_list_dupe_tracking = {}
+        self.downloader_list_mods_tracking.clear()
+        self.downloader_list_dupe_tracking.clear()
 
     def _downloader_item_ContextMenuEvent(self, point: QPoint) -> None:
         context_item = self.downloader_list.itemAt(point)


### PR DESCRIPTION
Addressing git issue #562 

From my understanding '.clear()' clears the list and all references to it while '= []' only initialized that specific list to an empty list, and did not touch any references to itself.

Issue seemed to be that here we create a reference to this list in the signal:
![image](https://github.com/user-attachments/assets/0a439ff7-e137-4c61-a71b-bf522ba4cfef)


And it retained the old data even if the list was 'cleared'

While I did not look into it, I assume we want the same behavior for the **downloader_list_dupe_tracking** dict, so I changed it to use .clear() as well.