### PR TITLE
Change instance name separator to |

### DIFF
--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -910,7 +910,7 @@ class MainWindow(QMainWindow):
         
         :param instance: Name of the instance currently being used.
         """
-        self.setWindowTitle(f"RimSort {AppInfo().app_version}: {instance} Instance")
+        self.setWindowTitle(f"RimSort {AppInfo().app_version} | {instance} Instance")
 
     def initialize_watchdog(self) -> None:
         logger.info("Initializing watchdog FS Observer")


### PR DESCRIPTION
Separator was ```:``` now changed to ```|```

Had two people mention they want ```|``` vs one for ```:```

We will give this a go


![image](https://github.com/user-attachments/assets/3f4505c3-a820-45d2-8a73-d3750dec1ace)
