### PR TITLE
Add window size and position configuration

### DIFF
--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -667,10 +667,13 @@ class SettingsController(QObject):
         self.language_controller.populate_languages_combobox(
             self.settings_dialog.language_combobox
         )
-
         self.language_controller.setup_language_dialog(
             self.settings_dialog, self.settings
         )
+        self.settings_dialog.window_x_spinbox.setValue(self.settings.window_x)
+        self.settings_dialog.window_y_spinbox.setValue(self.settings.window_y)
+        self.settings_dialog.window_width_spinbox.setValue(self.settings.window_width)
+        self.settings_dialog.window_height_spinbox.setValue(self.settings.window_height)
 
         # Advanced tab
         self.settings_dialog.debug_logging_checkbox.setChecked(
@@ -868,10 +871,12 @@ class SettingsController(QObject):
         self.settings.font_family = (
             self.settings_dialog.font_family_combobox.currentText()
         )
-
         self.settings.font_size = self.settings_dialog.font_size_spinbox.value()
-
         self.settings.language = self.settings_dialog.language_combobox.currentData()
+        self.settings.window_x = self.settings_dialog.window_x_spinbox.value()
+        self.settings.window_y = self.settings_dialog.window_y_spinbox.value()
+        self.settings.window_width = self.settings_dialog.window_width_spinbox.value()
+        self.settings.window_height = self.settings_dialog.window_height_spinbox.value()
 
         # Advanced tab
         self.settings.debug_logging_enabled = (
@@ -944,6 +949,7 @@ class SettingsController(QObject):
         self.settings_dialog.close()
         self._update_model_from_view()
         self.settings.save()
+        self.settings_dialog.apply_window_geometry_from_spinboxes()
         self.theme_controller.set_font(
             self.settings.font_family,
             self.settings.font_size,

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -94,6 +94,12 @@ class Settings(QObject):
         # Language
         self.language = "en_US"
 
+        # Window size configuration
+        self.window_x: int = 0
+        self.window_y: int = 0
+        self.window_width: int = 0
+        self.window_height: int = 0
+
         # Advanced
         self.debug_logging_enabled: bool = False
         self.watchdog_toggle: bool = True

--- a/app/utils/gui_info.py
+++ b/app/utils/gui_info.py
@@ -5,6 +5,8 @@ from PySide6.QtCore import QMargins
 from PySide6.QtGui import QFont, QFontMetrics, QPixmap
 from PySide6.QtWidgets import QApplication, QFileDialog, QMessageBox
 
+from app.models.settings import Settings
+
 
 class GUIInfo:
     """
@@ -63,6 +65,49 @@ class GUIInfo:
             self._app_icon = QPixmap(icon_path)
         else:
             self._app_icon = QPixmap()
+
+    def set_window_size(self) -> tuple[int, int, int, int]:
+        """
+        Calculate the recommended window size and position.
+
+        Returns:
+            tuple[int, int, int, int]: The x position, y position, width, and height for the window.
+        """
+        # Get the screen size and calculate window dimensions based on it
+        screen = QApplication.primaryScreen()
+        screen_geometry = screen.geometry()
+        window_width = int(screen_geometry.width() * 0.5)
+        window_height = int(screen_geometry.height() * 0.5)
+
+        # Calculate position to center the window on screen
+        x_position = int((screen_geometry.width() - window_width) / 2.5)
+        y_position = int((screen_geometry.height() - window_height) / 5)
+
+        # Return values for setGeometry (x, y, width, height)
+        return x_position, y_position, window_width, window_height
+
+    def get_window_geometry(self) -> tuple[int, int, int, int]:
+        """
+        Get window geometry (x, y, width, height) using saved settings if valid,
+        else fallback to default window size.
+        Always reloads settings from disk to ensure up-to-date values.
+        """
+        settings = Settings()
+        settings.load()  # Ensure settings are reloaded from disk
+        if (
+            settings.window_width > 900
+            or settings.window_height > 600
+            or settings.window_x > 0
+            or settings.window_y > 30
+        ):
+            return (
+                settings.window_x,
+                settings.window_y,
+                settings.window_width,
+                settings.window_height,
+            )
+        else:
+            return self.set_window_size()
 
     @property
     def default_font(self) -> QFont:

--- a/app/utils/steam/browser.py
+++ b/app/utils/steam/browser.py
@@ -4,7 +4,7 @@ from functools import partial
 from typing import Any
 
 from loguru import logger
-from PySide6.QtCore import QPoint, QSize, Qt, QUrl, Signal
+from PySide6.QtCore import QPoint, Qt, QUrl, Signal
 from PySide6.QtGui import QAction, QPixmap
 from PySide6.QtWebEngineCore import QWebEnginePage
 from PySide6.QtWebEngineWidgets import QWebEngineView
@@ -26,6 +26,7 @@ from PySide6.QtWidgets import (
 from app.models.image_label import ImageLabel
 from app.utils.app_info import AppInfo
 from app.utils.generic import extract_page_title_steam_browser
+from app.utils.gui_info import GUIInfo
 from app.utils.metadata import MetadataManager
 from app.utils.steam.webapi.wrapper import (
     ISteamRemoteStorage_GetCollectionDetails,
@@ -179,7 +180,8 @@ class SteamBrowser(QWidget):
         # Put it all together
         self.setWindowTitle(self.current_title)
         self.setLayout(self.window_layout)
-        self.setMinimumSize(QSize(800, 600))
+        # Use GUIInfo to set the window size and position from settings
+        self.setGeometry(*GUIInfo().get_window_geometry())
 
     def __browse_to_location(self) -> None:
         url = QUrl(self.location.text())

--- a/app/views/file_search_dialog.py
+++ b/app/views/file_search_dialog.py
@@ -25,6 +25,7 @@ from PySide6.QtWidgets import (
 
 from app.utils.app_info import AppInfo
 from app.utils.generic import platform_specific_open
+from app.utils.gui_info import GUIInfo
 
 
 class FileSearchDialog(QDialog):
@@ -39,7 +40,8 @@ class FileSearchDialog(QDialog):
         super().__init__(parent)
         self.setWindowTitle("File Search")
         self.setWindowFlags(Qt.WindowType.Window)
-        self.resize(900, 700)  # Set a reasonable default size
+        # Use GUIInfo to set the window size and position from settings
+        self.setGeometry(*GUIInfo().get_window_geometry())
         self._search_paths: list[str] = []
         self._recent_searches: list[str] = []
         self._max_recent_searches = 10

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -6,7 +6,7 @@ from traceback import format_exc
 from typing import Any
 
 from loguru import logger
-from PySide6.QtCore import QSize, QTimer
+from PySide6.QtCore import QTimer
 from PySide6.QtGui import QShowEvent
 from PySide6.QtWidgets import (
     QApplication,
@@ -78,7 +78,9 @@ class MainWindow(QMainWindow):
         # Set up the window
         current_instance = self.settings_controller.settings.current_instance
         self.__set_window_title(current_instance)
-        self.setMinimumSize(QSize(1024, 768))
+        # Use GUIInfo to set the window size and position from settings
+        self.setGeometry(*GUIInfo().get_window_geometry())
+        print(f"Window geometry: {self.geometry()}")
 
         # Create the window layout
         app_layout = QVBoxLayout()
@@ -214,8 +216,6 @@ class MainWindow(QMainWindow):
         EventBus().do_restore_instance_from_archive.connect(
             self.__restore_instance_from_archive
         )
-
-        self.setGeometry(100, 100, 1024, 768)
         logger.debug("Finished MainWindow initialization")
 
     def __disable_enable_widgets(self, enable: bool) -> None:

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -35,7 +35,7 @@ class SettingsDialog(QDialog):
 
         self.setWindowTitle(self.tr("Settings"))
         self.setObjectName("settingsPanel")
-        self.resize(900, 600)
+        self.setGeometry(*GUIInfo().get_window_geometry())
 
         main_layout = QVBoxLayout()
         self.setLayout(main_layout)
@@ -777,6 +777,7 @@ class SettingsDialog(QDialog):
         tab_layout = QVBoxLayout(tab)
         tab_layout.setAlignment(Qt.AlignmentFlag.AlignTop)
 
+        # Theme settings group
         theme_group_label = QLabel(self.tr("Theme Settings"))
         theme_group_label.setFont(GUIInfo().emphasis_font)
         tab_layout.addWidget(theme_group_label)
@@ -814,6 +815,7 @@ class SettingsDialog(QDialog):
         self.theme_location_open_button.setText(self.tr("Open Theme Location"))
         theme_layout.addWidget(self.theme_location_open_button)
 
+        # Font settings group
         font_group_label = QLabel(self.tr("Font Settings"))
         font_group_label.setFont(GUIInfo().emphasis_font)
         tab_layout.addWidget(font_group_label)
@@ -867,7 +869,7 @@ class SettingsDialog(QDialog):
         else:
             self.themes_combobox.clear()
 
-        # temporarily added here
+        # Language configuration group
         language_group_label = QLabel(self.tr("Language Setting"))
         language_group_label.setFont(GUIInfo().emphasis_font)
         tab_layout.addWidget(language_group_label)
@@ -891,6 +893,37 @@ class SettingsDialog(QDialog):
         language_group_layout.addWidget(self.language_combobox)
 
         self.connect_populate_languages_combobox()
+
+        # Window size configuration group
+        window_size_group = QGroupBox(self.tr("Window Size Configuration"))
+        tab_layout.addWidget(window_size_group)
+
+        window_size_layout = QGridLayout()
+        window_size_group.setLayout(window_size_layout)
+
+        window_x_label = QLabel(self.tr("Window X Position:"))
+        window_size_layout.addWidget(window_x_label, 0, 0)
+        self.window_x_spinbox = QSpinBox()
+        self.window_x_spinbox.setRange(0, 900)
+        window_size_layout.addWidget(self.window_x_spinbox, 0, 1)
+
+        window_y_label = QLabel(self.tr("Window Y Position:"))
+        window_size_layout.addWidget(window_y_label, 1, 0)
+        self.window_y_spinbox = QSpinBox()
+        self.window_y_spinbox.setRange(30, 250)
+        window_size_layout.addWidget(self.window_y_spinbox, 1, 1)
+
+        window_width_label = QLabel(self.tr("Window Width:"))
+        window_size_layout.addWidget(window_width_label, 2, 0)
+        self.window_width_spinbox = QSpinBox()
+        self.window_width_spinbox.setRange(900, 1200)
+        window_size_layout.addWidget(self.window_width_spinbox, 2, 1)
+
+        window_height_label = QLabel(self.tr("Window Height:"))
+        window_size_layout.addWidget(window_height_label, 3, 0)
+        self.window_height_spinbox = QSpinBox()
+        self.window_height_spinbox.setRange(600, 900)
+        window_size_layout.addWidget(self.window_height_spinbox, 3, 1)
 
     def reset_font_settings(self) -> None:
         default_font = QApplication.font()
@@ -1084,3 +1117,11 @@ class SettingsDialog(QDialog):
         """Using arg__1 instead of event to avoid name conflict"""
         super().showEvent(arg__1)
         self.global_ok_button.setFocus()
+
+    def apply_window_geometry_from_spinboxes(self) -> None:
+        """Set the dialog geometry to match the values in the window size spinboxes."""
+        x = self.window_x_spinbox.value()
+        y = self.window_y_spinbox.value()
+        w = self.window_width_spinbox.value()
+        h = self.window_height_spinbox.value()
+        self.setGeometry(x, y, w, h)

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -35,6 +35,7 @@ class SettingsDialog(QDialog):
 
         self.setWindowTitle(self.tr("Settings"))
         self.setObjectName("settingsPanel")
+        # Use GUIInfo to set the window size and position from settings
         self.setGeometry(*GUIInfo().get_window_geometry())
 
         main_layout = QVBoxLayout()

--- a/app/windows/base_mods_panel.py
+++ b/app/windows/base_mods_panel.py
@@ -1,7 +1,7 @@
 from functools import partial
 from typing import Callable, Self, TypeVar
 
-from PySide6.QtCore import QEvent, QObject, QSize, Qt
+from PySide6.QtCore import QEvent, QObject, Qt
 from PySide6.QtGui import QStandardItem, QStandardItemModel
 from PySide6.QtWidgets import (
     QAbstractItemView,
@@ -18,6 +18,7 @@ from PySide6.QtWidgets import (
 )
 
 from app.utils.event_bus import EventBus
+from app.utils.gui_info import GUIInfo
 from app.utils.metadata import MetadataManager
 
 # By default, we assume Stretch for all columns.
@@ -46,7 +47,6 @@ class BaseModsPanel(QWidget):
         title_text: str,
         details_text: str,
         additional_columns: list[HeaderColumn],
-        minimum_size: QSize = QSize(800, 600),
     ):
         super().__init__()
         # Utility and Setup
@@ -149,7 +149,8 @@ class BaseModsPanel(QWidget):
         # Put it all together
         self.setWindowTitle(window_title)
         self.setLayout(layout)
-        self.setMinimumSize(minimum_size)
+        # Use GUIInfo to set the window size and position from settings
+        self.setGeometry(*GUIInfo().get_window_geometry())
 
     def eventFilter(self, watched: QObject, event: QEvent) -> bool:
         if event.type() == QEvent.Type.KeyPress and event.type() == Qt.Key.Key_Escape:

--- a/app/windows/missing_dependencies_dialog.py
+++ b/app/windows/missing_dependencies_dialog.py
@@ -12,6 +12,7 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
+from app.utils.gui_info import GUIInfo
 from app.utils.metadata import MetadataManager
 
 
@@ -35,7 +36,8 @@ class MissingDependenciesDialog(QDialog):
         Set up the UI components of the dialog.
         """
         self.setWindowTitle("Dependency Manager")
-        self.resize(700, 500)
+        # Use GUIInfo to set the window size and position from settings
+        self.setGeometry(*GUIInfo().get_window_geometry())
 
         main_layout = QVBoxLayout(self)
 

--- a/app/windows/rule_editor_panel.py
+++ b/app/windows/rule_editor_panel.py
@@ -7,7 +7,6 @@ from PySide6.QtCore import (
     QModelIndex,
     QPersistentModelIndex,
     QPoint,
-    QSize,
     Qt,
     Signal,
 )
@@ -31,6 +30,7 @@ from PySide6.QtWidgets import (
 )
 
 from app.utils.app_info import AppInfo
+from app.utils.gui_info import GUIInfo
 from app.utils.metadata import MetadataManager
 from app.views.dialogue import show_dialogue_input, show_warning
 
@@ -508,7 +508,8 @@ class RuleEditor(QWidget):
         # Setup the window
         self.setWindowTitle("RimSort - Rule Editor")
         self.setLayout(layout)
-        self.setMinimumSize(QSize(800, 600))
+        # Use GUIInfo to set the window size and position from settings
+        self.setGeometry(*GUIInfo().get_window_geometry())
 
     def createDropEvent(
         self, destination_list: QListWidget

--- a/app/windows/runner_panel.py
+++ b/app/windows/runner_panel.py
@@ -17,6 +17,7 @@ from PySide6.QtWidgets import (
 )
 
 from app.utils.app_info import AppInfo
+from app.utils.gui_info import GUIInfo
 from app.utils.steam.webapi.wrapper import (
     ISteamRemoteStorage_GetPublishedFileDetails,
 )
@@ -140,7 +141,8 @@ class RunnerPanel(QWidget):
         self.main_layout.addLayout(self.actions_bar_layout)
         # WINDOW
         self.setLayout(self.main_layout)
-        self.resize(800, 600)
+        # Use GUIInfo to set the window size and position from settings
+        self.setGeometry(*GUIInfo().get_window_geometry())
 
         self._do_clear_runner()
 

--- a/app/windows/use_this_instead_panel.py
+++ b/app/windows/use_this_instead_panel.py
@@ -2,7 +2,7 @@ from functools import partial
 from typing import Any, Dict
 
 from loguru import logger
-from PySide6.QtCore import QSize, Qt
+from PySide6.QtCore import Qt
 from PySide6.QtGui import QAction, QStandardItem
 from PySide6.QtWidgets import QMenu, QPushButton, QToolButton
 
@@ -41,7 +41,6 @@ class UseThisInsteadPanel(BaseModsPanel):
                 self.tr("Replacement Author"),
                 self.tr("Replacement Workshop Page"),
             ],
-            minimum_size=QSize(1100, 600),
         )
 
         def __subscribe_cb(_: UseThisInsteadPanel) -> None:


### PR DESCRIPTION
Introduce settings to configure the window size and position, along with functionality to calculate and retrieve window geometry based on the primary screen. 
This enhancement allows for a more user-friendly interface by centering the window and applying saved settings.

Should also fix 
#547