### PR TITLE
Fix dependabot exclusion for misc changes in release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -16,7 +16,7 @@ changelog:
         - "*"
       exclude:
         authors:
-          - dependabot[bot]
+          - dependabot
     - title: "Dependency Updates"
       labels:
         - dependencies


### PR DESCRIPTION
dependabot exclusion didn't seem to work before. Hopefully, this fixes it.