### PR TITLE
Adds Odyssey to Tier One Dependencies

### DIFF
--- a/app/sort/dependencies.py
+++ b/app/sort/dependencies.py
@@ -89,6 +89,7 @@ def gen_tier_one_deps_graph(
         "ludeon.rimworld.ideology",
         "ludeon.rimworld.biotech",
         "ludeon.rimworld.anomaly",
+        "ludeon.rimworld.odyssey",
         "unlimitedhugs.hugslib",
     }
     # Bug fix: if there are circular dependencies in tier one mods


### PR DESCRIPTION
Adds "ludeon.rimworld.odyssey" to the list of tier one mod dependencies.

This ensures that Odyssey is correctly identified and handled during dependency resolution.