### PR TITLE
Fix rendering unity rich text

### DIFF
--- a/app/views/description_widget.py
+++ b/app/views/description_widget.py
@@ -67,6 +67,7 @@ class DescriptionWidget(QTextBrowser):
         }
         tag_mapping_type2 = {
             r"<color=(#[0-9a-fA-F]{6}|#[0-9a-fA-F]{8}|[a-zA-Z]+)>": r'<span style="color:\1">',
+            r"<color=\"(#[0-9a-fA-F]{6}|#[0-9a-fA-F]{8}|[a-zA-Z]+)\">": r'<span style="color:\1">',
             r"</color>": "</span>",
             r"<size=(\d+)>": r'<span style="font-size:\1px">',
             r"</size>": "</span>",


### PR DESCRIPTION
Some mods might define colors with \" surrounding them.

<img width="482" height="110" alt="image" src="https://github.com/user-attachments/assets/9370b849-4007-4861-9974-a55b3ca18bec" />
