### PR TITLE
Fix minor linting errors

### DIFF
--- a/app/utils/watchdog.py
+++ b/app/utils/watchdog.py
@@ -49,7 +49,7 @@ class WatchdogHandler(FileSystemEventHandler, QObject):
         for path in targets:
             if path and os.path.exists(path) and os.path.isdir(path):
                 if self.watchdog_observer is not None:
-                    self.watchdog_observer.schedule(  # type: ignore # Lib doesn't have proper return type
+                    self.watchdog_observer.schedule(
                         self,
                         path,
                         recursive=True,

--- a/app/utils/win_find_steam.py
+++ b/app/utils/win_find_steam.py
@@ -19,8 +19,8 @@ if sys.platform == "win32":
             tuple[str, bool]: The path to the steam folder and a boolean indicating if the path was found
         """
         candidate_reg_keys = [
-            "SOFTWARE\Wow6432Node\Valve\Steam",
-            "SOFTWARE\Valve\Steam",
+            r"SOFTWARE\Wow6432Node\Valve\Steam",
+            r"SOFTWARE\Valve\Steam",
         ]
 
         for reg_key in candidate_reg_keys:


### PR DESCRIPTION
- Small change such that the windows style paths for registry keys don't trigger a linting error on linux.
- Remove watchdog type ignore