### PR TITLE
Fix "Use This Instead" database local selection to choose folder instead of file

### DIFF
--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -1538,7 +1538,7 @@ class SettingsController(QObject):
         Open a file dialog to select the "Use This Instead" folder and handle the result.
         """
         use_this_instead_db_location = show_dialogue_file(
-            mode="open",
+            mode="open_dir",
             caption='Select "Use This Instead" Folder',
             _dir=str(self._last_file_dialog_path),
         )

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -57,7 +57,7 @@ class Settings(QObject):
 
         self.external_use_this_instead_metadata_source: str = "None"
         self.external_use_this_instead_file_path: str = str(
-            AppInfo().app_storage_folder / "UseThisInstead"
+            AppInfo().app_storage_folder / "UseThisInstead" / "Replacements"
         )
         self.external_use_this_instead_repo_path: str = (
             "https://github.com/emipa606/UseThisInstead"


### PR DESCRIPTION
Update the file dialog to open folders instead of files and adjust the default path for replacement database selection.