### PR TITLE
ci: Add status check job to auto build workflow

### DIFF
--- a/.github/workflows/auto_build.yml
+++ b/.github/workflows/auto_build.yml
@@ -53,3 +53,16 @@ jobs:
     with:
       version_format: ${{ needs.pre-build.outputs.version_format }}
       attest: false
+
+  status-check:
+    name: Status Check
+    runs-on: ubuntu-latest
+    needs:
+      - pre-test
+      - pre-build
+      - attested-build
+      - non-attested-build
+    if: always()
+    steps:
+      - name: Set status check
+        run: echo "All required jobs have completed."


### PR DESCRIPTION
This is to have a unified target for the branch ruleset to have.