### PR TITLE
Sort the inactive mod list alphabetically

### DIFF
--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -87,9 +87,24 @@ class ModsPanelSortKey(Enum):
     """
     Enum class representing different sorting keys for mods.
     """
+    NOKEY = 0
+    MODNAME = 1
 
-    NOKEY = None
-    MODNAME = uuid_to_mod_name
+
+def sort_uuids(uuids: List[str], key: ModsPanelSortKey) -> List[str]:
+    """
+    Sort the list of UUIDs based on the provided key.
+    Args:
+        key (ModsPanelSortKey): The key to sort the list by.
+    Returns:
+        None
+    """
+    # Sort the list of UUIDs based on the provided key
+    if key == ModsPanelSortKey.MODNAME:
+        sort_function = uuid_to_mod_name
+    else:
+        sort_function = lambda uuid: uuid
+    return sorted(uuids, key=sort_function)
 
 
 class ModListItemInner(QWidget):
@@ -1917,9 +1932,10 @@ class ModListWidget(QListWidget):
             None
         """
         # TODO: Fix this or just get rid of it
-        sorted_uuids = uuids
+        # sorted_uuids = uuids
         # if key != ModsPanelSortKey.NOKEY:
         #    sorted_uuids = sorted(uuids, key=key)
+        sorted_uuids = sort_uuids(uuids, key = key)
         self.recreate_mod_list(list_type, sorted_uuids)
 
     def recreate_mod_list(self, list_type: str, uuids: List[str]) -> None:


### PR DESCRIPTION
Hi guys!

It seems the sorting functionality was gone since some big updates ago. I checked this part of code and tried to make it work again. 

It seems that there are some consideration for performance impacts of the recreate_mod_list function and it has been resolved. 

I did my own tests by adding a `print('sorting')` in the `sort_uuids` function and it looks like there's no abundant sorting anymore (I removed that print clause in this commit). However, I'm not 100% sure this is not creating any issues and I really wish someone would like to really look into this and test its impact on performance. 

For me, it's doing very well and not having any issues in performance right now.

Changes in this pull request: 
1. update the ModsPanelSortKey enum class to use numbers not functions as enum values
2. add a sort_uuids global function to sort the uuids based on the ModsPanelSortKey parameter
3. update the behaviour of `recreate_mod_list_and_sort` to use sorted uuids rather than the original uuids list