### PR TITLE
[619] Fix git url parsing, add improved git action dialogue contents, fix metadata deletion race condition crash

### DIFF
--- a/app/utils/generic.py
+++ b/app/utils/generic.py
@@ -291,3 +291,33 @@ def upload_data_to_0x0_st(path: str) -> tuple[bool, str]:
             f"Failed to upload data to http://0x0.st. Status code: {request.status_code}"
         )
         return False, f"Status code: {request.status_code}"
+
+
+def extract_git_dir_name(url: str) -> str:
+    """
+    Function to extract the directory name from a git url
+
+    :param url: a string url to a git repository
+    :return: a string that is the directory name of the git repository
+    """
+    return url.rstrip("/").rsplit("/", maxsplit=1)[-1].removesuffix(".git")
+
+
+def extract_git_user_or_org(url: str) -> str:
+    """
+    Function to extract the organization or user name from a git url
+
+    :param url: a string url to a git repository
+    :return: a string that is the organization name of the git repository
+    """
+    return url.rstrip("/").rsplit("/", maxsplit=2)[-2].removesuffix(".git")
+
+
+def check_valid_http_git_url(url: str) -> bool:
+    """
+    Function to check if a given url is a valid http/s git url
+
+    :param url: a string url to a git repository
+    :return: a boolean indicating whether the url is a valid git url
+    """
+    return url and url != "" and url.startswith("http://") or url.startswith("https://")

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -2401,7 +2401,7 @@ class MainContent(QObject):
                         title="Repo force updated",
                         text="The configured repository was updated!",
                         information=f"{repo_path} ->\n "
-                        + f"{repo.head.commit.message.decode() if isinstance(repo.head.commit.message, bytes) else repo.head.commit.message}",
+                        + f"Latest Commit: {repo.head.commit.message.decode() if isinstance(repo.head.commit.message, bytes) else repo.head.commit.message}",
                     )
                     # Cleanup
                     self._do_cleanup_gitpython(repo=repo)

--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -224,9 +224,7 @@ class ModListItemInner(QWidget):
                 self.uuid,
             )
         )
-        self.error_icon_label.setPixmap(
-            ModListIcons.error_icon().pixmap(QSize(20, 20))
-        )
+        self.error_icon_label.setPixmap(ModListIcons.error_icon().pixmap(QSize(20, 20)))
         # Default to hidden to avoid showing early
         self.error_icon_label.setHidden(True)
         # Icons by mod source
@@ -427,7 +425,7 @@ class ModListItemInner(QWidget):
             self.error_icon_label.setToolTip(error_tooltip)
         else:  # Hide the error icon if no error tool tip text
             self.error_icon_label.setHidden(True)
-            self.error_icon_label.setToolTip("") 
+            self.error_icon_label.setToolTip("")
         if warning_tooltip:
             self.warning_icon_label.setHidden(False)
             self.warning_icon_label.setToolTip(warning_tooltip)
@@ -635,7 +633,7 @@ class ModListWidget(QListWidget):
         logger.debug(
             f"Emitting {self.list_type} list update signal after rows dropped [{self.count()}]"
         )
-        # Only emit "drop" signal if a mod was dragged and dropped within the same modlist 
+        # Only emit "drop" signal if a mod was dragged and dropped within the same modlist
         if source_widget == self:
             self.list_update_signal.emit("drop")
 
@@ -1579,11 +1577,11 @@ class ModListWidget(QListWidget):
         item = QListWidgetItem(self)
         item.setData(Qt.ItemDataRole.UserRole, data)
         self.addItem(item)
-        
+
     def get_all_mod_list_items(self) -> list[QListWidgetItem]:
         """
         This gets all modlist items.
-        
+
         :return: List of all modlist items as QListWidgetItem
         """
         mod_list_items = []
@@ -1596,7 +1594,7 @@ class ModListWidget(QListWidget):
         """
         This gets all modlist items as ModListItemInner.
         Mods that have not been loaded or lazy loaded will not be returned.
-        
+
         :return: List of all modlist items as ModListItemInner
         """
         mod_list_items = []
@@ -1610,7 +1608,7 @@ class ModListWidget(QListWidget):
     def get_all_loaded_and_toggled_mod_list_items(self) -> list[QListWidgetItem]:
         """
         This returns all modlist items that have their warnings toggled.
-        
+
         :return: List of all toggled modlist items as QListWidgetItem
         """
         mod_list_items = []
@@ -1862,14 +1860,16 @@ class ModListWidget(QListWidget):
                 uuid
             )
             # Set an item's validity dynamically based on the version mismatch value
-            if (mod_data["packageid"] not in self.ignore_warning_list 
-                and not current_item_data["warning_toggled"]):
+            if (
+                mod_data["packageid"] not in self.ignore_warning_list
+                and not current_item_data["warning_toggled"]
+            ):
                 current_item_data["mismatch"] = mod_errors["version_mismatch"]
             else:
                 # If a mod has been moved for eg. inactive -> active. We keep ignoring the warnings.
                 # This makes sure to add the mod to the ignore list of the new modlist.
                 # TODO: Check if toggle_warning method can add a mod to the ignore list
-                # of each ModListWidget. Then we can remove some of this confusing code...  
+                # of each ModListWidget. Then we can remove some of this confusing code...
                 if not current_item_data["warning_toggled"]:
                     if mod_data["packageid"] in self.ignore_warning_list:
                         self.ignore_warning_list.remove(mod_data["packageid"])
@@ -1984,7 +1984,7 @@ class ModListWidget(QListWidget):
                 total_error_text += f"\n\n{mod_data['name']}"
                 total_error_text += "\n" + "=" * len(mod_data["name"])
                 total_error_text += tool_tip_text
-                
+
             # Add to warning summary if any loadBefore or loadAfter violations, or version mismatch
             # Version mismatch is determined earlier without checking if the mod is in ignore_warning_list
             # so we have to check it again here in order to not display a faulty, empty version warning
@@ -2008,7 +2008,9 @@ class ModListWidget(QListWidget):
                 total_warning_text += tool_tip_text
             # Add tooltip to item data and set the data back to the item
             current_item_data["errors_warnings"] = tool_tip_text.strip()
-            current_item_data["warnings"] = tool_tip_text[len(current_item_data["errors"]):].strip()
+            current_item_data["warnings"] = tool_tip_text[
+                len(current_item_data["errors"]) :
+            ].strip()
             current_item_data["errors"] = current_item_data["errors"].strip()
             current_item.setData(Qt.ItemDataRole.UserRole, current_item_data)
         logger.info(f"Finished recalculating {self.list_type} list errors")
@@ -2100,6 +2102,7 @@ class ModListWidget(QListWidget):
             item_data["warning_toggled"] = False
         item.setData(Qt.ItemDataRole.UserRole, item_data)
         self.recalculate_warnings_signal.emit()
+
 
 class ModsPanel(QWidget):
     """

--- a/tests/utils/test_generic.py
+++ b/tests/utils/test_generic.py
@@ -1,0 +1,35 @@
+from app.utils.generic import (
+    check_valid_http_git_url,
+    extract_git_dir_name,
+    extract_git_user_or_org,
+)
+
+GIT_URLS = [
+    "https://github.com/org/RimSort.git",
+    "https://github.com/org/RimSort",
+    "https://github.com/org/RimSort/",
+    "http://github.com/org/RimSort.git",
+    "github.com/org/RimSort.git",
+    "github.com/org/RimSort",
+    "github.com/org/RimSort/",
+]
+
+
+def test_get_git_dir_name() -> None:
+    for url in GIT_URLS:
+        assert extract_git_dir_name(url) == "RimSort"
+
+
+def test_get_git_org_or_user() -> None:
+    for url in GIT_URLS:
+        assert extract_git_user_or_org(url) == "org"
+
+
+def test_check_valid_http_git_url() -> None:
+    assert check_valid_http_git_url("") is False
+
+    assert check_valid_http_git_url("github.com/org/RimSort.git") is False
+
+    assert check_valid_http_git_url("https://github.com/org/RimSort.git") is True
+
+    assert check_valid_http_git_url("http://github.com/org/RimSort.git/") is True


### PR DESCRIPTION
Fixes #619.

Makes it such that url parsing of http/s git urls should be much more robust. This includes the situation where the given url ends in a `/` with no other contents afterwards. Previously, that situation when parsing for the repo dir name would return an empty string as there was nothing after the last slash. These methods were factored out into generic with corresponding tests.

Additionally, the git clone action dialogue contents were improved. On bad url detection, the url is printed in the details section. On clone success, the display of the git url is not hyperlinked.