### PR TITLE
Add toggle for versioned About.xml tags to take precedence

### DIFF
--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -856,6 +856,13 @@ class SettingsController(QObject):
             )
         except Exception:
             pass
+        # Prefer versioned About.xml tags over base tags
+        try:
+            self.settings_dialog.prefer_versioned_about_tags_checkbox.setChecked(
+                self.settings.prefer_versioned_about_tags
+            )
+        except Exception:
+            pass
         self.settings_dialog.enable_aux_db_behavior_editing.setChecked(
             self.settings.enable_aux_db_behavior_editing
         )
@@ -1128,6 +1135,13 @@ class SettingsController(QObject):
         try:
             self.settings.consider_alternative_package_ids = (
                 self.settings_dialog.consider_alternative_package_ids_checkbox.isChecked()
+            )
+        except Exception:
+            pass
+        # Prefer versioned About.xml tags over base tags
+        try:
+            self.settings.prefer_versioned_about_tags = (
+                self.settings_dialog.prefer_versioned_about_tags_checkbox.isChecked()
             )
         except Exception:
             pass

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -147,6 +147,11 @@ class Settings(QObject):
         # Dependencies: treat alternativePackageIds as satisfying dependencies
         self.consider_alternative_package_ids: bool = False
 
+        # XML parsing behavior
+        # If enabled, About.xml *ByVersion tags take precedence over base tags
+        # e.g., modDependenciesByVersion, loadAfterByVersion, loadBeforeByVersion, incompatibleWithByVersion, descriptionsByVersion
+        self.prefer_versioned_about_tags: bool = False
+
         # Authentication
         self.rentry_auth_code: str = ""
         self.github_username: str = ""

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -1357,6 +1357,19 @@ This basically preserves your mod coloring, user notes etc. for this many second
         )
         group_layout.addWidget(self.update_databases_on_startup_checkbox)
 
+        # Prefer versioned About.xml tags over base tags
+        self.prefer_versioned_about_tags_checkbox = QCheckBox(
+            self.tr("Prefer versioned About.xml tags over base tags")
+        )
+        self.prefer_versioned_about_tags_checkbox.setToolTip(
+            self.tr(
+                "When enabled, *ByVersion tags (e.g., modDependenciesByVersion, loadAfterByVersion, "
+                "loadBeforeByVersion, incompatibleWithByVersion, descriptionsByVersion) take precedence "
+                "over the base tags. If a matching version tag exists but is empty, the base tag is ignored."
+            )
+        )
+        group_layout.addWidget(self.prefer_versioned_about_tags_checkbox)
+
         run_args_group = QGroupBox()
         tab_layout.addWidget(run_args_group)
 


### PR DESCRIPTION
Addresses https://github.com/RimSort/RimSort/issues/1150

Changes:
- ByVersion precedence: Implemented toggleable support across dependencies, incompatibilities, loadAfter/loadBefore, and description.
 - ON: use matching vX.Y only; empty = no requirement; no match = fallback to base; non-additive.
 - OFF: ignore all byVersion tags; use base only (preserves prior behavior).
- Safety: Guarded game version parsing and byVersion shapes; use safe `.get('li')` with empty defaults; no crashes on missing/empty tags.
- Idempotency: Dependencies, incompatibilities, and load rules use sets; no duplicates when base/byVersion overlap.
- Warnings: Aligned with toggle and precedence; byVersion empties/missing produce debug logs only; base-tag warnings unchanged.

Tested by going into some mod's About.xml, adding a `loadBeforeByVersion` `v1.6` entry for some mod that was loaded before. When toggle is OFF, nothing is changed. When toggle is ON, an error shows and sorting puts the mod after, as expected.

This is kinda complicated so hopefully I don't break anything. I put all of this behind a toggle just in case.