### PR TITLE
Quote current directory during update on Windows

### DIFF
--- a/update.bat
+++ b/update.bat
@@ -72,7 +72,7 @@ if exist "%executable_path%" (
 REM Perform the update with robust error handling
 echo.
 echo Updating RimSort files...
-robocopy "%update_source_folder%" %current_dir_no_slash% /MIR /NFL /NDL /NJH /NJS /nc /ns /np /R:3 /W:1
+robocopy "%update_source_folder%" "%current_dir_no_slash%" /MIR /NFL /NDL /NJH /NJS /nc /ns /np /R:3 /W:1
 
 REM Check if robocopy was successful
 if errorlevel 8 (


### PR DESCRIPTION
Sometimes, when you install Windows 11 and use a Microsoft account it decides that your username and therefore your home directory in C:\Users\ should be your full name with a space in it. The update script quotes the source directory path but not the destination, so the robocopy command fails if you have a space anywhere in the latter path.

Tested with an update from 1.0.23 to 1.0.24 on Windows 11.