### PR TITLE
Adds support for RimWorld Odyssey DLC

### DIFF
--- a/app/utils/constants.py
+++ b/app/utils/constants.py
@@ -57,6 +57,12 @@ RIMWORLD_DLC_METADATA = {
         "steam_url": "https://store.steampowered.com/app/2380740/RimWorld__Anomaly/",
         "description": "DLC #4",
     },
+    "3022790": {
+        "packageid": "ludeon.rimworld.odyssey",
+        "name": "RimWorld - Odyssey",
+        "steam_url": "https://store.steampowered.com/app/3022790/RimWorld__Odyssey/",
+        "description": "DLC #5",
+    },
 }
 RIMWORLD_PACKAGE_IDS = [v["packageid"] for v in RIMWORLD_DLC_METADATA.values()]
 SEARCH_DATA_SOURCE_FILTER_INDEXES = [

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -1277,6 +1277,7 @@ class MainContent(QObject):
             app_constants.RIMWORLD_DLC_METADATA["1392840"]["packageid"],
             app_constants.RIMWORLD_DLC_METADATA["1826140"]["packageid"],
             app_constants.RIMWORLD_DLC_METADATA["2380740"]["packageid"],
+            app_constants.RIMWORLD_DLC_METADATA["3022790"]["packageid"],
         ]
         # Create a set of all package IDs from mod_data
         package_ids_set = set(


### PR DESCRIPTION
Adds metadata and package ID to support the new RimWorld Odyssey DLC.

This ensures the application correctly identifies and handles the latest expansion when processing mod data and other relevant information.