### PR TITLE
Fix: After an update, restart when the OS is in French/German

### DIFF
--- a/update.bat
+++ b/update.bat
@@ -112,7 +112,7 @@ rd /s /q "%update_source_folder%" 2>nul
 REM Launch updated RimSort
 echo.
 echo Launching RimSort in 5 seconds. Press any key to cancel.
-choice /t 5 /d y /n >nul
+choice /c YN /d Y /t 5 /n >nul
 if errorlevel 2 (
     echo Launch cancelled by user.
     pause


### PR DESCRIPTION
Only the first `choice` was updated in the pull request #1033 . This commit updates the second, for automatic restart for french/german.

Problem adressed by @koko1ooo : https://github.com/RimSort/RimSort/issues/1051#issuecomment-3097273869
Pull request suggested by @LionelColaso : https://github.com/RimSort/RimSort/issues/1051#issuecomment-3097279270

Oddly, only the first `choice` was fixed in a pull request, but not the second. The program is updated automatically, but it doesn't restart automatically. This error only occurs when the OS language is not English, but French or German. The second `choice` is updated to include the improvements made to the first `choice`.