### PR TITLE
Add optional 'Delete Before Update' checkbox to SteamCMD settings

### DIFF
--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -669,6 +669,9 @@ class SettingsController(QObject):
                 self.settings.current_instance
             ].steamcmd_auto_clear_depot_cache
         )
+        self.settings_dialog.steamcmd_delete_before_update_checkbox.setChecked(
+            self.settings.steamcmd_delete_before_update
+        )
         self.settings_dialog.steamcmd_install_location.setText(
             str(
                 self.settings.instances[
@@ -934,6 +937,9 @@ class SettingsController(QObject):
         # SteamCMD tab
         self.settings.steamcmd_validate_downloads = (
             self.settings_dialog.steamcmd_validate_downloads_checkbox.isChecked()
+        )
+        self.settings.steamcmd_delete_before_update = (
+            self.settings_dialog.steamcmd_delete_before_update_checkbox.isChecked()
         )
         self.settings.instances[
             self.settings.current_instance

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -95,6 +95,7 @@ class Settings(QObject):
 
         # SteamCMD
         self.steamcmd_validate_downloads: bool = True
+        self.steamcmd_delete_before_update: bool = False
 
         # todds
         self.todds_preset: str = "optimized"

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -672,6 +672,14 @@ class SettingsDialog(QDialog):
         )
         group_layout.addWidget(self.steamcmd_auto_clear_depot_cache_checkbox)
 
+        self.steamcmd_delete_before_update_checkbox = QCheckBox(
+            self.tr("Delete before update")
+        )
+        self.steamcmd_delete_before_update_checkbox.setToolTip(
+            self.tr("This is useful if you want to ensure clean mod updates.")
+        )
+        group_layout.addWidget(self.steamcmd_delete_before_update_checkbox)
+
         group_box = QGroupBox()
         tab_layout.addWidget(group_box)
 

--- a/app/windows/base_mods_panel.py
+++ b/app/windows/base_mods_panel.py
@@ -1,3 +1,5 @@
+import os
+import shutil
 from functools import partial
 from typing import Callable, Self, TypeVar, Union
 
@@ -19,6 +21,7 @@ from PySide6.QtWidgets import (
 
 from app.utils.event_bus import EventBus
 from app.utils.metadata import MetadataManager
+from app.utils.mod_utils import get_mod_path_from_pfid
 
 # By default, we assume Stretch for all columns.
 # Tuples should be used if this should be overridden
@@ -50,6 +53,7 @@ class BaseModsPanel(QWidget):
         super().__init__()
         # Utility and Setup
         self.metadata_manager = MetadataManager.instance()
+        self.settings_controller = self.metadata_manager.settings_controller
 
         # Start of UI
         self.installEventFilter(self)
@@ -151,7 +155,7 @@ class BaseModsPanel(QWidget):
 
         # Set the window size
         self.resize(900, 600)
-        
+
     def eventFilter(self, watched: QObject, event: QEvent) -> bool:
         if event.type() == QEvent.Type.KeyPress and event.type() == Qt.Key.Key_Escape:
             self.close()
@@ -211,6 +215,8 @@ class BaseModsPanel(QWidget):
         for publishedfileid, mode in pfids:
             if mode == "SteamCMD":
                 steamcmd_publishedfileids.append(publishedfileid)
+                # Call to delete selected mods before update
+                self._delete_selected_mods(pfid_column, mode)
             elif mode == "Steam":
                 steam_publishedfileids.append(publishedfileid)
 
@@ -268,3 +274,26 @@ class BaseModsPanel(QWidget):
                 return combo_box.currentText()
 
         return __selected_text_by_column
+
+    def _delete_selected_mods(self, pfid_column: int, mode: str | int) -> None:
+        delete_before_update_state = (
+            self.settings_controller.settings.steamcmd_delete_before_update
+        )
+        if delete_before_update_state:
+            pfid_fn = self._get_selected_text_by_column(pfid_column)
+            mode_fn = (
+                self._get_selected_text_by_column(mode)
+                if isinstance(mode, int)
+                else lambda _: mode
+            )
+            pfid_mode_pairs = self._run_for_selected_rows(
+                lambda row: (pfid_fn(row), mode_fn(row))
+            )
+            for pfid, mod_mode in pfid_mode_pairs:
+                if mod_mode == "SteamCMD":
+                    mod_path = get_mod_path_from_pfid(pfid)
+                    if mod_path and os.path.exists(mod_path):
+                        try:
+                            shutil.rmtree(mod_path)
+                        except Exception as e:
+                            print(f"Error deleting mod directory {mod_path}: {e}")

--- a/app/windows/rule_editor_panel.py
+++ b/app/windows/rule_editor_panel.py
@@ -568,7 +568,7 @@ class RuleEditor(QWidget):
         # Setup the window
         self.setWindowTitle("RimSort - Rule Editor")
         self.setLayout(layout)
-         # Set the window size
+        # Set the window size
         self.resize(900, 600)
 
     def createDropEvent(


### PR DESCRIPTION
Introduces a new checkbox in the SteamCMD settings allowing users to optionally delete mods before updating them. This ensures clean mod updates by removing old files prior to applying updates.
This feature is off by default and can be enabled in the settings