### PR TITLE
Ask to enable steam integration at setup

### DIFF
--- a/app/models/instance.py
+++ b/app/models/instance.py
@@ -39,6 +39,9 @@ class Instance(msgspec.Struct):
 
     :param steam_client_integration: Whether to integrate the Steam client with the instance
     :type steam_client_integration: bool
+
+    :param initial_setup: Whether the instance is in the initial setup state
+    :type initial_setup: bool
     """
 
     name: str = "Default"
@@ -54,6 +57,8 @@ class Instance(msgspec.Struct):
     steamcmd_ignore: bool = False
     steam_client_integration: bool = False
 
+    initial_setup: bool = True
+
     def __setattr__(self, name: str, value: Any) -> None:
         # If the value is the same as the current value, do nothing
         if getattr(self, name) == value:
@@ -61,19 +66,19 @@ class Instance(msgspec.Struct):
         super().__setattr__(name, value)
         EventBus().settings_have_changed.emit()
 
-    def as_dict(self) -> dict[str, Any]:
-        return {
-            "name": self.name,
-            "game_folder": self.game_folder,
-            "config_folder": self.config_folder,
-            "local_folder": self.local_folder,
-            "workshop_folder": self.workshop_folder,
-            "run_args": self.run_args,
-            "steamcmd_auto_clear_depot_cache": self.steamcmd_auto_clear_depot_cache,
-            "steamcmd_install_path": self.steamcmd_install_path,
-            "steamcmd_ignore": self.steamcmd_ignore,
-            "steam_client_integration": self.steam_client_integration,
-        }
+    def as_dict(self, skip_private: bool = True) -> dict[str, Any]:
+        skip_attributes: list[str] = []
+
+        data = {}
+
+        for key in self.__struct_fields__:
+            if key in skip_attributes:
+                continue
+            if skip_private and key.startswith("_"):
+                continue
+            data[key] = getattr(self, key)
+
+        return data
 
     def validate_paths(self, clear: bool = True) -> list[str]:
         """Validates the paths of the instance. If clear is True, invalid paths are set to an empty string.

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -202,6 +202,30 @@ class MainWindow(QMainWindow):
             # Setup watchdog
             self.initialize_watchdog()
 
+        self.__check_steam_integration()
+
+        # Force initial setup to False and save settings
+        if self.settings_controller.active_instance.initial_setup:
+            self.settings_controller.active_instance.initial_setup = False
+            self.settings_controller.settings.save()
+
+    def __check_steam_integration(self) -> None:
+        """Ask the user if they would like to enable Steam Client Integration for the active instance if it is the first time they are setting up RimSort."""
+        instance = self.settings_controller.active_instance
+
+        if instance.initial_setup and not instance.steam_client_integration:
+            diag = BinaryChoiceDialog(
+                title="Steam Client Integration",
+                text="<h2>Would you like to enable Steam Client Integration for this instance?</h2>",
+                information="This will allow you to use RimSort features that require the Steam Client.",
+                negative_text="No",
+            )
+            if diag.exec_is_positive():
+                instance.steam_client_integration = True
+                self.settings_controller.set_instance(instance)
+
+        return
+
     def __ask_for_new_instance_name(self) -> str | None:
         instance_name, ok = show_dialogue_input(
             title="Create new instance",

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -216,8 +216,10 @@ class MainWindow(QMainWindow):
         if instance.initial_setup and not instance.steam_client_integration:
             diag = BinaryChoiceDialog(
                 title="Steam Client Integration",
-                text="<h2>Would you like to enable Steam Client Integration for this instance?</h2>",
-                information="This will allow you to use RimSort features that require the Steam Client.",
+                text="<h3>Would you like to enable Steam Client Integration for this instance?</h3>",
+                information="""This will allow you to use RimSort features that require the Steam Client. This includes, among other things, unsubscribing from workshop mods and opening workshop links via the Steam Client. 
+                <br><br>
+                You can change this in the settings under the Advanced tab.""",
                 negative_text="No",
             )
             if diag.exec_is_positive():


### PR DESCRIPTION
At the initial setup of an instance, display a dialog asking if the user would like to enable steam integration. The only checks for displaying this or not are if this is initial setup of this instance, and if steam integration is already on for whatever reason (for grandfathering in existing setups). 

![image](https://github.com/user-attachments/assets/5a2faa8e-54b1-4413-bd18-cb2a6374a25e)

Internally, this introduces a new attribute at the instance level to track whenever or not this was the initial setup. At init of the object it is True, but after all setup steps in main_window, it is forced to False. The current implementation violates MVC a bit and will need to be potentially overhauled more deeply in a future refactor.

Also, improves the internals of instance's `as_dict` so it does not need to be manually expanded whenever a new attribute is added to `instance`.
