### PR TITLE
Comment out edge removal in cycle breaker to disable breaking cycles

### DIFF
--- a/app/sort/cycle_breaker.py
+++ b/app/sort/cycle_breaker.py
@@ -12,11 +12,11 @@ def break_known_cycles(dependency_graph: dict[str, set[str]]) -> dict[str, set[s
     # Make a copy to avoid mutating the original graph
     new_graph = {k: set(v) for k, v in dependency_graph.items()}
 
-    if mod_a in new_graph and mod_b in new_graph[mod_a]:
+    """if mod_a in new_graph and mod_b in new_graph[mod_a]:
         logger.info(
             f"Breaking cycle by removing dependency edge from {mod_a} to {mod_b}"
         )
-        new_graph[mod_a].remove(mod_b)
+        new_graph[mod_a].remove(mod_b)"""
 
     # Also check the reverse edge in case the cycle is bidirectional
     if mod_b in new_graph and mod_a in new_graph[mod_b]:


### PR DESCRIPTION
Temporarily disable the removal of the dependency edge from mod_a to mod_b in break_known_cycles function by commenting out the code. This change prevents breaking cycles in one direction while still checking the reverse edge