### PR TITLE
feat: View About.XML `incompatibilities` in Rule Editor

### DIFF
--- a/app/models/metadata/metadata_structure.py
+++ b/app/models/metadata/metadata_structure.py
@@ -519,8 +519,6 @@ class SubExternalBoolRule(msgspec.Struct, omit_defaults=True):
 class ExternalRule(msgspec.Struct, omit_defaults=True):
     loadAfter: dict[str, SubExternalRule] = {}
     loadBefore: dict[str, SubExternalRule] = {}
-    incompatibleWith: dict[str, SubExternalRule] = {}
-    compatibleWith: dict[str, SubExternalRule] = {}
     loadTop: SubExternalBoolRule = msgspec.field(default_factory=SubExternalBoolRule)
     loadBottom: SubExternalBoolRule = msgspec.field(default_factory=SubExternalBoolRule)
 

--- a/app/models/metadata/metadata_structure.py
+++ b/app/models/metadata/metadata_structure.py
@@ -9,6 +9,8 @@ from uuid import uuid4
 
 import msgspec
 
+from app.utils.files import subfolder_contains_candidate_path
+
 
 class ModType(Enum):
     LOCAL = "Local"
@@ -338,28 +340,12 @@ class ListedMod(BaseMod):
     @functools.cached_property
     def c_sharp_mod(self) -> bool:
         """Return whether the mod is a C# mod based on the contents of the mod path. Looks for binaries in the Assemblies folder."""
-        if self.mod_path is None:
-            return False
+        return subfolder_contains_candidate_path(self.mod_path, "Assemblies", "*.dll")
 
-        subfolder_paths = [self.mod_path]
-        subfolder_paths.extend(
-            [
-                self.mod_path / folder
-                for folder in os.listdir(self.mod_path)
-                if os.path.isdir(str(self.mod_path / folder))
-            ]
-        )
-
-        for subfolder_path in subfolder_paths:
-            candidate_path = subfolder_path / "Assemblies"
-            if candidate_path.exists():
-                # Check for .dll or .DLL files in the Assemblies folder using glob
-                if any(candidate_path.glob("*.dll")) or any(
-                    candidate_path.glob("*.DLL")
-                ):
-                    return True
-
-        return False
+    @functools.cached_property
+    def xml_patch_mod(self) -> bool:
+        """Return whether the mod is a C# mod based on the contents of the mod path. Looks for binaries in the Assemblies folder."""
+        return subfolder_contains_candidate_path(self.mod_path, "Patches", "*.xml")
 
     @property
     def preview_img_path(self) -> Path | None:
@@ -533,6 +519,8 @@ class SubExternalBoolRule(msgspec.Struct, omit_defaults=True):
 class ExternalRule(msgspec.Struct, omit_defaults=True):
     loadAfter: dict[str, SubExternalRule] = {}
     loadBefore: dict[str, SubExternalRule] = {}
+    incompatibleWith: dict[str, SubExternalRule] = {}
+    compatibleWith: dict[str, SubExternalRule] = {}
     loadTop: SubExternalBoolRule = msgspec.field(default_factory=SubExternalBoolRule)
     loadBottom: SubExternalBoolRule = msgspec.field(default_factory=SubExternalBoolRule)
 

--- a/app/utils/files.py
+++ b/app/utils/files.py
@@ -1,0 +1,33 @@
+import os
+from pathlib import Path
+
+
+def subfolder_contains_candidate_path(
+    subfolder: Path | None,
+    candidate_directory: Path | str | None,
+    glob: str,
+    case_sensitive: bool = False,
+) -> bool:
+    if subfolder is None:
+        return False
+
+    if candidate_directory is None:
+        candidate_directory = ""
+
+    subfolder_paths = [subfolder]
+    subfolder_paths.extend(
+        [
+            subfolder / folder
+            for folder in os.listdir(subfolder)
+            if os.path.isdir(str(subfolder / folder))
+        ]
+    )
+
+    for subfolder_path in subfolder_paths:
+        candidate_path = subfolder_path / candidate_directory
+        if candidate_path.exists():
+            # Check for .dll or .DLL files in the Assemblies folder using glob
+            if any(candidate_path.glob(glob, case_sensitive=case_sensitive)):
+                return True
+
+    return False

--- a/app/windows/rule_editor_panel.py
+++ b/app/windows/rule_editor_panel.py
@@ -181,8 +181,12 @@ class RuleEditor(QWidget):
         # local metadata
         self.local_metadata_loadAfter_label = QLabel("About.xml (loadAfter)")
         self.local_metadata_loadBefore_label = QLabel("About.xml (loadBefore)")
+        self.local_metadata_incompatibilities_label = QLabel(
+            "About.xml (incompatibilities)"
+        )
         self.local_metadata_loadAfter_list = QListWidget()
         self.local_metadata_loadBefore_list = QListWidget()
+        self.local_metadata_incompatibilities_list = QListWidget()
 
         # community rules
         self.external_community_rules_loadAfter_label = QLabel(
@@ -389,6 +393,12 @@ class RuleEditor(QWidget):
         )
         self.internal_local_metadata_layout.addWidget(
             self.local_metadata_loadBefore_list
+        )
+        self.internal_local_metadata_layout.addWidget(
+            self.local_metadata_incompatibilities_label
+        )
+        self.internal_local_metadata_layout.addWidget(
+            self.local_metadata_incompatibilities_list
         )
         self.external_community_rules_layout.addWidget(
             self.external_community_rules_loadAfter_label
@@ -648,6 +658,7 @@ class RuleEditor(QWidget):
         self.mods_list.clear()
         self.local_metadata_loadAfter_list.clear()
         self.local_metadata_loadBefore_list.clear()
+        self.local_metadata_incompatibilities_list.clear()
         self.external_community_rules_loadAfter_list.clear()
         self.external_community_rules_loadBefore_list.clear()
         self.external_user_rules_loadAfter_list.clear()
@@ -725,6 +736,7 @@ class RuleEditor(QWidget):
                     rule_types = {
                         "loadafter": self.local_metadata_loadAfter_list,
                         "loadbefore": self.local_metadata_loadBefore_list,
+                        "incompatiblewith": self.local_metadata_incompatibilities_list,
                     }
 
                     for rule_type, _list in rule_types.items():
@@ -753,6 +765,7 @@ class RuleEditor(QWidget):
                         metadata=metadata.get("packageid"),
                     )
 
+        # TODO: Not able to handle user/community incompatible with rules yet.
         def _parse_rules(
             rules: dict[str, Any],
             loadAfter_list: QListWidget,


### PR DESCRIPTION
introduce simple UI to view existing About.XML incompatibilities - this was helpful to me to quickly check things out while debugging a crash.

Also extracts file ending search to utils for future use - I will be using it to investigate XML patch conflicts and to potentially support "cross mod compatibility warnings" like https://github.com/Ionfrigate12345/Rimworld_SOS2_VEHG_Patch/