### PR TITLE
Typo fix for db merger file selection

### DIFF
--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -3239,7 +3239,7 @@ class MainContent(QObject):
         logger.info("Opening file dialog to specify input file B")
         input_path_b = dialogue.show_dialogue_file(
             mode="open",
-            caption='Input "to-be-updated" database, input A',
+            caption='Input "update source" database, input B',
             _dir=str(AppInfo().app_storage_folder),
             _filter="JSON (*.json)",
         )


### PR DESCRIPTION
Simple typo that left me confused sometimes, presumably from a hasty copy & paste. Fixes #864 which I created seconds ago.