### PR TITLE
ci: Add merge_group to relevant workflow files

### DIFF
--- a/.github/workflows/auto_build.yml
+++ b/.github/workflows/auto_build.yml
@@ -13,12 +13,13 @@ on:
       - "app/**"
       - "distribute.py"
       - "requirements*.txt"
+  merge_group:
 
 permissions: {}
 
 jobs:
   pre-test:
-    permissions: 
+    permissions:
       contents: read
     uses: ./.github/workflows/pytest.yml
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,6 +18,7 @@ on:
     branches: ["main"]
   schedule:
     - cron: "18 23 * * 6"
+  merge_group:
 
 permissions: {}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,7 @@ on:
       - main
       - master
   pull_request: null
+  merge_group:
 
 permissions: {}
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,6 +16,7 @@ on:
         description: "Deploy to GitHub Pages"
         type: boolean
         default: false
+  merge_group:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,6 +2,7 @@ name: Run Pytest
 on:
   workflow_call: null
   workflow_dispatch: null
+  merge_group:
 
 permissions: {}
 


### PR DESCRIPTION
This PR adds `merge_group` to relevant workflow files. This is intended to be preparation to enable the merge queue to improve workflows.