### PR TITLE
Add option to selectively download mods from collections

### DIFF
--- a/app/utils/steam/browser.py
+++ b/app/utils/steam/browser.py
@@ -186,7 +186,15 @@ class SteamBrowser(QWidget):
         elif self.url_prefix_workshop in self.current_url:
             publishedfileid = self.current_url.split(self.url_prefix_workshop, 1)[1]
         else:
-            logger.error(f"Unable to parse pfid from url: {self.current_url}")
+            logger.error(
+                f"Unable to parse publishedfileid from url: {self.current_url}"
+            )
+            show_warning(
+                title="No publishedfileid found",
+                text="Unable to parse publishedfileid from url, Please check if url is in the correct format",
+                information=f"Url: {self.current_url}",
+            )
+            return None
         # If there is extra data after the PFID, strip it
         if self.searchtext_string in publishedfileid:
             publishedfileid = publishedfileid.split(self.searchtext_string)[0]


### PR DESCRIPTION
## Description
Adds a prompt when adding mods from a Steam Workshop collection, allowing users to:
- Add all mods from the collection (existing behavior)
- Add only mods that aren't already installed

## Related Issue
Closes #720 

## Screenshots
New dialog prompt
![image](https://github.com/user-attachments/assets/92a44895-f6a1-48d9-8b78-902905595d60)
