### PR TITLE
base_mods_panel: Fix syntax error

### DIFF
--- a/app/windows/base_mods_panel.py
+++ b/app/windows/base_mods_panel.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import Callable, Self, TypeVar
+from typing import Callable, Self, TypeVar, Union
 
 from PySide6.QtCore import QEvent, QObject, Qt
 from PySide6.QtGui import QStandardItem, QStandardItemModel
@@ -192,7 +192,7 @@ class BaseModsPanel(QWidget):
     def _update_mods_from_table(
         self,
         pfid_column: int,
-        mode: str | int,
+        mode: Union[str, int],
         steamworks_cmd: str = "resubscribe",
         completed: Callable[[Self], None] = lambda self: (self.close(), None)[1],
     ) -> None:


### PR DESCRIPTION
Replaced the union type hint str | int with Union[str, int] in the function _update_mods_from_table in app/windows/base_mods_panel.py 
This fix resolves the syntax error that caused the RimSort application to crash.

Fixes
<img width="1604" height="1260" alt="image" src="https://github.com/user-attachments/assets/9cae07e9-07d5-4dd5-87e7-096656efbf73" />

