### PR TITLE
Report RimSort version at init of application in logs

### DIFF
--- a/app/__main__.py
+++ b/app/__main__.py
@@ -208,5 +208,5 @@ if __name__ == "__main__":
 
         logger.debug("Running using Nuitka bundle")
 
-    logger.debug("Initializing RimSort application")
+    logger.info(f"Initializing RimSort application: {AppInfo().app_version}")
     main_thread()


### PR DESCRIPTION
Report RimSort version at init of application in logs at info level. Replaces the existing debug level RimSort application init log.

This is to make it a little easier to analyze user reports when logs are provided.

Example when the version is unknown:
![image](https://github.com/user-attachments/assets/4e54fde5-eac6-4a0b-b4cd-292bf9fea794)
