### PR TITLE
Skips qtbase translation files when listing languages

### DIFF
--- a/app/controllers/language_controller.py
+++ b/app/controllers/language_controller.py
@@ -48,8 +48,10 @@ class LanguageController:
             for file in folder.glob("*.qm"):
                 if file.is_file():
                     language_name = file.stem
-                    supported_languages.add(language_name)
-                    logger.info(f"Found language: {language_name} in {folder}")
+                    # Skip qtbase files
+                    if not language_name.startswith("qtbase_"):
+                        supported_languages.add(language_name)
+                        logger.info(f"Found language: {language_name} in {folder}")
         return supported_languages
 
     def populate_languages_combobox(self, combox: QComboBox) -> None:


### PR DESCRIPTION
This pull request includes a small but important change to the `language_controller.py` file. The change ensures that `.qm` files starting with `qtbase_` are excluded when retrieving language names from a folder.