### PR TITLE
Avoid some redundant error/warning recalculations

### DIFF
--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -437,8 +437,7 @@ class MainContent(QObject):
                 for item in items_to_move:
                     iml.insertItem(count, item)
                     count += 1
-            self.mods_panel.active_mods_list.recalculate_warnings_signal.emit()
-            self.mods_panel.inactive_mods_list.recalculate_warnings_signal.emit()
+        # List error/warnings are automatically recalculated when a mod is inserted/removed from a list
 
     def __handle_inactive_mod_key_press(self, key: str) -> None:
         """
@@ -491,8 +490,7 @@ class MainContent(QObject):
                 for item in items_to_move:
                     aml.insertItem(count, item)
                     count += 1
-            self.mods_panel.active_mods_list.recalculate_warnings_signal.emit()
-            self.mods_panel.inactive_mods_list.recalculate_warnings_signal.emit()
+        # List error/warnings are automatically recalculated when a mod is inserted/removed from a list
 
     def __insert_data_into_lists(
         self, active_mods_uuids: list[str], inactive_mods_uuids: list[str]
@@ -1007,22 +1005,19 @@ class MainContent(QObject):
         # If we are refreshing cache from user action
         if not is_initial:
             # Reset the data source filters to default and clear searches
+            # Avoid recalculating warnings/errors when clearing search
+            # Recalculation for each list will be triggered by mods being reinserted into inactive and active list automatically
             self.mods_panel.active_mods_filter_data_source_index = len(
                 self.mods_panel.data_source_filter_icons
             )
-            self.mods_panel.signal_clear_search(list_type="Active")
+            self.mods_panel.signal_clear_search(list_type="Active", avoid_recalculate=True)
             self.mods_panel.inactive_mods_filter_data_source_index = len(
                 self.mods_panel.data_source_filter_icons
             )
-            self.mods_panel.signal_clear_search(list_type="Inactive")
+            self.mods_panel.signal_clear_search(list_type="Inactive", avoid_recalculate=True)
             self.mods_panel.active_mods_filter_data_source_index = len(
                 self.mods_panel.data_source_filter_icons
             )
-            self.mods_panel.signal_clear_search(list_type="Active")
-            self.mods_panel.inactive_mods_filter_data_source_index = len(
-                self.mods_panel.data_source_filter_icons
-            )
-            self.mods_panel.signal_clear_search(list_type="Inactive")
         # Check if paths are set
         if self.check_if_essential_paths_are_set(prompt=is_initial):
             # Run expensive calculations to set cache data

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -1010,11 +1010,11 @@ class MainContent(QObject):
             self.mods_panel.active_mods_filter_data_source_index = len(
                 self.mods_panel.data_source_filter_icons
             )
-            self.mods_panel.signal_clear_search(list_type="Active", avoid_recalculate=True)
+            self.mods_panel.signal_clear_search(list_type="Active", recalculate_list_errors_warnings=False)
             self.mods_panel.inactive_mods_filter_data_source_index = len(
                 self.mods_panel.data_source_filter_icons
             )
-            self.mods_panel.signal_clear_search(list_type="Inactive", avoid_recalculate=True)
+            self.mods_panel.signal_clear_search(list_type="Inactive", recalculate_list_errors_warnings=False)
             self.mods_panel.active_mods_filter_data_source_index = len(
                 self.mods_panel.data_source_filter_icons
             )

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -1006,7 +1006,7 @@ class MainContent(QObject):
         if not is_initial:
             # Reset the data source filters to default and clear searches
             # Avoid recalculating warnings/errors when clearing search
-            # Recalculation for each list will be triggered by mods being reinserted into inactive and active list automatically
+            # Recalculation for each list will be triggered by mods being reinserted into inactive and active lists automatically
             self.mods_panel.active_mods_filter_data_source_index = len(
                 self.mods_panel.data_source_filter_icons
             )

--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -2079,6 +2079,7 @@ class ModListWidget(QListWidget):
             current_item_data["errors"] = current_item_data["errors"].strip()
             current_item.setData(Qt.ItemDataRole.UserRole, current_item_data)
         logger.info(f"Finished recalculating {self.list_type} list errors and warnings")
+        print("Finished recalculating", self.list_type, "list errors and warnings")
         return total_error_text, total_warning_text, num_errors, num_warnings
 
     def _has_replacement(
@@ -2483,14 +2484,14 @@ class ModsPanel(QWidget):
             partial(self.recalculate_list_errors_warnings, list_type="Inactive")
         )
 
-    def mod_list_updated(self, count: str, list_type: str, recalculate_list_errors_warning: bool = True) -> None:
+    def mod_list_updated(self, count: str, list_type: str, recalculate_list_errors_warnings: bool = True) -> None:
         # If count is 'drop', it indicates that the update was just a drag and drop within the list
         if count != "drop":
             logger.info(f"{list_type} mod count changed to: {count}")
             self.update_count(list_type=list_type)
         # Signal save button animation
         self.save_btn_animation_signal.emit()
-        if recalculate_list_errors_warning:
+        if recalculate_list_errors_warnings:
             # Update the mod list widget errors and warnings
             self.recalculate_list_errors_warnings(list_type=list_type)
 
@@ -2654,18 +2655,18 @@ class ModsPanel(QWidget):
             # Calculate internal errors and warnings for all mods in the respective mod list
             self.inactive_mods_list.recalculate_internal_errors_warnings()
 
-    def signal_clear_search(self, list_type: str, recalculate_list_errors_warning: bool = True) -> None:
+    def signal_clear_search(self, list_type: str, recalculate_list_errors_warnings: bool = True) -> None:
         if list_type == "Active":
             self.active_mods_search.clear()
-            self.signal_search_and_filters(list_type=list_type, pattern="", recalculate_list_errors_warning=recalculate_list_errors_warning)
+            self.signal_search_and_filters(list_type=list_type, pattern="", recalculate_list_errors_warnings=recalculate_list_errors_warnings)
             self.active_mods_search.clearFocus()
         elif list_type == "Inactive":
             self.inactive_mods_search.clear()
-            self.signal_search_and_filters(list_type=list_type, pattern="", recalculate_list_errors_warning=recalculate_list_errors_warning)
+            self.signal_search_and_filters(list_type=list_type, pattern="", recalculate_list_errors_warnings=recalculate_list_errors_warnings)
             self.inactive_mods_search.clearFocus()
 
     def signal_search_and_filters(
-        self, list_type: str, pattern: str, filters_active: bool = False, recalculate_list_errors_warning: bool = True
+        self, list_type: str, pattern: str, filters_active: bool = False, recalculate_list_errors_warnings: bool = True
     ) -> None:
         _filter = None
         filter_state = None
@@ -2754,7 +2755,7 @@ class ModsPanel(QWidget):
             # Update item data
             item_data["filtered"] = item_filtered
             item.setData(Qt.ItemDataRole.UserRole, item_data)
-        self.mod_list_updated(str(len(uuids)), list_type, recalculate_list_errors_warning=recalculate_list_errors_warning)
+        self.mod_list_updated(str(len(uuids)), list_type, recalculate_list_errors_warnings=recalculate_list_errors_warnings)
 
     def signal_search_mode_filter(self, list_type: str) -> None:
         if list_type == "Active":

--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -2483,15 +2483,16 @@ class ModsPanel(QWidget):
             partial(self.recalculate_list_errors_warnings, list_type="Inactive")
         )
 
-    def mod_list_updated(self, count: str, list_type: str) -> None:
+    def mod_list_updated(self, count: str, list_type: str, avoid_recalculate: bool = False) -> None:
         # If count is 'drop', it indicates that the update was just a drag and drop within the list
         if count != "drop":
             logger.info(f"{list_type} mod count changed to: {count}")
             self.update_count(list_type=list_type)
         # Signal save button animation
         self.save_btn_animation_signal.emit()
-        # Update the mod list widget errors and warnings
-        self.recalculate_list_errors_warnings(list_type=list_type)
+        if not avoid_recalculate:
+            # Update the mod list widget errors and warnings
+            self.recalculate_list_errors_warnings(list_type=list_type)
 
     def on_active_mods_list_updated(self, count: str) -> None:
         self.mod_list_updated(count=count, list_type="Active")
@@ -2653,18 +2654,18 @@ class ModsPanel(QWidget):
             # Calculate internal errors and warnings for all mods in the respective mod list
             self.inactive_mods_list.recalculate_internal_errors_warnings()
 
-    def signal_clear_search(self, list_type: str) -> None:
+    def signal_clear_search(self, list_type: str, avoid_recalculate: bool = False) -> None:
         if list_type == "Active":
             self.active_mods_search.clear()
-            self.signal_search_and_filters(list_type=list_type, pattern="")
+            self.signal_search_and_filters(list_type=list_type, pattern="", avoid_recalculate=avoid_recalculate)
             self.active_mods_search.clearFocus()
         elif list_type == "Inactive":
             self.inactive_mods_search.clear()
-            self.signal_search_and_filters(list_type=list_type, pattern="")
+            self.signal_search_and_filters(list_type=list_type, pattern="", avoid_recalculate=avoid_recalculate)
             self.inactive_mods_search.clearFocus()
 
     def signal_search_and_filters(
-        self, list_type: str, pattern: str, filters_active: bool = False
+        self, list_type: str, pattern: str, filters_active: bool = False, avoid_recalculate: bool = False
     ) -> None:
         _filter = None
         filter_state = None
@@ -2753,7 +2754,7 @@ class ModsPanel(QWidget):
             # Update item data
             item_data["filtered"] = item_filtered
             item.setData(Qt.ItemDataRole.UserRole, item_data)
-        self.mod_list_updated(str(len(uuids)), list_type)
+        self.mod_list_updated(str(len(uuids)), list_type, avoid_recalculate=avoid_recalculate)
 
     def signal_search_mode_filter(self, list_type: str) -> None:
         if list_type == "Active":

--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -2483,14 +2483,14 @@ class ModsPanel(QWidget):
             partial(self.recalculate_list_errors_warnings, list_type="Inactive")
         )
 
-    def mod_list_updated(self, count: str, list_type: str, avoid_recalculate: bool = False) -> None:
+    def mod_list_updated(self, count: str, list_type: str, recalculate_list_errors_warning: bool = True) -> None:
         # If count is 'drop', it indicates that the update was just a drag and drop within the list
         if count != "drop":
             logger.info(f"{list_type} mod count changed to: {count}")
             self.update_count(list_type=list_type)
         # Signal save button animation
         self.save_btn_animation_signal.emit()
-        if not avoid_recalculate:
+        if recalculate_list_errors_warning:
             # Update the mod list widget errors and warnings
             self.recalculate_list_errors_warnings(list_type=list_type)
 
@@ -2654,18 +2654,18 @@ class ModsPanel(QWidget):
             # Calculate internal errors and warnings for all mods in the respective mod list
             self.inactive_mods_list.recalculate_internal_errors_warnings()
 
-    def signal_clear_search(self, list_type: str, avoid_recalculate: bool = False) -> None:
+    def signal_clear_search(self, list_type: str, recalculate_list_errors_warning: bool = True) -> None:
         if list_type == "Active":
             self.active_mods_search.clear()
-            self.signal_search_and_filters(list_type=list_type, pattern="", avoid_recalculate=avoid_recalculate)
+            self.signal_search_and_filters(list_type=list_type, pattern="", recalculate_list_errors_warning=recalculate_list_errors_warning)
             self.active_mods_search.clearFocus()
         elif list_type == "Inactive":
             self.inactive_mods_search.clear()
-            self.signal_search_and_filters(list_type=list_type, pattern="", avoid_recalculate=avoid_recalculate)
+            self.signal_search_and_filters(list_type=list_type, pattern="", recalculate_list_errors_warning=recalculate_list_errors_warning)
             self.inactive_mods_search.clearFocus()
 
     def signal_search_and_filters(
-        self, list_type: str, pattern: str, filters_active: bool = False, avoid_recalculate: bool = False
+        self, list_type: str, pattern: str, filters_active: bool = False, recalculate_list_errors_warning: bool = True
     ) -> None:
         _filter = None
         filter_state = None
@@ -2754,7 +2754,7 @@ class ModsPanel(QWidget):
             # Update item data
             item_data["filtered"] = item_filtered
             item.setData(Qt.ItemDataRole.UserRole, item_data)
-        self.mod_list_updated(str(len(uuids)), list_type, avoid_recalculate=avoid_recalculate)
+        self.mod_list_updated(str(len(uuids)), list_type, recalculate_list_errors_warning=recalculate_list_errors_warning)
 
     def signal_search_mode_filter(self, list_type: str) -> None:
         if list_type == "Active":

--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -2078,7 +2078,7 @@ class ModListWidget(QListWidget):
             ].strip()
             current_item_data["errors"] = current_item_data["errors"].strip()
             current_item.setData(Qt.ItemDataRole.UserRole, current_item_data)
-        logger.info(f"Finished recalculating {self.list_type} list errors")
+        logger.info(f"Finished recalculating {self.list_type} list errors and warnings")
         return total_error_text, total_warning_text, num_errors, num_warnings
 
     def _has_replacement(

--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -2079,7 +2079,6 @@ class ModListWidget(QListWidget):
             current_item_data["errors"] = current_item_data["errors"].strip()
             current_item.setData(Qt.ItemDataRole.UserRole, current_item_data)
         logger.info(f"Finished recalculating {self.list_type} list errors and warnings")
-        print("Finished recalculating", self.list_type, "list errors and warnings")
         return total_error_text, total_warning_text, num_errors, num_warnings
 
     def _has_replacement(


### PR DESCRIPTION
Avoids some redundant error/warning recalculations. As far as I can tell there was no need for all these recalculations. I removed some explicit triggers, and added a parameter to avoid recalculations when clearing search. All these changes seemed to have no unexpected affects on RimSorts behavior.

This just utilizes the existing logic of recalculating errors/warnings whenever a mod is inserted/removed from a list. It could be optimized further, might look into that...


Originally when clicking refresh it recalculated each list three times, now it does it once.

Originally when moving a mod from Inactive->Active through double click it recalculated each list twice, now it does it once.
