### PR TITLE
Automatically set local folder from game folder and Disable Mods path selection

### DIFF
--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -125,12 +125,12 @@ class SettingsController(QObject):
         self.settings_dialog.local_mods_folder_location_open_button.clicked.connect(
             self._on_local_mods_folder_location_open_button_clicked
         )
-        self.settings_dialog.local_mods_folder_location_choose_button.clicked.connect(
+        """self.settings_dialog.local_mods_folder_location_choose_button.clicked.connect(
             self._on_local_mods_folder_location_choose_button_clicked
         )
         self.settings_dialog.local_mods_folder_location_clear_button.clicked.connect(
             self._on_local_mods_folder_location_clear_button_clicked
-        )
+        )"""  # Disable button connections for now
 
         self.settings_dialog.locations_clear_button.clicked.connect(
             self._on_locations_clear_button_clicked
@@ -752,8 +752,11 @@ class SettingsController(QObject):
 
     @Slot()
     def _on_game_location_text_changed(self) -> None:
-        self.settings_dialog.game_location_open_button.setEnabled(
-            self.settings_dialog.game_location.text() != ""
+        game_folder = self.settings_dialog.game_location.text()
+        self.settings_dialog.game_location_open_button.setEnabled(game_folder != "")
+        # Automatically set local folder from game folder
+        self.settings_dialog.local_mods_folder_location.setText(
+            str(Path(game_folder) / "Mods") if game_folder else ""
         )
 
     @Slot()

--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -125,9 +125,6 @@ class SettingsController(QObject):
         self.settings_dialog.local_mods_folder_location_open_button.clicked.connect(
             self._on_local_mods_folder_location_open_button_clicked
         )
-        """self.settings_dialog.local_mods_folder_location_clear_button.clicked.connect(
-            self._on_local_mods_folder_location_clear_button_clicked
-        )"""  # Disable button connections for now
 
         self.settings_dialog.locations_clear_button.clicked.connect(
             self._on_locations_clear_button_clicked
@@ -877,10 +874,6 @@ class SettingsController(QObject):
     @Slot()
     def _on_local_mods_folder_location_open_button_clicked(self) -> None:
         platform_specific_open(self.settings_dialog.local_mods_folder_location.text())
-
-    @Slot()
-    def _on_local_mods_folder_location_clear_button_clicked(self) -> None:
-        self.settings_dialog.local_mods_folder_location.setText("")
 
     @Slot()
     def _on_locations_clear_button_clicked(

--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -125,10 +125,7 @@ class SettingsController(QObject):
         self.settings_dialog.local_mods_folder_location_open_button.clicked.connect(
             self._on_local_mods_folder_location_open_button_clicked
         )
-        """self.settings_dialog.local_mods_folder_location_choose_button.clicked.connect(
-            self._on_local_mods_folder_location_choose_button_clicked
-        )
-        self.settings_dialog.local_mods_folder_location_clear_button.clicked.connect(
+        """self.settings_dialog.local_mods_folder_location_clear_button.clicked.connect(
             self._on_local_mods_folder_location_clear_button_clicked
         )"""  # Disable button connections for now
 
@@ -880,24 +877,6 @@ class SettingsController(QObject):
     @Slot()
     def _on_local_mods_folder_location_open_button_clicked(self) -> None:
         platform_specific_open(self.settings_dialog.local_mods_folder_location.text())
-
-    @Slot()
-    def _on_local_mods_folder_location_choose_button_clicked(self) -> None:
-        """
-        Open a directory dialog to select the local mods folder and handle the result.
-        """
-        local_mods_folder_location = show_dialogue_file(
-            mode="open_dir",
-            caption="Select Local Mods Folder",
-            _dir=str(self._last_file_dialog_path),
-        )
-        if not local_mods_folder_location:
-            return
-
-        self.settings_dialog.local_mods_folder_location.setText(
-            local_mods_folder_location
-        )
-        self._last_file_dialog_path = str(Path(local_mods_folder_location).parent)
 
     @Slot()
     def _on_local_mods_folder_location_clear_button_clicked(self) -> None:

--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -119,9 +119,6 @@ class SettingsController(QObject):
             self._on_steam_mods_folder_location_clear_button_clicked
         )
 
-        self.settings_dialog.local_mods_folder_location.textChanged.connect(
-            self._on_local_mods_folder_location_text_changed
-        )
         self.settings_dialog.local_mods_folder_location_open_button.clicked.connect(
             self._on_local_mods_folder_location_open_button_clicked
         )
@@ -749,9 +746,16 @@ class SettingsController(QObject):
         game_folder = self.settings_dialog.game_location.text()
         self.settings_dialog.game_location_open_button.setEnabled(game_folder != "")
         # Automatically set local folder from game folder
-        self.settings_dialog.local_mods_folder_location.setText(
-            str(Path(game_folder) / "Mods") if game_folder else ""
-        )
+        if game_folder:
+            self.settings_dialog.local_mods_folder_location.setText(
+                str(Path(game_folder) / "Mods")
+            )
+            self.settings_dialog.local_mods_folder_location_open_button.setEnabled(True)
+        else:  # Reset local mods folder location
+            self.settings_dialog.local_mods_folder_location.setText("")
+            self.settings_dialog.local_mods_folder_location_open_button.setEnabled(
+                False
+            )
 
     @Slot()
     def _on_game_location_open_button_clicked(self) -> None:
@@ -802,6 +806,7 @@ class SettingsController(QObject):
     @Slot()
     def _on_game_location_clear_button_clicked(self) -> None:
         self.settings_dialog.game_location.setText("")
+        self.settings_dialog.local_mods_folder_location.setText("")
 
     @Slot()
     def _on_config_folder_location_text_changed(self) -> None:
@@ -864,12 +869,6 @@ class SettingsController(QObject):
     @Slot()
     def _on_steam_mods_folder_location_clear_button_clicked(self) -> None:
         self.settings_dialog.steam_mods_folder_location.setText("")
-
-    @Slot()
-    def _on_local_mods_folder_location_text_changed(self) -> None:
-        self.settings_dialog.local_mods_folder_location_open_button.setEnabled(
-            self.settings_dialog.local_mods_folder_location.text() != ""
-        )
 
     @Slot()
     def _on_local_mods_folder_location_open_button_clicked(self) -> None:

--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -363,6 +363,13 @@ class SettingsController(QObject):
         self.settings_dialog.local_mods_folder_location_open_button.setEnabled(
             self.settings_dialog.local_mods_folder_location.text() != ""
         )
+        game_folder = self.settings.instances[
+            self.settings.current_instance
+        ].game_folder  # Automatically set local folder from game folder
+        if game_folder != "":
+            self.settings_dialog.local_mods_folder_location.setText(
+                str(Path(game_folder) / "Mods")
+            )
 
         # Databases tab
         if self.settings.external_community_rules_metadata_source == "None":

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -228,6 +228,9 @@ class SettingsDialog(QDialog):
         self.local_mods_folder_location.setFixedHeight(
             GUIInfo().default_font_line_height * 2
         )
+        self.local_mods_folder_location.setPlaceholderText(
+            "Game location sets local mods location."
+        )
         group_layout.addWidget(self.local_mods_folder_location)
 
     def _do_databases_tab(self) -> None:

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -223,11 +223,6 @@ class SettingsDialog(QDialog):
         self.local_mods_folder_location_open_button.setText("Open…")
         header_layout.addWidget(self.local_mods_folder_location_open_button)
 
-        # Disable the buttons for now
-        """self.local_mods_folder_location_clear_button = QToolButton()
-        self.local_mods_folder_location_clear_button.setText("Clear…")
-        header_layout.addWidget(self.local_mods_folder_location_clear_button)"""
-
         self.local_mods_folder_location = QLineEdit(readOnly=True)
         self.local_mods_folder_location.setTextMargins(GUIInfo().text_field_margins)
         self.local_mods_folder_location.setFixedHeight(

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -224,11 +224,7 @@ class SettingsDialog(QDialog):
         header_layout.addWidget(self.local_mods_folder_location_open_button)
 
         # Disable the buttons for now
-        """self.local_mods_folder_location_choose_button = QToolButton()
-        self.local_mods_folder_location_choose_button.setText("Choose…")
-        header_layout.addWidget(self.local_mods_folder_location_choose_button)
-
-        self.local_mods_folder_location_clear_button = QToolButton()
+        """self.local_mods_folder_location_clear_button = QToolButton()
         self.local_mods_folder_location_clear_button.setText("Clear…")
         header_layout.addWidget(self.local_mods_folder_location_clear_button)"""
 

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -223,15 +223,16 @@ class SettingsDialog(QDialog):
         self.local_mods_folder_location_open_button.setText("Open…")
         header_layout.addWidget(self.local_mods_folder_location_open_button)
 
-        self.local_mods_folder_location_choose_button = QToolButton()
+        # Disable the buttons for now
+        """self.local_mods_folder_location_choose_button = QToolButton()
         self.local_mods_folder_location_choose_button.setText("Choose…")
         header_layout.addWidget(self.local_mods_folder_location_choose_button)
 
         self.local_mods_folder_location_clear_button = QToolButton()
         self.local_mods_folder_location_clear_button.setText("Clear…")
-        header_layout.addWidget(self.local_mods_folder_location_clear_button)
+        header_layout.addWidget(self.local_mods_folder_location_clear_button)"""
 
-        self.local_mods_folder_location = QLineEdit()
+        self.local_mods_folder_location = QLineEdit(readOnly=True)
         self.local_mods_folder_location.setTextMargins(GUIInfo().text_field_margins)
         self.local_mods_folder_location.setFixedHeight(
             GUIInfo().default_font_line_height * 2


### PR DESCRIPTION
1) When game_folder is set "/Mods" is added to it to set local_folder
2) when game folder is cleared, it also clears local_folder
3) Removed "Choose…" and "Clear…" buttons for local_folder

![image](https://github.com/user-attachments/assets/e7b4591f-0d07-4264-a65c-50b88e2cdd2f)
