### PR TITLE
Add ClickablePathLabel for Opening Mod Folder from Mod Info Panel

### DIFF
--- a/app/views/mod_info_panel.py
+++ b/app/views/mod_info_panel.py
@@ -5,7 +5,14 @@ from re import match
 from loguru import logger
 from PySide6.QtCore import QCoreApplication, Qt
 from PySide6.QtGui import QMouseEvent, QPixmap
-from PySide6.QtWidgets import QFrame, QHBoxLayout, QLabel, QSizePolicy, QVBoxLayout
+from PySide6.QtWidgets import (
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QSizePolicy,
+    QVBoxLayout,
+    QWidget,
+)
 
 from app.models.image_label import ImageLabel
 from app.utils.app_info import AppInfo
@@ -20,25 +27,25 @@ class ClickablePathLabel(QLabel):
     Inherits text color from the application's theme system.
     """
 
-    def __init__(self, parent=None):
+    def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self.clickable = True
         self.setCursor(Qt.CursorShape.PointingHandCursor)
         self.setStyleSheet("text-decoration: underline;")
         self.path = ""
 
-    def setPath(self, path: str):
+    def setPath(self, path: str | None) -> None:
         """Set the path and update the display text."""
-        self.path = path
         if path:
-            self.setText(f"{path}")
+            self.path = path
+            self.setText(path)
             self.setToolTip(f"Click to open folder: {path}")
         else:
+            self.path = ""
             self.setText("")
             self.setToolTip("")
-            self.path = ""
 
-    def setClickable(self, clickable: bool):
+    def setClickable(self, clickable: bool) -> None:
         """Set whether the label is clickable, updating cursor accordingly."""
         self.clickable = clickable
         if clickable:
@@ -46,14 +53,17 @@ class ClickablePathLabel(QLabel):
         else:
             self.setCursor(Qt.CursorShape.ArrowCursor)
 
-    def mousePressEvent(self, event: QMouseEvent):
+    def mousePressEvent(self, event: QMouseEvent) -> None:
         """Handle mouse click to open the folder if clickable."""
         if event.button() == Qt.MouseButton.LeftButton and self.path and self.clickable:
             try:
                 path_obj = Path(self.path)
                 if path_obj.exists():
-                    platform_specific_open(self.path)
-                    logger.info(f"Opening mod folder: {self.path}")
+                    if path_obj.is_dir():
+                        platform_specific_open(self.path)
+                        logger.info(f"Opening mod folder: {self.path}")
+                    else:
+                        logger.warning(f"Path is not a directory: {self.path}")
                 else:
                     logger.warning(f"Mod folder does not exist: {self.path}")
             except Exception as e:

--- a/app/views/mod_info_panel.py
+++ b/app/views/mod_info_panel.py
@@ -4,14 +4,61 @@ from re import match
 
 from loguru import logger
 from PySide6.QtCore import QCoreApplication, Qt
-from PySide6.QtGui import QPixmap
+from PySide6.QtGui import QMouseEvent, QPixmap
 from PySide6.QtWidgets import QFrame, QHBoxLayout, QLabel, QSizePolicy, QVBoxLayout
 
 from app.models.image_label import ImageLabel
 from app.utils.app_info import AppInfo
+from app.utils.generic import platform_specific_open
 from app.utils.metadata import MetadataManager
 from app.views.description_widget import DescriptionWidget
 
+
+class ClickablePathLabel(QLabel):
+    """
+    A clickable QLabel that opens the folder in the file manager when clicked.
+    Inherits text color from the application's theme system.
+    """
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.clickable = True
+        self.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.setStyleSheet("text-decoration: underline;")
+        self.path = ""
+
+    def setPath(self, path: str):
+        """Set the path and update the display text."""
+        self.path = path
+        if path:
+            self.setText(f"{path}")
+            self.setToolTip(f"Click to open folder: {path}")
+        else:
+            self.setText("")
+            self.setToolTip("")
+            self.path = ""
+
+    def setClickable(self, clickable: bool):
+        """Set whether the label is clickable, updating cursor accordingly."""
+        self.clickable = clickable
+        if clickable:
+            self.setCursor(Qt.CursorShape.PointingHandCursor)
+        else:
+            self.setCursor(Qt.CursorShape.ArrowCursor)
+
+    def mousePressEvent(self, event: QMouseEvent):
+        """Handle mouse click to open the folder if clickable."""
+        if event.button() == Qt.MouseButton.LeftButton and self.path and self.clickable:
+            try:
+                path_obj = Path(self.path)
+                if path_obj.exists():
+                    platform_specific_open(self.path)
+                    logger.info(f"Opening mod folder: {self.path}")
+                else:
+                    logger.warning(f"Mod folder does not exist: {self.path}")
+            except Exception as e:
+                logger.error(f"Failed to open mod folder {self.path}: {e}")
+        super().mousePressEvent(event)
 
 class ModInfo:
     """
@@ -122,7 +169,7 @@ class ModInfo:
         self.mod_info_supported_versions_value.setObjectName("summaryValue")
         self.mod_info_path_label = QLabel(self.tr("Path:"))
         self.mod_info_path_label.setObjectName("summaryLabel")
-        self.mod_info_path_value = QLabel()
+        self.mod_info_path_value = ClickablePathLabel()
         self.mod_info_path_value.setObjectName("summaryValue")
         self.mod_info_path_value.setTextInteractionFlags(
             Qt.TextInteractionFlag.TextSelectableByMouse
@@ -215,24 +262,28 @@ class ModInfo:
             # Set invalid value style
             for widget in (
                 self.mod_info_name_value,
-                self.mod_info_path_value,
                 self.mod_info_author_value,
                 self.mod_info_package_id_value,
             ):
                 widget.setObjectName("summaryValueInvalid")
                 widget.style().unpolish(widget)
                 widget.style().polish(widget)
+            # Set invalid path style (red color, no clickable styling)
+            self.mod_info_path_value.setStyleSheet("color: #cc0000; text-decoration: none;")
+            self.mod_info_path_value.setClickable(False)
         else:
             # Set valid value style
             for widget in (
                 self.mod_info_name_value,
-                self.mod_info_path_value,
                 self.mod_info_author_value,
                 self.mod_info_package_id_value,
             ):
                 widget.setObjectName("summaryValue")
                 widget.style().unpolish(widget)
                 widget.style().polish(widget)
+            # Set valid path style (inherits theme color, clickable styling)
+            self.mod_info_path_value.setStyleSheet("text-decoration: underline;")
+            self.mod_info_path_value.setClickable(True)
         # Set name value
         name_value = mod_info.get("name", "Not specified")
         if isinstance(name_value, dict):
@@ -307,7 +358,7 @@ class ModInfo:
             for widget in self.base_mod_info_widgets + self.scenario_info_widgets:
                 widget.hide()
 
-        self.mod_info_path_value.setText(mod_info.get("path"))
+        self.mod_info_path_value.setPath(mod_info.get("path"))
         # Set the scrolling description for the Mod Info Panel
         self.description.setText("")
         if "description" in mod_info:

--- a/tests/views/test_mod_info_panel.py
+++ b/tests/views/test_mod_info_panel.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Tuple
 from unittest.mock import MagicMock
 
 import pytest
@@ -9,12 +9,25 @@ from app.views.mod_info_panel import ClickablePathLabel
 
 @pytest.fixture
 def label(qtbot: Any) -> ClickablePathLabel:
+    """Create a ClickablePathLabel instance for testing.
+    
+    Args:
+        qtbot: Pytest-Qt bot for widget testing.
+        
+    Returns:
+        ClickablePathLabel: A configured label instance for testing.
+    """
     lbl = ClickablePathLabel()
     qtbot.addWidget(lbl)
     return lbl
 
 
 def test_initialization(label: ClickablePathLabel) -> None:
+    """Test that ClickablePathLabel initializes with correct default values.
+    
+    Args:
+        label: The ClickablePathLabel instance to test.
+    """
     assert label.clickable is True
     assert label.cursor().shape() == Qt.CursorShape.PointingHandCursor
     assert label.styleSheet() == "text-decoration: underline;"
@@ -24,6 +37,11 @@ def test_initialization(label: ClickablePathLabel) -> None:
 
 
 def test_set_path(label: ClickablePathLabel) -> None:
+    """Test setting and clearing the path property.
+    
+    Args:
+        label: The ClickablePathLabel instance to test.
+    """
     test_path = "/test/path"
     label.setPath(test_path)
     assert label.path == test_path
@@ -42,6 +60,11 @@ def test_set_path(label: ClickablePathLabel) -> None:
 
 
 def test_set_clickable(label: ClickablePathLabel) -> None:
+    """Test enabling and disabling clickable behavior.
+    
+    Args:
+        label: The ClickablePathLabel instance to test.
+    """
     label.setClickable(False)
     assert label.clickable is False
     assert label.cursor().shape() == Qt.CursorShape.ArrowCursor
@@ -51,122 +74,128 @@ def test_set_clickable(label: ClickablePathLabel) -> None:
     assert label.cursor().shape() == Qt.CursorShape.PointingHandCursor
 
 
-def test_mouse_press_event_open_folder(label: ClickablePathLabel, monkeypatch: Any, qtbot: Any) -> None:
-    test_path = "/test/path"
-    label.setPath(test_path)
-
+@pytest.fixture
+def mocked_env(monkeypatch: Any) -> Tuple[MagicMock, MagicMock, MagicMock]:
+    """Create mocked environment for path-related tests.
+    
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+        
+    Returns:
+        Tuple containing mocked Path, platform_specific_open, and logger objects.
+    """
     mock_path = MagicMock()
-    mock_path.exists.return_value = True
-    mock_path.is_dir.return_value = True
     monkeypatch.setattr("app.views.mod_info_panel.Path", lambda p: mock_path)
-
     mock_open = MagicMock()
     monkeypatch.setattr("app.views.mod_info_panel.platform_specific_open", mock_open)
-
     mock_logger = MagicMock()
     monkeypatch.setattr("app.views.mod_info_panel.logger", mock_logger)
-
-    # Simulate left mouse click via pytest-qt
-    qtbot.mouseClick(label, Qt.MouseButton.LeftButton)
-
-    mock_open.assert_called_once_with(test_path)
-    mock_logger.info.assert_called_once_with(f"Opening mod folder: {test_path}")
+    return mock_path, mock_open, mock_logger
 
 
-def test_mouse_press_event_folder_not_exist(label: ClickablePathLabel, monkeypatch: Any, qtbot: Any) -> None:
+@pytest.mark.parametrize(
+    "exists_return, is_dir_return, exists_side_effect, expected_open, expected_log_level, expected_log_msg",
+    [
+        (True, True, None, "/test/path", "info", "Opening mod folder: /test/path"),
+        (False, None, None, None, "warning", "Mod folder does not exist: /test/path"),
+        (True, False, None, None, "warning", "Path is not a directory: /test/path"),
+        (None, None, Exception("Test exception"), None, "error", "Failed to open mod folder /test/path: Test exception"),
+    ]
+)
+def test_mouse_press_path_scenarios(
+    label: ClickablePathLabel,
+    mocked_env: Tuple[MagicMock, MagicMock, MagicMock],
+    qtbot: Any,
+    exists_return: Any,
+    is_dir_return: Any,
+    exists_side_effect: Any,
+    expected_open: Any,
+    expected_log_level: Any,
+    expected_log_msg: Any,
+) -> None:
+    """Test various path scenarios when clicking the label.
+    
+    This test covers different path validation scenarios:
+    - Valid directory path (should open folder)
+    - Non-existent path (should log warning)
+    - File path instead of directory (should log warning)
+    - Exception during path validation (should log error)
+    
+    Args:
+        label: The ClickablePathLabel instance to test.
+        mocked_env: Tuple of mocked objects (path, open, logger).
+        qtbot: Pytest-Qt bot for widget testing.
+        exists_return: Return value for Path.exists().
+        is_dir_return: Return value for Path.is_dir().
+        exists_side_effect: Side effect for Path.exists() (for exceptions).
+        expected_open: Expected path to be opened, or None if no open expected.
+        expected_log_level: Expected log level (info, warning, error).
+        expected_log_msg: Expected log message.
+    """
+    mock_path, mock_open, mock_logger = mocked_env
     test_path = "/test/path"
     label.setPath(test_path)
-
-    mock_path = MagicMock()
-    mock_path.exists.return_value = False
-    monkeypatch.setattr("app.views.mod_info_panel.Path", lambda p: mock_path)
-
-    mock_open = MagicMock()
-    monkeypatch.setattr("app.views.mod_info_panel.platform_specific_open", mock_open)
-
-    mock_logger = MagicMock()
-    monkeypatch.setattr("app.views.mod_info_panel.logger", mock_logger)
-
-    # Simulate left mouse click via pytest-qt
+    
+    # Configure mock behavior based on test parameters
+    if exists_return is not None:
+        mock_path.exists.return_value = exists_return
+    if is_dir_return is not None:
+        mock_path.is_dir.return_value = is_dir_return
+    if exists_side_effect is not None:
+        mock_path.exists.side_effect = exists_side_effect
+    
+    # Simulate left mouse click
     qtbot.mouseClick(label, Qt.MouseButton.LeftButton)
-
-    mock_open.assert_not_called()
-    mock_logger.warning.assert_called_once_with(f"Mod folder does not exist: {test_path}")
-
-
-def test_mouse_press_event_not_folder(label: ClickablePathLabel, monkeypatch: Any, qtbot: Any) -> None:
-    test_path = "/test/file.txt"
-    label.setPath(test_path)
-
-    mock_path = MagicMock()
-    mock_path.exists.return_value = True
-    mock_path.is_dir.return_value = False
-    monkeypatch.setattr("app.views.mod_info_panel.Path", lambda p: mock_path)
-
-    mock_open = MagicMock()
-    monkeypatch.setattr("app.views.mod_info_panel.platform_specific_open", mock_open)
-
-    mock_logger = MagicMock()
-    monkeypatch.setattr("app.views.mod_info_panel.logger", mock_logger)
-
-    # Simulate left mouse click via pytest-qt
-    qtbot.mouseClick(label, Qt.MouseButton.LeftButton)
-
-    mock_open.assert_not_called()
-    mock_logger.warning.assert_called_once_with(f"Path is not a directory: {test_path}")
+    
+    # Verify expected behavior
+    if expected_open:
+        mock_open.assert_called_once_with(expected_open)
+    else:
+        mock_open.assert_not_called()
+    if expected_log_level:
+        getattr(mock_logger, expected_log_level).assert_called_once_with(expected_log_msg)
 
 
-def test_mouse_press_event_exception(label: ClickablePathLabel, monkeypatch: Any, qtbot: Any) -> None:
+def test_mouse_press_event_not_left_button(label: ClickablePathLabel, mocked_env: Tuple[MagicMock, MagicMock, MagicMock], qtbot: Any) -> None:
+    """Test that right mouse button clicks are ignored.
+    
+    Args:
+        label: The ClickablePathLabel instance to test.
+        mocked_env: Tuple of mocked objects (path, open, logger).
+        qtbot: Pytest-Qt bot for widget testing.
+    """
+    _, mock_open, _ = mocked_env
     test_path = "/test/path"
     label.setPath(test_path)
-
-    mock_path = MagicMock()
-    mock_path.exists.side_effect = Exception("Test exception")
-    monkeypatch.setattr("app.views.mod_info_panel.Path", lambda p: mock_path)
-
-    mock_logger = MagicMock()
-    monkeypatch.setattr("app.views.mod_info_panel.logger", mock_logger)
-
-    # Simulate left mouse click via pytest-qt
-    qtbot.mouseClick(label, Qt.MouseButton.LeftButton)
-
-    mock_logger.error.assert_called_once_with(f"Failed to open mod folder {test_path}: Test exception")
-
-
-def test_mouse_press_event_not_left_button(label: ClickablePathLabel, monkeypatch: Any, qtbot: Any) -> None:
-    test_path = "/test/path"
-    label.setPath(test_path)
-
-    mock_open = MagicMock()
-    monkeypatch.setattr("app.views.mod_info_panel.platform_specific_open", mock_open)
-
-    # Simulate right mouse click via pytest-qt
     qtbot.mouseClick(label, Qt.MouseButton.RightButton)
-
     mock_open.assert_not_called()
 
 
-def test_mouse_press_event_not_clickable(label: ClickablePathLabel, monkeypatch: Any, qtbot: Any) -> None:
+def test_mouse_press_event_not_clickable(label: ClickablePathLabel, mocked_env: Tuple[MagicMock, MagicMock, MagicMock], qtbot: Any) -> None:
+    """Test that clicks are ignored when label is not clickable.
+    
+    Args:
+        label: The ClickablePathLabel instance to test.
+        mocked_env: Tuple of mocked objects (path, open, logger).
+        qtbot: Pytest-Qt bot for widget testing.
+    """
+    _, mock_open, _ = mocked_env
     test_path = "/test/path"
     label.setPath(test_path)
     label.setClickable(False)
-
-    mock_open = MagicMock()
-    monkeypatch.setattr("app.views.mod_info_panel.platform_specific_open", mock_open)
-
-    # Simulate left mouse click via pytest-qt
     qtbot.mouseClick(label, Qt.MouseButton.LeftButton)
-
     mock_open.assert_not_called()
 
 
-def test_mouse_press_event_no_path(label: ClickablePathLabel, monkeypatch: Any, qtbot: Any) -> None:
+def test_mouse_press_event_no_path(label: ClickablePathLabel, mocked_env: Tuple[MagicMock, MagicMock, MagicMock], qtbot: Any) -> None:
+    """Test that clicks are ignored when no path is set.
+    
+    Args:
+        label: The ClickablePathLabel instance to test.
+        mocked_env: Tuple of mocked objects (path, open, logger).
+        qtbot: Pytest-Qt bot for widget testing.
+    """
+    _, mock_open, _ = mocked_env
     label.setPath("")
-
-    mock_open = MagicMock()
-    monkeypatch.setattr("app.views.mod_info_panel.platform_specific_open", mock_open)
-
-    # Simulate left mouse click via pytest-qt
     qtbot.mouseClick(label, Qt.MouseButton.LeftButton)
-
     mock_open.assert_not_called() 

--- a/tests/views/test_mod_info_panel.py
+++ b/tests/views/test_mod_info_panel.py
@@ -1,4 +1,3 @@
-# jscpd:ignore-file
 from typing import Any
 from unittest.mock import MagicMock
 

--- a/tests/views/test_mod_info_panel.py
+++ b/tests/views/test_mod_info_panel.py
@@ -1,3 +1,4 @@
+# jscpd:ignore-file
 from typing import Any
 from unittest.mock import MagicMock
 

--- a/tests/views/test_mod_info_panel.py
+++ b/tests/views/test_mod_info_panel.py
@@ -1,0 +1,172 @@
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from PySide6.QtCore import Qt
+
+from app.views.mod_info_panel import ClickablePathLabel
+
+
+@pytest.fixture
+def label(qtbot: Any) -> ClickablePathLabel:
+    lbl = ClickablePathLabel()
+    qtbot.addWidget(lbl)
+    return lbl
+
+
+def test_initialization(label: ClickablePathLabel) -> None:
+    assert label.clickable is True
+    assert label.cursor().shape() == Qt.CursorShape.PointingHandCursor
+    assert label.styleSheet() == "text-decoration: underline;"
+    assert label.path == ""
+    assert label.text() == ""
+    assert label.toolTip() == ""
+
+
+def test_set_path(label: ClickablePathLabel) -> None:
+    test_path = "/test/path"
+    label.setPath(test_path)
+    assert label.path == test_path
+    assert label.text() == test_path
+    assert label.toolTip() == f"Click to open folder: {test_path}"
+
+    label.setPath("")
+    assert label.path == ""
+    assert label.text() == ""
+    assert label.toolTip() == ""
+
+    label.setPath(None)
+    assert label.path == ""
+    assert label.text() == ""
+    assert label.toolTip() == ""
+
+
+def test_set_clickable(label: ClickablePathLabel) -> None:
+    label.setClickable(False)
+    assert label.clickable is False
+    assert label.cursor().shape() == Qt.CursorShape.ArrowCursor
+
+    label.setClickable(True)
+    assert label.clickable is True
+    assert label.cursor().shape() == Qt.CursorShape.PointingHandCursor
+
+
+def test_mouse_press_event_open_folder(label: ClickablePathLabel, monkeypatch: Any, qtbot: Any) -> None:
+    test_path = "/test/path"
+    label.setPath(test_path)
+
+    mock_path = MagicMock()
+    mock_path.exists.return_value = True
+    mock_path.is_dir.return_value = True
+    monkeypatch.setattr("app.views.mod_info_panel.Path", lambda p: mock_path)
+
+    mock_open = MagicMock()
+    monkeypatch.setattr("app.views.mod_info_panel.platform_specific_open", mock_open)
+
+    mock_logger = MagicMock()
+    monkeypatch.setattr("app.views.mod_info_panel.logger", mock_logger)
+
+    # Simulate left mouse click via pytest-qt
+    qtbot.mouseClick(label, Qt.MouseButton.LeftButton)
+
+    mock_open.assert_called_once_with(test_path)
+    mock_logger.info.assert_called_once_with(f"Opening mod folder: {test_path}")
+
+
+def test_mouse_press_event_folder_not_exist(label: ClickablePathLabel, monkeypatch: Any, qtbot: Any) -> None:
+    test_path = "/test/path"
+    label.setPath(test_path)
+
+    mock_path = MagicMock()
+    mock_path.exists.return_value = False
+    monkeypatch.setattr("app.views.mod_info_panel.Path", lambda p: mock_path)
+
+    mock_open = MagicMock()
+    monkeypatch.setattr("app.views.mod_info_panel.platform_specific_open", mock_open)
+
+    mock_logger = MagicMock()
+    monkeypatch.setattr("app.views.mod_info_panel.logger", mock_logger)
+
+    # Simulate left mouse click via pytest-qt
+    qtbot.mouseClick(label, Qt.MouseButton.LeftButton)
+
+    mock_open.assert_not_called()
+    mock_logger.warning.assert_called_once_with(f"Mod folder does not exist: {test_path}")
+
+
+def test_mouse_press_event_not_folder(label: ClickablePathLabel, monkeypatch: Any, qtbot: Any) -> None:
+    test_path = "/test/file.txt"
+    label.setPath(test_path)
+
+    mock_path = MagicMock()
+    mock_path.exists.return_value = True
+    mock_path.is_dir.return_value = False
+    monkeypatch.setattr("app.views.mod_info_panel.Path", lambda p: mock_path)
+
+    mock_open = MagicMock()
+    monkeypatch.setattr("app.views.mod_info_panel.platform_specific_open", mock_open)
+
+    mock_logger = MagicMock()
+    monkeypatch.setattr("app.views.mod_info_panel.logger", mock_logger)
+
+    # Simulate left mouse click via pytest-qt
+    qtbot.mouseClick(label, Qt.MouseButton.LeftButton)
+
+    mock_open.assert_not_called()
+    mock_logger.warning.assert_called_once_with(f"Path is not a directory: {test_path}")
+
+
+def test_mouse_press_event_exception(label: ClickablePathLabel, monkeypatch: Any, qtbot: Any) -> None:
+    test_path = "/test/path"
+    label.setPath(test_path)
+
+    mock_path = MagicMock()
+    mock_path.exists.side_effect = Exception("Test exception")
+    monkeypatch.setattr("app.views.mod_info_panel.Path", lambda p: mock_path)
+
+    mock_logger = MagicMock()
+    monkeypatch.setattr("app.views.mod_info_panel.logger", mock_logger)
+
+    # Simulate left mouse click via pytest-qt
+    qtbot.mouseClick(label, Qt.MouseButton.LeftButton)
+
+    mock_logger.error.assert_called_once_with(f"Failed to open mod folder {test_path}: Test exception")
+
+
+def test_mouse_press_event_not_left_button(label: ClickablePathLabel, monkeypatch: Any, qtbot: Any) -> None:
+    test_path = "/test/path"
+    label.setPath(test_path)
+
+    mock_open = MagicMock()
+    monkeypatch.setattr("app.views.mod_info_panel.platform_specific_open", mock_open)
+
+    # Simulate right mouse click via pytest-qt
+    qtbot.mouseClick(label, Qt.MouseButton.RightButton)
+
+    mock_open.assert_not_called()
+
+
+def test_mouse_press_event_not_clickable(label: ClickablePathLabel, monkeypatch: Any, qtbot: Any) -> None:
+    test_path = "/test/path"
+    label.setPath(test_path)
+    label.setClickable(False)
+
+    mock_open = MagicMock()
+    monkeypatch.setattr("app.views.mod_info_panel.platform_specific_open", mock_open)
+
+    # Simulate left mouse click via pytest-qt
+    qtbot.mouseClick(label, Qt.MouseButton.LeftButton)
+
+    mock_open.assert_not_called()
+
+
+def test_mouse_press_event_no_path(label: ClickablePathLabel, monkeypatch: Any, qtbot: Any) -> None:
+    label.setPath("")
+
+    mock_open = MagicMock()
+    monkeypatch.setattr("app.views.mod_info_panel.platform_specific_open", mock_open)
+
+    # Simulate left mouse click via pytest-qt
+    qtbot.mouseClick(label, Qt.MouseButton.LeftButton)
+
+    mock_open.assert_not_called() 


### PR DESCRIPTION
### Summary

This PR introduces a new `ClickablePathLabel` class to enhance the Mod Info Panel with clickable folder paths. When the displayed path is valid and clickable, clicking it opens the corresponding folder in the system's file manager. This improves the user experience by providing direct access to mod directories.

<img width="590" height="116" src="https://github.com/user-attachments/assets/48a1e3d7-6a89-452d-b6d4-6d879adc5faa" />

### Key Changes

- Added `ClickablePathLabel`, a subclass of `QLabel`, which:
  - Displays the mod path with underline styling.
  - Opens the directory on left mouse click if the path is valid.
  - Adjusts its interactivity and cursor depending on validity.
- Replaced `QLabel` with `ClickablePathLabel` in `ModInfo` for displaying mod path.
- Adjusted style and clickability dynamically based on mod validity.
- Introduced a comprehensive test suite in `tests/views/test_mod_info_panel.py` covering:
  - Initialization
  - Path setting
  - Click handling under various conditions (non-existent path, not a folder, exceptions, etc.)
