### PR TITLE
Adds support for No Version Warning xml file

### DIFF
--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -157,6 +157,26 @@ class SettingsController(QObject):
             EventBus().do_download_community_rules_db_from_github
         )
 
+        self.settings_dialog.no_version_update_db_none_radio.clicked.connect(
+            self._on_no_version_update_db_radio_clicked
+        )
+        self.settings_dialog.no_version_update_db_github_radio.clicked.connect(
+            self._on_no_version_update_db_radio_clicked
+        )
+        self.settings_dialog.no_version_update_db_local_file_radio.clicked.connect(
+            self._on_no_version_update_db_radio_clicked
+        )
+
+        self.settings_dialog.no_version_update_db_local_file_choose_button.clicked.connect(
+            self._on_no_version_update_db_local_file_choose_button_clicked
+        )
+        self.settings_dialog.no_version_update_db_github_upload_button.clicked.connect(
+            EventBus().do_upload_no_version_update_db_to_github
+        )
+        self.settings_dialog.no_version_update_db_github_download_button.clicked.connect(
+            EventBus().do_download_no_version_update_db_from_github
+        )
+
         self.settings_dialog.steam_workshop_db_none_radio.clicked.connect(
             self._on_steam_workshop_db_radio_clicked
         )
@@ -407,7 +427,50 @@ class SettingsController(QObject):
         self.settings_dialog.community_rules_db_github_url.setText(
             self.settings.external_community_rules_repo
         )
-        self.settings_dialog.community_rules_db_github_url.setCursorPosition(0)
+        if self.settings.external_no_version_update_metadata_source == "None":
+            self.settings_dialog.no_version_update_db_none_radio.setChecked(True)
+            self.settings_dialog.no_version_update_db_github_url.setEnabled(False)
+            self.settings_dialog.no_version_update_db_github_download_button.setEnabled(
+                False
+            )
+            self.settings_dialog.no_version_update_db_local_file.setEnabled(False)
+            self.settings_dialog.no_version_update_db_local_file_choose_button.setEnabled(
+                False
+            )
+        elif (
+            self.settings.external_no_version_update_metadata_source
+            == "Configured remote file path"
+        ):
+            self.settings_dialog.no_version_update_db_github_radio.setChecked(True)
+            self.settings_dialog.no_version_update_db_github_url.setEnabled(True)
+            self.settings_dialog.no_version_update_db_github_download_button.setEnabled(
+                True
+            )
+            self.settings_dialog.no_version_update_db_local_file.setEnabled(False)
+            self.settings_dialog.no_version_update_db_local_file_choose_button.setEnabled(
+                False
+            )
+        elif (
+            self.settings.external_no_version_update_metadata_source
+            == "Configured local file path"
+        ):
+            self.settings_dialog.no_version_update_db_local_file_radio.setChecked(True)
+            self.settings_dialog.no_version_update_db_github_url.setEnabled(False)
+            self.settings_dialog.no_version_update_db_github_download_button.setEnabled(
+                False
+            )
+            self.settings_dialog.no_version_update_db_local_file.setEnabled(True)
+            self.settings_dialog.no_version_update_db_local_file_choose_button.setEnabled(
+                True
+            )
+        self.settings_dialog.no_version_update_db_local_file.setText(
+            self.settings.external_no_version_update_file_path
+        )
+        self.settings_dialog.no_version_update_db_local_file.setCursorPosition(0)
+        self.settings_dialog.no_version_update_db_github_url.setText(
+            self.settings.external_no_version_update_repo_path
+        )
+        self.settings_dialog.no_version_update_db_github_url.setCursorPosition(0)
         if self.settings.external_steam_metadata_source == "None":
             self.settings_dialog.steam_workshop_db_none_radio.setChecked(True)
             self.settings_dialog.steam_workshop_db_github_url.setEnabled(False)
@@ -588,6 +651,22 @@ class SettingsController(QObject):
         )
         self.settings.external_community_rules_repo = (
             self.settings_dialog.community_rules_db_github_url.text()
+        )
+        if self.settings_dialog.no_version_update_db_none_radio.isChecked():
+            self.settings.external_no_version_update_metadata_source = "None"
+        elif self.settings_dialog.no_version_update_db_local_file_radio.isChecked():
+            self.settings.external_no_version_update_metadata_source = (
+                "Configured local file path"
+            )
+        elif self.settings_dialog.no_version_update_db_github_radio.isChecked():
+            self.settings.external_no_version_update_metadata_source = (
+                "Configured remote file path"
+            )
+        self.settings.external_no_version_update_file_path = (
+            self.settings_dialog.no_version_update_db_local_file.text()
+        )
+        self.settings.external_no_version_update_repo_path = (
+            self.settings_dialog.no_version_update_db_github_url.text()
         )
         if self.settings_dialog.steam_workshop_db_none_radio.isChecked():
             self.settings.external_steam_metadata_source = "None"
@@ -1098,6 +1177,81 @@ class SettingsController(QObject):
             community_rules_db_location
         )
         self._last_file_dialog_path = str(Path(community_rules_db_location).parent)
+
+    @Slot(bool)
+    def _on_no_version_update_db_radio_clicked(self, checked: bool = True) -> None:
+        """
+        This function handles the "no version update" db radio buttons. Clicking one button
+        enables the associated widgets and disables the other widgets.
+        """
+        if (
+            self.sender() == self.settings_dialog.no_version_update_db_none_radio
+            and checked
+        ):
+            self.settings_dialog.no_version_update_db_github_url.setEnabled(False)
+            self.settings_dialog.no_version_update_db_github_download_button.setEnabled(
+                False
+            )
+            self.settings_dialog.no_version_update_db_local_file.setEnabled(False)
+            self.settings_dialog.no_version_update_db_local_file_choose_button.setEnabled(
+                False
+            )
+            app_instance = QApplication.instance()
+            if isinstance(app_instance, QApplication):
+                focused_widget = app_instance.focusWidget()
+                if focused_widget is not None:
+                    focused_widget.clearFocus()
+            return
+
+        if (
+            self.sender() == self.settings_dialog.no_version_update_db_github_radio
+            and checked
+        ):
+            self.settings_dialog.no_version_update_db_github_url.setEnabled(True)
+            self.settings_dialog.no_version_update_db_github_download_button.setEnabled(
+                True
+            )
+            self.settings_dialog.no_version_update_db_local_file.setEnabled(False)
+            self.settings_dialog.no_version_update_db_local_file_choose_button.setEnabled(
+                False
+            )
+            self.settings_dialog.no_version_update_db_github_url.setFocus()
+            return
+
+        if (
+            self.sender() == self.settings_dialog.no_version_update_db_local_file_radio
+            and checked
+        ):
+            self.settings_dialog.no_version_update_db_github_url.setEnabled(False)
+            self.settings_dialog.no_version_update_db_github_download_button.setEnabled(
+                False
+            )
+            self.settings_dialog.no_version_update_db_local_file.setEnabled(True)
+            self.settings_dialog.no_version_update_db_local_file_choose_button.setEnabled(
+                True
+            )
+            self.settings_dialog.no_version_update_db_local_file.setFocus()
+            return
+
+    @Slot()
+    def _on_no_version_update_db_local_file_choose_button_clicked(self) -> None:
+        """
+        Open a file dialog to select the "no version update" xml file and handle the result.
+        """
+        no_version_update_db_location = show_dialogue_file(
+            mode="open",
+            caption="Select No Version Update XML File",
+            _dir=str(self._last_file_dialog_path),
+        )
+        if not no_version_update_db_location:
+            return
+
+        self.settings_dialog.no_version_update_db_local_file.setText(
+            no_version_update_db_location
+        )
+        self._last_file_dialog_path = str(Path(no_version_update_db_location).parent)
+
+
 
     @Slot(bool)
     def _on_steam_workshop_db_radio_clicked(self, checked: bool = True) -> None:

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -43,6 +43,15 @@ class Settings(QObject):
         self.external_community_rules_repo: str = (
             "https://github.com/RimSort/Community-Rules-Database"
         )
+
+        self.external_no_version_update_metadata_source: str = "None"
+        self.external_no_version_update_file_path: str = str(
+            AppInfo().app_storage_folder / "noVersionUpdate.xml"
+        )
+        self.external_no_version_update_repo_path: str = (
+            "https://raw.githubusercontent.com/emipa606/NoVersionWarning/refs/heads/main/1.5/ModIdsToFix.xml"
+        )
+
         self.database_expiry: int = 604800  # 7 days
 
         # Sorting

--- a/app/utils/event_bus.py
+++ b/app/utils/event_bus.py
@@ -69,6 +69,8 @@ class EventBus(QObject):
     # SettingsDialog signals
     do_upload_community_rules_db_to_github = Signal()
     do_download_community_rules_db_from_github = Signal()
+    do_upload_no_version_update_db_to_github = Signal()
+    do_download_no_version_update_db_from_github = Signal()
     do_upload_steam_workshop_db_to_github = Signal()
     do_download_steam_workshop_db_from_github = Signal()
     do_upload_rimsort_log = Signal()

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -145,6 +145,12 @@ class MainContent(QObject):
             EventBus().do_download_community_rules_db_from_github.connect(
                 self._on_do_download_community_db_from_github
             )
+            EventBus().do_upload_no_version_update_db_to_github.connect(
+                self._on_do_upload_no_version_update_db_to_github
+            )
+            EventBus().do_download_no_version_update_db_from_github.connect(
+                self._on_do_download_no_version_update_db_from_github
+            )
             EventBus().do_upload_steam_workshop_db_to_github.connect(
                 self._on_do_upload_steam_workshop_db_to_github
             )
@@ -2318,6 +2324,32 @@ class MainContent(QObject):
         else:
             self._do_notify_no_git()
 
+
+    def _do_download_single_file_to_path(self, output_file_path: str, file_url: str, silent: bool = False) -> None:
+        """
+        Downloads a single file from a URL to a specified path
+        The name of the file is extracted from the URL and appended to the base_path
+        """
+        try:
+            response = requests_get(file_url)
+            response.raise_for_status()
+            with open(output_file_path, "wb") as file:
+                file.write(response.content)
+            logger.info(f"Downloaded file to: {output_file_path}")
+            if not silent:
+                dialogue.show_information(
+                    title="File downloaded",
+                    text="The file was successfully downloaded",
+                    information=f"from {file_url} to {output_file_path}",
+                )
+        except Exception as e:
+            logger.error(f"Failed to download file from {file_url}: {e}")
+            dialogue.show_warning(
+                title="Failed to download file",
+                text=f"Failed to download file from {file_url}",
+                information=str(e),
+            )
+
     def _do_clone_repo_to_path(self, base_path: str, repo_url: str) -> None:
         """
         Checks validity of configured git repo, as well as if it exists
@@ -2686,6 +2718,13 @@ class MainContent(QObject):
         )
         if answer == "&Yes":
             open_url_browser("https://git-scm.com/downloads")
+
+    def _do_notify_not_yet_implemented(self) -> None:
+        dialogue.show_warning(
+            title="Not yet implemented",
+            text="This feature is not yet implemented!",
+            information="This feature may or may not planned for a future release.",
+        )
 
     def _do_open_rule_editor(
         self, compact: bool, initial_mode: str, packageid: str | None = None
@@ -3282,6 +3321,17 @@ class MainContent(QObject):
             )
         else:
             self._do_notify_no_git()
+
+    @Slot()
+    def _on_do_upload_no_version_update_db_to_github(self) -> None:
+        self._do_notify_not_yet_implemented()
+
+    @Slot()
+    def _on_do_download_no_version_update_db_from_github(self) -> None:
+        self._do_download_single_file_to_path(
+            output_file_path=str(os.path.join(AppInfo().databases_folder, "noVersionUpdate.xml")),
+            file_url=self.settings_controller.settings.external_no_version_update_repo_path,
+        )
 
     @Slot()
     def _on_do_upload_steam_workshop_db_to_github(self) -> None:

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -245,6 +245,7 @@ class SettingsDialog(QDialog):
         tab.setLayout(tab_layout)
 
         self._do_community_rules_db_group(tab_layout)
+        self._do_no_version_update_db_group(tab_layout)
         self._do_steam_workshop_db_group(tab_layout)
 
     def __create_db_group(
@@ -407,6 +408,22 @@ class SettingsDialog(QDialog):
         self.database_expiry.setTextMargins(GUIInfo().text_field_margins)
         self.database_expiry.setFixedHeight(GUIInfo().default_font_line_height * 2)
         group_layout.addWidget(self.database_expiry)
+
+    def _do_no_version_update_db_group(self, tab_layout: QBoxLayout) -> None:
+        section_lbl = "\"No Version Update\" XML file"
+        none_lbl = "\"No Version Update\" XML file"
+
+        (
+            _,
+            self.no_version_update_db_none_radio,
+            self.no_version_update_db_github_radio,
+            self.no_version_update_db_github_url,
+            self.no_version_update_db_github_upload_button,
+            self.no_version_update_db_github_download_button,
+            self.no_version_update_db_local_file_radio,
+            self.no_version_update_db_local_file,
+            self.no_version_update_db_local_file_choose_button,
+        ) = self.__create_db_group(section_lbl, none_lbl, tab_layout)
 
     def _do_sorting_tab(self) -> None:
         tab = QWidget()


### PR DESCRIPTION
While it's a minor issue, the "Version Mismatch" warning icons within RimSort were getting on my nerves for mods that are validated to work with 1.5 via [https://github.com/emipa606/NoVersionWarning](https://github.com/emipa606/NoVersionWarning)

This PR adds the ability to optionally use either a local copy or a url reference to https://raw.githubusercontent.com/emipa606/NoVersionWarning/refs/heads/main/1.5/ModIdsToFix.xml -- which contains a listing of mod ids that have been tested as compatible with the latest version of the game.

This is my first PR to RimSort - so please let me know if there are any style issues or other changes that need to be made.

I want to take a look at adding support for https://github.com/emipa606/UseThisInstead in a future PR.