### PR TITLE
Include setup_web_channel_script.js in package

### DIFF
--- a/rimsort.nuitka-package.config.yml
+++ b/rimsort.nuitka-package.config.yml
@@ -11,6 +11,7 @@
     - patterns:
         - "../update.sh"
         - "../update.bat"
+        - "../app/utils/steam/steambrowser/setup_web_channel_script.js"
 
   dlls:
     - from_filenames:


### PR DESCRIPTION
- Ensures the setup script for the web channel is included in the Nuitka package configuration.

- Allows the application to properly configure the web channel when packaged with Nuitka.