### PR TITLE
Fixed steam_appid.txt being in the wrong location on macOS

### DIFF
--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -3229,7 +3229,7 @@ class MainContent(QObject):
             ) as f:
                 f.write("294100")
         elif not steam_client_integration and steam_appid_path.exists():
-            os.remove(steam_appid_path)
+            steam_appid_path.unlink()
 
         # Launch independent game process without Steamworks API
         launch_game_process(game_install_path=game_install_path, args=run_args)


### PR DESCRIPTION
Fixed steam_appid.txt being in the wrong location on macOS by making ternary statement that moves the steam_appid.txt outside the game directory or app bundle on macOS. 
With the file adjacent to the app bundle the steam integration also works with the new Apple Games application.

Also changed more of the code to use pathlib. 

This fixes issues like: 
https://github.com/RimSort/RimSort/issues/435
