### PR TITLE
Add environment variable RIMSORT_DISABLE_UPDATER to disable update checking

### DIFF
--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -746,6 +746,10 @@ class MainContent(QObject):
         4. Downloads and extracts the update if user confirms
         5. Launches the appropriate update script for the platform
         """
+        if os.getenv("RIMSORT_DISABLE_UPDATER"):
+            logger.debug("RIMSORT_DISABLE_UPDATER is set, skipping update check silently.")
+            return
+        
         logger.debug("Checking for RimSort update...")
 
         # NOT NUITKA


### PR DESCRIPTION
For the in progress Nix package, RimSort is run from "source", not nuitka. This adds an easy way to hide the "skipping update check" dialog that runs every time the app is refreshed.