### PR TITLE
Adds game version validation for replacements

### DIFF
--- a/app/utils/metadata.py
+++ b/app/utils/metadata.py
@@ -1305,6 +1305,12 @@ class MetadataManager(QObject):
             return None
         replacement_data = xml_path_to_json(str(check_path))["ModReplacement"]
 
+        # check if replacement supports  the game version
+        major, minor = self.game_version.split(".")[:2]
+        version_regex = rf"{major}.{minor}"
+        if version_regex not in replacement_data["ReplacementVersions"]:
+            return None
+
         return ModReplacement(
             name=replacement_data["ReplacementName"],
             author=replacement_data["ReplacementAuthor"],


### PR DESCRIPTION
Adds a check to ensure that mod replacements are compatible with the current game version.

This prevents applying incompatible replacements that could lead to errors or unexpected behavior.
The check uses a regex generated from the game version to determine compatibility.