### PR TITLE
Critical: Fix workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,8 +150,7 @@ jobs:
         with:
           nuitka-version: main
           script-name: app/__main__.py
-          onefile: false
-          mode: standalone
+          mode: ${{ runner.os == 'macos' && 'app' || 'standalone' }}
           static-libpython: auto
           product-version: >-
             ${{ steps.sem_version.outputs.major }}.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -72,7 +72,6 @@ jobs:
           # Linter not up to date
           GITHUB_ACTIONS_COMMAND_ARGS: >-
             -ignore 'unknown permission scope "attestations"'
-            -ignore '"ubuntu-24.04" is unknown'
           PYTHON_RUFF_CONFIG_FILE: pyproject.toml
           PYTHON_MYPY_CONFIG_FILE: pyproject.toml
           FILTER_REGEX_EXCLUDE: "LICENSE.md"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -9,7 +9,7 @@ jobs:
   pytest:
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@main
       - name: Set up Python

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -9,7 +9,7 @@ jobs:
   pytest:
     permissions:
       contents: read
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main
       - name: Set up Python
@@ -24,7 +24,7 @@ jobs:
       - name: Install missing Linux libs for gui tests
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential libegl-dev libgl1-mesa-glx libglib2.0-0 xvfb libxcb-cursor-dev 
+          sudo apt-get install -y build-essential libegl-dev libgl1 libglx-mesa0 libglib2.0-0 xvfb libxcb-cursor-dev
           sudo apt-get install -y libxkbcommon-x11-0 libxcb-icccm4 libxcb-keysyms1 libxcb-shape0
         shell: bash
       - name: Test with pytest

--- a/app/__main__.py
+++ b/app/__main__.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 # Compilation mode
-# nuitka-project: --mode=standalone
 # nuitka-project: --assume-yes-for-downloads
 # nuitka-project: --output-filename=RimSort
 # nuitka-project: --output-dir={MAIN_DIRECTORY}/../build/
@@ -14,10 +13,12 @@
 # The PySide6 plugin covers qt-plugins
 # nuitka-project: --enable-plugin=pyside6
 
-# Mac-Specific options
+# OS-Specific options
 # nuitka-project-if: {OS} == "Darwin":
-#   nuitka-project: --macos-create-app-bundle
+#   nuitka-project: --mode=app
 #   nuitka-project: --macos-app-icon={MAIN_DIRECTORY}/../themes/default-icons/AppIcon_a.icns
+# nuitka-project-else:
+#   nuitka-project: --mode=standalone
 
 # nuitka-project-if: os.path.exists("{MAIN_DIRECTORY}/../version.xml"):
 #   nuitka-project: --include-data-file={MAIN_DIRECTORY}/../version.xml=version.xml


### PR DESCRIPTION
- [x] Fixes Issue that causes "Mac" build fails due to recent changes in Nuitka 
fixes error
FATAL: Cannot use both '--mode=' and deprecated options that specify mode.

- [x] For Pytest replace `libgl1-mesa-glx` with` libgl1 libglx-mesa0`
fixes error 
E: Package 'libgl1-mesa-glx' has no installation candidate
