### PR TITLE
feat(browser): Quick add/remove buttons on tiles

### DIFF
--- a/app/utils/steam/js_bridge.py
+++ b/app/utils/steam/js_bridge.py
@@ -1,10 +1,10 @@
-
 from typing import TYPE_CHECKING, Optional
 
 from PySide6.QtCore import QObject, Slot
 
 if TYPE_CHECKING:
     from app.utils.steam.browser import SteamBrowser
+
 
 class JavaScriptBridge(QObject):
     """

--- a/app/utils/steam/js_bridge.py
+++ b/app/utils/steam/js_bridge.py
@@ -1,0 +1,25 @@
+from PySide6.QtCore import QObject, Slot
+
+
+class JavaScriptBridge(QObject):
+    """
+    A minimal QObject to act as a bridge between QWebEngineView's JavaScript
+    and the Python SteamBrowser class, exposing only specific methods.
+    """
+    def __init__(self, browser_instance, parent=None):
+        super().__init__(parent)
+        self._browser_instance = browser_instance
+
+    @Slot(str, str)
+    def add_mod_from_js(self, publishedfileid: str, mod_title: str):
+        """
+        Slot callable from JavaScript to add a mod to the download list.
+        """
+        self._browser_instance._add_mod_to_list(publishedfileid=publishedfileid, title=mod_title)
+
+    @Slot(str)
+    def remove_mod_from_js(self, mod_id: str) -> None:
+        """
+        Slot callable from JavaScript to remove a mod from the download list.
+        """
+        self._browser_instance._remove_mod_from_list(mod_id)

--- a/app/utils/steam/js_bridge.py
+++ b/app/utils/steam/js_bridge.py
@@ -1,21 +1,31 @@
+
+from typing import TYPE_CHECKING, Optional
+
 from PySide6.QtCore import QObject, Slot
 
+if TYPE_CHECKING:
+    from app.utils.steam.browser import SteamBrowser
 
 class JavaScriptBridge(QObject):
     """
     A minimal QObject to act as a bridge between QWebEngineView's JavaScript
     and the Python SteamBrowser class, exposing only specific methods.
     """
-    def __init__(self, browser_instance, parent=None):
+
+    def __init__(
+        self, browser_instance: "SteamBrowser", parent: Optional[QObject] = None
+    ) -> None:
         super().__init__(parent)
         self._browser_instance = browser_instance
 
     @Slot(str, str)
-    def add_mod_from_js(self, publishedfileid: str, mod_title: str):
+    def add_mod_from_js(self, publishedfileid: str, mod_title: str) -> None:
         """
         Slot callable from JavaScript to add a mod to the download list.
         """
-        self._browser_instance._add_mod_to_list(publishedfileid=publishedfileid, title=mod_title)
+        self._browser_instance._add_mod_to_list(
+            publishedfileid=publishedfileid, title=mod_title
+        )
 
     @Slot(str)
     def remove_mod_from_js(self, mod_id: str) -> None:

--- a/app/utils/steam/setup_web_channel_script.js
+++ b/app/utils/steam/setup_web_channel_script.js
@@ -1,0 +1,175 @@
+const BadgeState = $badge_state_js;
+
+if (typeof QWebChannel !== 'undefined') {
+    new QWebChannel(qt.webChannelTransport, function(channel) {
+        window.browserBridge = channel.objects.browserBridge;
+        console.log("QWebChannel bridge to Python ready!");
+
+        window.updateModBadge = function(modId, status) {
+            const tile = document.querySelector(`.workshopItem a[href*="id=$${modId}"]`)?.closest('.workshopItem');
+            if (!tile) {
+                console.log(`Mod tile for $${modId} not found.`);
+                return;
+            }
+
+            let modStatusBadge = tile.querySelector('.rimsort-modstatus-badge');
+
+            if (!modStatusBadge) {
+                modStatusBadge = document.createElement('div');
+                modStatusBadge.className = 'rimsort-modstatus-badge';
+
+                const modTitleElement = tile.querySelector('.workshopItemTitle');
+                const modTitleText = modTitleElement ? modTitleElement.textContent.trim() : modId;
+
+                const mouseoverHandler = function() {
+                    if (modStatusBadge.classList.contains('rimsort-mod-default')) {
+                        modStatusBadge.classList.add('hovered');
+                    }
+                };
+                const mouseoutHandler = function() {
+                    if (modStatusBadge.classList.contains('rimsort-mod-default')) {
+                        modStatusBadge.classList.remove('hovered');
+                    }
+                };
+
+                tile.addEventListener('mouseover', mouseoverHandler);
+                tile.addEventListener('mouseout', mouseoutHandler);
+
+
+                modStatusBadge.addEventListener('click', function() {
+                    if (!window.browserBridge) return;
+
+                    modStatusBadge.classList.add('pressed');
+                    setTimeout(() => {
+                        modStatusBadge.classList.remove('pressed');
+                    }, 150);
+
+                    if (modStatusBadge.classList.contains('rimsort-mod-default')) {
+                        window.browserBridge.add_mod_from_js(modId, modTitleText);
+                    } else if (modStatusBadge.classList.contains('rimsort-mod-added')) {
+                        window.browserBridge.remove_mod_from_js(modId);
+                    }
+                });
+
+                tile.style.position = 'relative';
+                tile.appendChild(modStatusBadge);
+            }
+
+            // Update badge based on status
+            if (status === BadgeState.INSTALLED) {
+                modStatusBadge.title = 'Already installed';
+                modStatusBadge.innerHTML = '✓';
+                modStatusBadge.classList.remove('rimsort-mod-added');
+                modStatusBadge.classList.remove('rimsort-mod-default');
+                modStatusBadge.classList.add('rimsort-mod-installed');
+                const modTitleElement = tile.querySelector('.workshopItemTitle');
+                if (modTitleElement) {
+                    modTitleElement.style.color = '#4CAF50';
+                }
+            } else if (status === BadgeState.ADDED) {
+                modStatusBadge.title = 'Preparing to download';
+                modStatusBadge.innerHTML = '-';
+                modStatusBadge.classList.remove('rimsort-mod-installed');
+                modStatusBadge.classList.remove('rimsort-mod-default');
+                modStatusBadge.classList.add('rimsort-mod-added');
+                const modTitleElement = tile.querySelector('.workshopItemTitle');
+                if (modTitleElement) {
+                    modTitleElement.style.color = '';
+                }
+            } else {
+                modStatusBadge.title = 'Add to list';
+                modStatusBadge.innerHTML = '+';
+                modStatusBadge.classList.remove('rimsort-mod-installed');
+                modStatusBadge.classList.remove('rimsort-mod-added');
+                modStatusBadge.classList.add('rimsort-mod-default');
+                if (tile.matches(':hover')) {
+                    modStatusBadge.classList.add('hovered');
+                } else {
+                    modStatusBadge.classList.remove('hovered');
+                }
+                const modTitleElement = tile.querySelector('.workshopItemTitle');
+                if (modTitleElement) {
+                    modTitleElement.style.color = '';
+                }
+            }
+        };
+
+        window.updateAllModBadges = function() {
+            const modTiles = document.querySelectorAll('.workshopItem');
+            const installedMods = $installed_mods || [];
+            const addedMods = $added_mods || [];
+
+            modTiles.forEach(function(tile) {
+                const link = tile.querySelector('a[href*="id="]');
+                if (!link) return;
+                const match = link.href.match(/id=(\d+)/);
+                if (!match) return;
+                const modId = match[1];
+
+                if (installedMods.includes(modId)) {
+                    window.updateModBadge(modId, BadgeState.INSTALLED);
+                } else if (addedMods.includes(modId)) {
+                    window.updateModBadge(modId, BadgeState.ADDED);
+                } else {
+                    window.updateModBadge(modId, BadgeState.DEFAULT);
+                }
+            });
+        };
+
+        window.updateAllModBadges();
+    });
+} else {
+    console.error("QWebChannel is not defined. Cannot setup bridge.");
+}
+
+const style = document.createElement('style');
+style.textContent = `
+    .rimsort-modstatus-badge {
+        position: absolute;
+        top: 5px;
+        right: 5px;
+        color: white;
+        width: 32px;
+        height: 32px;
+        border-radius: 6px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-weight: bold;
+        font-size: 20px;
+        box-shadow: 0 0 4px black;
+        cursor: default;
+        user-select: none;
+        transition: transform 0.1s ease, box-shadow 0.1s ease, opacity 0.2s ease, visibility 0.2s ease;
+    }
+
+    .rimsort-mod-installed {
+        background-color: #4CAF50;
+        opacity: 1;
+        visibility: visible;
+    }
+
+    .rimsort-mod-added {
+        background-color: #FFA500;
+        opacity: 1;
+        visibility: visible;
+        cursor: pointer;
+    }
+
+    .rimsort-mod-default {
+        background-color: #2196F3;
+        opacity: 0;
+        visibility: hidden;
+    }
+
+    .rimsort-mod-default.hovered {
+        opacity: 1;
+        visibility: visible;
+        cursor: pointer;
+    }
+
+    .rimsort-modstatus-badge.pressed {
+        transform: scale(0.9);
+    }
+`;
+document.head.appendChild(style);


### PR DESCRIPTION
### Description
- Add badges/buttons to quickly add/remove mods from the list, to mod tiles in the workshop browser.
  - Supports mod tiles on collection pages as well.
- Refactor some bits of the code related to this.
### More Detailed Description
- Badges:
  - Hidden by default for not-installed and not-added mods, unless you hover the mod, to not clutter the UI.
  - Have a minor effect when you click on them, to add responsiveness.
  - Have a hover-over effect.
- JS bridge stuff:  
  - Use `QWebChannel` to have a bridge between JS and python.
  - No idea if this is the best way, I just found it to work, and it was the first thing I found on the internet.
  - Had to manually inject `qwebchannel.js` with `QWebEngineScript`, as I have no idea how to get it to work otherwise.
- JS script stuff:
  - Move the main badge/button JS script to a separate JS file, to have proper intellisense and less bloat in the `SteamBrowser` class.
  - Use `Template()`>`substitute()`>`json.dumps()` to replace template vars in JS with vars from python, to avoid the need to inject said variables directly into the page.
### TODO
- Nail the file structure, as I've just placed everything in the same folder, which may be not ideal.
- Test this on other systems perhaps, as I'm not sure if there could be problems with the bridge and stuff.
- Generally do more edge-case testing as well.
- ~Add a hover-over effect to badges, because all cool kids should have that.~
- In some other PR, split the huge `_web_view_load_finished()` method into smaller parts.
- In some other PRx2, maybe move some other big JS function to separate files.
### Preview
<details>
<summary>Spoiler</summary>

https://github.com/user-attachments/assets/3d0d5539-22de-4f45-bc6f-026705aabf13

</details>