### PR TITLE
Load widgets after showing mods with warnings/errors

### DIFF
--- a/app/controllers/mods_panel_controller.py
+++ b/app/controllers/mods_panel_controller.py
@@ -110,6 +110,7 @@ class ModsPanelController(QObject):
                 elif not mod_data["hidden_by_filter"]:
                     mod.setHidden(False)
         self.mods_panel.update_count("Active")
+        self.mods_panel.active_mods_list.check_widgets_visible()
         logger.debug("Finished hiding mods without warnings.")
 
     @Slot()
@@ -136,4 +137,5 @@ class ModsPanelController(QObject):
                 elif not mod_data["hidden_by_filter"]:
                     mod.setHidden(False)
         self.mods_panel.update_count("Active")
+        self.mods_panel.active_mods_list.check_widgets_visible()
         logger.debug("Finished hiding mods without errors.")


### PR DESCRIPTION
Fixes issue where not all mods with warnigns/errors would show up

<img width="305" height="551" alt="image" src="https://github.com/user-attachments/assets/e794cfee-845c-479c-8b58-17f4cced51dc" />
