### PR TITLE
Remove warnings when exiting rentry/workshop import dialogue

### DIFF
--- a/app/utils/rentry/wrapper.py
+++ b/app/utils/rentry/wrapper.py
@@ -129,14 +129,16 @@ class RentryImport:
 
     def input_dialog(self) -> None:
         # Initialize the UI for entering Rentry.co links
-        link_input = show_dialogue_input(
+        self.link_input = show_dialogue_input(
             title="Enter Rentry.co link",
             label="Enter the Rentry.co link:",
         )
-
-        self.link_input = link_input
-        self.import_rentry_link()
         logger.info("Rentry link Input UI initialized successfully!")
+        if self.link_input[1]:
+            self.import_rentry_link()
+        else:
+            logger.info("User exited rentry import window.")
+            return
 
     def is_valid_rentry_link(self, link: str) -> bool:
         """

--- a/app/utils/steam/webapi/wrapper.py
+++ b/app/utils/steam/webapi/wrapper.py
@@ -59,8 +59,12 @@ class CollectionImport:
             title="Add Workshop collection link",
             label="Add Workshop collection link",
         )
-        self.import_collection_link()
         logger.info("Workshop collection link Input UI initialized successfully!")
+        if self.link_input[1]:
+            self.import_collection_link()
+        else:
+            logger.info("User exited workshop collection import window.")
+            return
 
     def is_valid_collection_link(self, link: str) -> bool:
         """

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -1374,11 +1374,8 @@ class MainContent(QObject):
 
     def _do_import_list_workshop_collection(self) -> None:
         # Create an instance of collection_import
+        # This also triggers the import dialogue and gets result
         collection_import = CollectionImport(metadata_manager=self.metadata_manager)
-
-        # Trigger the import dialogue and get the result
-        collection_import.import_collection_link()
-
         # Exit if user cancels or no package IDs
         if not collection_import.package_ids:
             logger.debug("USER ACTION: pressed cancel or no package IDs, passing")


### PR DESCRIPTION
Fixes some unnecessary warnings when exiting import window for rentry/collection.

Also removed a duplicate warning when incorrect link was given for workshop collection.

Fixes #687 