### PR TITLE
Add modlist folder to RimSort

### DIFF
--- a/app/utils/app_info.py
+++ b/app/utils/app_info.py
@@ -147,6 +147,16 @@ class AppInfo:
         return self._app_storage_folder
 
     @property
+    def saved_modlists_folder(self) -> Path:
+        """
+        Get the path to the folder where user modlists are saved.
+
+        Returns:
+            Path: The path to the saved modlists folder.
+        """
+        return self._saved_modlists_folder
+
+    @property
     def app_settings_file(self) -> Path:
         """
         Get the path to the file where user-specific data for the application is stored.

--- a/app/utils/app_info.py
+++ b/app/utils/app_info.py
@@ -151,6 +151,8 @@ class AppInfo:
         """
         Get the path to the folder where user modlists are saved.
 
+        This directory is determined using platform-specific conventions.
+
         Returns:
             Path: The path to the saved modlists folder.
         """

--- a/app/utils/app_info.py
+++ b/app/utils/app_info.py
@@ -80,6 +80,7 @@ class AppInfo:
         # Derive some secondary directory paths
 
         self._databases_folder: Path = self._app_storage_folder / "dbs"
+        self._saved_modlists_folder: Path = self._app_storage_folder / "modlists"
         self._theme_data_folder: Path = self._application_folder / "themes"
         self._settings_file: Path = self._app_storage_folder / "settings.json"
 
@@ -87,6 +88,7 @@ class AppInfo:
 
         self._app_storage_folder.mkdir(parents=True, exist_ok=True)
         self._user_log_folder.mkdir(parents=True, exist_ok=True)
+        self._saved_modlists_folder.mkdir(parents=True, exist_ok=True)
 
         self._databases_folder.mkdir(parents=True, exist_ok=True)
 

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -1219,7 +1219,7 @@ class MainContent(QObject):
         file_path = dialogue.show_dialogue_file(
             mode="open",
             caption="Open RimWorld mod list",
-            _dir=str(AppInfo()._saved_modlists_folder),
+            _dir=str(AppInfo().saved_modlists_folder),
             _filter="RimWorld mod list (*.rml *.rws *.xml)",
         )
         logger.info(f"Selected path: {file_path}")
@@ -1269,7 +1269,7 @@ class MainContent(QObject):
         file_path = dialogue.show_dialogue_file(
             mode="save",
             caption="Save mod list",
-            _dir=str(AppInfo()._saved_modlists_folder),
+            _dir=str(AppInfo().saved_modlists_folder),
             _filter="XML (*.xml)",
         )
         logger.info(f"Selected path: {file_path}")

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -1219,7 +1219,7 @@ class MainContent(QObject):
         file_path = dialogue.show_dialogue_file(
             mode="open",
             caption="Open RimWorld mod list",
-            _dir=str(AppInfo().app_storage_folder),
+            _dir=str(AppInfo()._saved_modlists_folder),
             _filter="RimWorld mod list (*.rml *.rws *.xml)",
         )
         logger.info(f"Selected path: {file_path}")
@@ -1269,7 +1269,7 @@ class MainContent(QObject):
         file_path = dialogue.show_dialogue_file(
             mode="save",
             caption="Save mod list",
-            _dir=str(AppInfo().app_storage_folder),
+            _dir=str(AppInfo()._saved_modlists_folder),
             _filter="XML (*.xml)",
         )
         logger.info(f"Selected path: {file_path}")


### PR DESCRIPTION
Closes #679 

Adds a ```modlists``` folder to RimSort for users to store their saved modlists in.

When choosing to open or save a modlist it will default to opening this folder.

![image](https://github.com/user-attachments/assets/498c239b-1b1d-4900-b7ab-6074eda99782)
