### PR TITLE
Speed up folder size calculation. Also cache at init/refresh

### DIFF
--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -78,7 +78,12 @@ from app.utils.system_info import SystemInfo
 from app.utils.todds.wrapper import ToddsInterface
 from app.utils.xml import json_to_xml_write
 from app.views.mod_info_panel import ModInfo
-from app.views.mods_panel import ModListWidget, ModsPanel, ModsPanelSortKey
+from app.views.mods_panel import (
+    ModListWidget,
+    ModsPanel,
+    ModsPanelSortKey,
+    uuid_to_folder_size,
+)
 from app.windows.missing_dependencies_dialog import MissingDependenciesDialog
 from app.windows.missing_mods_panel import MissingModsPrompt
 from app.windows.rule_editor_panel import RuleEditor
@@ -1244,6 +1249,11 @@ class MainContent(QObject):
         """
         EventBus().refresh_started.emit()
         EventBus().do_save_button_animation_stop.emit()
+        # Build foldersize cache at cost of load time
+        active_uuids = self.mods_panel.active_mods_list.uuids
+        inactive_uuids = self.mods_panel.inactive_mods_list.uuids
+        for uuid in active_uuids + inactive_uuids:
+            uuid_to_folder_size(uuid)
         # If we are refreshing cache from user action
         if not is_initial:
             # Reset the data source filters to default and clear searches

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -82,7 +82,6 @@ from app.views.mods_panel import (
     ModListWidget,
     ModsPanel,
     ModsPanelSortKey,
-    uuid_to_folder_size,
 )
 from app.windows.missing_dependencies_dialog import MissingDependenciesDialog
 from app.windows.missing_mods_panel import MissingModsPrompt

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -1249,11 +1249,6 @@ class MainContent(QObject):
         """
         EventBus().refresh_started.emit()
         EventBus().do_save_button_animation_stop.emit()
-        # Build foldersize cache at cost of load time
-        active_uuids = self.mods_panel.active_mods_list.uuids
-        inactive_uuids = self.mods_panel.inactive_mods_list.uuids
-        for uuid in active_uuids + inactive_uuids:
-            uuid_to_folder_size(uuid)
         # If we are refreshing cache from user action
         if not is_initial:
             # Reset the data source filters to default and clear searches

--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -171,14 +171,20 @@ def uuid_to_folder_size(uuid: str) -> int:
         return cached[1]
 
     total_size = 0
-    for root, _, files in os.walk(mod_path):
-        for file_name in files:
-            file_path = os.path.join(root, file_name)
-            try:
-                total_size += os.path.getsize(file_path)
-            except OSError:
-                # Skip files we cannot access
-                continue
+
+    try:
+        total_size = os.path.getsize(Path(mod_path))
+    except OSError:
+        # Use slower method to get as accurate size as possible
+        for root, _, files in os.walk(mod_path):
+            for file_name in files:
+                file_path = os.path.join(root, file_name)
+                try:
+                    total_size += os.path.getsize(file_path)
+                except OSError:
+                    # Skip files we cannot access
+                    continue
+   
     _FOLDER_SIZE_CACHE[mod_path] = (mtime, total_size)
     return total_size
 

--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -2433,6 +2433,8 @@ class ModListWidget(QListWidget):
         self.uuids = list()
         if uuids:  # Insert data...
             for uuid_key in uuids:
+                # Build foldersize cache at cost of load time
+                uuid_to_folder_size(uuid_key)
                 mod_path = self.metadata_manager.internal_local_metadata[uuid_key][
                     "path"
                 ]


### PR DESCRIPTION
This speeds up scrolling down a modlist when loading new items for the first time.

For a 7k+ modlist, when launching first time this is the same speed as before while caching the folder sizes.