### PR TITLE
Suppresses update notification when up to date

### DIFF
--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -794,13 +794,8 @@ class MainContent(QObject):
             current_version_parsed = version.parse("0.0.0")
 
         if current_version_parsed >= latest_version:
-            logger.debug("Up to date!")
-            dialogue.show_information(
-                title=self.tr("RimSort is up to date!"),
-                text=self.tr(
-                    "You are already running the latest release: {latest_tag_name}"
-                ).format(latest_tag_name=latest_tag_name),
-            )
+            # No update needed then return and log the check no need to notify user
+            logger.info("Up to date!")
             return
 
         # Show update prompt


### PR DESCRIPTION
Suppresses the update available notification when the application is already running the latest version.

- Prevents unnecessary interruption of the user.
- The update check now logs an info message when no update is needed, instead of showing a dialog.

Fixes #860 