### PR TITLE
Add setting to hide invalid mods when filtering

### DIFF
--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -512,6 +512,9 @@ class SettingsController(QObject):
         self.settings_dialog.mod_type_filter_checkbox.setChecked(
             self.settings.mod_type_filter_toggle
         )
+        self.settings_dialog.hide_invalid_mods_when_filtering_checkbox.setChecked(
+            self.settings.hide_invalid_mods_when_filtering_toggle
+        )
         self.settings_dialog.show_duplicate_mods_warning_checkbox.setChecked(
             self.settings.duplicate_mods_warning
         )
@@ -655,6 +658,9 @@ class SettingsController(QObject):
         )
         self.settings.mod_type_filter_toggle = (
             self.settings_dialog.mod_type_filter_checkbox.isChecked()
+        )
+        self.settings.hide_invalid_mods_when_filtering_toggle = (
+            self.settings_dialog.hide_invalid_mods_when_filtering_checkbox.isChecked()
         )
         self.settings.duplicate_mods_warning = (
             self.settings_dialog.show_duplicate_mods_warning_checkbox.isChecked()

--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -512,9 +512,6 @@ class SettingsController(QObject):
         self.settings_dialog.mod_type_filter_checkbox.setChecked(
             self.settings.mod_type_filter_toggle
         )
-        self.settings_dialog.hide_invalid_mods_when_filtering_checkbox.setChecked(
-            self.settings.hide_invalid_mods_when_filtering_toggle
-        )
         self.settings_dialog.show_duplicate_mods_warning_checkbox.setChecked(
             self.settings.duplicate_mods_warning
         )

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -67,6 +67,7 @@ class Settings(QObject):
         self.debug_logging_enabled: bool = False
         self.watchdog_toggle: bool = True
         self.mod_type_filter_toggle: bool = True
+        self.hide_invalid_mods_when_filtering_toggle: bool = True
         self.duplicate_mods_warning: bool = False
         self.steam_mods_update_check: bool = False
         self.try_download_missing_mods: bool = False

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -67,7 +67,7 @@ class Settings(QObject):
         self.debug_logging_enabled: bool = False
         self.watchdog_toggle: bool = True
         self.mod_type_filter_toggle: bool = True
-        self.hide_invalid_mods_when_filtering_toggle: bool = True
+        self.hide_invalid_mods_when_filtering_toggle: bool = False
         self.duplicate_mods_warning: bool = False
         self.steam_mods_update_check: bool = False
         self.try_download_missing_mods: bool = False

--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -2517,8 +2517,16 @@ class ModsPanel(QWidget):
             self.inactive_mods_search.clearFocus()
 
     def signal_search_and_filters(self, list_type: str, pattern: str, filters_active: bool = False) -> None:
+        """
+        Performs a search and/or applies filters based on the given parameters.
+
+        Args:
+            list_type (str): The type of list to search within (Active or Inactive).
+            pattern (str): The pattern to search for.
+            filters_active (bool): If any filter is active (inc. pattern search).
+        """
         _filter = None
-        filter_state = None
+        filter_state = None # The 'Hide Filter' state
         source_filter = None
         uuids = None
         # Determine which list to filter
@@ -2555,15 +2563,16 @@ class ModsPanel(QWidget):
             metadata = self.metadata_manager.internal_local_metadata[uuid]
             if pattern != '':
                 filters_active = True
-            # Hide invalid items
-            invalid = item_data["invalid"]
-            if invalid and filters_active:
-                item_data["filtered"] = True
-                item.setHidden(True)
-                continue
-            elif invalid and not filters_active:
-                item_data["filtered"] = False
-                item.setHidden(False)
+            # Hide invalid items if enabled in settings
+            if self.settings_controller.settings.hide_invalid_mods_when_filtering_toggle:
+                invalid = item_data["invalid"]
+                if invalid and filters_active:
+                    item_data["filtered"] = True
+                    item.setHidden(True)
+                    continue
+                elif invalid and not filters_active:
+                    item_data["filtered"] = False
+                    item.setHidden(False)
             # Check if the item is filtered
             item_filtered = item_data["filtered"]
             # Check if the item should be filtered or not based on search filter

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -708,6 +708,9 @@ class SettingsDialog(QDialog):
         self.mod_type_filter_checkbox = QCheckBox("Enable mod type filter")
         group_layout.addWidget(self.mod_type_filter_checkbox)
 
+        self.hide_invalid_mods_when_filtering_checkbox = QCheckBox("Hide invalid mods when filtering")
+        group_layout.addWidget(self.hide_invalid_mods_when_filtering_checkbox)
+
         self.show_duplicate_mods_warning_checkbox = QCheckBox(
             "Show duplicate mods warning"
         )


### PR DESCRIPTION
Enabled by default
Located in Advanced tab
![image](https://github.com/user-attachments/assets/52167051-1c5e-44f4-aff2-cd59962fa853)


If enabled it will hide invalid items when any filters are active:
![image](https://github.com/user-attachments/assets/365f137e-e1af-47b3-abac-96a6ce368ecf)
![image](https://github.com/user-attachments/assets/03240ced-4e43-4ab6-ab66-faa4f79884da)
![image](https://github.com/user-attachments/assets/1d927a35-475f-4b7e-b7d8-50e483cd8234)




Otherwise it shows them:
![image](https://github.com/user-attachments/assets/e1fe0964-7f82-4df3-915a-cad0583ab27a)
![image](https://github.com/user-attachments/assets/d59569cf-4b6f-403c-8054-649e3f76949c)
![image](https://github.com/user-attachments/assets/1063db77-4faf-4317-838c-69b65afe55f7)
![image](https://github.com/user-attachments/assets/02b8d73f-7c1b-402b-bb58-9c287d3286ef)



Behavior should apply to active and inactive modlists.
