### PR TITLE
Add RimThunder: Core as a replacement dependency for Engine Industries by AOBA 

### DIFF
--- a/app/utils/constants.py
+++ b/app/utils/constants.py
@@ -68,4 +68,7 @@ SEARCH_DATA_SOURCE_FILTER_INDEXES = [
     "csharp",
     "xml",
 ]
-KNOWN_MOD_REPLACEMENTS = {"brrainz.harmony": {"zetrith.prepatcher"}}
+KNOWN_MOD_REPLACEMENTS = {
+ "brrainz.harmony": {"zetrith.prepatcher"},
+ "aoba.motorization.engine": {"rimthunder.core"}
+}


### PR DESCRIPTION
According to the [steampage for Rimthunder - CORE](https://steamcommunity.com/sharedfiles/filedetails/?id=3070495204) it can be used as a replacement for any mods requiring Engine Industries by AOBA. Thus I added it.

Let me know if I've done something wrong, and I will try to fix it to the best of my ability. I don't know python, I just looked at the code and tried to infer what to do from that.