### PR TITLE
Fixes Translations and Refactors QMessageBox usage for clarity 

### DIFF
--- a/app/controllers/main_content_controller.py
+++ b/app/controllers/main_content_controller.py
@@ -8,7 +8,7 @@ from typing import List, Optional, cast
 from github import Github, Repository
 from loguru import logger
 from PySide6.QtCore import QObject, QThreadPool, Slot
-from PySide6.QtWidgets import QInputDialog
+from PySide6.QtWidgets import QInputDialog, QMessageBox
 
 from app.controllers.settings_controller import SettingsController
 from app.utils import git_utils
@@ -670,7 +670,7 @@ class MainContentController(QObject):
                 text=self.tr("Local repository does not exist."),
                 information=self.tr("Would you like to clone the repository first?"),
             )
-            if answer == "&Yes":
+            if answer == QMessageBox.StandardButton.Yes:
                 self._do_git_clone(
                     base_path=str(AppInfo().databases_folder),
                     repo_url=repo_url,
@@ -1261,7 +1261,7 @@ class MainContentController(QObject):
                 ).format(url=pull_request.html_url),
             )
 
-            if answer == "&Yes":
+            if answer == QMessageBox.StandardButton.Yes:
                 # Open URL in browser
                 try:
                     import webbrowser

--- a/app/utils/steam/steamcmd/wrapper.py
+++ b/app/utils/steam/steamcmd/wrapper.py
@@ -12,6 +12,7 @@ from zipfile import ZipFile
 import requests
 from loguru import logger
 from PySide6.QtCore import QCoreApplication
+from PySide6.QtWidgets import QMessageBox
 
 import app.utils.symlink as symlink
 from app.controllers.settings_controller import SettingsController
@@ -352,6 +353,10 @@ class SteamcmdInterface:
         else:
             btn_text = ["&Yes", "&No"]
 
+        # Translate button texts explicitly before passing to show_dialogue_conditional
+        translated_btn_text = [
+            self.translate("SteamcmdInterface", btn) for btn in btn_text
+        ]
         answer = show_dialogue_conditional(
             title=self.translate("SteamcmdInterface", "RimSort - SteamCMD setup"),
             text=self.translate(
@@ -360,14 +365,17 @@ class SteamcmdInterface:
             ),
             information=f"{self.steamcmd_prefix if self.steamcmd_prefix else '<None>'}\n\n"
             + self.translate("SteamcmdInterface", "Do you want to setup SteamCMD?"),
-            button_text_override=btn_text,
+            button_text_override=translated_btn_text,
         )
-        if answer == "&Yes":
+        yes_text = self.translate("SteamcmdInterface", "&Yes")
+        dont_ask_text = self.translate("SteamcmdInterface", "&Don't Ask Again")
+
+        if answer == yes_text:
             EventBus().do_install_steamcmd.emit()
         if runner:
             runner.close()
 
-        if ask_ignore and answer == "&Don't Ask Again":
+        if ask_ignore and answer == dont_ask_text:
             if settings_controller is not None:
                 settings_controller.active_instance.steamcmd_ignore = True
                 settings_controller.settings.save()
@@ -487,7 +495,7 @@ class SteamcmdInterface:
                 "Would you like to reinstall SteamCMD?",
                 f"Existing install: {self.steamcmd_install_path}",
             )
-            if answer == "&Yes":
+            if answer == QMessageBox.StandardButton.Yes:
                 runner.message(f"Reinstalling SteamCMD: {self.steamcmd_install_path}")
                 self.setup_steamcmd(symlink_source_path, True, runner)
         if installed:
@@ -530,7 +538,7 @@ class SteamcmdInterface:
                     )
                     + symlink_destination_path,
                 )
-                if answer == "&Yes":  # Re-create symlink
+                if answer == QMessageBox.StandardButton.Yes:  # Re-create symlink
                     self.setup = self.create_symlink(
                         symlink_source_path, symlink_destination_path, runner=runner
                     )
@@ -563,7 +571,9 @@ class SteamcmdInterface:
                     )
                     + symlink_destination_path,
                 )
-                if answer == "&Yes":  # Re-create symlink/junction
+                if (
+                    answer == QMessageBox.StandardButton.Yes
+                ):  # Re-create symlink/junction
                     self.setup = self.create_symlink(
                         symlink_source_path, symlink_destination_path, runner=runner
                     )
@@ -585,7 +595,7 @@ class SteamcmdInterface:
                     )
                     + symlink_destination_path,
                 )
-                if answer == "&Yes":
+                if answer == QMessageBox.StandardButton.Yes:
                     self.setup = self.create_symlink(
                         symlink_source_path, symlink_destination_path, runner=runner
                     )

--- a/app/views/deletion_menu.py
+++ b/app/views/deletion_menu.py
@@ -5,7 +5,7 @@ from typing import Callable
 
 from loguru import logger
 from PySide6.QtGui import QAction
-from PySide6.QtWidgets import QMenu
+from PySide6.QtWidgets import QMenu, QMessageBox
 
 from app.utils.event_bus import EventBus
 from app.utils.generic import (
@@ -24,8 +24,8 @@ from app.views.dialogue import (
 class DialogueResponse(Enum):
     """Enumeration for dialogue response constants."""
 
-    YES = "&Yes"
-    NO = "&No"
+    YES = QMessageBox.StandardButton.Yes
+    NO = QMessageBox.StandardButton.No
 
 
 class DeletionResult:

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -814,7 +814,7 @@ class MainContent(QObject):
             ).format(current_version=current_version),
         )
 
-        if answer != "&Yes":
+        if answer != QMessageBox.StandardButton.Yes:
             return
 
         # Perform update
@@ -1008,7 +1008,7 @@ class MainContent(QObject):
                 information=f"\nSuccessfully retrieved latest release.\nThe update will be installed from: {temp_path}",
             )
 
-            if answer != "&Yes":
+            if answer != QMessageBox.StandardButton.Yes:
                 return
 
             # Launch update script
@@ -2739,7 +2739,7 @@ class MainContent(QObject):
                 )
             ),
         )
-        if answer == "&Yes":
+        if answer == QMessageBox.StandardButton.Yes:
             open_url_browser("https://git-scm.com/downloads")
 
     def _do_open_rule_editor(
@@ -2993,7 +2993,7 @@ class MainContent(QObject):
                         + "a separate, authenticated instance of SteamCMD, if you do not want to anonymously download via RimSort."
                     ),
                 )
-                if answer == "&Yes":
+                if answer == QMessageBox.StandardButton.Yes:
                     for (
                         metadata_values
                     ) in self.metadata_manager.internal_local_metadata.values():

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -13,6 +13,7 @@ from PySide6.QtWidgets import (
     QHBoxLayout,
     QLabel,
     QMainWindow,
+    QMessageBox,
     QPushButton,
     QTabWidget,
     QVBoxLayout,
@@ -933,7 +934,7 @@ class MainWindow(QMainWindow):
                         "This will try to generate run args for the new instance based on the configured Game/Config folders."
                     ),
                 )
-                if answer == "&Yes":
+                if answer == QMessageBox.StandardButton.Yes:
                     # Append new run args to the existing run args
                     generated_instance_run_args = [
                         "-logfile",

--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -29,6 +29,7 @@ from PySide6.QtWidgets import (
     QLineEdit,
     QListWidget,
     QMenu,
+    QMessageBox,
     QPushButton,
     QToolButton,
     QVBoxLayout,
@@ -1113,7 +1114,7 @@ class ModListWidget(QListWidget):
                         ).format(len=len(git_paths)),
                         information=self.tr("Do you want to proceed?"),
                     )
-                    if answer == "&Yes":
+                    if answer == QMessageBox.StandardButton.Yes:
                         logger.debug(f"Updating {len(git_paths)} git mod(s)")
                         self.update_git_mods_signal.emit(git_paths)
                     return True
@@ -1210,7 +1211,7 @@ class ModListWidget(QListWidget):
                             + "and attempt to re-download the mods via SteamCMD. Do you want to proceed?"
                         ),
                     )
-                    if answer == "&Yes":
+                    if answer == QMessageBox.StandardButton.Yes:
                         logger.debug(
                             f"Deleting + redownloading {len(steamcmd_publishedfileid_to_redownload)} SteamCMD mod(s)"
                         )
@@ -1305,7 +1306,7 @@ class ModListWidget(QListWidget):
                             "\nThis operation will potentially delete .dds textures leftover. Steam is unreliable for this. Do you want to proceed?"
                         ),
                     )
-                    if answer == "&Yes":
+                    if answer == QMessageBox.StandardButton.Yes:
                         logger.debug(
                             f"Unsubscribing + re-subscribing to {len(publishedfileids)} mod(s)"
                         )
@@ -1333,7 +1334,7 @@ class ModListWidget(QListWidget):
                         ).format(len=len(publishedfileids)),
                         information=self.tr("\nDo you want to proceed?"),
                     )
-                    if answer == "&Yes":
+                    if answer == QMessageBox.StandardButton.Yes:
                         logger.debug(
                             f"Unsubscribing from {len(publishedfileids)} mod(s)"
                         )
@@ -1406,7 +1407,7 @@ class ModListWidget(QListWidget):
                         + "from your configured Steam DB blacklist."
                         + "\nDo you want to proceed?",
                     )
-                    if answer == "&Yes":
+                    if answer == QMessageBox.StandardButton.Yes:
                         self.steamdb_blacklist_signal.emit(
                             [steamdb_remove_blacklist, False]
                         )

--- a/app/windows/runner_panel.py
+++ b/app/windows/runner_panel.py
@@ -9,6 +9,7 @@ from PySide6.QtCore import QProcess, Qt, Signal
 from PySide6.QtGui import QCloseEvent, QFont, QIcon, QKeyEvent, QTextCursor
 from PySide6.QtWidgets import (
     QHBoxLayout,
+    QMessageBox,
     QPlainTextEdit,
     QProgressBar,
     QToolButton,
@@ -531,7 +532,7 @@ class RunnerPanel(QWidget):
                 ),
                 details=details,
             )
-            == "&Yes"
+            == QMessageBox.StandardButton.Yes
         ):
             self.steamcmd_downloader_signal.emit(self.steamcmd_download_tracking)
         else:


### PR DESCRIPTION
This pull request refactors the codebase to improve the consistency and maintainability of message box interactions.

- Uses `QMessageBox.StandardButton` enum for button comparisons instead of string literals, enhancing code readability and type safety.
- Ensures proper translation of button texts in SteamCMD setup dialogues for improved localization support.
- Updates the dialogue response enum to use the standard button enum from `QMessageBox`, avoiding hardcoded string values.