### PR TITLE
Add option to update databases on startup

### DIFF
--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -269,56 +269,6 @@ class SettingsController(QObject):
             logger.error("Unable to parse settings file")
             show_settings_error()
 
-        # After loading settings, update databases if enabled
-        # Note: This is commented out because it needs to be called after MainContentController is initialized
-        # self.update_databases_on_startup_if_enabled()
-
-    def update_databases_on_startup_if_enabled(self) -> None:
-        """
-        If update_databases_on_startup is enabled and databases are configured with GitHub links,
-        emit signals to download the databases from GitHub automatically.
-        """
-        if not self.settings.update_databases_on_startup:
-            logger.info("Update databases on startup is disabled.")
-            return
-
-        event_bus = EventBus()
-
-        # Community Rules database
-        if (
-            self.settings.external_community_rules_metadata_source
-            == "Configured git repository"
-            and self.settings.external_community_rules_repo
-        ):
-            logger.info("Auto-updating Community Rules database from GitHub.")
-            event_bus.do_download_community_rules_db_from_github.emit()
-
-        # Steam Workshop database
-        if (
-            self.settings.external_steam_metadata_source == "Configured git repository"
-            and self.settings.external_steam_metadata_repo
-        ):
-            logger.info("Auto-updating Steam Workshop database from GitHub.")
-            event_bus.do_download_steam_workshop_db_from_github.emit()
-
-        # No Version Warning database
-        if (
-            self.settings.external_no_version_warning_metadata_source
-            == "Configured git repository"
-            and self.settings.external_no_version_warning_repo_path
-        ):
-            logger.info('Auto-updating "No Version Warning" database from GitHub.')
-            event_bus.do_download_no_version_warning_db_from_github.emit()
-
-        # Use This Instead database (Cross Version Databases)
-        if (
-            self.settings.external_use_this_instead_metadata_source
-            == "Configured git repository"
-            and self.settings.external_use_this_instead_repo_path
-        ):
-            logger.info('Auto-updating "Use This Instead" database from GitHub.')
-            event_bus.do_download_use_this_instead_db_from_github.emit()
-
     def get_mod_paths(self) -> list[str]:
         """
         Get the mod paths for the current instance. Return the Default instance if the current instance is not found.

--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -270,7 +270,8 @@ class SettingsController(QObject):
             show_settings_error()
 
         # After loading settings, update databases if enabled
-        self.update_databases_on_startup_if_enabled()
+        # Note: This is commented out because it needs to be called after MainContentController is initialized
+        # self.update_databases_on_startup_if_enabled()
 
     def update_databases_on_startup_if_enabled(self) -> None:
         """

--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -269,6 +269,55 @@ class SettingsController(QObject):
             logger.error("Unable to parse settings file")
             show_settings_error()
 
+        # After loading settings, update databases if enabled
+        self.update_databases_on_startup_if_enabled()
+
+    def update_databases_on_startup_if_enabled(self) -> None:
+        """
+        If update_databases_on_startup is enabled and databases are configured with GitHub links,
+        emit signals to download the databases from GitHub automatically.
+        """
+        if not self.settings.update_databases_on_startup:
+            logger.info("Update databases on startup is disabled.")
+            return
+
+        event_bus = EventBus()
+
+        # Community Rules database
+        if (
+            self.settings.external_community_rules_metadata_source
+            == "Configured git repository"
+            and self.settings.external_community_rules_repo
+        ):
+            logger.info("Auto-updating Community Rules database from GitHub.")
+            event_bus.do_download_community_rules_db_from_github.emit()
+
+        # Steam Workshop database
+        if (
+            self.settings.external_steam_metadata_source == "Configured git repository"
+            and self.settings.external_steam_metadata_repo
+        ):
+            logger.info("Auto-updating Steam Workshop database from GitHub.")
+            event_bus.do_download_steam_workshop_db_from_github.emit()
+
+        # No Version Warning database
+        if (
+            self.settings.external_no_version_warning_metadata_source
+            == "Configured git repository"
+            and self.settings.external_no_version_warning_repo_path
+        ):
+            logger.info('Auto-updating "No Version Warning" database from GitHub.')
+            event_bus.do_download_no_version_warning_db_from_github.emit()
+
+        # Use This Instead database (Cross Version Databases)
+        if (
+            self.settings.external_use_this_instead_metadata_source
+            == "Configured git repository"
+            and self.settings.external_use_this_instead_repo_path
+        ):
+            logger.info('Auto-updating "Use This Instead" database from GitHub.')
+            event_bus.do_download_use_this_instead_db_from_github.emit()
+
     def get_mod_paths(self) -> list[str]:
         """
         Get the mod paths for the current instance. Return the Default instance if the current instance is not found.
@@ -713,6 +762,9 @@ class SettingsController(QObject):
         self.settings_dialog.render_unity_rich_text_checkbox.setChecked(
             self.settings.render_unity_rich_text
         )
+        self.settings_dialog.update_databases_on_startup_checkbox.setChecked(
+            self.settings.update_databases_on_startup
+        )
         self.settings_dialog.rentry_auth_code.setText(self.settings.rentry_auth_code)
         self.settings_dialog.rentry_auth_code.setCursorPosition(0)
         self.settings_dialog.github_username.setText(self.settings.github_username)
@@ -920,6 +972,9 @@ class SettingsController(QObject):
         )
         self.settings.render_unity_rich_text = (
             self.settings_dialog.render_unity_rich_text_checkbox.isChecked()
+        )
+        self.settings.update_databases_on_startup = (
+            self.settings_dialog.update_databases_on_startup_checkbox.isChecked()
         )
         self.settings.rentry_auth_code = self.settings_dialog.rentry_auth_code.text()
         self.settings.github_username = self.settings_dialog.github_username.text()

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -112,6 +112,7 @@ class Settings(QObject):
         self.steam_mods_update_check: bool = False
         self.try_download_missing_mods: bool = False
         self.render_unity_rich_text: bool = True
+        self.update_databases_on_startup: bool = True
 
         self.rentry_auth_code: str = ""
 

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -237,6 +237,65 @@ class MainWindow(QMainWindow):
         # Call the original showEvent handler
         super().showEvent(event)
 
+    def _update_databases_on_startup_if_enabled_silent(self) -> None:
+        """
+        Silently update databases on startup if enabled.
+        Directly calls MainContentController methods instead of emitting signals.
+        """
+        if not self.settings_controller.settings.update_databases_on_startup:
+            logger.info("Update databases on startup is disabled.")
+            return
+
+        from app.utils.app_info import AppInfo
+
+        # Community Rules database
+        if (
+            self.settings_controller.settings.external_community_rules_metadata_source
+            == "Configured git repository"
+            and self.settings_controller.settings.external_community_rules_repo
+        ):
+            logger.info("Auto-updating Community Rules database from GitHub.")
+            self.main_content_controller._do_auto_database_update(
+                str(AppInfo().databases_folder),
+                self.settings_controller.settings.external_community_rules_repo,
+            )
+
+        # Steam Workshop database
+        if (
+            self.settings_controller.settings.external_steam_metadata_source
+            == "Configured git repository"
+            and self.settings_controller.settings.external_steam_metadata_repo
+        ):
+            logger.info("Auto-updating Steam Workshop database from GitHub.")
+            self.main_content_controller._do_auto_database_update(
+                str(AppInfo().databases_folder),
+                self.settings_controller.settings.external_steam_metadata_repo,
+            )
+
+        # No Version Warning database
+        if (
+            self.settings_controller.settings.external_no_version_warning_metadata_source
+            == "Configured git repository"
+            and self.settings_controller.settings.external_no_version_warning_repo_path
+        ):
+            logger.info('Auto-updating "No Version Warning" database from GitHub.')
+            self.main_content_controller._do_auto_database_update(
+                str(AppInfo().databases_folder),
+                self.settings_controller.settings.external_no_version_warning_repo_path,
+            )
+
+        # Use This Instead database (Cross Version Databases)
+        if (
+            self.settings_controller.settings.external_use_this_instead_metadata_source
+            == "Configured git repository"
+            and self.settings_controller.settings.external_use_this_instead_repo_path
+        ):
+            logger.info('Auto-updating "Use This Instead" database from GitHub.')
+            self.main_content_controller._do_auto_database_update(
+                str(AppInfo().databases_folder),
+                self.settings_controller.settings.external_use_this_instead_repo_path,
+            )
+
     def initialize_content(self, is_initial: bool = True) -> None:
         # POPULATE INSTANCES SUBMENU
         self.menu_bar_controller._on_instances_submenu_population(
@@ -263,7 +322,7 @@ class MainWindow(QMainWindow):
         # UPDATE DATABASES ON STARTUP IF ENABLED
         # This is called here after all controllers are initialized and signals are connected
         if is_initial:
-            self.settings_controller.update_databases_on_startup_if_enabled()
+            self._update_databases_on_startup_if_enabled_silent()
 
         # CHECK USER PREFERENCE FOR WATCHDOG
         if self.settings_controller.settings.watchdog_toggle:

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -237,65 +237,6 @@ class MainWindow(QMainWindow):
         # Call the original showEvent handler
         super().showEvent(event)
 
-    def _update_databases_on_startup_if_enabled_silent(self) -> None:
-        """
-        Silently update databases on startup if enabled.
-        Directly calls MainContentController methods instead of emitting signals.
-        """
-        if not self.settings_controller.settings.update_databases_on_startup:
-            logger.info("Update databases on startup is disabled.")
-            return
-
-        from app.utils.app_info import AppInfo
-
-        # Community Rules database
-        if (
-            self.settings_controller.settings.external_community_rules_metadata_source
-            == "Configured git repository"
-            and self.settings_controller.settings.external_community_rules_repo
-        ):
-            logger.info("Auto-updating Community Rules database from GitHub.")
-            self.main_content_controller._do_auto_database_update(
-                str(AppInfo().databases_folder),
-                self.settings_controller.settings.external_community_rules_repo,
-            )
-
-        # Steam Workshop database
-        if (
-            self.settings_controller.settings.external_steam_metadata_source
-            == "Configured git repository"
-            and self.settings_controller.settings.external_steam_metadata_repo
-        ):
-            logger.info("Auto-updating Steam Workshop database from GitHub.")
-            self.main_content_controller._do_auto_database_update(
-                str(AppInfo().databases_folder),
-                self.settings_controller.settings.external_steam_metadata_repo,
-            )
-
-        # No Version Warning database
-        if (
-            self.settings_controller.settings.external_no_version_warning_metadata_source
-            == "Configured git repository"
-            and self.settings_controller.settings.external_no_version_warning_repo_path
-        ):
-            logger.info('Auto-updating "No Version Warning" database from GitHub.')
-            self.main_content_controller._do_auto_database_update(
-                str(AppInfo().databases_folder),
-                self.settings_controller.settings.external_no_version_warning_repo_path,
-            )
-
-        # Use This Instead database (Cross Version Databases)
-        if (
-            self.settings_controller.settings.external_use_this_instead_metadata_source
-            == "Configured git repository"
-            and self.settings_controller.settings.external_use_this_instead_repo_path
-        ):
-            logger.info('Auto-updating "Use This Instead" database from GitHub.')
-            self.main_content_controller._do_auto_database_update(
-                str(AppInfo().databases_folder),
-                self.settings_controller.settings.external_use_this_instead_repo_path,
-            )
-
     def initialize_content(self, is_initial: bool = True) -> None:
         # POPULATE INSTANCES SUBMENU
         self.menu_bar_controller._on_instances_submenu_population(
@@ -322,7 +263,7 @@ class MainWindow(QMainWindow):
         # UPDATE DATABASES ON STARTUP IF ENABLED
         # This is called here after all controllers are initialized and signals are connected
         if is_initial:
-            self._update_databases_on_startup_if_enabled_silent()
+            self.main_content_controller._update_databases_on_startup_if_enabled_silent()
 
         # CHECK USER PREFERENCE FOR WATCHDOG
         if self.settings_controller.settings.watchdog_toggle:

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -259,6 +259,12 @@ class MainWindow(QMainWindow):
                 )
         else:
             self.steamcmd_wrapper.setup = True
+
+        # UPDATE DATABASES ON STARTUP IF ENABLED
+        # This is called here after all controllers are initialized and signals are connected
+        if is_initial:
+            self.settings_controller.update_databases_on_startup_if_enabled()
+
         # CHECK USER PREFERENCE FOR WATCHDOG
         if self.settings_controller.settings.watchdog_toggle:
             # Setup watchdog

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -1026,6 +1026,17 @@ class SettingsDialog(QDialog):
         )
         group_layout.addWidget(self.render_unity_rich_text_checkbox)
 
+        self.update_databases_on_startup_checkbox = QCheckBox(
+            self.tr("Update databases on startup")
+        )
+        self.update_databases_on_startup_checkbox.setToolTip(
+            self.tr(
+                "Enable this option to automatically update enabled databases when RimSort starts. "
+                "This will check for updates and download them if available."
+            )
+        )
+        group_layout.addWidget(self.update_databases_on_startup_checkbox)
+
         auth_group = QGroupBox()
         tab_layout.addWidget(auth_group)
 


### PR DESCRIPTION
Introduce a setting that allows users to automatically update databases from GitHub when the application starts. This feature includes a checkbox in the settings dialog and triggers updates for various configured databases if enabled.