### PR TITLE
Remove pytz and types-Deprecated, replace outdated type libs with new typeshed libs

### DIFF
--- a/app/sort/topo_sort.py
+++ b/app/sort/topo_sort.py
@@ -50,7 +50,7 @@ def do_topo_sort(
 
 
 def find_circular_dependencies(dependency_graph: dict[str, set[str]]) -> None:
-    G = nx.DiGraph(dependency_graph)
+    G = nx.DiGraph(dependency_graph)  # type: ignore # Stubs seem to be broken for args
     cycles = list(nx.simple_cycles(G))
 
     cycle_strings = []

--- a/app/utils/app_info.py
+++ b/app/utils/app_info.py
@@ -62,11 +62,15 @@ class AppInfo:
         version_file = str(self._application_folder / "version.xml")
         if os.path.exists(version_file):
             root = objectify.parse(version_file, parser=etree.XMLParser(recover=True))
-            self._app_version = root.find("version").text
+            ver = root.find("version")
+            if ver is not None and ver.text is not None:
+                self._app_version = ver.text
 
             # If edge in version_string, append short sha
             if "edge" in self._app_version.lower():
-                self._app_version += f"+{root.find('commit').text[:7]}"
+                commit = root.find("commit")
+                if commit is not None and commit.text is not None:
+                    self._app_version += f"+{commit[:7]}"
 
         # Define important directories using platformdirs
 

--- a/app/utils/rentry/wrapper.py
+++ b/app/utils/rentry/wrapper.py
@@ -62,7 +62,8 @@ class RentryUpload:
                 self.handle_upload_failure(response)
             else:
                 self.upload_success = True
-                self.url = response["url"]
+                url = response.get("url")
+                self.url = url if isinstance(url, str) else None
         finally:
             if self.upload_success:
                 logger.debug(

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -1617,8 +1617,12 @@ class MainContent(QObject):
         # Upload the report to Rentry.co
         rentry_uploader = RentryUpload(active_mods_rentry_report)
         successful = rentry_uploader.upload_success
-        host = urlparse(rentry_uploader.url).hostname if successful else None
-        if rentry_uploader.url and host and host.endswith("rentry.co"):  # type: ignore
+        host = (
+            urlparse(rentry_uploader.url).hostname
+            if successful and (rentry_uploader.url is not None)
+            else None
+        )
+        if rentry_uploader.url and host and host.endswith("rentry.co"):
             copy_to_clipboard_safely(rentry_uploader.url)
             dialogue.show_information(
                 title="Uploaded active mod list",

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -158,9 +158,9 @@ class MainWindow(QMainWindow):
     def __disable_enable_widgets(self, enable: bool) -> None:
         # Disable widgets
         q_app = QApplication.instance()
-        if q_app is None:
+        if not isinstance(q_app, QApplication):
             return
-        for widget in q_app.allWidgets():  # type: ignore # Broken pyside stub
+        for widget in q_app.allWidgets():
             widget.setEnabled(enable)
 
     def showEvent(self, event: QShowEvent) -> None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,14 +7,13 @@ msgspec==0.18.6
 natsort==8.4.0
 networkx==3.3
 platformdirs==4.3.2
+psutil==6.0.0
 PyGithub==2.3.0
 pyperclip==1.9.0
 PySide6
 PySide6==6.7.2; sys_platform == 'darwin'
 PySide6==6.7.2; sys_platform == 'linux'
 PySide6==6.7.2; sys_platform == 'win32'
-psutil==6.0.0
-pytz==2024.1
 requests==2.32.3
 steam==1.4.4
 toposort==1.10

--- a/requirements_develop.txt
+++ b/requirements_develop.txt
@@ -1,12 +1,11 @@
-ruff
 mypy
+pytest
+pytest-qt
+ruff
 types-Deprecated
+types-lxml
+types-networkx
 types-psutil
-#types-pyside6
 types-requests
 types-toposort
 types-xmltodict
-networkx-stubs
-lxml-stubs
-pytest
-pytest-qt

--- a/requirements_develop.txt
+++ b/requirements_develop.txt
@@ -2,7 +2,6 @@ mypy
 pytest
 pytest-qt
 ruff
-types-Deprecated
 types-lxml
 types-networkx
 types-psutil


### PR DESCRIPTION
- Removed pytz from requirements as it was not being used anywhere and the library recommends that projects using 3.9 or later use the standard lib instead. https://pypi.org/project/pytz/
- Removed types-Deprecated as the Deprecated lib was not being used directly
- Replaced networkx-stubs and lxml-stubs with their typeshed equivalents
- Cleaned up and sorted requirements files
- Fixed any emerging type errors