### PR TITLE
Fix SQLite failing to open Aux database when it doesn't exist

### DIFF
--- a/app/controllers/metadata_db_controller.py
+++ b/app/controllers/metadata_db_controller.py
@@ -12,7 +12,17 @@ from app.utils.steam.steamfiles.wrapper import acf_to_dict
 
 class MetadataDbController:
     def __init__(self, db: Path | str) -> None:
-        self.engine = create_engine(f"sqlite+pysqlite:///{db}")
+        # Ensure parent directory exists before opening SQLite file
+        db_path = Path(db) if not isinstance(db, Path) else db
+        try:
+            if db_path.parent:
+                db_path.parent.mkdir(parents=True, exist_ok=True)
+        except Exception as e:
+            logger.exception(
+                f"Failed to ensure database directory exists for {db_path}: {e}"
+            )
+
+        self.engine = create_engine(f"sqlite+pysqlite:///{db_path}")
         self.Session = sessionmaker(bind=self.engine, expire_on_commit=False)
 
 


### PR DESCRIPTION
Was running into infinite crashes on startup. Turns out you can get in a state where SQLite fails to open the aux metadata database because the instance directory for the file (e.g., …/instances/Default/) doesn't exist yet. I updated `MetadataDbController.__init__` to create the database file’s parent directory (`mkdir(parents=True, exist_ok=True)`) before initializing the SQLAlchemy engine. This ensures the path exists and prevents the “unable to open database file” error.