### PR TITLE
Make Log Reader and File Search table width fixed and adjustable

### DIFF
--- a/app/views/file_search_dialog.py
+++ b/app/views/file_search_dialog.py
@@ -4,9 +4,10 @@ import subprocess
 from typing import Any, Optional
 
 from loguru import logger
-from PySide6.QtCore import QPoint, Qt, Signal
-from PySide6.QtGui import QFont, QKeyEvent
+from PySide6.QtCore import QPoint, Qt, QTimer, Signal
+from PySide6.QtGui import QFont, QKeyEvent, QResizeEvent, QShowEvent
 from PySide6.QtWidgets import (
+    QAbstractItemView,
     QApplication,
     QCheckBox,
     QComboBox,
@@ -296,7 +297,7 @@ class FileSearchDialog(QDialog):
         results_header.addWidget(results_label)
 
         # Add a right-aligned label with instructions
-        results_help = QLabel(self.tr("Double-click a result to open the file"))
+        results_help = QLabel(self.tr("Right-click a result for actions"))
         results_help.setAlignment(Qt.AlignmentFlag.AlignRight)
         results_header.addWidget(results_help)
 
@@ -325,25 +326,26 @@ class FileSearchDialog(QDialog):
         # Set a minimum height for the results table
         self.results_table.setMinimumHeight(300)
 
-        # Configure column stretching
+        # Configure columns: full-width fit + manual resizing using proportional weights
+        self.results_table.setHorizontalScrollBarPolicy(
+            Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+        )
         header = self.results_table.horizontalHeader()
-        header.setSectionResizeMode(
-            0, QHeaderView.ResizeMode.ResizeToContents
-        )  # Mod name
-        header.setSectionResizeMode(
-            1, QHeaderView.ResizeMode.ResizeToContents
-        )  # File name
-        header.setSectionResizeMode(2, QHeaderView.ResizeMode.ResizeToContents)  # Path
-        header.setSectionResizeMode(
-            3, QHeaderView.ResizeMode.Stretch
-        )  # Preview (stretch to fill remaining space)
+        header.setSectionResizeMode(QHeaderView.ResizeMode.Interactive)
+        header.setMinimumSectionSize(40)
+        self._results_col_weights: list[float] = []
+        header.sectionResized.connect(self._on_results_section_resized)
 
         # Enable context menu
         self.results_table.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self.results_table.customContextMenuRequested.connect(self._show_context_menu)
 
-        # Connect double-click to open file
-        self.results_table.cellDoubleClicked.connect(self._on_cell_double_clicked)
+        # Make double-click edit cells (like ACF Log Reader)
+        self.results_table.setEditTriggers(
+            QAbstractItemView.EditTrigger.DoubleClicked
+            | QAbstractItemView.EditTrigger.SelectedClicked
+            | QAbstractItemView.EditTrigger.EditKeyPressed
+        )
 
         # Add table to results layout
         results_table_layout.addWidget(self.results_table)
@@ -358,6 +360,10 @@ class FileSearchDialog(QDialog):
 
         # Connect filter input to filter method
         self.filter_input.textChanged.connect(self._on_filter_changed)
+
+        # Initialize/sync and apply proportional widths
+        self._init_or_sync_results_weights()
+        self._apply_results_widths_to_viewport()
 
         # Connect search button to start search timer
         self.search_button.clicked.connect(self._on_search_start)
@@ -516,6 +522,60 @@ class FileSearchDialog(QDialog):
             # Fallback to default opener
             self._open_file(path)
 
+    # ----- Results table width management (manual resize + full-width fit) -----
+    def _results_viewport_width(self) -> int:
+        try:
+            return max(0, int(self.results_table.viewport().width()))
+        except Exception:
+            return max(0, int(self.results_table.width()))
+
+    def _init_or_sync_results_weights(self) -> None:
+        col_count = self.results_table.columnCount()
+        if col_count <= 0:
+            return
+        if not getattr(self, "_results_col_weights", None) or len(self._results_col_weights) != col_count:
+            # Initialize equal weights
+            self._results_col_weights = [1.0 / col_count for _ in range(col_count)]
+
+    def _recalculate_results_weights(self) -> None:
+        col_count = self.results_table.columnCount()
+        if col_count <= 0:
+            return
+        header = self.results_table.horizontalHeader()
+        sizes = [header.sectionSize(i) for i in range(col_count)]
+        total = sum(sizes) or 1
+        self._results_col_weights = [s / total for s in sizes]
+
+    def _apply_results_widths_to_viewport(self) -> None:
+        col_count = self.results_table.columnCount()
+        if col_count <= 0:
+            return
+        self._init_or_sync_results_weights()
+        vpw = self._results_viewport_width()
+        if vpw <= 0:
+            return
+        header = self.results_table.horizontalHeader()
+        min_w = max(40, int(vpw * 0.05 / col_count))
+        widths = [max(min_w, int(round(w * vpw))) for w in self._results_col_weights]
+        diff = vpw - sum(widths)
+        widths[-1] = max(min_w, widths[-1] + diff)
+        self._suppress_results_section_updates = True
+        try:
+            for i, w in enumerate(widths):
+                header.resizeSection(i, w)
+        finally:
+            self._suppress_results_section_updates = False
+
+    def _on_results_section_resized(self, index: int, old: int, new: int) -> None:  # noqa: ARG002
+        if getattr(self, "_suppress_results_section_updates", False):
+            return
+        self._recalculate_results_weights()
+        self._apply_results_widths_to_viewport()
+
+    def resizeEvent(self, event: QResizeEvent) -> None:
+        super().resizeEvent(event)
+        self._apply_results_widths_to_viewport()
+
     def keyPressEvent(self, event: QKeyEvent) -> None:
         """Handle keyboard shortcuts"""
         # Get currently selected row
@@ -547,13 +607,12 @@ class FileSearchDialog(QDialog):
         else:
             super().keyPressEvent(event)
 
-    def _on_cell_double_clicked(self, row: int, column: int) -> None:
-        """Handle double-click on a cell"""
-        logger.debug(f"Cell double-clicked at row {row}, column {column}.")
-        if row >= 0:
-            path_item = self.results_table.item(row, 2)
-            if path_item is not None:
-                self._open_file(path_item.text())
+    # Note: Double-click now edits cells; no open-on-double-click handler
+
+    def showEvent(self, event: QShowEvent) -> None:
+        super().showEvent(event)
+        # Ensure initial full-width fit after the dialog is shown
+        QTimer.singleShot(0, self._apply_results_widths_to_viewport)
 
     def get_search_options(self) -> dict[str, Any]:
         """Get current search options as a dictionary, including exclude options."""
@@ -652,7 +711,7 @@ class FileSearchDialog(QDialog):
             mod_item.setToolTip(f"Mod: {mod_name}")
             file_item.setToolTip(f"File: {file_name}")
             path_item.setToolTip(f"Path: {path}")
-            preview_item.setToolTip(self.tr("Double-click to open file"))
+            preview_item.setToolTip(self.tr("Right-click for actions"))
             preview_item.setFont(QFont("Courier New", 9))
             preview_item.setFlags(preview_item.flags() ^ Qt.ItemFlag.ItemIsEditable)
 


### PR DESCRIPTION
Address https://github.com/RimSort/RimSort/issues/1106 and https://github.com/RimSort/RimSort/issues/708.
For both the ACF Log Reader and File Search tables...
- Remove the need for a horizontal scrollbar by making the total table width always the width of the window.
- Added ability to drag to resize columns widths
- Tweaked what clicking on cell does for File Search so people can see the full cell text easily