### PR TITLE
Add "Installed" markers to mod tiles on workshop pages

### DIFF
--- a/app/utils/steam/browser.py
+++ b/app/utils/steam/browser.py
@@ -74,6 +74,12 @@ class SteamBrowser(QWidget):
         self.url_prefix_workshop = (
             "https://steamcommunity.com/workshop/filedetails/?id="
         )
+        self.section_readytouseitems = (
+            "section=readytouseitems"
+        )
+        self.section_collections = (
+            "section=collections"
+        )
 
         # LAYOUTS
         self.window_layout = QHBoxLayout()
@@ -482,115 +488,21 @@ class SteamBrowser(QWidget):
             # }
             # """
 
-            if (
+            is_item_page = (
                 self.url_prefix_sharedfiles in self.current_url
-                or self.url_prefix_workshop in self.current_url
-            ):
-                # get mod id from steam workshop url
-                if self.url_prefix_sharedfiles in self.current_url:
-                    publishedfileid = self.current_url.split(
-                        self.url_prefix_sharedfiles, 1
-                    )[1]
-                else:
-                    publishedfileid = self.current_url.split(
-                        self.url_prefix_workshop, 1
-                    )[1]
-                if self.searchtext_string in publishedfileid:
-                    publishedfileid = publishedfileid.split(self.searchtext_string)[0]
-                # check if mod is installed
-                is_installed = self._is_mod_installed(publishedfileid)
-                # Remove area that shows "Subscribe to download" and "Subscribe"/"Unsubscribe" button for mods
-                mod_subscribe_area_removal_script = """
-                var elements = document.getElementsByClassName("game_area_purchase_game");
-                while (elements.length > 0) {
-                    elements[0].parentNode.removeChild(elements[0]);
-                }
-                """
-                self.web_view.page().runJavaScript(
-                    mod_subscribe_area_removal_script, 0, lambda result: None
-                )
-                # Remove area that shows "Subscribe to all" and "Unsubscribe to all" buttons for collections
-                mod_unsubscribe_button_removal_script = """
-                var elements = document.getElementsByClassName("subscribeCollection");
-                while (elements.length > 0) {
-                    elements[0].parentNode.removeChild(elements[0]);
-                }
-                """
-                self.web_view.page().runJavaScript(
-                    mod_unsubscribe_button_removal_script, 0, lambda result: None
-                )
-                # Remove "Subscribe" buttons from any mods shown in a collection
-                subscribe_buttons_removal_script = """
-                var elements = document.getElementsByClassName("general_btn subscribe");
-                while (elements.length > 0) {
-                    elements[0].parentNode.removeChild(elements[0]);
-                }
-                """
-                self.web_view.page().runJavaScript(
-                    subscribe_buttons_removal_script, 0, lambda result: None
-                )
-                # add buttons for collection items
-                add_collection_buttons_script = """
-                // find all collection items
-                var collectionItems = document.getElementsByClassName('collectionItem');
-                
-                for (var i = 0; i < collectionItems.length; i++) {
-                    var item = collectionItems[i];
-                    
-                    // get the mod id from the item
-                    var modId = item.id.replace('sharedfile_', '');
-                    
-                    // find the subscription controls div
-                    var subscriptionControls = item.querySelector('.subscriptionControls');
-                    if (!subscriptionControls) {
-                        continue;
-                    }
-                    
-                    // check if mod is installed
-                    var isInstalled = window.installedMods && window.installedMods.includes(modId);
-                    
-                    if (isInstalled) {
-                        // create installed indicator
-                        var installedIndicator = document.createElement('div');
-                        installedIndicator.innerHTML = '✓';
-                        installedIndicator.style.backgroundColor = '#4CAF50';
-                        installedIndicator.style.color = 'white';
-                        installedIndicator.style.width = '24px';
-                        installedIndicator.style.height = '24px';
-                        installedIndicator.style.borderRadius = '4px';
-                        installedIndicator.style.display = 'flex';
-                        installedIndicator.style.alignItems = 'center';
-                        installedIndicator.style.justifyContent = 'center';
-                        installedIndicator.style.fontWeight = 'bold';
-                        installedIndicator.style.fontSize = '16px';
-                        
-                        // Replace subscription controls with our indicator
-                        subscriptionControls.innerHTML = '';
-                        subscriptionControls.appendChild(installedIndicator);
-                    } else {
-                        // create link button
-                        var linkButton = document.createElement('a');
-                        linkButton.innerHTML = '→';
-                        linkButton.href = 'https://steamcommunity.com/sharedfiles/filedetails/?id=' + modId;
-                        linkButton.style.backgroundColor = '#2196F3';
-                        linkButton.style.color = 'white';
-                        linkButton.style.width = '24px';
-                        linkButton.style.height = '24px';
-                        linkButton.style.borderRadius = '4px';
-                        linkButton.style.display = 'flex';
-                        linkButton.style.alignItems = 'center';
-                        linkButton.style.justifyContent = 'center';
-                        linkButton.style.cursor = 'pointer';
-                        linkButton.style.fontWeight = 'bold';
-                        linkButton.style.fontSize = '20px';
-                        linkButton.style.textDecoration = 'none';
-                        
-                        // Replace subscription controls with our button
-                        subscriptionControls.innerHTML = '';
-                        subscriptionControls.appendChild(linkButton);
-                    }
-                }
-                """
+            )
+            is_collection_page = (
+                self.url_prefix_workshop in self.current_url
+            )
+            is_collections_page = (
+                self.section_collections in self.current_url
+            )
+            is_items_page = (
+                self.section_readytouseitems in self.current_url
+                or not is_collections_page and "section=" in self.current_url
+            )
+
+            if is_item_page or is_collection_page or is_items_page:
                 # Get list of installed mod IDs and inject into page
                 installed_mods = []
                 for metadata in self.metadata_manager.internal_local_metadata.values():
@@ -602,33 +514,177 @@ class SteamBrowser(QWidget):
                 self.web_view.page().runJavaScript(
                     inject_installed_mods_script, 0, lambda result: None
                 )
-                self.web_view.page().runJavaScript(
-                    add_collection_buttons_script, 0, lambda result: None
-                )
-                # add installed indicator if mod is installed
-                if is_installed:
-                    add_installed_indicator_script = """
-                    // Create a new div for the installed indicator
-                    var installedDiv = document.createElement('div');
-                    installedDiv.style.backgroundColor = '#4CAF50';  // Green background
-                    installedDiv.style.color = 'white';
-                    installedDiv.style.padding = '10px';
-                    installedDiv.style.borderRadius = '5px';
-                    installedDiv.style.marginBottom = '10px';
-                    installedDiv.style.textAlign = 'center';
-                    installedDiv.style.fontWeight = 'bold';
-                    installedDiv.innerHTML = '✓ Already Installed';
-                    // Insert it at the top of the page content
-                    var contentDiv = document.querySelector('.workshopItemDetailsHeader');
-                    if (contentDiv) {
-                        contentDiv.parentNode.insertBefore(installedDiv, contentDiv);
+
+                if is_item_page or is_collection_page:
+                    # get mod id from steam workshop url
+                    if self.url_prefix_sharedfiles in self.current_url:
+                        publishedfileid = self.current_url.split(
+                            self.url_prefix_sharedfiles, 1
+                        )[1]
+                    else:
+                        publishedfileid = self.current_url.split(
+                            self.url_prefix_workshop, 1
+                        )[1]
+                    if self.searchtext_string in publishedfileid:
+                        publishedfileid = publishedfileid.split(self.searchtext_string)[0]
+                    # check if mod is installed
+                    is_installed = self._is_mod_installed(publishedfileid)
+                    # Remove area that shows "Subscribe to download" and "Subscribe"/"Unsubscribe" button for mods
+                    mod_subscribe_area_removal_script = """
+                    var elements = document.getElementsByClassName("game_area_purchase_game");
+                    while (elements.length > 0) {
+                        elements[0].parentNode.removeChild(elements[0]);
                     }
                     """
                     self.web_view.page().runJavaScript(
-                        add_installed_indicator_script, 0, lambda result: None
+                        mod_subscribe_area_removal_script, 0, lambda result: None
                     )
-                # Show the add_to_list_button
-                self.nav_bar.addAction(self.add_to_list_button)
+                    # Remove area that shows "Subscribe to all" and "Unsubscribe to all" buttons for collections
+                    mod_unsubscribe_button_removal_script = """
+                    var elements = document.getElementsByClassName("subscribeCollection");
+                    while (elements.length > 0) {
+                        elements[0].parentNode.removeChild(elements[0]);
+                    }
+                    """
+                    self.web_view.page().runJavaScript(
+                        mod_unsubscribe_button_removal_script, 0, lambda result: None
+                    )
+                    # Remove "Subscribe" buttons from any mods shown in a collection
+                    subscribe_buttons_removal_script = """
+                    var elements = document.getElementsByClassName("general_btn subscribe");
+                    while (elements.length > 0) {
+                        elements[0].parentNode.removeChild(elements[0]);
+                    }
+                    """
+                    self.web_view.page().runJavaScript(
+                        subscribe_buttons_removal_script, 0, lambda result: None
+                    )
+                    # add buttons for collection items
+                    add_collection_buttons_script = """
+                    // find all collection items
+                    var collectionItems = document.getElementsByClassName('collectionItem');
+                    
+                    for (var i = 0; i < collectionItems.length; i++) {
+                        var item = collectionItems[i];
+                        
+                        // get the mod id from the item
+                        var modId = item.id.replace('sharedfile_', '');
+                        
+                        // find the subscription controls div
+                        var subscriptionControls = item.querySelector('.subscriptionControls');
+                        if (!subscriptionControls) {
+                            continue;
+                        }
+                        
+                        // check if mod is installed
+                        var isInstalled = window.installedMods && window.installedMods.includes(modId);
+                        
+                        if (isInstalled) {
+                            // create installed indicator
+                            var installedIndicator = document.createElement('div');
+                            installedIndicator.innerHTML = '✓';
+                            installedIndicator.style.backgroundColor = '#4CAF50';
+                            installedIndicator.style.color = 'white';
+                            installedIndicator.style.width = '24px';
+                            installedIndicator.style.height = '24px';
+                            installedIndicator.style.borderRadius = '4px';
+                            installedIndicator.style.display = 'flex';
+                            installedIndicator.style.alignItems = 'center';
+                            installedIndicator.style.justifyContent = 'center';
+                            installedIndicator.style.fontWeight = 'bold';
+                            installedIndicator.style.fontSize = '16px';
+                            
+                            // Replace subscription controls with our indicator
+                            subscriptionControls.innerHTML = '';
+                            subscriptionControls.appendChild(installedIndicator);
+                        } else {
+                            // create link button
+                            var linkButton = document.createElement('a');
+                            linkButton.innerHTML = '→';
+                            linkButton.href = 'https://steamcommunity.com/sharedfiles/filedetails/?id=' + modId;
+                            linkButton.style.backgroundColor = '#2196F3';
+                            linkButton.style.color = 'white';
+                            linkButton.style.width = '24px';
+                            linkButton.style.height = '24px';
+                            linkButton.style.borderRadius = '4px';
+                            linkButton.style.display = 'flex';
+                            linkButton.style.alignItems = 'center';
+                            linkButton.style.justifyContent = 'center';
+                            linkButton.style.cursor = 'pointer';
+                            linkButton.style.fontWeight = 'bold';
+                            linkButton.style.fontSize = '20px';
+                            linkButton.style.textDecoration = 'none';
+                            
+                            // Replace subscription controls with our button
+                            subscriptionControls.innerHTML = '';
+                            subscriptionControls.appendChild(linkButton);
+                        }
+                    }
+                    """
+                    self.web_view.page().runJavaScript(
+                        add_collection_buttons_script, 0, lambda result: None
+                    )
+                    # add installed indicator if mod is installed
+                    if is_installed:
+                        add_installed_indicator_script = """
+                        // Create a new div for the installed indicator
+                        var installedDiv = document.createElement('div');
+                        installedDiv.style.backgroundColor = '#4CAF50';  // Green background
+                        installedDiv.style.color = 'white';
+                        installedDiv.style.padding = '10px';
+                        installedDiv.style.borderRadius = '5px';
+                        installedDiv.style.marginBottom = '10px';
+                        installedDiv.style.textAlign = 'center';
+                        installedDiv.style.fontWeight = 'bold';
+                        installedDiv.innerHTML = '✓ Already Installed';
+                        // Insert it at the top of the page content
+                        var contentDiv = document.querySelector('.workshopItemDetailsHeader');
+                        if (contentDiv) {
+                            contentDiv.parentNode.insertBefore(installedDiv, contentDiv);
+                        }
+                        """
+                        self.web_view.page().runJavaScript(
+                            add_installed_indicator_script, 0, lambda result: None
+                        )
+                    # Show the add_to_list_button
+                    self.nav_bar.addAction(self.add_to_list_button)
+
+                if is_items_page:
+                    add_item_markers_script = """
+                    var modTiles = document.querySelectorAll('.workshopItem');
+                    modTiles.forEach(function(tile) {
+                        var link = tile.querySelector('a[href*="id="]');
+                        if (!link) return;
+
+                        var match = link.href.match(/id=(\\d+)/);
+                        if (!match) return;
+
+                        var modId = match[1];
+
+                        if (window.installedMods && window.installedMods.includes(modId)) {
+                            // Only add if not already present
+                            if (!tile.querySelector('.rimsort-installed-badge')) {
+                                var installedBadge = document.createElement('div');
+                                installedBadge.className = 'rimsort-installed-badge';
+                                installedBadge.innerHTML = '✓ Installed';
+                                installedBadge.style.position = 'absolute';
+                                installedBadge.style.top = '5px';
+                                installedBadge.style.right = '5px';
+                                installedBadge.style.backgroundColor = '#4CAF50';
+                                installedBadge.style.color = 'white';
+                                installedBadge.style.padding = '2px 6px';
+                                installedBadge.style.borderRadius = '4px';
+                                installedBadge.style.fontSize = '12px';
+                                installedBadge.style.fontWeight = 'bold';
+                                tile.style.position = 'relative';
+                                tile.appendChild(installedBadge);
+                            }
+                        }
+                    });
+                    """
+                    self.web_view.page().runJavaScript(
+                        add_item_markers_script, 0, lambda result: None
+                    )
             else:
                 self.nav_bar.removeAction(self.add_to_list_button)
 

--- a/app/utils/steam/browser.py
+++ b/app/utils/steam/browser.py
@@ -679,8 +679,9 @@ class SteamBrowser(QWidget):
                                 installedBadge.style.alignItems = 'center';
                                 installedBadge.style.justifyContent = 'center';
                                 installedBadge.style.fontWeight = 'bold';
-                                installedBadge.style.fontSize = '18px';
+                                installedBadge.style.fontSize = '20px';
                                 installedBadge.style.boxShadow = '0 0 4px black';
+                                installedBadge.style.cursor = 'default';
                                 tile.style.position = 'relative';
                                 tile.appendChild(installedBadge);
                             }

--- a/app/utils/steam/browser.py
+++ b/app/utils/steam/browser.py
@@ -684,6 +684,11 @@ class SteamBrowser(QWidget):
                                 installedBadge.style.cursor = 'default';
                                 tile.style.position = 'relative';
                                 tile.appendChild(installedBadge);
+
+                                var modTitle = tile.querySelector('.workshopItemTitle');
+                                if (modTitle) {
+                                    modTitle.style.color = '#4CAF50';
+                                }
                             }
                         }
                     });

--- a/app/utils/steam/browser.py
+++ b/app/utils/steam/browser.py
@@ -666,16 +666,21 @@ class SteamBrowser(QWidget):
                             if (!tile.querySelector('.rimsort-installed-badge')) {
                                 var installedBadge = document.createElement('div');
                                 installedBadge.className = 'rimsort-installed-badge';
-                                installedBadge.innerHTML = '✓ Installed';
+                                installedBadge.innerHTML = '✓';
                                 installedBadge.style.position = 'absolute';
                                 installedBadge.style.top = '5px';
                                 installedBadge.style.right = '5px';
                                 installedBadge.style.backgroundColor = '#4CAF50';
                                 installedBadge.style.color = 'white';
-                                installedBadge.style.padding = '2px 6px';
-                                installedBadge.style.borderRadius = '4px';
-                                installedBadge.style.fontSize = '12px';
+                                installedBadge.style.width = '32px';
+                                installedBadge.style.height = '32px';
+                                installedBadge.style.borderRadius = '6px';
+                                installedBadge.style.display = 'flex';
+                                installedBadge.style.alignItems = 'center';
+                                installedBadge.style.justifyContent = 'center';
                                 installedBadge.style.fontWeight = 'bold';
+                                installedBadge.style.fontSize = '18px';
+                                installedBadge.style.boxShadow = '0 0 4px black';
                                 tile.style.position = 'relative';
                                 tile.appendChild(installedBadge);
                             }


### PR DESCRIPTION
Hello there. o/
This is my first PR here, so let me know what I did wrong. If needed, I'm available in the discord: "`@ettykitty.`" 

At first, I wanted to leave a suggestion, but then decided to try to do it by myself, because as someone who maintains a project as well, I feel like there are always more than enough "suggestions" on your plate.
I'm not used to python at all and just a bit more used to js, and had to google every other minute, but I got it working (I hope?).

### Purpose and Description
- Add "Installed" badges/markers to (duh) installed mod tiles on the items and search items workshop pages.
- I think it's pretty handy and not super intrusive.
- I'm not sure if `Feature: Check if the mod is already installed` from #406 meant what I did here. If not - let me know if I should create a separate issue as per guidelines.
### Testing done
- Built and fiddled around the workshop for a bit, to test some edge cases.
- Run into a caveat along the way - if you search from the "Home" page, the search will run in the items section, but the URL will not have it specified (`section=`). I was able to band-aid it, though.

<details>
<summary>Some screenshots are under this spoiler</summary>
<img width="668" height="500" alt="image" src="https://github.com/user-attachments/assets/cacd7ea5-e3e6-4b9d-ad21-9583350cb2a7" />
<img width="677" height="305" alt="image" src="https://github.com/user-attachments/assets/1a6caa46-f4ec-420f-8c4d-133225707914" />
</details>
