### PR TITLE
Introduce Tier Zero Mod Classification System

### DIFF
--- a/app/controllers/sort_controller.py
+++ b/app/controllers/sort_controller.py
@@ -51,6 +51,10 @@ class Sorter:
             self.active_uuids, list(self.active_package_ids)
         )
 
+        tier_zero_graph, tier_zero_mods = sort_deps.gen_tier_zero_deps_graph(
+            dependencies_graph
+        )
+
         tier_one_graph, tier_one_mods = sort_deps.gen_tier_one_deps_graph(
             dependencies_graph
         )
@@ -66,10 +70,10 @@ class Sorter:
             list(self.active_package_ids),
             tier_one_mods,
             tier_three_mods,
-            use_moddependencies_as_loadTheseBefore=self.use_moddependencies_as_loadTheseBefore,
+            self.use_moddependencies_as_loadTheseBefore,
         )
 
-        return [tier_one_graph, tier_two_graph, tier_three_graph]
+        return [tier_zero_graph, tier_one_graph, tier_two_graph, tier_three_graph]
 
     def sort(
         self, dependency_graphs: list[dict[str, set[str]]] | None = None

--- a/app/sort/dependencies.py
+++ b/app/sort/dependencies.py
@@ -76,7 +76,13 @@ def gen_tier_zero_deps_graph(
 ) -> tuple[dict[str, set[str]], set[str]]:
     """
     Generate the dependency graph for tier zero mods, which are mods that should be loaded before any other mod.
-    This includes mods that are required for the game to function properly, such as core mods or essential libraries.
+    This includes mods that are required for the game to function properly,
+    These are Harmony, Core, DLC's, etc which are essential.
+    This list of mods is exhaustive, so we need to add any other mod that these mods
+    eg. "Faster Game Loading" before "Core" but after "Harmony".
+    These mods have to be added to the list of known tier zero mods, using the loadBefore flag in the database.
+    but this is not recommended. so we add it manually for now.
+    TODO: pull from a config like the other tiers incase we want to allow users to add more mods
     """
     logger.info("Generating dependencies graph for tier zero mods")
     tier_zero_mods = KNOWN_TIER_ZERO_MODS
@@ -94,13 +100,14 @@ def gen_tier_zero_deps_graph(
 def gen_tier_one_deps_graph(
     dependencies_graph: dict[str, set[str]],
 ) -> tuple[dict[str, set[str]], set[str]]:
-    # Below is a list of mods determined to be "tier one", in the sense that they
-    # should be loaded first before any other regular mod. Tier one mods will have specific
-    # load order needs within themselves, e.g. Harmony before core. There is no guarantee that
-    # this list of mods is exhaustive, so we need to add any other mod that these mods depend on
-    # into this list as well.
-    # TODO: pull from a config
-
+    """
+    Generate the dependency graph for "tier one" mods, which are mods that are required by other mods to function properly,
+    These are mods such as Framework mods.
+    Tier one mods will have specific load order needs within themselves,
+    This list of mods is exhaustive, so we need to add any other mod that these mods
+    e.g. "Vanilla Backgrounds Expanded" before "Vaniila Expanded Framework".
+    These can also be added to the list of known tier one mods, using the "loadTop" flag, in the database.
+    """
     logger.info("Generating dependencies graph for tier one mods")
     metadata_manager = MetadataManager.instance()
     known_tier_one_mods = KNOWN_TIER_ONE_MODS
@@ -161,13 +168,14 @@ def gen_tier_three_deps_graph(
     reverse_dependencies_graph: dict[str, set[str]],
     active_mods_uuids: set[str],
 ) -> tuple[dict[str, set[str]], set[str]]:
-    # Below is a list of mods determined to be "tier three", in the sense that they
-    # should be loaded after any other regular mod, potentially at the very end of the load order.
-    # Tier three mods will have specific load order needs within themselves. There is no guarantee that
-    # this list of mods is exhaustive, so we need to add any other mod that these mods depend on
-    # into this list as well.
-    # TODO: pull from a config
-    # Cache MetadataManager instance
+    """
+    Below is a list of mods determined to be "tier three",
+    These should be loaded after any other regular mod, potentially at the very end of the load order.
+    Tier three mods will have specific load order needs within themselves. There is no guarantee that his list of mods is exhaustive,
+    So we need to add any other mod that these mods depend on into this list as well.
+    eg. "RocketMan".
+    These can also be added to the list of known tier one mods, using the "loadBottom" flag, in the database.
+    """
     metadata_manager = MetadataManager.instance()
     logger.info("Generating dependencies graph for tier three mods")
     known_tier_three_mods = {

--- a/app/sort/dependencies.py
+++ b/app/sort/dependencies.py
@@ -1,6 +1,6 @@
 from loguru import logger
 
-from app.utils.constants import KNOWN_TIER_ONE_MODS
+from app.utils.constants import KNOWN_TIER_ONE_MODS, KNOWN_TIER_ZERO_MODS
 from app.utils.metadata import MetadataManager
 
 
@@ -69,6 +69,26 @@ def gen_rev_deps_graph(
         f"Finished generating reverse dependencies graph of {len(reverse_dependencies_graph)}"
     )
     return reverse_dependencies_graph
+
+
+def gen_tier_zero_deps_graph(
+    dependencies_graph: dict[str, set[str]],
+) -> tuple[dict[str, set[str]], set[str]]:
+    """
+    Generate the dependency graph for tier zero mods, which are mods that should be loaded before any other mod.
+    This includes mods that are required for the game to function properly, such as core mods or essential libraries.
+    """
+    logger.info("Generating dependencies graph for tier zero mods")
+    tier_zero_mods = KNOWN_TIER_ZERO_MODS
+    tier_zero_dependency_graph = {}
+    for tier_zero_mod in tier_zero_mods:
+        # Tier zero mods will only ever reference other tier zero mods in their dependencies graph
+        if tier_zero_mod in dependencies_graph:
+            tier_zero_dependency_graph[tier_zero_mod] = dependencies_graph[
+                tier_zero_mod
+            ]
+    logger.info("Attached corresponding dependencies to every tier zero mod, returning")
+    return tier_zero_dependency_graph, tier_zero_mods
 
 
 def gen_tier_one_deps_graph(

--- a/app/sort/topo_sort.py
+++ b/app/sort/topo_sort.py
@@ -58,7 +58,7 @@ def do_topo_sort(
 
 
 def find_circular_dependencies(dependency_graph: dict[str, set[str]]) -> None:
-    graph = nx.DiGraph(dependency_graph) # type: ignore # A set is fine, but linters warn about it
+    graph = nx.DiGraph(dependency_graph)  # type: ignore # A set is fine, but linters warn about it
     cycles = list(nx.simple_cycles(graph))  # find all cycles in the graph
 
     cycle_strings = []

--- a/app/utils/constants.py
+++ b/app/utils/constants.py
@@ -80,7 +80,7 @@ KNOWN_MOD_REPLACEMENTS = {
     "brrainz.harmony": {"zetrith.prepatcher"},
     "aoba.motorization.engine": {"rimthunder.core"},
 }
-KNOWN_TIER_ONE_MODS = {
+KNOWN_TIER_ZERO_MODS = {
     "zetrith.prepatcher",
     "brrainz.harmony",
     "ludeon.rimworld",
@@ -89,5 +89,7 @@ KNOWN_TIER_ONE_MODS = {
     "ludeon.rimworld.biotech",
     "ludeon.rimworld.anomaly",
     "ludeon.rimworld.odyssey",
+}
+KNOWN_TIER_ONE_MODS = {
     "unlimitedhugs.hugslib",
 }

--- a/app/utils/constants.py
+++ b/app/utils/constants.py
@@ -83,6 +83,9 @@ KNOWN_MOD_REPLACEMENTS = {
 KNOWN_TIER_ZERO_MODS = {
     "zetrith.prepatcher",
     "brrainz.harmony",
+    "taranchuk.fastergameloading",
+    "ilyvion.loadingprogress",
+    "brrainz.visualexceptions",
     "ludeon.rimworld",
     "ludeon.rimworld.royalty",
     "ludeon.rimworld.ideology",

--- a/app/utils/constants.py
+++ b/app/utils/constants.py
@@ -91,5 +91,9 @@ KNOWN_TIER_ZERO_MODS = {
     "ludeon.rimworld.odyssey",
 }
 KNOWN_TIER_ONE_MODS = {
+    "vanillaexpanded.backgrounds",
+    "redmattis.betterprerequisites",
+    "adaptive.storage.framework",
+    "oskarpotocki.vanillafactionsexpanded.core",
     "unlimitedhugs.hugslib",
 }


### PR DESCRIPTION
1. This PR implements a new tier zero classification for essential RimWorld mods, splitting the existing tier system into four tiers (0-3) instead of three.
2. It renames KNOWN_TIER_ONE_MODS to KNOWN_TIER_ZERO_MODS, moves 'unlimitedhugs.hugslib' to tier one.
3. Adds new core mods to tier zero and tier one.
4. It updates the sorting algorithm to handle the new tier zero dependency graph for improved mod loading granularity.
5. Updated the Doc string accordingly with examples