### PR TITLE
fix and Improve SteamCMD ACF file handling

### DIFF
--- a/app/utils/metadata.py
+++ b/app/utils/metadata.py
@@ -1379,7 +1379,18 @@ class MetadataManager(QObject):
         """
         # Parse the SteamCMD workshop .acf metadata file
         acf_path = self.steamcmd_wrapper.steamcmd_appworkshop_acf_path
-        acf_metadata = acf_to_dict(path=acf_path)
+        if not os.path.exists(acf_path):
+            logger.warning(
+                f"SteamCMD ACF file not found at: {acf_path}, Skipping removing mods from ACF."
+            )
+            return
+
+        try:
+            acf_metadata = acf_to_dict(path=acf_path)
+        except Exception as e:
+            logger.error(f"Failed to parse SteamCMD ACF file: {e}")
+            return
+
         depotcache_path = self.steamcmd_wrapper.steamcmd_depotcache_path
         # WorkshopItemsInstalled
         workshop_items_installed = acf_metadata.get("AppWorkshop", {}).get(


### PR DESCRIPTION
1) Add explicit file existence check before ACF parsing

2) Add error handling for ACF parsing failures

3) Return early on file not found or parse errors

4) Prevents potential crashes when SteamCMD ACF file is missing or corrupted.

5) Maintain existing functionality while adding safety checks

Specific error
Traceback (most recent call last):
  File "views\mods_panel.py", line 1206, in eventFilter
  File "utils\metadata.py", line 1382, in steamcmd_purge_mods
  File "utils\steam\steamfiles\wrapper.py", line 11, in acf_to_dict
FileNotFoundError: [Errno 2] No such file or directory: 'D:\\Games\\SteamCmd\\steam\\steamapps\\workshop\\appworkshop_294100.acf'