### PR TITLE
Refactor default settings for database and mod warnings

### DIFF
--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -111,7 +111,7 @@ class Settings(QObject):
         self.hide_invalid_mods_when_filtering_toggle: bool = False
         self.duplicate_mods_warning: bool = True
         self.steam_mods_update_check: bool = False
-        self.try_download_missing_mods: bool = False
+        self.try_download_missing_mods: bool = True
         self.render_unity_rich_text: bool = True
         self.update_databases_on_startup: bool = True
 

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -109,7 +109,7 @@ class Settings(QObject):
         self.watchdog_toggle: bool = True
         self.mod_type_filter_toggle: bool = True
         self.hide_invalid_mods_when_filtering_toggle: bool = False
-        self.duplicate_mods_warning: bool = False
+        self.duplicate_mods_warning: bool = True
         self.steam_mods_update_check: bool = False
         self.try_download_missing_mods: bool = False
         self.render_unity_rich_text: bool = True

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -45,7 +45,8 @@ class Settings(QObject):
             "https://github.com/RimSort/Community-Rules-Database"
         )
 
-        self.database_expiry: int = 604800  # 7 days
+        # Disable by default previously this was 7 days "604800"
+        self.database_expiry: int = 0
 
         self.external_no_version_warning_metadata_source: str = "None"
         self.external_no_version_warning_file_path: str = str(

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -403,7 +403,7 @@ class SettingsDialog(QDialog):
         ) = self.__create_db_group(section_lbl, none_lbl, tab_layout)
         database_expiry_label = QLabel(
             self.tr(
-                "Steam Workshop database expiry in Epoch Time (Use 0 to Disable Notification. Default is 7 Days)"
+                "Database expiry in seconds for example, 604800 for 7 days. and 0 for no expiry."
             )
         )
         database_expiry_label.setFont(GUIInfo().emphasis_font)


### PR DESCRIPTION
Adjust default settings to disable database expiry, clarify notification messages, and enable warnings for duplicate mods and missing downloads.