### PR TITLE
Fixes SyntaxError: f-string expression part cannot include a backslash

### DIFF
--- a/app/controllers/file_search_controller.py
+++ b/app/controllers/file_search_controller.py
@@ -386,7 +386,8 @@ class SearchWorker(QThread):
             header += f"Path: {os.path.dirname(file_path)}\n"
             header += f"Match at line {match_line_index + 1}:\n"
 
-            return f"{header}\n{prefix}{'\n'.join(preview_lines)}{suffix}"
+            joined_preview = "\n".join(preview_lines)
+            return f"{header}\n{prefix}{joined_preview}{suffix}"
         except Exception as e:
             logger.warning(f"Failed to get preview for {file_path}: {e}")
             return f"Error generating preview: {e}"

--- a/app/utils/steam/browser.py
+++ b/app/utils/steam/browser.py
@@ -74,12 +74,8 @@ class SteamBrowser(QWidget):
         self.url_prefix_workshop = (
             "https://steamcommunity.com/workshop/filedetails/?id="
         )
-        self.section_readytouseitems = (
-            "section=readytouseitems"
-        )
-        self.section_collections = (
-            "section=collections"
-        )
+        self.section_readytouseitems = "section=readytouseitems"
+        self.section_collections = "section=collections"
 
         # LAYOUTS
         self.window_layout = QHBoxLayout()
@@ -488,18 +484,13 @@ class SteamBrowser(QWidget):
             # }
             # """
 
-            is_item_page = (
-                self.url_prefix_sharedfiles in self.current_url
-            )
-            is_collection_page = (
-                self.url_prefix_workshop in self.current_url
-            )
-            is_collections_page = (
-                self.section_collections in self.current_url
-            )
+            is_item_page = self.url_prefix_sharedfiles in self.current_url
+            is_collection_page = self.url_prefix_workshop in self.current_url
+            is_collections_page = self.section_collections in self.current_url
             is_items_page = (
                 self.section_readytouseitems in self.current_url
-                or not is_collections_page and "section=" in self.current_url
+                or not is_collections_page
+                and "section=" in self.current_url
             )
 
             if is_item_page or is_collection_page or is_items_page:
@@ -526,7 +517,9 @@ class SteamBrowser(QWidget):
                             self.url_prefix_workshop, 1
                         )[1]
                     if self.searchtext_string in publishedfileid:
-                        publishedfileid = publishedfileid.split(self.searchtext_string)[0]
+                        publishedfileid = publishedfileid.split(self.searchtext_string)[
+                            0
+                        ]
                     # check if mod is installed
                     is_installed = self._is_mod_installed(publishedfileid)
                     # Remove area that shows "Subscribe to download" and "Subscribe"/"Unsubscribe" button for mods


### PR DESCRIPTION
Improves the codebase in the following ways:

- Enhances readability in file preview generation by explicitly joining preview lines with newline characters, ensuring consistent formatting.
- Formats `browser.py` using Ruff, adhering to consistent code style guidelines.

Fixes
<img width="1049" height="380" alt="image" src="https://github.com/user-attachments/assets/3e9c6475-9ee1-45a4-9e05-558821ec1061" />
