### PR TITLE
Use folder path instead of file path for settings

### DIFF
--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -588,7 +588,7 @@ class SettingsController(QObject):
                 True
             )
         self.settings_dialog.use_this_instead_db_local_file.setText(
-            self.settings.external_use_this_instead_file_path
+            self.settings.external_use_this_instead_folder_path
         )
         self.settings_dialog.use_this_instead_db_local_file.setCursorPosition(0)
         self.settings_dialog.use_this_instead_db_github_url.setText(
@@ -810,7 +810,7 @@ class SettingsController(QObject):
             self.settings.external_use_this_instead_metadata_source = (
                 "Configured git repository"
             )
-        self.settings.external_use_this_instead_file_path = (
+        self.settings.external_use_this_instead_folder_path = (
             self.settings_dialog.use_this_instead_db_local_file.text()
         )
         self.settings.external_use_this_instead_repo_path = (

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -56,7 +56,7 @@ class Settings(QObject):
         )
 
         self.external_use_this_instead_metadata_source: str = "None"
-        self.external_use_this_instead_file_path: str = str(
+        self.external_use_this_instead_folder_path: str = str(
             AppInfo().app_storage_folder / "UseThisInstead" / "Replacements"
         )
         self.external_use_this_instead_repo_path: str = (

--- a/app/utils/metadata.py
+++ b/app/utils/metadata.py
@@ -1242,7 +1242,7 @@ class MetadataManager(QObject):
             == "Configured file path"
         ):
             path = Path(
-                self.settings_controller.settings.external_use_this_instead_file_path
+                self.settings_controller.settings.external_use_this_instead_folder_path
             )
         elif (
             self.settings_controller.settings.external_use_this_instead_metadata_source


### PR DESCRIPTION
Update the settings to utilize a folder path instead of a file path for the "Use This Instead" feature, ensuring consistency across the application.