### PR TITLE
ci: Build documentation pages artifact for PRs

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,18 +1,14 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
-# Sample workflow for building and deploying a Jekyll site to GitHub Pages
-name: Deploy Jekyll site to Pages
+# Workflow for building and deploying a Jekyll site to GitHub Pages
+name: Build (and deploy to Pages) documentation Jekyll site
 
 on:
   push:
     branches: ["main"]
     paths:
       - "docs/**"
-
-  # Allows you to run this workflow manually from the Actions tab
+  pull_request:
+    paths:
+      - "docs/**"
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
@@ -59,6 +55,7 @@ jobs:
 
   # Deployment job
   deploy:
+    if: ${{ github.event_name != 'pull_request'}}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
This PR allows for documentation pages to build as an artifact for PRs. Note that the page is only deployed when this workflow is triggered manually, or when merging to main.