### PR TITLE
Add cross-version databases tab and reorganize database groups

### DIFF
--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -73,6 +73,7 @@ class SettingsDialog(QDialog):
         """Initialize all tabs in the settings dialog."""
         self._do_locations_tab()
         self._do_databases_tab()
+        self._do_cross_version_databases_tab()
         self._do_sorting_tab()
         self._do_db_builder_tab()
         self._do_steamcmd_tab()
@@ -248,6 +249,14 @@ class SettingsDialog(QDialog):
 
         self._do_community_rules_db_group(tab_layout)
         self._do_steam_workshop_db_group(tab_layout)
+
+    def _do_cross_version_databases_tab(self) -> None:
+        tab = QWidget()
+        self.tab_widget.addTab(tab, self.tr("Additional Databases"))
+
+        tab_layout = QVBoxLayout()
+        tab.setLayout(tab_layout)
+
         self._do_no_version_warning_db_group(tab_layout)
         self._do_use_this_instead_db_group(tab_layout)
 


### PR DESCRIPTION
Introduce a new tab for cross-version databases and reorganize existing database groups for better clarity.