### PR TITLE
Fix macOS game path handling

### DIFF
--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -1242,7 +1242,9 @@ class MainContent(QObject):
         success, new_order = sorter.sort()
 
         # Log the sort result and the order
-        logger.debug(f"Sort result: {success}, new order: {new_order}, current order: {current_order}")
+        logger.debug(
+            f"Sort result: {success}, new order: {new_order}, current order: {current_order}"
+        )
         # Check if successful and orders differ
         if success and new_order != current_order:
             logger.info(
@@ -3202,6 +3204,11 @@ class MainContent(QObject):
         game_install_path = Path(
             self.settings_controller.settings.instances[current_instance].game_folder
         )
+
+        # Remove ".app" suffix for required for Darwin (macOS)
+        if str(game_install_path).endswith(".app"):
+            game_install_path = Path(str(game_install_path)[:-4])
+
         # Run args is inconsistent and is sometimes a string and sometimes a list
         run_args: list[str] | str = self.settings_controller.settings.instances[
             current_instance


### PR DESCRIPTION
Adjust the game path handling to remove the ".app" suffix on macOS, ensuring compatibility with game execution.