### PR TITLE
Fix crash when __setattr__ for instances, where the key does not exist.

### DIFF
--- a/app/models/instance.py
+++ b/app/models/instance.py
@@ -59,11 +59,11 @@ class Instance(msgspec.Struct):
 
     initial_setup: bool = True
 
-    def __setattr__(self, name: str, value: Any) -> None:
+    def __setattr__(self, key: str, value: Any) -> None:
         # If the value is the same as the current value, do nothing
-        if getattr(self, name) == value:
+        if hasattr(self, key) and getattr(self, key) == value:
             return
-        super().__setattr__(name, value)
+        super().__setattr__(key, value)
         EventBus().settings_have_changed.emit()
 
     def as_dict(self, skip_private: bool = True) -> dict[str, Any]:

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -6,6 +6,7 @@ from shutil import copytree, rmtree
 from time import time
 from typing import Any, Dict
 
+import msgspec
 from loguru import logger
 from PySide6.QtCore import QObject
 
@@ -237,7 +238,7 @@ class Settings(QObject):
                 if isinstance(instance_data, Instance):
                     instances[instance_name] = instance_data
                 elif isinstance(instance_data, dict):
-                    instances[instance_name] = Instance(**instance_data)
+                    instances[instance_name] = msgspec.convert(instance_data, Instance)
                 else:
                     logger.warning(
                         f"Instance data for {instance_name} is not a valid type: {type(instance_data)}"


### PR DESCRIPTION
Fixes crash when using __setattr__ for instances, where the key does not exist.

This should fix crashes where there is an unexpected entry in the settings file for an instance. This copies the behavior for settings that are global scoped. The unexpected entry is simply ignored.