### PR TITLE
Add cycle breaking logic and fix circular dependency in mod sorting

### DIFF
--- a/app/sort/alphabetical_sort.py
+++ b/app/sort/alphabetical_sort.py
@@ -1,5 +1,6 @@
 from loguru import logger
 
+from app.sort.cycle_breaker import break_known_cycles
 from app.utils.metadata import MetadataManager
 
 
@@ -9,6 +10,10 @@ def do_alphabetical_sort(
     logger.info(f"Starting Alphabetical sort for {len(dependency_graph)} mods")
     # Cache MetadataManager instance
     metadata_manager = MetadataManager.instance()
+
+    # Break known cycles before sorting
+    dependency_graph = break_known_cycles(dependency_graph)
+
     # Get an alphabetized list of dependencies
     active_mods_id_to_name = dict(
         (

--- a/app/sort/cycle_breaker.py
+++ b/app/sort/cycle_breaker.py
@@ -1,0 +1,28 @@
+from loguru import logger
+
+
+def break_known_cycles(dependency_graph: dict[str, set[str]]) -> dict[str, set[str]]:
+    """
+    Break known cycles in the dependency graph by removing one edge in the cycle.
+    Currently targets the cycle between 'vanillaexpanded.vtexe.facialanims' and 'reel.facialanims'.
+    """
+    mod_a = "vanillaexpanded.vtexe.facialanims"
+    mod_b = "reel.facialanims"
+
+    # Make a copy to avoid mutating the original graph
+    new_graph = {k: set(v) for k, v in dependency_graph.items()}
+
+    if mod_a in new_graph and mod_b in new_graph[mod_a]:
+        logger.info(
+            f"Breaking cycle by removing dependency edge from {mod_a} to {mod_b}"
+        )
+        new_graph[mod_a].remove(mod_b)
+
+    # Also check the reverse edge in case the cycle is bidirectional
+    if mod_b in new_graph and mod_a in new_graph[mod_b]:
+        logger.info(
+            f"Breaking cycle by removing dependency edge from {mod_b} to {mod_a}"
+        )
+        new_graph[mod_b].remove(mod_a)
+
+    return new_graph

--- a/app/sort/topo_sort.py
+++ b/app/sort/topo_sort.py
@@ -3,6 +3,7 @@ from loguru import logger
 from PySide6.QtCore import QCoreApplication
 from toposort import CircularDependencyError, toposort
 
+from app.sort.cycle_breaker import break_known_cycles
 from app.utils.metadata import MetadataManager
 from app.views.dialogue import show_warning
 
@@ -17,6 +18,10 @@ def do_topo_sort(
     logger.info(f"Initializing toposort for {len(dependency_graph)} mods")
     # Cache MetadataManager instance
     metadata_manager = MetadataManager.instance()
+
+    # Break known cycles before sorting
+    dependency_graph = break_known_cycles(dependency_graph)
+
     try:
         sorted_dependencies = list(toposort(dependency_graph))
     except CircularDependencyError as e:


### PR DESCRIPTION
Integrate cycle breaking in both topological and alphabetical sorting modules. Automatically detect and break known cycle between 'vanillaexpanded.vtexe.facialanims' and 'reel.facialanims'.