### PR TITLE
Added indication of mod installation status in Workshop pages

### DIFF
--- a/app/utils/steam/browser.py
+++ b/app/utils/steam/browser.py
@@ -25,6 +25,7 @@ from PySide6.QtWidgets import (
 
 from app.models.image_label import ImageLabel
 from app.utils.app_info import AppInfo
+from app.utils.metadata import MetadataManager
 from app.utils.steam.webapi.wrapper import (
     ISteamRemoteStorage_GetCollectionDetails,
     ISteamRemoteStorage_GetPublishedFileDetails,
@@ -40,9 +41,12 @@ class SteamBrowser(QWidget):
     steamcmd_downloader_signal = Signal(list)
     steamworks_subscription_signal = Signal(list)
 
-    def __init__(self, startpage: str):
+    def __init__(self, startpage: str, metadata_manager: MetadataManager):
         super().__init__()
         logger.debug("Initializing SteamBrowser")
+
+        # store metadata manager reference so we can use it to check if mods are installed
+        self.metadata_manager = metadata_manager
 
         # This is used to fix issue described here on non-Windows platform:
         # https://doc.qt.io/qt-6/qtwebengine-platform-notes.html#sandboxing-support
@@ -390,19 +394,28 @@ class SteamBrowser(QWidget):
             self.web_view.page().runJavaScript(
                 change_target_a_script, 0, lambda result: None
             )
-            # Remove "Login" button
-            # login_button_removal_script = """
-            # var elements = document.getElementsByClassName("global_action_link");
-            # while (elements.length > 0) {
-            #     elements[0].parentNode.removeChild(elements[0]);
-            # }
-            # """
 
             if (
                 self.url_prefix_sharedfiles in self.current_url
                 or self.url_prefix_workshop in self.current_url
             ):
-                # Remove area that shows "Subscribe to download" and "Subscribe"/"Unsubscribe" button for mods
+                # get mod id from steam workshop url
+                if self.url_prefix_sharedfiles in self.current_url:
+                    publishedfileid = self.current_url.split(
+                        self.url_prefix_sharedfiles, 1
+                    )[1]
+                else:
+                    publishedfileid = self.current_url.split(
+                        self.url_prefix_workshop, 1
+                    )[1]
+                if self.searchtext_string in publishedfileid:
+                    publishedfileid = publishedfileid.split(self.searchtext_string)[0]
+
+                # check if mod is installed
+                is_installed = self._is_mod_installed(publishedfileid)
+
+                # remove area that shows "Subscribe to download" and "Subscribe"/"Unsubscribe" button for mods
+                # it doesnt show in rimsort if user is not logged in
                 mod_subscribe_area_removal_script = """
                 var elements = document.getElementsByClassName("game_area_purchase_game");
                 while (elements.length > 0) {
@@ -432,7 +445,111 @@ class SteamBrowser(QWidget):
                 self.web_view.page().runJavaScript(
                     subscribe_buttons_removal_script, 0, lambda result: None
                 )
-                # Show the add_to_list_button
+
+                # add buttons for collection items
+                add_collection_buttons_script = """
+                // find all collection items
+                var collectionItems = document.getElementsByClassName('collectionItem');
+                
+                for (var i = 0; i < collectionItems.length; i++) {
+                    var item = collectionItems[i];
+                    
+                    // get the mod id from the item
+                    var modId = item.id.replace('sharedfile_', '');
+                    
+                    // find the subscription controls div
+                    var subscriptionControls = item.querySelector('.subscriptionControls');
+                    if (!subscriptionControls) {
+                        continue;
+                    }
+                    
+                    // check if mod is installed
+                    var isInstalled = window.installedMods && window.installedMods.includes(modId);
+                    
+                    if (isInstalled) {
+                        // create installed indicator
+                        var installedIndicator = document.createElement('div');
+                        installedIndicator.innerHTML = '✓';
+                        installedIndicator.style.backgroundColor = '#4CAF50';
+                        installedIndicator.style.color = 'white';
+                        installedIndicator.style.width = '24px';
+                        installedIndicator.style.height = '24px';
+                        installedIndicator.style.borderRadius = '4px';
+                        installedIndicator.style.display = 'flex';
+                        installedIndicator.style.alignItems = 'center';
+                        installedIndicator.style.justifyContent = 'center';
+                        installedIndicator.style.fontWeight = 'bold';
+                        installedIndicator.style.fontSize = '16px';
+                        
+                        // Replace subscription controls with our indicator
+                        subscriptionControls.innerHTML = '';
+                        subscriptionControls.appendChild(installedIndicator);
+                    } else {
+                        // create link button
+                        var linkButton = document.createElement('a');
+                        linkButton.innerHTML = '→';
+                        linkButton.href = 'https://steamcommunity.com/sharedfiles/filedetails/?id=' + modId;
+                        linkButton.style.backgroundColor = '#2196F3';
+                        linkButton.style.color = 'white';
+                        linkButton.style.width = '24px';
+                        linkButton.style.height = '24px';
+                        linkButton.style.borderRadius = '4px';
+                        linkButton.style.display = 'flex';
+                        linkButton.style.alignItems = 'center';
+                        linkButton.style.justifyContent = 'center';
+                        linkButton.style.cursor = 'pointer';
+                        linkButton.style.fontWeight = 'bold';
+                        linkButton.style.fontSize = '20px';
+                        linkButton.style.textDecoration = 'none';
+                        
+                        // Replace subscription controls with our button
+                        subscriptionControls.innerHTML = '';
+                        subscriptionControls.appendChild(linkButton);
+                    }
+                }
+                """
+
+                # Get list of installed mod IDs and inject into page
+                installed_mods = []
+                for metadata in self.metadata_manager.internal_local_metadata.values():
+                    if metadata.get("publishedfileid"):
+                        installed_mods.append(metadata["publishedfileid"])
+
+                inject_installed_mods_script = f"""
+                window.installedMods = {installed_mods};
+                """
+
+                self.web_view.page().runJavaScript(
+                    inject_installed_mods_script, 0, lambda result: None
+                )
+                self.web_view.page().runJavaScript(
+                    add_collection_buttons_script, 0, lambda result: None
+                )
+
+                # add installed indicator if mod is installed
+                if is_installed:
+                    add_installed_indicator_script = """
+                    // Create a new div for the installed indicator
+                    var installedDiv = document.createElement('div');
+                    installedDiv.style.backgroundColor = '#4CAF50';  // Green background
+                    installedDiv.style.color = 'white';
+                    installedDiv.style.padding = '10px';
+                    installedDiv.style.borderRadius = '5px';
+                    installedDiv.style.marginBottom = '10px';
+                    installedDiv.style.textAlign = 'center';
+                    installedDiv.style.fontWeight = 'bold';
+                    installedDiv.innerHTML = '✓ Already Installed';
+
+                    // Insert it at the top of the page content
+                    var contentDiv = document.querySelector('.workshopItemDetailsHeader');
+                    if (contentDiv) {
+                        contentDiv.parentNode.insertBefore(installedDiv, contentDiv);
+                    }
+                    """
+                    self.web_view.page().runJavaScript(
+                        add_installed_indicator_script, 0, lambda result: None
+                    )
+
                 self.nav_bar.addAction(self.add_to_list_button)
             else:
                 self.nav_bar.removeAction(self.add_to_list_button)
@@ -440,3 +557,11 @@ class SteamBrowser(QWidget):
     def __set_current_html(self, html: str) -> None:
         # Update cached html with html from current page
         self.current_html = html
+
+    def _is_mod_installed(self, publishedfileid: str) -> bool:
+        """Check if a mod is installed by looking through local and workshop folders"""
+        # check all mods in internal metadata
+        for metadata in self.metadata_manager.internal_local_metadata.values():
+            if metadata.get("publishedfileid") == publishedfileid:
+                return True
+        return False

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -1864,7 +1864,7 @@ class MainContent(QObject):
 
     def _do_browse_workshop(self) -> None:
         self.steam_browser = SteamBrowser(
-            "https://steamcommunity.com/app/294100/workshop/"
+            "https://steamcommunity.com/app/294100/workshop/", self.metadata_manager
         )
         self.steam_browser.steamcmd_downloader_signal.connect(
             self._do_download_mods_with_steamcmd


### PR DESCRIPTION
## Description
Adds visual indicators in Steam Workshop browser to show which mods are already installed:
- ✓ Green checkmark for installed mods in collections
- → Blue arrow button for uninstalled mods (links to mod page)
- Green banner at the top of individual mod pages showing installation status

## Related Issue
Closes #718 

## Screenshots
- Collection view with checkmarks and arrows
![image](https://github.com/user-attachments/assets/43f14ec0-3544-41d3-8da2-91b507fd370d)
- Individual mod page with "Already Installed" banner
![image](https://github.com/user-attachments/assets/72a04651-3cb7-4d4f-bd9c-86b8d707e6d4)

