### PR TITLE
Fix: Show real updated time of expired Steam DB

### DIFF
--- a/app/utils/metadata.py
+++ b/app/utils/metadata.py
@@ -210,7 +210,7 @@ class MetadataManager(QObject):
                             ).format(
                                 last_updated=strftime(
                                     "%Y-%m-%d %H:%M:%S",
-                                    localtime(db_data["version"] - life),
+                                    localtime(db_time),
                                 )
                             ),
                             "",


### PR DESCRIPTION
The last update is already what's stored in the file, there is no need to subtract the lifetime.