### PR TITLE
Centralize pygit2 imports and SSL handling

### DIFF
--- a/app/controllers/main_content_controller.py
+++ b/app/controllers/main_content_controller.py
@@ -1,6 +1,5 @@
 import datetime
 import json
-import os
 import time
 from pathlib import Path
 from typing import List, Optional, cast
@@ -19,7 +18,7 @@ from app.utils.generic import (
     extract_git_dir_name,
     extract_git_user_or_org,
 )
-from app.utils.git_utils import GitOperationConfig
+from app.utils.git_utils import GitOperationConfig, pygit2
 from app.utils.git_worker import (
     GitBatchPushResults,
     GitBatchPushWorker,
@@ -39,21 +38,6 @@ from app.views.dialogue import (
     show_internet_connection_error,
 )
 from app.views.main_content_panel import MainContent
-
-try:
-    import pygit2
-except Exception:
-    import certifi
-
-    os.environ["SSL_CERT_FILE"] = certifi.where()
-    os.environ["SSL_CERT_DIR"] = os.path.dirname(certifi.where())
-    logger.warning("Set SSL certificates using certifi")
-
-    try:
-        import pygit2
-    except Exception as e:
-        logger.error("Failed to import pygit2 after setting SSL certificates. ")
-        raise ImportError("Failed to import pygit2. ") from e
 
 
 class MainContentController(QObject):

--- a/app/utils/git_utils.py
+++ b/app/utils/git_utils.py
@@ -1484,3 +1484,25 @@ def get_repository_latest_commit(
         error_msg = str(e)
         logger.error(f"Error getting latest commit for {repo_path}: {error_msg}")
         return False, None, error_msg
+
+
+__all__ = [
+    "git_check_updates",
+    "git_pull",
+    "git_push",
+    "git_stage_commit",
+    "git_get_status",
+    "git_get_commit_info",
+    "git_cleanup",
+    "git_stash",
+    "git_stash_list",
+    "git_stash_drop",
+    "git_has_uncommitted_changes",
+    "git_is_repository",
+    "git_get_current_branch",
+    "git_get_remote_url",
+    "git_is_clean",
+    "get_latest_commit_info",
+    "get_repository_latest_commit",
+    "pygit2",
+]


### PR DESCRIPTION
Centralized pygit2 import logic with SSL handling in `git_utils.py`.
Removed duplicate try-catch blocks.