### PR TITLE
Set default formatter for Python files in VSCode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -99,5 +99,6 @@
   },
   "python.testing.pytestArgs": ["."],
   "python.testing.unittestEnabled": false,
-  "python.testing.pytestEnabled": true
+  "python.testing.pytestEnabled": true,
+  "editor.defaultFormatter": "charliermarsh.ruff"
 }


### PR DESCRIPTION
Ensure that the default formatter for Python files is set to `charliermarsh.ruff` in the VSCode configuration.