### PR TITLE
Fix 0x0.st log uploads with HTTPs and headers

### DIFF
--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -2221,7 +2221,7 @@ class MainContent(QObject):
             copy_to_clipboard_safely(ret)
             dialogue.show_information(
                 title=self.tr("Uploaded file"),
-                text=self.tr("Uploaded {path.name} to http://0x0.st/").format(
+                text=self.tr("Uploaded {path.name} to https://0x0.st/").format(
                     path=path
                 ),
                 information=self.tr(


### PR DESCRIPTION
Attempting to address https://github.com/RimSort/RimSort/issues/1146.

Changes:
- Switched uploads from `http://0x0.st/` to `https://0x0.st/`. 0x0.st expects HTTPS; HTTP can be rejected with 403.
- Added `headers={"User-Agent": f"RimSort/{AppInfo().app_version}"}` to the POST as 0x0.st asks client software to identify itself; generic or masked UAs are more likely to be blocked
- We now send `("RimSort.log", <file bytes>)` instead of `("/full/path/to/RimSort.log", <file bytes>)`. Sending a clean basename avoids server-side filters that may dislike slashes or full paths.

Testing: I was getting 403s before, now it works.

Can reviewers also try?