### PR TITLE
Update docs regarding macos gatekeeper

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -17,9 +17,13 @@ GEM
     faraday-net_http (3.3.0)
       net-http
     ffi (1.17.0-arm64-darwin)
+    ffi (1.17.0-x64-mingw-ucrt)
     ffi (1.17.0-x86_64-linux-gnu)
     forwardable-extended (2.6.0)
     google-protobuf (4.28.2-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.28.2-x64-mingw-ucrt)
       bigdecimal
       rake (>= 13)
     google-protobuf (4.28.2-x86_64-linux)
@@ -90,6 +94,8 @@ GEM
     safe_yaml (1.0.5)
     sass-embedded (1.78.0-arm64-darwin)
       google-protobuf (~> 4.27)
+    sass-embedded (1.78.0-x64-mingw-ucrt)
+      google-protobuf (~> 4.27)
     sass-embedded (1.78.0-x86_64-linux-gnu)
       google-protobuf (~> 4.27)
     sawyer (0.9.2)
@@ -103,6 +109,7 @@ GEM
 
 PLATFORMS
   arm64-darwin
+  x64-mingw-ucrt
   x86_64-linux-gnu
 
 DEPENDENCIES

--- a/docs/development-guide/development-setup.md
+++ b/docs/development-guide/development-setup.md
@@ -76,7 +76,7 @@ RimSort is built in Python using the [PySide6](https://pypi.org/project/PySide6/
   - You can circumvent this issue by using `xattr` command to manually whitelist:
     - `xattr -d com.apple.quarantine /path/to/RimSort.app`
     - `xattr -d com.apple.quarantine /path/to/libsteam_api.dylib`
-  - Replace `/path/to/` with the actual path where the file/folder is, Example:
+  - Replace `/path/to/` with the actual path where the file/folder is, example:
     - `xattr -d com.apple.quarantine /Users/John/Downloads/RimSort.app`
 
 ### Setting up steamfiles module

--- a/docs/development-guide/development-setup.md
+++ b/docs/development-guide/development-setup.md
@@ -74,8 +74,10 @@ RimSort is built in Python using the [PySide6](https://pypi.org/project/PySide6/
 - Mac users should also keep in mind that Apple has its own Runtime Protection called [Gatekeeper](https://support.apple.com/guide/security/gatekeeper-and-runtime-protection-sec5599b66df/web)
   - This can cause issues when trying to run RimSort (or execute dependent libs)!
   - You can circumvent this issue by using `xattr` command to manually whitelist:
-    - `xattr -d com.apple.quarantine RimSort.app`
-    - `xattr -d com.apple.quarantine libsteam_api.dylib`
+    - `xattr -d com.apple.quarantine /path/to/RimSort.app`
+    - `xattr -d com.apple.quarantine /path/to/libsteam_api.dylib`
+  - Replace `/path/to/` with the actual path where the file/folder is, Example:
+    - `xattr -d com.apple.quarantine /Users/John/Downloads/RimSort.app`
 
 ### Setting up steamfiles module
 

--- a/docs/user-guide/downloading-and-installing.md
+++ b/docs/user-guide/downloading-and-installing.md
@@ -53,9 +53,13 @@ macOS
 > Apple has it's own Runtime Protection called [Gatekeeper](https://support.apple.com/guide/security/gatekeeper-and-runtime-protection-sec5599b66df/web) that can cause issues when trying to run RimSort (or execute dependent libs)!
 > You can circumvent this issue by using `xattr` command to manually whitelist:
 >
->     xattr -d com.apple.quarantine RimSort.app
->     xattr -d com.apple.quarantine libsteam_api.dylib
-> 
+>     xattr -d com.apple.quarantine /path/to/RimSort.app
+>     xattr -d com.apple.quarantine /path/to/libsteam_api.dylib
+>
+> Replace `/path/to/` with the actual path where the file/folder is, example:
+>
+>     xattr -d com.apple.quarantine /Users/John/Downloads/RimSort.app
+>
 > If you are for some reason trying to run the `i386` build on Apple silicon, don't enable watchdog when running the build through Rosetta
 
 {: .note }


### PR DESCRIPTION
Small update to docs to hopefully prevent some user reports in the future.

I dont have a mac, but I think the example paths are correct...

![image](https://github.com/user-attachments/assets/f9f6cb26-1c37-4e80-ad31-63d3496620a2)


![image](https://github.com/user-attachments/assets/b898dc15-2613-408d-b666-346759f90d9f)
