### PR TITLE
Improves robustness in mod name/package ID handling

### DIFF
--- a/app/sort/alphabetical_sort.py
+++ b/app/sort/alphabetical_sort.py
@@ -24,8 +24,15 @@ def do_alphabetical_sort(
         )
         for uuid in active_mods_uuids
     )
+
+    def safe_name(name: object) -> str:
+        if isinstance(name, str):
+            return name.lower()
+        else:
+            return "name error in mod about.xml"
+
     active_mods_alphabetized = sorted(
-        active_mods_id_to_name.items(), key=lambda x: x[1], reverse=False
+        active_mods_id_to_name.items(), key=lambda x: safe_name(x[1]), reverse=False
     )
     dependencies_alphabetized = {}
     for tuple_id_name in active_mods_alphabetized:

--- a/app/sort/topo_sort.py
+++ b/app/sort/topo_sort.py
@@ -35,10 +35,18 @@ def do_topo_sort(
             if package_id in active_mods_packageid_to_uuid:
                 mod_uuid = active_mods_packageid_to_uuid[package_id]
                 temp_mod_set.add(mod_uuid)
+
         # Sort packages in this topological level by name
+        def safe_name(uuid: str) -> str:
+            name = metadata_manager.internal_local_metadata[uuid].get("name")
+            if isinstance(name, str):
+                return name.lower()
+            else:
+                return "name error in mod about.xml"
+
         sorted_temp_mod_set = sorted(
             temp_mod_set,
-            key=lambda uuid: metadata_manager.internal_local_metadata[uuid]["name"],
+            key=safe_name,
             reverse=False,
         )
         # Add into reordered set

--- a/app/utils/metadata.py
+++ b/app/utils/metadata.py
@@ -1751,7 +1751,14 @@ class ModParser(QRunnable):
                                     mod_metadata["packageid"] = potential_packageid
                                     break
                         # Normalize package ID in metadata
-                        mod_metadata["packageid"] = mod_metadata["packageid"].lower()
+                        if isinstance(mod_metadata["packageid"], str):
+                            mod_metadata["packageid"] = mod_metadata[
+                                "packageid"
+                            ].lower()
+                        else:
+                            mod_metadata["packageid"] = (
+                                "packageid error in mod about.xml"
+                            )
                     else:  # ...otherwise, we don't have one from About.xml, and we can check Steam DB...
                         # ...this can be needed if a mod depends on a RW generated packageid via built-in hashing mechanism.
                         if (

--- a/app/views/mod_info_panel.py
+++ b/app/views/mod_info_panel.py
@@ -236,7 +236,11 @@ class ModInfo:
                 widget.style().unpolish(widget)
                 widget.style().polish(widget)
         # Set name value
-        self.mod_info_name_value.setText(mod_info.get("name", "Not specified"))
+        name_value = mod_info.get("name", "Not specified")
+        if isinstance(name_value, dict):
+            # Convert dict to string representation or fallback
+            name_value = str(name_value)
+        self.mod_info_name_value.setText(name_value)
         # Show essential info widgets
         for widget in self.essential_info_widgets:
             if not widget.isVisible():

--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -80,10 +80,13 @@ def uuid_to_mod_name(uuid: str) -> str:
     Args:
         uuid (str): The UUID of the mod.
     Returns:
-        str: If mod name not None, returns mod name in lowercase. Otherwise, returns "# unnamed mod".
+        str: If mod name not None and is a string, returns mod name in lowercase. Otherwise, returns "name error in mod about.xml".
     """
     name = MetadataManager.instance().internal_local_metadata[uuid]["name"]
-    return name.lower() if name is not None else "# unnamed mod"
+    if isinstance(name, str):
+        return name.lower()
+    else:
+        return "name error in mod about.xml"
 
 
 class ModsPanelSortKey(Enum):
@@ -174,10 +177,12 @@ class ModListItemInner(QWidget):
         # in this variable. This is exactly equal to the dict value of a
         # single all_mods key-value
         self.uuid = uuid
-        self.list_item_name = (
-            self.metadata_manager.internal_local_metadata.get(self.uuid, {}).get("name")
-            or "METADATA ERROR"
-        )
+        name_value = self.metadata_manager.internal_local_metadata.get(
+            self.uuid, {}
+        ).get("name")
+        if not isinstance(name_value, str):
+            name_value = "name error in mod about.xml"
+        self.list_item_name = name_value
         self.main_label = QLabel()
 
         # Visuals


### PR DESCRIPTION
Improves the application's robustness by ensuring mod names and package IDs are handled as strings, preventing potential errors during sorting and display.

- Addresses potential crashes and unexpected behavior caused by non-string mod names or package IDs.
- Implements fallback mechanisms to display a generic error message when a mod name or package ID is not a string.
- Normalizes package IDs to lowercase only when they are strings.
- Converts dictionary values for mod names to string representations.