### PR TITLE
Use TYPE_CHECKING to fix Repo and GitCommandError being unbound when git not available

### DIFF
--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -18,29 +18,8 @@ from typing import TYPE_CHECKING, Any, Callable, Self
 from urllib.parse import urlparse
 from zipfile import ZipFile
 
-from loguru import logger
-
-from app.utils.generic import (
-    check_valid_http_git_url,
-    extract_git_dir_name,
-    extract_git_user_or_org,
-    platform_specific_open,
-)
-from app.utils.system_info import SystemInfo
-
-# GitPython depends on git executable being available in PATH
-try:
-    from git import Repo
-    from git.exc import GitCommandError
-
-    GIT_EXISTS = True
-except ImportError:
-    logger.warning(
-        "git not detected in your PATH! Do you have git installed...? git integration will be disabled! You may need to restart the app if you installed it."
-    )
-    GIT_EXISTS = False
-
 from github import Github
+from loguru import logger
 from PySide6.QtCore import (
     QEventLoop,
     QObject,
@@ -60,11 +39,15 @@ from app.models.animations import LoadingAnimation
 from app.utils.app_info import AppInfo
 from app.utils.event_bus import EventBus
 from app.utils.generic import (
+    check_valid_http_git_url,
     chunks,
     copy_to_clipboard_safely,
     delete_files_except_extension,
+    extract_git_dir_name,
+    extract_git_user_or_org,
     launch_game_process,
     open_url_browser,
+    platform_specific_open,
     upload_data_to_0x0_st,
 )
 from app.utils.metadata import MetadataManager, SettingsController
@@ -80,6 +63,7 @@ from app.utils.steam.webapi.wrapper import (
     CollectionImport,
     ISteamRemoteStorage_GetPublishedFileDetails,
 )
+from app.utils.system_info import SystemInfo
 from app.utils.todds.wrapper import ToddsInterface
 from app.utils.xml import json_to_xml_write
 from app.views.mod_info_panel import ModInfo
@@ -93,6 +77,22 @@ from app.windows.workshop_mod_updater_panel import ModUpdaterPrompt
 
 if TYPE_CHECKING:
     from app.views.main_window import MainWindow
+
+# GitPython depends on git executable being available in PATH
+try:
+    from git import Repo
+    from git.exc import GitCommandError
+
+    GIT_EXISTS = True
+except ImportError:
+    logger.warning(
+        "git not detected in your PATH! Do you have git installed...? git integration will be disabled! You may need to restart the app if you installed it."
+    )
+    GIT_EXISTS = False
+    # Using TYPE_CHECKING to avoid unbound issues when git is not available
+    if TYPE_CHECKING:
+        from git import Repo
+        from git.exc import GitCommandError
 
 
 class MainContent(QObject):


### PR DESCRIPTION
Use TYPE_CHECKING to fix Repo and GitCommandError being unbound when git not available