### PR TITLE
feat: prompt restart on language change in settings

### DIFF
--- a/app/controllers/language_controller.py
+++ b/app/controllers/language_controller.py
@@ -101,7 +101,6 @@ class LanguageController:
             settings.save()
 
             answer = dialogue.show_dialogue_conditional(
-                # title=QCoreApplication.translate("LanguageController", "Language Changed"),
                 title=self.tr("Language Changed"),
                 text=self.tr("The language has been updated."),
                 information=self.tr(

--- a/app/utils/generic.py
+++ b/app/utils/generic.py
@@ -18,6 +18,7 @@ from pyperclip import (  # type: ignore # Stubs don't exist for pyperclip
     copy as copy_to_clipboard,
 )
 from PySide6.QtCore import QCoreApplication
+from PySide6.QtWidgets import QApplication
 
 import app.views.dialogue as dialogue
 
@@ -550,3 +551,19 @@ def check_internet_connection(
         logger.warning(f"Curl command to www.microsoft.com failed: {e}")
 
     return False
+
+def restart_application() -> None:
+    if getattr(sys, 'frozen', False):
+        cmd = [sys.executable] + sys.argv[1:]
+    else:
+        cmd = [sys.executable] + sys.argv
+
+    subprocess.Popen(cmd)
+
+    instance = QApplication.instance()
+    if instance:
+        logger.info("Restarting the application")
+        instance.quit()
+    else:
+        logger.warning("No QApplication instance found, cannot restart the application")
+        


### PR DESCRIPTION
This patch introduces functionality to prompt the user to restart the application after changing the language from the settings dialog.
When the user selects a new language, it saves the setting and prompts for application restart.
Implemented a generic `restart_application()` utility in `generic.py`.
Closed #1102 