### PR TITLE
Workflows: add cleanup

### DIFF
--- a/.github/workflows/auto_build.yml
+++ b/.github/workflows/auto_build.yml
@@ -2,6 +2,7 @@
 # Not recommended to release these builds due to versioning.
 
 name: Auto Build
+
 on:
   pull_request:
     types: [opened, synchronize]
@@ -27,8 +28,55 @@ jobs:
     with:
       format_only: true
 
+  cleanup:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Enhanced Cleanup
+        shell: bash
+        run: |
+          TARGET_DIR="build/__main__.app/Contents/Resources/qtwebengine_locales"
+          if [ -d "$TARGET_DIR" ]; then
+            echo "Attempting to remove directory..."
+            # Check for open files and terminate processes if needed
+            lsof +D "$TARGET_DIR" || echo "No processes using the directory."
+            lsof +D "$TARGET_DIR" | awk '{print $2}' | xargs -r kill -9 || echo "Failed to terminate some processes."
+            
+            # Set write permissions and attempt deletion
+            chmod -R u+w "$TARGET_DIR" || echo "Failed to set write permissions."
+            rm -rf "$TARGET_DIR" || echo "Failed to delete directory."
+
+            # Retry mechanism
+            for i in {1..3}; do
+              if [ -d "$TARGET_DIR" ]; then
+                echo "Retrying directory cleanup (Attempt $i)..."
+                chmod -R u+w "$TARGET_DIR"
+                rm -rf "$TARGET_DIR"
+                sleep 5
+              else
+                break
+              fi
+            done
+
+            # Final check
+            if [ -d "$TARGET_DIR" ]; then
+              echo "Directory cleanup failed after retries. Exiting."
+              exit 1
+            else
+              echo "Directory successfully removed."
+            fi
+          else
+            echo "Directory does not exist; no cleanup needed."
+          fi
+
+      - name: Debug Directory State
+        shell: bash
+        run: ls -la build/__main__.app/Contents/Resources/qtwebengine_locales || echo "Directory does not exist"
+
   attested-build:
-    needs: pre-build
+    needs: [pre-build, cleanup]
     if: github.event_name != 'pull_request'
     permissions:
       id-token: write
@@ -41,7 +89,7 @@ jobs:
       attest: true
 
   non-attested-build:
-    needs: pre-build
+    needs: [pre-build, cleanup]
     if: github.event_name == 'pull_request'
     permissions:
       id-token: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,5 @@
 name: Build
+
 on:
   workflow_call:
     inputs:
@@ -71,6 +72,7 @@ jobs:
             env:
               BUILD_OUTPUT: "__main__.dist"
               Executable: RimSort.exe
+
     steps:
       - name: Check-out repository
         uses: actions/checkout@main
@@ -93,6 +95,15 @@ jobs:
           brew remove --force --ignore-dependencies openssl@3
           brew cleanup openssl@3
         if: runner.os == 'macos' && matrix.arch == 'i386'
+
+      - name: Pre-Build Enhanced Cleanup
+        run: |
+          TARGET_DIR="build/__main__.app/Contents/Resources/qtwebengine_locales"
+          if [ -d "$TARGET_DIR" ]; then
+            echo "Cleaning up residual directories..."
+            chmod -R u+w "$TARGET_DIR"
+            rm -rf "$TARGET_DIR"
+          fi
 
       - name: Get semantic version
         id: sem_version
@@ -199,7 +210,6 @@ jobs:
         with:
           subject-path: ./build/${{ steps.filename.outputs.FILENAME }}.tar
 
-        # Upload folder as artifact
       - name: Upload folder as artifact
         uses: actions/upload-artifact@main
         with:


### PR DESCRIPTION
fixes error

Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/nuitka/__main__.py", line 209, in <module>
    main()
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/nuitka/__main__.py", line 191, in main
    MainControl.main()
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/nuitka/MainControl.py", line 1160, in main
    _main()
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/nuitka/MainControl.py", line 1051, in _main
    copyDllsUsed(
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/nuitka/freezer/Standalone.py", line 247, in copyDllsUsed
    os.rename(fullpath, resources_path)
OSError: [Errno 66] Directory not empty: 'build/__main__.app/Contents/MacOS/qtwebengine_locales' -> 'build/__main__.app/Contents/Resources/qtwebengine_locales' Nuitka-Reports: Compilation crash report written to file 'nuitka-crash-report.xml'. Please include it in your bug report. Error: Process completed with exit code 1.