### PR TITLE
Fix relative links in FAQ documentation

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -26,7 +26,7 @@ Unfortunately, because RimSort is compiled Python, it has a tendency to trigger 
 
 For **_windows defender (WD)_** specifically, we tend to try and send samples to Microsoft to whitelist the RimSort release if there are any false detections. This process can still take at least a full day, and needs to be repeated every release. Thus, if WD is false flagging RimSort, we still appreciate a quick report, but it should be safe to override WD. 
 
-For **_macOS_,** we'd require a similar yet separate yearly fee to sign apps on macOS. Mac users can, for now, use [this workaround](https://github.com/RimSort/RimSort/wiki/User-Guide#macos). There is no solution for us on macOS other than paying Apple.
+For **_macOS_,** we'd require a similar yet separate yearly fee to sign apps on macOS. Mac users can, for now, use [this workaround](./user-guide/downloading-and-installing#macos). There is no solution for us on macOS other than paying Apple.
 
 ## Where are game paths located?
 
@@ -38,11 +38,11 @@ Game paths and other location settings are located in the settings panel under `
 
 ## What is the Steam Workshop Database used for?
 
-RimSort uses the Steam Workshop Database (Steam DB) for loading mod dependency data that is only available on Steam (the "required items" section). While modders should strive to specify this data also in their mods about.xml, the Steam DB allows RimSort to use a mods Steam data, in addition to its about.xml. For details, see the [user guide](/user-guide/databases)
+RimSort uses the Steam Workshop Database (Steam DB) for loading mod dependency data that is only available on Steam (the "required items" section). While modders should strive to specify this data also in their mods about.xml, the Steam DB allows RimSort to use a mods Steam data, in addition to its about.xml. For details, see the [user guide](./user-guide/databases)
 
 ## What is the Community Rules Database used for?
 
-The Community Rules Database (Community Rules DB / CR DB) is used for getting RimSort to place mods in the correct load order. These rules are found and submitted by the community and then collected for shared use in the CR DB. You can contribute to the CR DB by submitting pull requests on GitHub. For details about the DB, see the [user guide](/user-guide/databases).
+The Community Rules Database (Community Rules DB / CR DB) is used for getting RimSort to place mods in the correct load order. These rules are found and submitted by the community and then collected for shared use in the CR DB. You can contribute to the CR DB by submitting pull requests on GitHub. For details about the DB, see the [user guide](./user-guide/databases).
 
 ## How do I enable Steam client integration features like `Open mod in Steam` if I have Steam installed?
 

--- a/docs/faq.zh-cn.md
+++ b/docs/faq.zh-cn.md
@@ -28,7 +28,7 @@ RimSort 不是恶意软件，可以安全使用。你可以放心忽略任何杀
 
 对于 **_Windows Defender_**，我们通常会尝试向微软提交样本，以便在出现误报时将 RimSort 版本加入白名单。这个过程可能至少需要一整天，并且每次发布都需要重复。因此，如果 WD 误报 RimSort，我们仍然感谢你的报告，但你可以安全地忽略 WD 的警告。
 
-对于 **_macOS_**，我们需要向苹果支付类似的年费才能在 macOS 上签名应用程序。目前，Mac 用户可以使用 [这个临时解决方案](https://github.com/RimSort/RimSort/wiki/User-Guide#macos)。除了向苹果支付费用外，我们在 macOS 上没有其他方案解决这个问题。
+对于 **_macOS_**，我们需要向苹果支付类似的年费才能在 macOS 上签名应用程序。目前，Mac 用户可以使用 [这个临时解决方案](./user-guide/downloading-and-installing#macos)。除了向苹果支付费用外，我们在 macOS 上没有其他方案解决这个问题。
 
 ## 游戏路径在哪里？
 
@@ -40,11 +40,11 @@ RimSort 不是恶意软件，可以安全使用。你可以放心忽略任何杀
 
 ## Steam 创意工坊数据库有什么用？
 
-RimSort 使用 Steam 创意工坊数据库（Steam DB）来加载 Steam 平台提供的 Mod 依赖数据（指工坊中「必需物品」部分）。尽管 Mod 作者应尽量在其 Mod 的 about.xml 文件中也明确指定这些数据，但通过 Steam DB，RimSort 可以同时利用 Mod 的 Steam 数据和 about.xml 文件中的信息。有关详细信息，请参阅 [用户指南](/user-guide/databases)。
+RimSort 使用 Steam 创意工坊数据库（Steam DB）来加载 Steam 平台提供的 Mod 依赖数据（指工坊中「必需物品」部分）。尽管 Mod 作者应尽量在其 Mod 的 about.xml 文件中也明确指定这些数据，但通过 Steam DB，RimSort 可以同时利用 Mod 的 Steam 数据和 about.xml 文件中的信息。有关详细信息，请参阅 [用户指南](./user-guide/databases.zh-cn)。
 
 ## 社区规则数据库有什么作用？
 
-社区规则数据库（Community Rules DB）用于指导 RimSort 将 Mod 按正确顺序加载。这些规则由社区发现并提交，之后被收集到社区规则库中共用。你可以通过在 GitHub 上提交 pull request 来为社区规则库做贡献。有关该数据库的详细信息，请参阅 [用户指南](/user-guide/databases)。
+社区规则数据库（Community Rules DB）用于指导 RimSort 将 Mod 按正确顺序加载。这些规则由社区发现并提交，之后被收集到社区规则库中共用。你可以通过在 GitHub 上提交 pull request 来为社区规则库做贡献。有关该数据库的详细信息，请参阅 [用户指南](./user-guide/databases.zh-cn)。
 
 ## 如果已安装 Steam，如何启用如 `在 Steam 打开 Mod（Open mod in Steam）` 等 Steam 客户端集成功能？
 


### PR DESCRIPTION
Updated the links in docs/faq.md and docs/faq.zh-cn.md to use local relative paths instead of absolute URLs.

This improves navigation within the documentation and ensures consistency across different language versions.

Specifically, links to the user guide sections for macOS workaround and databases were corrected to relative paths.