### PR TITLE
Fix variable name for pushing branch to remote repository

### DIFF
--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -3020,7 +3020,7 @@ class MainContent(QObject):
                     try:
                         # Push the changes to the remote repository and create a pull request from new_branch
                         origin = local_repo.remote()
-                        origin.push(new_branch)
+                        origin.push(new_branch_name)
                     except Exception:
                         stacktrace = traceback.format_exc()
                         dialogue.show_warning(


### PR DESCRIPTION
Correct the variable name used for pushing the branch to ensure the correct branch is referenced.