### PR TITLE
Centralize Known Tier One Mods Set

### DIFF
--- a/app/sort/dependencies.py
+++ b/app/sort/dependencies.py
@@ -1,5 +1,6 @@
 from loguru import logger
 
+from app.utils.constants import KNOWN_TIER_ONE_MODS
 from app.utils.metadata import MetadataManager
 
 
@@ -82,17 +83,7 @@ def gen_tier_one_deps_graph(
 
     logger.info("Generating dependencies graph for tier one mods")
     metadata_manager = MetadataManager.instance()
-    known_tier_one_mods = {
-        "zetrith.prepatcher",
-        "brrainz.harmony",
-        "ludeon.rimworld",
-        "ludeon.rimworld.royalty",
-        "ludeon.rimworld.ideology",
-        "ludeon.rimworld.biotech",
-        "ludeon.rimworld.anomaly",
-        "ludeon.rimworld.odyssey",
-        "unlimitedhugs.hugslib",
-    }
+    known_tier_one_mods = KNOWN_TIER_ONE_MODS
     # Add mods with loadTop set to True to known_tier_one_mods
     for uuid in metadata_manager.internal_local_metadata:
         if metadata_manager.internal_local_metadata[uuid].get("loadTop"):

--- a/app/utils/constants.py
+++ b/app/utils/constants.py
@@ -80,3 +80,14 @@ KNOWN_MOD_REPLACEMENTS = {
     "brrainz.harmony": {"zetrith.prepatcher"},
     "aoba.motorization.engine": {"rimthunder.core"},
 }
+KNOWN_TIER_ONE_MODS = {
+    "zetrith.prepatcher",
+    "brrainz.harmony",
+    "ludeon.rimworld",
+    "ludeon.rimworld.royalty",
+    "ludeon.rimworld.ideology",
+    "ludeon.rimworld.biotech",
+    "ludeon.rimworld.anomaly",
+    "ludeon.rimworld.odyssey",
+    "unlimitedhugs.hugslib",
+}


### PR DESCRIPTION
1. Moved the known tier one mods set to a dedicated constant in app/utils/constants.py for better maintainability.
2. Updated app/sort/dependencies.py to use the centralized known tier one mods constant.
3. This change improves the modularity and extensibility of tier one mod handling in the dependency graph generation.