### PR TITLE
json_dump (just incase if required)

### DIFF
--- a/app/controllers/app_controller.py
+++ b/app/controllers/app_controller.py
@@ -36,7 +36,7 @@ class AppController(QObject):
         if not user_rules_path.exists():
             initial_rules_db = DEFAULT_USER_RULES
             with open(user_rules_path, "w", encoding="utf-8") as output:
-                json.dump(initial_rules_db, output, indent=4)
+                output.write(json.dumps(initial_rules_db, indent=4))
 
         # Instantiate the settings model, view and controller
         self.settings = Settings()

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -218,7 +218,7 @@ class Settings(QObject):
             self._debug_file.unlink(missing_ok=True)
 
         with open(str(self._settings_file), "w") as file:
-            json.dump(self._to_dict(), file, indent=4)
+            file.write(json.dumps(self._to_dict(), indent=4))
 
     def _from_dict(self, data: Dict[str, Any]) -> None:
         special_attributes = ["instances"]

--- a/app/utils/metadata.py
+++ b/app/utils/metadata.py
@@ -305,7 +305,7 @@ class MetadataManager(QObject):
                 "w",
                 encoding="utf-8",
             ) as output:
-                json.dump(DEFAULT_USER_RULES, output, indent=4)
+                output.write(json.dumps(DEFAULT_USER_RULES, indent=4))
             self.external_user_rules = (
                 DEFAULT_USER_RULES["rules"]
                 if isinstance(DEFAULT_USER_RULES["rules"], dict)
@@ -2355,7 +2355,7 @@ class SteamDatabaseBuilder(QThread):
                     recurse_exceptions=DB_BUILDER_RECURSE_EXCEPTIONS,
                 )
                 with open(self.output_database_path, "w", encoding="utf-8") as output:
-                    json.dump(db_to_update, output, indent=4)
+                    output.write(json.dumps(db_to_update, indent=4))
             else:
                 self.db_builder_message_output_signal.emit(
                     "Unable to load database from specified path! Does the file exist...?"
@@ -2368,13 +2368,13 @@ class SteamDatabaseBuilder(QThread):
                     f"\nCaching DynamicQuery result:\n\n{appended_path}"
                 )
                 with open(appended_path, "w", encoding="utf-8") as output:
-                    json.dump(database, output, indent=4)
+                    output.write(json.dumps(database, indent=4))
         else:  # Dump new db to specified path, effectively "overwriting" the db with fresh data
             self.db_builder_message_output_signal.emit(
                 f"\nCaching DynamicQuery result:\n{self.output_database_path}"
             )
             with open(self.output_database_path, "w", encoding="utf-8") as output:
-                json.dump(database, output, indent=4)
+                output.write(json.dumps(database, indent=4))
 
 
 # Misc helper functions

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -2815,16 +2815,17 @@ class MainContent(QObject):
                 "w",
                 encoding="utf-8",
             ) as output:
-                json.dump(
-                    {
-                        "version": int(
-                            time.time()
-                            + self.settings_controller.settings.database_expiry
-                        ),
-                        "database": self.metadata_manager.external_steam_metadata,
-                    },
-                    output,
-                    indent=4,
+                output.write(
+                    json.dumps(
+                        {
+                            "version": int(
+                                time.time()
+                                + self.settings_controller.settings.database_expiry
+                            ),
+                            "database": self.metadata_manager.external_steam_metadata,
+                        },
+                        indent=4,
+                    )
                 )
             self._do_refresh()
 
@@ -3114,7 +3115,7 @@ class MainContent(QObject):
             if not output_path.endswith(".json"):
                 output_path += ".json"  # Handle file extension if needed
             with open(output_path, "w", encoding="utf-8") as output:
-                json.dump(db_output_c, output, indent=4)
+                output.write(json.dumps(db_output_c, indent=4))
         else:
             logger.warning("Steam DB Builder: User cancelled selection...")
             return
@@ -3171,7 +3172,7 @@ class MainContent(QObject):
         )
         if answer == "&Yes":
             with open(path, "w", encoding="utf-8") as output:
-                json.dump(db_output_c, output, indent=4)
+                output.write(json.dumps(db_output_c, indent=4))
             self._do_refresh()
         else:
             logger.debug("USER ACTION: declined to continue rules database update.")


### PR DESCRIPTION
Expected type 'SupportsWrite[str]', got 'TextIO' instead

The issue "Expected type 'SupportsWrite[str]', got 'TextIO' instead" is due to a type mismatch in the json.dump() function. In Python 3.10 and later, the json.dump() function expects the second argument to be a file like object that supports writing strings (SupportsWrite[str]). However, the output variable is a TextIO object, which is a file-like object that supports writing bytes.