### PR TITLE
[575] Re-create symlink option when reinstalling SteamCMD

### DIFF
--- a/app/utils/steam/steamcmd/wrapper.py
+++ b/app/utils/steam/steamcmd/wrapper.py
@@ -323,15 +323,15 @@ class SteamcmdInterface:
             )
             runner.message(f"Symlink source : {symlink_source_path}")
             runner.message(f"Symlink destination: {symlink_destination_path}")
-            if os.path.exists(symlink_destination_path): # Symlink exists
+            if self.is_junction_or_link(symlink_destination_path): # Symlink/junction exists
                 runner.message(
                     f"Symlink destination already exists! Please remove existing destination:\n\n{symlink_destination_path}\n"
                 )
                 answer = show_dialogue_conditional(
                 "Re-create Symlink?",
-                "The symlink destination path already exists."
-                " Would you like to delete the existing path and create a new symlink?",
-                f"Existing destination: {symlink_destination_path}",
+                "An existing symlink already exists."
+                " Would you like to delete and re-create the symlink?",
+                f"Existing symlink: {symlink_destination_path}",
                 "The symlink makes SteamCMD download mods to the local mods folder"
                 + " and is required for SteamCMD mod downloads to work correctly."
                 "\n\nNew symlink:"
@@ -339,7 +339,23 @@ class SteamcmdInterface:
             )
                 if answer == "&Yes": # Re-create symlink
                     self.create_symlink(runner, symlink_source_path, symlink_destination_path)
-            else: # Symlink does not exist
+            elif os.path.exists(symlink_destination_path): # A dir exists (not a symlink/junction)
+                runner.message(
+                    f"Symlink destination already exists! Please remove existing destination:\n\n{symlink_destination_path}\n"
+                )
+                answer = show_dialogue_conditional(
+                "Create Symlink?",
+                "The symlink destination path already exists."
+                " Would you like to remove the existing destination and create a new symlink in it's place?",
+                f"Existing destination: {symlink_destination_path}",
+                "The symlink makes SteamCMD download mods to the local mods folder"
+                + " and is required for SteamCMD mod downloads to work correctly."
+                "\n\nNew symlink:"
+                f"\n[{symlink_source_path}] -> " + symlink_destination_path,
+            )
+                if answer == "&Yes": # Re-create symlink/junction
+                    self.create_symlink(runner, symlink_source_path, symlink_destination_path)
+            else: # Symlink/junction does not exist
                 answer = show_dialogue_conditional(
                     "Create symlink?",
                     "The symlink makes SteamCMD download mods to the local mods folder"

--- a/app/utils/steam/steamcmd/wrapper.py
+++ b/app/utils/steam/steamcmd/wrapper.py
@@ -154,7 +154,7 @@ class SteamcmdInterface:
                 ) or os.path.ismount(symlink_destination_path):
                     os.unlink(symlink_destination_path)
                 elif os.path.isdir(symlink_destination_path):
-                    os.rmdir(symlink_destination_path)
+                    shutil.rmtree(symlink_destination_path)
                 else:
                     os.remove(symlink_destination_path)
             if self.system != "Windows":

--- a/app/utils/steam/steamcmd/wrapper.py
+++ b/app/utils/steam/steamcmd/wrapper.py
@@ -187,7 +187,7 @@ class SteamcmdInterface:
         """
         This checks if a path is a symlink.
         
-        Additionaly on Windows it checks if the path is a junction.
+        Additionally on Windows it checks if the path is a junction.
         
         If the path does not exist or is not a symlink/junction, 
         it will catch an OSError, and return false.
@@ -331,9 +331,9 @@ class SteamcmdInterface:
                 "Re-create Symlink?",
                 "An existing symlink already exists."
                 " Would you like to delete and re-create the symlink?",
-                f"Existing symlink: {symlink_destination_path}",
                 "The symlink makes SteamCMD download mods to the local mods folder"
-                + " and is required for SteamCMD mod downloads to work correctly."
+                + " and is required for SteamCMD mod downloads to work correctly.",
+                f"Existing symlink: {symlink_destination_path}"
                 "\n\nNew symlink:"
                 f"\n[{symlink_source_path}] -> " + symlink_destination_path,
             )
@@ -347,9 +347,9 @@ class SteamcmdInterface:
                 "Create Symlink?",
                 "The symlink destination path already exists."
                 " Would you like to remove the existing destination and create a new symlink in it's place?",
-                f"Existing destination: {symlink_destination_path}",
                 "The symlink makes SteamCMD download mods to the local mods folder"
-                + " and is required for SteamCMD mod downloads to work correctly."
+                + " and is required for SteamCMD mod downloads to work correctly.",
+                f"Existing destination: {symlink_destination_path}"
                 "\n\nNew symlink:"
                 f"\n[{symlink_source_path}] -> " + symlink_destination_path,
             )

--- a/app/utils/steam/steamcmd/wrapper.py
+++ b/app/utils/steam/steamcmd/wrapper.py
@@ -358,7 +358,7 @@ class SteamcmdInterface:
             else: # Symlink/junction does not exist
                 answer = show_dialogue_conditional(
                     "Create Symlink?",
-                    "Create symlink?",
+                    "Do you want to create a symlink?",
                     "The symlink makes SteamCMD download mods to the local mods folder"
                     + " and is required for SteamCMD mod downloads to work correctly.",
                     "New symlink:"

--- a/app/utils/steam/steamcmd/wrapper.py
+++ b/app/utils/steam/steamcmd/wrapper.py
@@ -357,10 +357,10 @@ class SteamcmdInterface:
                     self.create_symlink(runner, symlink_source_path, symlink_destination_path)
             else: # Symlink/junction does not exist
                 answer = show_dialogue_conditional(
+                    "Create Symlink?",
                     "Create symlink?",
                     "The symlink makes SteamCMD download mods to the local mods folder"
                     + " and is required for SteamCMD mod downloads to work correctly.",
-                    "",
                     "New symlink:"
                     f"\n[{symlink_source_path}] -> " + symlink_destination_path,
                 )

--- a/app/utils/steam/steamcmd/wrapper.py
+++ b/app/utils/steam/steamcmd/wrapper.py
@@ -171,7 +171,7 @@ class SteamcmdInterface:
                 )
             self.setup = True
             runner.message(
-                f"Finished creating symlink\n"
+                "Finished creating symlink\n"
             )
         except Exception as e:
             runner.message(

--- a/app/utils/steam/steamcmd/wrapper.py
+++ b/app/utils/steam/steamcmd/wrapper.py
@@ -329,8 +329,9 @@ class SteamcmdInterface:
                 )
                 answer = show_dialogue_conditional(
                 "Re-create Symlink?",
-                "An existing symlink already exists. Would you like to delete and re-create the symlink?",
-                f"Existing symlink: {symlink_destination_path}",
+                "The symlink destination path already exists."
+                " Would you like to delete the existing path and create a new symlink?",
+                f"Existing destination: {symlink_destination_path}",
                 "The symlink makes SteamCMD download mods to the local mods folder"
                 + " and is required for SteamCMD mod downloads to work correctly."
                 "\n\nNew symlink:"


### PR DESCRIPTION
Addressing git issue #575 

If user is reinstalling SteamCMD, ask if they want to delete and re-create the symlink.
![image](https://github.com/user-attachments/assets/971b4c05-8088-42a6-9af3-8435e62e2477)


Also added a small message to help explain what the symlink does.
![image](https://github.com/user-attachments/assets/16db9bf9-a299-4d2b-b004-f6317be23b8f)


I also moved the creation of a symlink into it's own method.

Changed the removal of the symlink dir to use shutil.rmtree, otherwise If a user downloaded a mod without a symlink, and then reinstalled SteamCMD and tried to 're-create symlink' it gave a non empty dir error.
![image](https://github.com/user-attachments/assets/38a44473-4ea8-4c0f-94d6-8a0711f6f195)
