### PR TITLE
fix(browser): "Add to list" button getting stuck

### DIFF
--- a/app/utils/steam/browser.py
+++ b/app/utils/steam/browser.py
@@ -419,6 +419,7 @@ class SteamBrowser(QWidget):
         # self.web_view.hide()
         # self.web_view_loading_placeholder.show()
         self.progress_bar.setTextVisible(True)
+        self.nav_bar.removeAction(self.add_to_list_button)
 
     def _web_view_load_progress(self, progress: int) -> None:
         # Progress bar progress
@@ -694,8 +695,6 @@ class SteamBrowser(QWidget):
                     self.web_view.page().runJavaScript(
                         add_item_markers_script, 0, lambda result: None
                     )
-            else:
-                self.nav_bar.removeAction(self.add_to_list_button)
 
     def __set_current_html(self, html: str) -> None:
         # Update cached html with html from current page


### PR DESCRIPTION
### The issue
"Add to list" button is not deleted after the user opens a page of any mod and then goes back to the browse mods screen.
Caused by me forgetting that I've changed the `if` block above `else` that contains button deletion, causing it to not get executed if page = browse mods.
### The fix
Now the button is deleted on every `_web_view_load_started` call. I think there is no reason not to.
### The tests
Tested that the original problem is solved, and that apparently no problems with individual mod or collection "Add to list" buttons popped out - they work fine.