### PR TITLE
feat(browser): Stop placeholder flashing; Edit the progress bar

### DIFF
--- a/app/utils/steam/browser.py
+++ b/app/utils/steam/browser.py
@@ -158,17 +158,11 @@ class SteamBrowser(QWidget):
         )
         # self.nav_bar.addSeparator()
         self.progress_bar = QProgressBar()
-        self.progress_bar.setObjectName("default")
+        self.progress_bar.setObjectName("browser")
         self.progress_bar.setRange(0, 100)
         self.progress_bar.setFixedHeight(8)
         self.progress_bar.setTextVisible(False)
         self.progress_bar.setVisible(True)
-        self.progress_bar.setStyleSheet("""
-            QProgressBar {
-                font-size: 10px;
-                border: 0px;
-            }
-        """)
 
         # Build the downloader layout
         self.downloader_layout.addWidget(self.downloader_label)

--- a/app/utils/steam/browser.py
+++ b/app/utils/steam/browser.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from loguru import logger
 from PySide6.QtCore import QPoint, Qt, QUrl, Signal
-from PySide6.QtGui import QAction, QPixmap
+from PySide6.QtGui import QAction
 from PySide6.QtWebEngineCore import QWebEnginePage
 from PySide6.QtWebEngineWidgets import QWebEngineView
 from PySide6.QtWidgets import (
@@ -24,8 +24,6 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from app.models.image_label import ImageLabel
-from app.utils.app_info import AppInfo
 from app.utils.generic import extract_page_title_steam_browser
 from app.utils.metadata import MetadataManager
 from app.utils.steam.webapi.wrapper import (
@@ -152,8 +150,19 @@ class SteamBrowser(QWidget):
         )
         # self.nav_bar.addSeparator()
         self.progress_bar = QProgressBar()
-        self.progress_bar.setMinimum(0)
-        self.progress_bar.setMaximum(100)
+        self.progress_bar.setRange(0, 100)
+        self.progress_bar.setFixedHeight(8)
+        self.progress_bar.setTextVisible(False)
+        self.progress_bar.setVisible(True)
+        self.progress_bar.setStyleSheet("""
+            QProgressBar {
+                font-size: 10px;
+                border: 0px solid gray;
+            }
+            QProgressBar::chunk {
+                background-color: #1a9fff;
+            }
+        """)
 
         # Build the downloader layout
         self.downloader_layout.addWidget(self.downloader_label)
@@ -406,9 +415,9 @@ class SteamBrowser(QWidget):
 
     def _web_view_load_started(self) -> None:
         # Progress bar start, placeholder start
-        self.progress_bar.show()
         self.web_view.hide()
         self.web_view_loading_placeholder.show()
+        self.progress_bar.setTextVisible(True)
 
     def _web_view_load_progress(self, progress: int) -> None:
         # Progress bar progress
@@ -420,8 +429,8 @@ class SteamBrowser(QWidget):
 
     def _web_view_load_finished(self) -> None:
         # Progress bar done
-        self.progress_bar.hide()
         self.progress_bar.setValue(0)
+        self.progress_bar.setTextVisible(False)
 
         # Cache information from page
         self.current_title = self.web_view.title()

--- a/app/utils/steam/browser.py
+++ b/app/utils/steam/browser.py
@@ -114,15 +114,10 @@ class SteamBrowser(QWidget):
 
         # BROWSER WIDGETS
         # "Loading..." placeholder
-        self.web_view_loading_placeholder = ImageLabel()
+        self.web_view_loading_placeholder = QLabel()
         self.web_view_loading_placeholder.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.web_view_loading_placeholder.setSizePolicy(
             QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding
-        )
-        self.web_view_loading_placeholder.setPixmap(
-            QPixmap(
-                str(AppInfo().theme_data_folder / "default-icons" / "AppIcon_b.png")
-            )
         )
         # WebEngineView
         self.web_view = QWebEngineView()

--- a/app/utils/steam/browser.py
+++ b/app/utils/steam/browser.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from loguru import logger
 from PySide6.QtCore import QPoint, Qt, QUrl, Signal
-from PySide6.QtGui import QAction
+from PySide6.QtGui import QAction, QPixmap
 from PySide6.QtWebEngineCore import QWebEnginePage
 from PySide6.QtWebEngineWidgets import QWebEngineView
 from PySide6.QtWidgets import (
@@ -24,6 +24,8 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
+from app.models.image_label import ImageLabel
+from app.utils.app_info import AppInfo
 from app.utils.generic import extract_page_title_steam_browser
 from app.utils.metadata import MetadataManager
 from app.utils.steam.webapi.wrapper import (
@@ -112,13 +114,19 @@ class SteamBrowser(QWidget):
 
         # BROWSER WIDGETS
         # "Loading..." placeholder
-        self.web_view_loading_placeholder = QLabel()
+        self.web_view_loading_placeholder = ImageLabel()
         self.web_view_loading_placeholder.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.web_view_loading_placeholder.setSizePolicy(
             QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding
         )
+        self.web_view_loading_placeholder.setPixmap(
+            QPixmap(
+                str(AppInfo().theme_data_folder / "default-icons" / "AppIcon_b.png")
+            )
+        )
         # WebEngineView
         self.web_view = QWebEngineView()
+        self.web_view.hide()
         self.web_view.loadStarted.connect(self._web_view_load_started)
         self.web_view.loadProgress.connect(self._web_view_load_progress)
         self.web_view.loadFinished.connect(self._web_view_load_finished)
@@ -413,8 +421,9 @@ class SteamBrowser(QWidget):
 
     def _web_view_load_started(self) -> None:
         # Progress bar start, placeholder start
-        self.web_view.hide()
-        self.web_view_loading_placeholder.show()
+        # Commented out to stop flashing on every page load
+        # self.web_view.hide()
+        # self.web_view_loading_placeholder.show()
         self.progress_bar.setTextVisible(True)
 
     def _web_view_load_progress(self, progress: int) -> None:

--- a/app/utils/steam/browser.py
+++ b/app/utils/steam/browser.py
@@ -150,6 +150,7 @@ class SteamBrowser(QWidget):
         )
         # self.nav_bar.addSeparator()
         self.progress_bar = QProgressBar()
+        self.progress_bar.setObjectName("default")
         self.progress_bar.setRange(0, 100)
         self.progress_bar.setFixedHeight(8)
         self.progress_bar.setTextVisible(False)
@@ -157,10 +158,7 @@ class SteamBrowser(QWidget):
         self.progress_bar.setStyleSheet("""
             QProgressBar {
                 font-size: 10px;
-                border: 0px solid gray;
-            }
-            QProgressBar::chunk {
-                background-color: #1a9fff;
+                border: 0px;
             }
         """)
 

--- a/app/windows/runner_panel.py
+++ b/app/windows/runner_panel.py
@@ -154,7 +154,7 @@ class RunnerPanel(QWidget):
         self.progress_bar = QProgressBar()
         self.progress_bar.setValue(0)
         self.progress_bar.hide()
-        self.progress_bar.setObjectName("default")
+        self.progress_bar.setObjectName("runner")
 
     def _setup_layouts(self) -> None:
         """Set up the widget layouts."""

--- a/themes/Modern/style.qss
+++ b/themes/Modern/style.qss
@@ -222,8 +222,15 @@ QProgressBar {
     color: #d6e0f3;
     text-align: center;
 }
-QProgressBar::chunk#default {
+QProgressBar#browser {
+    border: 0px;
+    border-radius: 0px;
+    font-size: 10px;
+}
+QProgressBar::chunk {
     background-color: #55698b;
+}
+QProgressBar::chunk#runner {
     width: 10px;
 }
 QProgressBar::chunk#warn {

--- a/themes/Nature/style.qss
+++ b/themes/Nature/style.qss
@@ -222,8 +222,15 @@ QProgressBar {
     color: #ffffff;
     text-align: center;
 }
-QProgressBar::chunk#default {
+QProgressBar#browser {
+    border: 0px;
+    border-radius: 0px;
+    font-size: 10px;
+}
+QProgressBar::chunk {
     background-color: #8fbc8f;
+}
+QProgressBar::chunk#runner {
     width: 10px;
 }
 QProgressBar::chunk#warn {

--- a/themes/RimPy/style.qss
+++ b/themes/RimPy/style.qss
@@ -223,8 +223,16 @@ QProgressBar {
     color: #e6edf3;
     text-align: center;
 }
-QProgressBar::chunk#default {
+QProgressBar#browser {
+    border: 0px;
+    border-radius: 0px;
+    font-size: 10px;
+}
+QProgressBar::chunk {
     background-color: #60798b;
+    width: 10px;
+}
+QProgressBar::chunk#runner {
     width: 10px;
 }
 QProgressBar::chunk#warn {

--- a/themes/SunSet/style.qss
+++ b/themes/SunSet/style.qss
@@ -222,8 +222,15 @@ QProgressBar {
     color: #ffffff;
     text-align: center;
 }
-QProgressBar::chunk#default {
+QProgressBar#browser {
+    border: 0px;
+    border-radius: 0px;
+    font-size: 10px;
+}
+QProgressBar::chunk {
     background-color: #ff6347;
+}
+QProgressBar::chunk#runner {
     width: 10px;
 }
 QProgressBar::chunk#warn {

--- a/themes/Wood/style.qss
+++ b/themes/Wood/style.qss
@@ -222,8 +222,15 @@ QProgressBar {
     color: #ffffff;
     text-align: center;
 }
-QProgressBar::chunk#default {
+QProgressBar#browser {
+    border: 0px;
+    border-radius: 0px;
+    font-size: 10px;
+}
+QProgressBar::chunk {
     background-color: #a0522d;
+}
+QProgressBar::chunk#runner {
     width: 10px;
 }
 QProgressBar::chunk#warn {


### PR DESCRIPTION
Hopefully, addresses things from #70.

### What's done
- Make the progress bar persistent, so that the page stops changing size when it disappears.
- Remove the progress bar border, so that it doesn't look ugly always sitting on the screen.
- Reduce the progress bar height to 8 pixels, so that it takes less space.
- The % text only visible when loading.
- Smaller % font.
- Progress bar color now properly changes with the theme.
- The placeholder only showed once, when the browser is opened for the first time.

### How tested
- Spent some time in the browser.
- Formatted/fixed with ruff.


