### PR TITLE
Add persistent warning/error toggling

### DIFF
--- a/app/controllers/mods_panel_controller.py
+++ b/app/controllers/mods_panel_controller.py
@@ -108,6 +108,22 @@ class ModsPanelController(QObject):
                         mod_data["uuid"]
                     ]["packageid"]
                     self._remove_from_all_ignore_lists(package_id)
+                    # Update Aux DB
+                    instance_path = Path(self.settings_controller.settings.current_instance_path)
+                    aux_metadata_controller = AuxMetadataController.get_or_create_cached_instance(
+                        instance_path / "aux_metadata.db"
+                    )
+                    uuid = mod_data["uuid"]
+                    if not uuid:
+                        logger.error("Unable to retrieve uuid when saving toggle_warning to Aux DB after menu bar reset.")
+                        return
+                    with aux_metadata_controller.Session() as aux_metadata_session:
+                            mod_path = widget.metadata_manager.internal_local_metadata[uuid]["path"]
+                            aux_metadata_controller.update(
+                                aux_metadata_session,
+                                mod_path,
+                                ignore_warnings=mod_data["warning_toggled"],
+                            )
                     logger.debug(f"Reset warning toggle for: {package_id}")
         self.mods_panel.active_mods_list.recalculate_warnings_signal.emit()
         self.mods_panel.inactive_mods_list.recalculate_warnings_signal.emit()

--- a/app/utils/aux_db_utils.py
+++ b/app/utils/aux_db_utils.py
@@ -81,3 +81,27 @@ def get_mod_user_notes(
         user_notes = entry.user_notes
 
     return user_notes
+
+
+def get_mod_warning_toggled(
+    settings_controller: SettingsController,
+    uuid: str,
+    aux_db_controller: AuxMetadataController | None,
+    session: Session | None,
+) -> bool:
+    """
+    Get the warning_toggled status for a mod from Aux Metadata DB.
+
+    :param settings_controller: SettingsController, settings controller instance
+    :param uuid: str, the uuid of the mod
+    :param aux_db_controller: AuxMetadataController | None, optional aux metadata controller instance
+    :return: bool, Warning toggled status for the mod
+    """
+    entry = get_aux_db_entry(
+        settings_controller, uuid, aux_db_controller, session
+    )
+    warning_toggled = False
+    if entry:
+        warning_toggled = entry.ignore_warnings
+
+    return warning_toggled

--- a/app/utils/custom_list_widget_item_metadata.py
+++ b/app/utils/custom_list_widget_item_metadata.py
@@ -6,7 +6,11 @@ from sqlalchemy.orm.session import Session
 
 from app.controllers.metadata_db_controller import AuxMetadataController
 from app.controllers.settings_controller import SettingsController
-from app.utils.aux_db_utils import get_mod_color, get_mod_user_notes
+from app.utils.aux_db_utils import (
+    get_mod_color,
+    get_mod_user_notes,
+    get_mod_warning_toggled,
+)
 from app.utils.metadata import MetadataManager
 
 
@@ -65,7 +69,12 @@ class CustomListWidgetItemMetadata:
         self.warnings = warnings
         self.filtered = filtered
         self.hidden_by_filter = hidden_by_filter
-        self.warning_toggled = warning_toggled
+        if not warning_toggled:
+            self.warning_toggled = get_mod_warning_toggled(
+                settings_controller, uuid, aux_metadata_controller, aux_metadata_session
+            )
+        else:
+            self.warning_toggled = warning_toggled
         self.invalid = (
             invalid if invalid is not None else self.get_invalid_by_uuid(uuid)
         )

--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -2683,6 +2683,22 @@ class ModListWidget(QListWidget):
         else:
             self.ignore_warning_list.remove(packageid)
             item_data["warning_toggled"] = False
+        # Update Aux DB
+        instance_path = Path(self.settings_controller.settings.current_instance_path)
+        aux_metadata_controller = AuxMetadataController.get_or_create_cached_instance(
+            instance_path / "aux_metadata.db"
+        )
+        uuid = item_data["uuid"]
+        if not uuid:
+            logger.error("Unable to retrieve uuid when saving toggle_warning to Aux DB.")
+            return
+        with aux_metadata_controller.Session() as aux_metadata_session:
+                mod_path = self.metadata_manager.internal_local_metadata[uuid]["path"]
+                aux_metadata_controller.update(
+                    aux_metadata_session,
+                    mod_path,
+                    ignore_warnings=item_data["warning_toggled"],
+                )
         item.setData(Qt.ItemDataRole.UserRole, item_data)
         self.recalculate_warnings_signal.emit()
 


### PR DESCRIPTION
Uses Aux Metadata DB to have persistent warning/error toggles.