### PR TITLE
Add option for clear to move DLC as well

### DIFF
--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -828,6 +828,10 @@ class SettingsController(QObject):
         self.settings_dialog.show_duplicate_mods_warning_checkbox.setChecked(
             self.settings.duplicate_mods_warning
         )
+        # Clear button behavior
+        self.settings_dialog.clear_moves_dlc_checkbox.setChecked(
+            self.settings.clear_moves_dlc
+        )
         self.settings_dialog.show_mod_updates_checkbox.setChecked(
             self.settings.steam_mods_update_check
         )
@@ -1091,6 +1095,10 @@ class SettingsController(QObject):
         )
         self.settings.duplicate_mods_warning = (
             self.settings_dialog.show_duplicate_mods_warning_checkbox.isChecked()
+        )
+        # Clear button behavior
+        self.settings.clear_moves_dlc = (
+            self.settings_dialog.clear_moves_dlc_checkbox.isChecked()
         )
         self.settings.steam_mods_update_check = (
             self.settings_dialog.show_mod_updates_checkbox.isChecked()
@@ -1955,5 +1963,4 @@ class SettingsController(QObject):
         if self.change_mod_coloring_mode:
             self.change_mod_coloring_mode = False
             EventBus().do_change_mod_coloring_mode.emit()
-
 

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -142,6 +142,8 @@ class Settings(QObject):
         self.update_databases_on_startup: bool = True
         # UI: Save-comparison labels and icons
         self.show_save_comparison_indicators: bool = True
+        # Clear button behavior
+        self.clear_moves_dlc: bool = False
 
         # Authentication
         self.rentry_auth_code: str = ""

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -1351,13 +1351,18 @@ class MainContent(QObject):
             app_constants.RIMWORLD_DLC_METADATA["2380740"]["packageid"],
             app_constants.RIMWORLD_DLC_METADATA["3022790"]["packageid"],
         ]
+        # If user wants Clear to also move DLC, only keep the base game in Active
+        if self.settings_controller.settings.clear_moves_dlc and package_id_order:
+            package_ids_to_keep_active = [package_id_order[0]]  # Base game only
+        else:
+            package_ids_to_keep_active = package_id_order
         # Create a set of all package IDs from mod_data
         package_ids_set = set(
             mod_data["packageid"]
             for mod_data in self.metadata_manager.internal_local_metadata.values()
         )
-        # Iterate over the DLC package IDs in the correct order
-        for package_id in package_id_order:
+        # Iterate over the package IDs we want to keep active
+        for package_id in package_ids_to_keep_active:
             if package_id in package_ids_set:
                 # Append the UUIDs to active_mods_uuids if the package ID exists in mod_data
                 active_mods_uuids.extend(

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -1300,6 +1300,12 @@ This basically preserves your mod coloring, user notes etc. for this many second
         )
         group_layout.addWidget(self.show_duplicate_mods_warning_checkbox)
 
+        # Clear button behavior
+        self.clear_moves_dlc_checkbox = QCheckBox(
+            self.tr("Clear also moves DLC")
+        )
+        group_layout.addWidget(self.clear_moves_dlc_checkbox)
+
         self.show_mod_updates_checkbox = QCheckBox(
             self.tr("Check for mod updates on refresh")
         )


### PR DESCRIPTION
Someone on the RimWorld Discord mentioned they'd like the ability for Clear to also move RimWorld DLC. Adding a toggle in Settings -> Advanced that allows you to do this.