### PR TITLE
fix: Fix type warning for creating DiGraph

### DIFF
--- a/app/sort/topo_sort.py
+++ b/app/sort/topo_sort.py
@@ -58,7 +58,7 @@ def do_topo_sort(
 
 
 def find_circular_dependencies(dependency_graph: dict[str, set[str]]) -> None:
-    graph = nx.DiGraph(dependency_graph)  # type: ignore # Type checkers want a iterable, but a set is fine.
+    graph = nx.DiGraph({k: list(v) for k, v in dependency_graph.items()})
     cycles = list(nx.simple_cycles(graph))  # find all cycles in the graph
 
     cycle_strings = []


### PR DESCRIPTION
The things that happen when we try to force static type checking onto Python. Too late to switch to a new language now...