### PR TITLE
Support for alternativePackageIds

### DIFF
--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -845,6 +845,13 @@ class SettingsController(QObject):
         self.settings_dialog.update_databases_on_startup_checkbox.setChecked(
             self.settings.update_databases_on_startup
         )
+        # Advanced: alternativePackageIds toggle
+        try:
+            self.settings_dialog.consider_alternative_package_ids_checkbox.setChecked(
+                self.settings.consider_alternative_package_ids
+            )
+        except Exception:
+            pass
         self.settings_dialog.enable_aux_db_behavior_editing.setChecked(
             self.settings.enable_aux_db_behavior_editing
         )
@@ -1109,6 +1116,13 @@ class SettingsController(QObject):
         self.settings.update_databases_on_startup = (
             self.settings_dialog.update_databases_on_startup_checkbox.isChecked()
         )
+        # Advanced: alternativePackageIds toggle
+        try:
+            self.settings.consider_alternative_package_ids = (
+                self.settings_dialog.consider_alternative_package_ids_checkbox.isChecked()
+            )
+        except Exception:
+            pass
         self.settings.enable_aux_db_behavior_editing = (
             self.settings_dialog.enable_aux_db_behavior_editing.isChecked()
         )
@@ -1955,5 +1969,4 @@ class SettingsController(QObject):
         if self.change_mod_coloring_mode:
             self.change_mod_coloring_mode = False
             EventBus().do_change_mod_coloring_mode.emit()
-
 

--- a/app/models/metadata/metadata_structure.py
+++ b/app/models/metadata/metadata_structure.py
@@ -228,6 +228,8 @@ class DependencyMod(BaseMod, PackageIdMod):
     """A mod which is a dependency of another mod."""
 
     workshop_url: str = ""
+    # New: alternative package IDs that can satisfy this dependency
+    alternative_package_ids: set[CaseInsensitiveStr] = field(default_factory=set)
 
 
 @dataclass

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -142,6 +142,8 @@ class Settings(QObject):
         self.update_databases_on_startup: bool = True
         # UI: Save-comparison labels and icons
         self.show_save_comparison_indicators: bool = True
+        # Dependencies: treat alternativePackageIds as satisfying dependencies
+        self.consider_alternative_package_ids: bool = False
 
         # Authentication
         self.rentry_auth_code: str = ""

--- a/app/utils/generic.py
+++ b/app/utils/generic.py
@@ -379,6 +379,9 @@ def flatten_to_list(obj: Any) -> list[Any] | dict[Any, Any] | Any:
         return list(obj)
     elif isinstance(obj, list):
         return [flatten_to_list(e) for e in obj]
+    elif isinstance(obj, tuple):
+        # Convert tuples to lists and recurse into elements
+        return [flatten_to_list(e) for e in obj]
     elif isinstance(obj, dict):
         return {k: flatten_to_list(v) for k, v in obj.items()}
     else:

--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -2268,6 +2268,7 @@ class ModListWidget(QListWidget):
         package_id_to_errors: dict[str, dict[str, None | set[str] | bool]] = {
             uuid: {
                 "missing_dependencies": set() if self.list_type == "Active" else None,
+                "alternative_dependencies": set() if self.list_type == "Active" else None,
                 "conflicting_incompatibilities": (
                     set() if self.list_type == "Active" else None
                 ),
@@ -2354,14 +2355,45 @@ class ModListWidget(QListWidget):
                 # Check dependencies (and replacements for dependencies)
                 # Note: dependency replacements are NOT assumed to be subject
                 # to the same load order rules as the orignal mods!
-                mod_errors["missing_dependencies"] = {
-                    dep
-                    for dep in mod_data.get("dependencies", [])
-                    if dep not in package_ids_set
-                    and not self._has_replacement(
-                        mod_data["packageid"], dep, package_ids_set
-                    )
-                }
+                # Build missing dependencies set while honoring alternativePackageIds
+                missing_deps: set[str] = set()
+                alternative_deps: set[str] = set()
+                consider_alternatives = (
+                    self.metadata_manager.settings_controller.settings.consider_alternative_package_ids
+                )
+                for dep_entry in mod_data.get("dependencies", []):
+                    alt_ids: set[str] = set()
+                    if isinstance(dep_entry, tuple):
+                        dep_id = dep_entry[0]
+                        if (
+                            len(dep_entry) > 1
+                            and isinstance(dep_entry[1], dict)
+                            and isinstance(dep_entry[1].get("alternatives"), set)
+                        ):
+                            alt_ids = dep_entry[1]["alternatives"]
+                    else:
+                        dep_id = dep_entry
+
+                    # Consider satisfied if main dep is present; optionally consider alternatives
+                    satisfied = dep_id in package_ids_set
+                    if not satisfied and consider_alternatives:
+                        satisfied = any(alt in package_ids_set for alt in alt_ids)
+                    # If not satisfied, also consider external replacement mapping
+                    if not satisfied and self._has_replacement(
+                        mod_data["packageid"], dep_id, package_ids_set
+                    ):
+                        satisfied = True
+
+                    if not satisfied:
+                        missing_deps.add(dep_id)
+                        # Only record alternatives if the advanced option is enabled
+                        if consider_alternatives:
+                            # Prefer to show only alternatives not already installed
+                            alt_candidates = {a for a in alt_ids if a not in package_ids_set}
+                            alternative_deps.update(alt_candidates if alt_candidates else alt_ids)
+
+                mod_errors["missing_dependencies"] = missing_deps
+                mod_errors["alternative_dependencies"] = alternative_deps
 
                 # Check incompatibilities
                 mod_errors["conflicting_incompatibilities"] = {
@@ -2393,10 +2425,15 @@ class ModListWidget(QListWidget):
                         mod_errors["load_after_violations"].add(load_this_after[0])
             # Calculate any needed string for errors
             tool_tip_text = ""
-            for error_type, tooltip_header in [
+            # Build tooltip sections, conditionally include alternatives
+            tooltip_sections = [
                 ("missing_dependencies", self.tr("\nMissing Dependencies:")),
                 ("conflicting_incompatibilities", self.tr("\nIncompatibilities:")),
-            ]:
+            ]
+            if self.metadata_manager.settings_controller.settings.consider_alternative_package_ids:
+                tooltip_sections.insert(1, ("alternative_dependencies", self.tr("\nAlternative Dependencies:")))
+
+            for error_type, tooltip_header in tooltip_sections:
                 if mod_errors[error_type]:
                     tool_tip_text += tooltip_header
                     errors = mod_errors[error_type]

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -1329,6 +1329,17 @@ This basically preserves your mod coloring, user notes etc. for this many second
         )
         group_layout.addWidget(self.render_unity_rich_text_checkbox)
 
+        # Dependencies: alternativePackageIds support
+        self.consider_alternative_package_ids_checkbox = QCheckBox(
+            self.tr("Consider alternativePackageIds as satisfying dependencies")
+        )
+        self.consider_alternative_package_ids_checkbox.setToolTip(
+            self.tr(
+                "If enabled, an alternativePackageIds entry in About.xml can satisfy a mod's dependency when the main dependency is missing."
+            )
+        )
+        group_layout.addWidget(self.consider_alternative_package_ids_checkbox)
+
         self.update_databases_on_startup_checkbox = QCheckBox(
             self.tr("Update databases on startup")
         )


### PR DESCRIPTION
This PR attempts to add support for the new 1.6 `alternativePackageIds`, which is a new field in `modDependencies`, e.g.

```
<modDependencies>
  <li>
    <packageId>erdelf.HumanoidAlienRaces</packageId>
    <displayName>Humanoid Alien Races</displayName>
    <steamWorkshopUrl>steam://url/CommunityFilePage/839005762</steamWorkshopUrl>
    <alternativePackageIds IgnoreIfNoMatchingField="True">
      <li>erdelf.HumanoidAlienRaces.dev</li>
    </alternativePackageIds>
  </li>
</modDependencies>
```

Internally, dependencies are now stored as a list of either a plain packageId or a tuple of (packageId, {"alternatives": set[...]}) so we can represent a primary dependency alongside its declared alternatives.

Alternative handling is strictly opt-in via a new Advanced setting: “Consider alternativePackageIds as satisfying dependencies.” When enabled, missing-dependency checks accept either the primary dependency or any declared alternative as satisfying the requirement. The “Check Dependencies” button, the optional pre‑sort dependency check, and the per‑mod error tooltips all respect this toggle. Tooltips also gain an “Alternative Dependencies” section to help users discover valid substitutes when the primary is missing (hidden when the toggle is off).

Sorting also respects alternatives when two settings are enabled: using About.xml dependencies for sorting, and the Advanced alternative toggle. In that case, tier‑two sorting will prefer the primary dependency if it’s active; otherwise, itwill use the first active alternative to build an inferred load-before edge. Explicit load rules remain authoritative and take precedence over inferred edges.

Additional stability fixes were made around JSON logging of mod info by teaching the flattener to convert tuples (and nested sets) before serialization. Default behavior remains unchanged unless the Advanced alternative setting is enabled.

TL;DR:
Net effect summary
- Default behavior is unchanged unless the Advanced alternative setting is enabled.
- When enabled, alternatives can satisfy dependencies in Check Dependencies, pre‑sort checks, and tier‑two inferred sorting; tooltips also surface alternative options for unmet deps.

Relevant issue: https://github.com/RimSort/RimSort/issues/1187.