### PR TITLE
Add support for "loadTop" mod loading rule in rule_editor, metadata and sorting

### DIFF
--- a/app/sort/dependencies.py
+++ b/app/sort/dependencies.py
@@ -81,6 +81,7 @@ def gen_tier_one_deps_graph(
     # TODO: pull from a config
 
     logger.info("Generating dependencies graph for tier one mods")
+    metadata_manager = MetadataManager.instance()
     known_tier_one_mods = {
         "zetrith.prepatcher",
         "brrainz.harmony",
@@ -92,6 +93,12 @@ def gen_tier_one_deps_graph(
         "ludeon.rimworld.odyssey",
         "unlimitedhugs.hugslib",
     }
+    # Add mods with loadTop set to True to known_tier_one_mods
+    for uuid in metadata_manager.internal_local_metadata:
+        if metadata_manager.internal_local_metadata[uuid].get("loadTop"):
+            known_tier_one_mods.add(
+                metadata_manager.internal_local_metadata[uuid]["packageid"]
+            )
     # Bug fix: if there are circular dependencies in tier one mods
     # then an infinite loop happens here unless we keep track of what has
     # already been processed.

--- a/app/utils/constants.py
+++ b/app/utils/constants.py
@@ -17,6 +17,7 @@ DB_BUILDER_RECURSE_EXCEPTIONS = [
     "incompatibleWith",
     "loadBefore",
     "loadAfter",
+    "loadTop",
     "loadBottom",
 ]
 MOD_RECURSE_EXCEPTIONS = [

--- a/app/utils/metadata.py
+++ b/app/utils/metadata.py
@@ -1094,6 +1094,15 @@ class MetadataManager(QObject):
                                     incompatibilities,
                                     self.internal_local_metadata,
                                 )
+                    load_this_top = self.external_community_rules[package_id].get(
+                        "loadTop"
+                    )
+                    if load_this_top:
+                        logger.debug(
+                            "Current mod should load at the top of a mods list, and will be considered a 'tier 1' mod"
+                        )
+                        for uuid in potential_uuids:
+                            self.internal_local_metadata[uuid]["loadTop"] = True
                     load_this_bottom = self.external_community_rules[package_id].get(
                         "loadBottom"
                     )
@@ -1177,6 +1186,13 @@ class MetadataManager(QObject):
                                     incompatibilities,
                                     self.internal_local_metadata,
                                 )
+                    load_this_top = self.external_user_rules[package_id].get("loadTop")
+                    if load_this_top:
+                        logger.debug(
+                            "Current mod should load at the top of a mods list, and will be considered a 'tier 1' mod"
+                        )
+                        for uuid in potential_uuids:
+                            self.internal_local_metadata[uuid]["loadTop"] = True
                     load_this_bottom = self.external_user_rules[package_id].get(
                         "loadBottom"
                     )


### PR DESCRIPTION
1. Add "loadTop" to mod loading exceptions in constants.py
2. Update MetadataManager to set "loadTop" flag from community and user rules
3. Modify dependencies graph generation to include "loadTop" mods as tier one mods
4. Extend RuleEditorPanel UI with checkbox and logic to toggle "loadTop" rule