### PR TITLE
Improvements to GitHub Issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -65,6 +65,7 @@ body:
   - type: dropdown
     id: coc_terms
     attributes:
+      multiple: true
       label: Code of Conduct
       description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/RimSort/RimSort/blob/main/CODE_OF_CONDUCT.md).
       options:
@@ -75,6 +76,7 @@ body:
   - type: dropdown
     id: dup_terms
     attributes:
+      multiple: true
       label: Duplicate Issue Check
       description: By submitting this issue, you attest that you've searched for similar [issues on GitHub](https://github.com/RimSort/RimSort/issues) and didn't find any.
       options:
@@ -85,6 +87,7 @@ body:
   - type: dropdown
     id: wiki_terms
     attributes:
+      multiple: true
       label: Wiki/FAQ Check
       description: By submitting this issue, you attest that you've checked [the Wiki](https://github.com/RimSort/RimSort/wiki) for potential solutions and didn't find any.
       options:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -26,8 +26,8 @@ body:
     id: version
     attributes:
       label: Version
-      description: What version are you using? Please include the commit hash if you're using a self-compiled version.
-      placeholder: Version number/Commit hash (e.g.,  v1.0.9, v1.0.10-edge49+b010fe5, b010fe5)
+      description: What version are you using? Please include the commit hash if you're not using a pre-compiled release.
+      placeholder: Version number/Commit hash (e.g., v1.0.9, b010fe5)
     validations:
       required: true
   - type: input
@@ -35,7 +35,7 @@ body:
     attributes:
       label: Operating System
       description: What Operating System are you using? Please include your CPU architecture if on MacOS and desktop environment if on Linux.
-      placeholder: Windows 11, macOS (Arm64), Arch (KDE), etc.
+      placeholder: Windows 11, macOS (ARM64), Arch (KDE), etc.
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,4 @@
 name: Bug Report
-title: "[Bug]: "
 description: Create a bug report to help us improve
 labels: ["bugs 🪲"]
 body:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -14,11 +14,11 @@ body:
       description: What release type(s) are you using?
       multiple: true
       options:
-        - Compiled Windows x86 64-bit
-        - Compiled Darwin x86 64-bit
-        - Compiled Darwin arm64
-        - Compiled Ubuntu 22.04
-        - Compiled Ubuntu 24.04
+        - Compiled (Windows x86-64)
+        - Compiled (Darwin x86-64)
+        - Compiled (Darwin ARM64)
+        - Compiled (Ubuntu 22.04)
+        - Compiled (Ubuntu 24.04)
         - Self-Compiled
         - Python Interpreter
     validations:
@@ -27,8 +27,8 @@ body:
     id: version
     attributes:
       label: Version
-      description: What version are you using?
-      placeholder: Version number/Commit hash
+      description: What version are you using? Please include the commit hash if you're using a self-compiled version.
+      placeholder: Version number/Commit hash (e.g.,  v1.0.9, v1.0.10-edge49+b010fe5, b010fe5)
     validations:
       required: true
   - type: input
@@ -45,7 +45,7 @@ body:
       label: Relevant logs
       description: Please provide a RimSort.log file. There may be circumstances where a log file is not generated but without logs, it is difficult to diagnose the issue.
       placeholder: Link to RimSort.log file
-  
+
   - type: textarea
     id: bug_description
     attributes:
@@ -62,29 +62,32 @@ body:
       description: Add additional context about the problem here.
       placeholder: Additional context about the problem.
 
-  - type: checkboxes
+  - type: dropdown
     id: coc_terms
     attributes:
       label: Code of Conduct
       description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/RimSort/RimSort/blob/main/CODE_OF_CONDUCT.md).
       options:
-        - label: I agree to follow this project's Code of Conduct
-          required: true
+        - I agree to follow this project's Code of Conduct
+    validations:
+      required: true
 
-  - type: checkboxes
+  - type: dropdown
     id: dup_terms
     attributes:
       label: Duplicate Issue Check
-      description: By submitting this issue, you attest that you've checked the issues tab for potential duplicates of this issue.
+      description: By submitting this issue, you attest that you've searched for similar [issues on GitHub](https://github.com/RimSort/RimSort/issues) and didn't find any.
       options:
-        - label: I've checked for duplicate issues
-          required: true
+        - I've checked for similar issues and didn't find anything
+    validations:
+      required: true
 
-  - type: checkboxes
+  - type: dropdown
     id: wiki_terms
     attributes:
       label: Wiki/FAQ Check
-      description: By submitting this issue, you attest that you've checked [the Wiki](https://github.com/RimSort/RimSort/wiki) for potential solutions
+      description: By submitting this issue, you attest that you've checked [the Wiki](https://github.com/RimSort/RimSort/wiki) for potential solutions and didn't find any.
       options:
-        - label: I've checked the Wiki for a solution
-          required: true
+        - I've checked the Wiki for a solution and didn't find a solution
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Wiki
+    url: https://github.com/RimSort/RimSort/wiki
+    about: Please check the Wiki for usage/contribution instructions, as well as solutions to common issues.
+  - name: Discord
+    url: https://discord.gg/ErTaTRwrTm
+    about: Visit our Discord server for discussions, extra support, and community interaction.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,4 @@
 name: Feature request
-title: "[Suggestion]: "
 description: Suggest an idea for this project
 labels: ["feature/improvement 🆕"]
 body:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -36,29 +36,32 @@ body:
       description: Add additional context about your feature request here.
       placeholder: Additional context about your feature request.
 
-  - type: checkboxes
+  - type: dropdown
     id: coc_terms
     attributes:
       label: Code of Conduct
       description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/RimSort/RimSort/blob/main/CODE_OF_CONDUCT.md).
       options:
-        - label: I agree to follow this project's Code of Conduct
-          required: true
+        - I agree to follow this project's Code of Conduct
+    validations:
+      required: true
 
-  - type: checkboxes
+  - type: dropdown
     id: dup_terms
     attributes:
       label: Duplicate Issue Check
-      description: By submitting this issue, you attest that you've checked the issues tab for potential duplicates of this issue.
+      description: By submitting this issue, you attest that you've searched for similar [issues on GitHub](https://github.com/RimSort/RimSort/issues) and didn't find any.
       options:
-        - label: I've checked for duplicate issues
-          required: true
+        - I've checked for similar issues and didn't find anything
+    validations:
+      required: true
 
-  - type: checkboxes
+  - type: dropdown
     id: wiki_terms
     attributes:
       label: Wiki/FAQ Check
-      description: By submitting this issue, you attest that you've checked [the Wiki](https://github.com/RimSort/RimSort/wiki) for potential solutions
+      description: By submitting this issue, you attest that you've checked [the Wiki](https://github.com/RimSort/RimSort/wiki) for potential solutions and didn't find any.
       options:
-        - label: I've checked the Wiki for a solution
-          required: true
+        - I've checked the Wiki for a solution and didn't find a solution
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -39,6 +39,7 @@ body:
   - type: dropdown
     id: coc_terms
     attributes:
+      multiple: true
       label: Code of Conduct
       description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/RimSort/RimSort/blob/main/CODE_OF_CONDUCT.md).
       options:
@@ -49,6 +50,7 @@ body:
   - type: dropdown
     id: dup_terms
     attributes:
+      multiple: true
       label: Duplicate Issue Check
       description: By submitting this issue, you attest that you've searched for similar [issues on GitHub](https://github.com/RimSort/RimSort/issues) and didn't find any.
       options:
@@ -59,6 +61,7 @@ body:
   - type: dropdown
     id: wiki_terms
     attributes:
+      multiple: true
       label: Wiki/FAQ Check
       description: By submitting this issue, you attest that you've checked [the Wiki](https://github.com/RimSort/RimSort/wiki) for potential solutions and didn't find any.
       options:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -92,5 +92,8 @@
     "steamworkspy",
     "todds",
     "virtualenv"
-  ]
+  ],
+  "yaml.schemas": {
+    "https://json.schemastore.org/github-issue-config.json": "file:///c%3A/Code%20Repos/RimSort/.github/ISSUE_TEMPLATE/config.yml"
+  }
 }


### PR DESCRIPTION
 * Added links to the Wiki and Discord under the issues page.
![image](https://github.com/user-attachments/assets/a37c4827-ab03-45bd-bc47-acd65b1dfd26)
 * Improved the description for the duplicate issue affirmation
 * Changed affirmation actions from checkboxes to multi-selection dropdowns. 
This is to prevent the result acting as a task item and prevent the rendering of tasks completed for created issues. Multi-selection dropdowns are utilized since this seems to be the only way to force a selection before submission for a dropdown. If it is not multi-selection, the dropdown seems to just default to the first option without input and no user action is required to pass required entry validation. This is not optimal as it requires an extra click for the user and should ideally be changed once GitHub fixes this behavior.
![image](https://github.com/user-attachments/assets/1c450d93-80fb-4ea3-9f0b-7b825502301d)
![image](https://github.com/user-attachments/assets/e09ff1e5-d0c0-441b-a607-5acd48aa8ba4)
 * Removed the default title
 This is to reduce the risk of issues being submitted without a title. The automated labels should be sufficient for organization.
  * For bug reports, improved the release type selection options to be more clear and concise
  ![image](https://github.com/user-attachments/assets/a0715498-e485-4bdc-be84-f06d1ad8e854)
  * For bug reports, improved placeholder text for inputs
  * For bug reports, ask the user to use the commit hash for the version if not using a pre-compiled release
![image](https://github.com/user-attachments/assets/9f131c37-362b-4cb4-8b3f-075b57b6398c)


 
