### PR TITLE
Fix Lint errors related to mypy type checking errors

### DIFF
--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -604,7 +604,11 @@ class SettingsController(QObject):
 
         # Use dependencies for sorting checkbox
         if self.settings.use_moddependencies_as_loadTheseBefore:
-            (self.settings_dialog.use_moddependencies_as_loadTheseBefore.setChecked(True))
+            (
+                self.settings_dialog.use_moddependencies_as_loadTheseBefore.setChecked(
+                    True
+                )
+            )
 
         # Set dependencies checkbox
         self.settings_dialog.check_deps_checkbox.setChecked(

--- a/app/controllers/sort_controller.py
+++ b/app/controllers/sort_controller.py
@@ -66,7 +66,7 @@ class Sorter:
             list(self.active_package_ids),
             tier_one_mods,
             tier_three_mods,
-            use_moddependencies_as_loadTheseBefore = self.use_moddependencies_as_loadTheseBefore,
+            use_moddependencies_as_loadTheseBefore=self.use_moddependencies_as_loadTheseBefore,
         )
 
         return [tier_one_graph, tier_two_graph, tier_three_graph]

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -68,7 +68,9 @@ class Settings(QObject):
         self.check_dependencies_on_sort: bool = (
             True  # Whether to check for missing dependencies when sorting
         )
-        self.use_moddependencies_as_loadTheseBefore: bool = False  # Whether to use moddependencies as loadTheseBefore
+        self.use_moddependencies_as_loadTheseBefore: bool = (
+            False  # Whether to use moddependencies as loadTheseBefore
+        )
 
         # DB Builder
         self.db_builder_include: str = "all_mods"

--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -2255,8 +2255,9 @@ class ModsPanel(QWidget):
         self.active_mods_search.textChanged.connect(self.on_active_mods_search)
         self.active_mods_search.inputRejected.connect(self.on_active_mods_search_clear)
         self.active_mods_search.setPlaceholderText(self.tr("Search by..."))
-        self.active_mods_search_clear_button = self.active_mods_search.findChild(
-            QToolButton
+        # Add explicit type annotation to help mypy
+        self.active_mods_search_clear_button = cast(
+            QToolButton, self.active_mods_search.findChild(QToolButton)
         )
         if not isinstance(self.active_mods_search_clear_button, QToolButton):
             raise TypeError("Could not find QToolButton in QLineEdit")
@@ -2397,8 +2398,9 @@ class ModsPanel(QWidget):
             self.on_inactive_mods_search_clear
         )
         self.inactive_mods_search.setPlaceholderText(self.tr("Search by..."))
-        self.inactive_mods_search_clear_button = self.inactive_mods_search.findChild(
-            QToolButton
+        # Add explicit type annotation to help mypy
+        self.inactive_mods_search_clear_button = cast(
+            QToolButton, self.inactive_mods_search.findChild(QToolButton)
         )
         if not isinstance(self.inactive_mods_search_clear_button, QToolButton):
             raise TypeError("Could not find QToolButton in QLineEdit")

--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -1943,9 +1943,7 @@ class ModListWidget(QListWidget):
                 current_item_data["alternative"]
                 and mod_data["packageid"] not in self.ignore_warning_list
             ):
-                tool_tip_text += (
-                    f"\nAn alternative updated mod is recommended:\n{current_item_data['alternative']}"
-                )
+                tool_tip_text += f"\nAn alternative updated mod is recommended:\n{current_item_data['alternative']}"
             # Add to error summary if any missing dependencies or incompatibilities
             if self.list_type == "Active" and any(
                 [

--- a/app/windows/rule_editor_panel.py
+++ b/app/windows/rule_editor_panel.py
@@ -108,6 +108,12 @@ class RuleEditor(QWidget):
 
     update_database_signal = Signal(list)
 
+    # Type annotations for class variables
+    mods_list: QListWidget
+    local_metadata_button: QPushButton
+    community_rules_button: QPushButton
+    user_rules_button: QPushButton
+
     def __init__(
         self,
         initial_mode: str,
@@ -766,9 +772,11 @@ class RuleEditor(QWidget):
                                     name = self.steam_workshop_metadata_packageids_to_name.get(
                                         rule.lower(), rule
                                     )
-                                    self._create_list_item(_list=_list, title=name)
+                                    # Ensure name is a string
+                                    name_str = str(name) if name is not None else rule
+                                    self._create_list_item(_list=_list, title=name_str)
                                     self._add_rule_to_table(
-                                        name=name,
+                                        name=name_str,
                                         packageid=rule,
                                         rule_source="About.xml",
                                         rule_type=rule_type,


### PR DESCRIPTION
This resolves several mypy type checking issues:

1. Fixed internal mypy error in app/views/mods_panel.py by adding explicit type 
   casting for QObject.findChild() method calls using typing.cast()

2. Added proper type annotations for class variables in RuleEditor class to 
   resolve "Cannot determine type" errors

3. Fixed potential None/str type incompatibility in rule_editor_panel.py by 
   ensuring string conversion before passing to methods that expect str

4. Format Files with Ruff
