### PR TITLE
Adds toggle for advanced filtering to improve mod panel performance

### DIFF
--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -564,8 +564,12 @@ class SettingsController(QObject):
         )
         self.settings_dialog.steam_workshop_db_github_url.setCursorPosition(0)
         self.settings_dialog.database_expiry.setText(str(self.settings.database_expiry))
-        self.settings_dialog.aux_db_time_limit.setText(str(self.settings.aux_db_time_limit))
-        self.settings_dialog.aux_db_time_limit.setEnabled(self.settings.enable_aux_db_behavior_editing)
+        self.settings_dialog.aux_db_time_limit.setText(
+            str(self.settings.aux_db_time_limit)
+        )
+        self.settings_dialog.aux_db_time_limit.setEnabled(
+            self.settings.enable_aux_db_behavior_editing
+        )
 
         # Cross Version DB Tab
         if self.settings.external_no_version_warning_metadata_source == "None":
@@ -863,6 +867,13 @@ class SettingsController(QObject):
             )
         except Exception:
             pass
+        # Advanced: enable advanced filtering toggle
+        try:
+            self.settings_dialog.enable_advanced_filtering_checkbox.setChecked(
+                self.settings.enable_advanced_filtering
+            )
+        except Exception:
+            pass
         self.settings_dialog.enable_aux_db_behavior_editing.setChecked(
             self.settings.enable_aux_db_behavior_editing
         )
@@ -973,7 +984,9 @@ class SettingsController(QObject):
             self.settings_dialog.use_this_instead_db_github_url.text()
         )
         try:
-            self.settings.aux_db_time_limit = int(self.settings_dialog.aux_db_time_limit.text())
+            self.settings.aux_db_time_limit = int(
+                self.settings_dialog.aux_db_time_limit.text()
+            )
         except Exception:
             logger.warning("Failed setting Aux DB time limit, falling back to -1")
             self.settings.aux_db_time_limit = -1
@@ -1133,8 +1146,13 @@ class SettingsController(QObject):
         )
         # Advanced: alternativePackageIds toggle
         try:
-            self.settings.consider_alternative_package_ids = (
-                self.settings_dialog.consider_alternative_package_ids_checkbox.isChecked()
+            self.settings.consider_alternative_package_ids = self.settings_dialog.consider_alternative_package_ids_checkbox.isChecked()
+        except Exception:
+            pass
+        # Advanced: enable advanced filtering toggle
+        try:
+            self.settings.enable_advanced_filtering = (
+                self.settings_dialog.enable_advanced_filtering_checkbox.isChecked()
             )
         except Exception:
             pass
@@ -1991,4 +2009,3 @@ class SettingsController(QObject):
         if self.change_mod_coloring_mode:
             self.change_mod_coloring_mode = False
             EventBus().do_change_mod_coloring_mode.emit()
-

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -146,6 +146,8 @@ class Settings(QObject):
         self.clear_moves_dlc: bool = False
         # Dependencies: treat alternativePackageIds as satisfying dependencies
         self.consider_alternative_package_ids: bool = False
+        # Advanced filtering options
+        self.enable_advanced_filtering: bool = True
 
         # XML parsing behavior
         # If enabled, About.xml *ByVersion tags take precedence over base tags

--- a/app/views/mod_info_panel.py
+++ b/app/views/mod_info_panel.py
@@ -466,8 +466,13 @@ class ModInfo:
 
             # Set folder size
             try:
-                size_bytes = uuid_to_folder_size(uuid)
-                self.mod_info_folder_size_value.setText(format_file_size(size_bytes))
+                if self.settings_controller.settings.enable_advanced_filtering:
+                    size_bytes = uuid_to_folder_size(uuid)
+                    self.mod_info_folder_size_value.setText(
+                        format_file_size(size_bytes)
+                    )
+                else:
+                    self.mod_info_folder_size_value.setText("Not available")
             except Exception:
                 self.mod_info_folder_size_value.setText("Not available")
 
@@ -486,7 +491,11 @@ class ModInfo:
 
             # Set filesystem modification time
             mod_path = mod_info.get("path")
-            if mod_path and os.path.exists(mod_path):
+            if (
+                self.settings_controller.settings.enable_advanced_filtering
+                and mod_path
+                and os.path.exists(mod_path)
+            ):
                 try:
                     fs_time = int(os.path.getmtime(mod_path))
                     dt_fs = datetime.fromtimestamp(fs_time)

--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -179,6 +179,7 @@ def uuid_to_folder_size(uuid: str) -> int:
     _FOLDER_SIZE_CACHE[mod_path] = (mtime, total_size)
     return total_size
 
+
 def get_dir_size(path: str) -> int:
     total = 0
     for entry in os.scandir(path):
@@ -190,6 +191,7 @@ def get_dir_size(path: str) -> int:
         except OSError:
             pass  # Skip file
     return total
+
 
 def format_file_size(size_in_bytes: int) -> str:
     """Format bytes to a human-readable string."""
@@ -503,7 +505,9 @@ class ModListItemInner(QWidget):
         self.main_item_layout.addWidget(
             self.in_save_icon_label, Qt.AlignmentFlag.AlignRight
         )
-        self.main_item_layout.addWidget(self.new_icon_label, Qt.AlignmentFlag.AlignRight)
+        self.main_item_layout.addWidget(
+            self.new_icon_label, Qt.AlignmentFlag.AlignRight
+        )
         self.main_item_layout.addWidget(
             self.warning_icon_label, Qt.AlignmentFlag.AlignRight
         )
@@ -604,10 +608,11 @@ class ModListItemInner(QWidget):
         mod_path = metadata.get("path")
         # Folder size: read from in-memory cache only; avoid computing on tooltip
         folder_size_line = "Folder Size: Not available\n"
-        if isinstance(mod_path, str):
-            cached = _FOLDER_SIZE_CACHE.get(mod_path)
-            if cached:
-                folder_size_line = f"Folder Size: {format_file_size(cached[1])}\n"
+        if self.settings_controller.settings.enable_advanced_filtering:
+            if isinstance(mod_path, str):
+                cached = _FOLDER_SIZE_CACHE.get(mod_path)
+                if cached:
+                    folder_size_line = f"Folder Size: {format_file_size(cached[1])}\n"
 
         # Filesystem modified time: prefer cached metadata value
         fs_time_val = metadata.get("internal_time_touched")
@@ -713,7 +718,9 @@ class ModListItemInner(QWidget):
         # Read list_type from persisted item metadata instead of Qt widget to satisfy static typing
         list_type = cast(str | None, item_data.__dict__.get("list_type"))
         # Respect setting toggle
-        show_indicators = self.settings_controller.settings.show_save_comparison_indicators
+        show_indicators = (
+            self.settings_controller.settings.show_save_comparison_indicators
+        )
         if not show_indicators:
             self.new_icon_label.setHidden(True)
             self.in_save_icon_label.setHidden(True)
@@ -2265,7 +2272,9 @@ class ModListWidget(QListWidget):
         package_id_to_errors: dict[str, dict[str, None | set[str] | bool]] = {
             uuid: {
                 "missing_dependencies": set() if self.list_type == "Active" else None,
-                "alternative_dependencies": set() if self.list_type == "Active" else None,
+                "alternative_dependencies": set()
+                if self.list_type == "Active"
+                else None,
                 "conflicting_incompatibilities": (
                     set() if self.list_type == "Active" else None
                 ),
@@ -2308,7 +2317,9 @@ class ModListWidget(QListWidget):
                 try:
                     pkg_id = internal_local_metadata[uuid]["packageid"]
                     is_in_save = (
-                        pkg_id in latest_save_ids if latest_save_ids is not None else False
+                        pkg_id in latest_save_ids
+                        if latest_save_ids is not None
+                        else False
                     )
                     if self.list_type == "Active":
                         current_item_data.__dict__["is_new"] = not is_in_save
@@ -2355,9 +2366,7 @@ class ModListWidget(QListWidget):
                 # Build missing dependencies set while honoring alternativePackageIds
                 missing_deps: set[str] = set()
                 alternative_deps: set[str] = set()
-                consider_alternatives = (
-                    self.metadata_manager.settings_controller.settings.consider_alternative_package_ids
-                )
+                consider_alternatives = self.metadata_manager.settings_controller.settings.consider_alternative_package_ids
                 for dep_entry in mod_data.get("dependencies", []):
                     alt_ids: set[str] = set()
                     if isinstance(dep_entry, tuple):
@@ -2386,8 +2395,12 @@ class ModListWidget(QListWidget):
                         # Only record alternatives if the advanced option is enabled
                         if consider_alternatives:
                             # Prefer to show only alternatives not already installed
-                            alt_candidates = {a for a in alt_ids if a not in package_ids_set}
-                            alternative_deps.update(alt_candidates if alt_candidates else alt_ids)
+                            alt_candidates = {
+                                a for a in alt_ids if a not in package_ids_set
+                            }
+                            alternative_deps.update(
+                                alt_candidates if alt_candidates else alt_ids
+                            )
 
                 mod_errors["missing_dependencies"] = missing_deps
                 mod_errors["alternative_dependencies"] = alternative_deps
@@ -2428,7 +2441,13 @@ class ModListWidget(QListWidget):
                 ("conflicting_incompatibilities", self.tr("\nIncompatibilities:")),
             ]
             if self.metadata_manager.settings_controller.settings.consider_alternative_package_ids:
-                tooltip_sections.insert(1, ("alternative_dependencies", self.tr("\nAlternative Dependencies:")))
+                tooltip_sections.insert(
+                    1,
+                    (
+                        "alternative_dependencies",
+                        self.tr("\nAlternative Dependencies:"),
+                    ),
+                )
 
             for error_type, tooltip_header in tooltip_sections:
                 if mod_errors[error_type]:
@@ -2616,10 +2635,17 @@ class ModListWidget(QListWidget):
         Returns:
             None
         """
-        sorted_uuids = sort_uuids(uuids, key=key)
-        self.recreate_mod_list(list_type, sorted_uuids)
+        filtering = self.settings_controller.settings.enable_advanced_filtering
 
-    def recreate_mod_list(self, list_type: str, uuids: list[str]) -> None:
+        if filtering:
+            sorted_uuids = sort_uuids(uuids, key=key)
+            self.recreate_mod_list(list_type, sorted_uuids, filtering=filtering)
+        else:
+            self.recreate_mod_list(list_type, uuids)
+
+    def recreate_mod_list(
+        self, list_type: str, uuids: list[str], filtering: bool = False
+    ) -> None:
         """
         Clear all mod items and add new ones from a dict.
 
@@ -2634,7 +2660,8 @@ class ModListWidget(QListWidget):
         if uuids:  # Insert data...
             for uuid_key in uuids:
                 # Build foldersize cache at cost of load time
-                uuid_to_folder_size(uuid_key)
+                if filtering:
+                    uuid_to_folder_size(uuid_key)
                 mod_path = self.metadata_manager.internal_local_metadata[uuid_key][
                     "path"
                 ]
@@ -2690,15 +2717,17 @@ class ModListWidget(QListWidget):
         )
         uuid = item_data["uuid"]
         if not uuid:
-            logger.error("Unable to retrieve uuid when saving toggle_warning to Aux DB.")
+            logger.error(
+                "Unable to retrieve uuid when saving toggle_warning to Aux DB."
+            )
             return
         with aux_metadata_controller.Session() as aux_metadata_session:
-                mod_path = self.metadata_manager.internal_local_metadata[uuid]["path"]
-                aux_metadata_controller.update(
-                    aux_metadata_session,
-                    mod_path,
-                    ignore_warnings=item_data["warning_toggled"],
-                )
+            mod_path = self.metadata_manager.internal_local_metadata[uuid]["path"]
+            aux_metadata_controller.update(
+                aux_metadata_session,
+                mod_path,
+                ignore_warnings=item_data["warning_toggled"],
+            )
         item.setData(Qt.ItemDataRole.UserRole, item_data)
         self.recalculate_warnings_signal.emit()
 
@@ -3020,10 +3049,18 @@ class ModsPanel(QWidget):
         # New mods label (next to warnings/errors)
         self.news_layout = QHBoxLayout()
         self.new_icon: QLabel = QLabel()
-        self.new_icon.setPixmap(QIcon(str(AppInfo().theme_data_folder / "default-icons" / "new.png")).pixmap(QSize(20, 20)))
-        self.new_text: AdvancedClickableQLabel = AdvancedClickableQLabel(self.tr("0 new"))
+        self.new_icon.setPixmap(
+            QIcon(
+                str(AppInfo().theme_data_folder / "default-icons" / "new.png")
+            ).pixmap(QSize(20, 20))
+        )
+        self.new_text: AdvancedClickableQLabel = AdvancedClickableQLabel(
+            self.tr("0 new")
+        )
         self.new_text.setObjectName("summaryValue")
-        self.new_text.setToolTip(self.tr("Click to only show active mods not in latest save"))
+        self.new_text.setToolTip(
+            self.tr("Click to only show active mods not in latest save")
+        )
         self.news_layout.addWidget(self.new_icon, 1)
         self.news_layout.addWidget(self.new_text, 99)
         self.warnings_errors_layout.addLayout(self.news_layout, 50)
@@ -3091,6 +3128,7 @@ class ModsPanel(QWidget):
             self.on_inactive_mods_search_clear
         )
         self.inactive_mods_search_filter: QComboBox = QComboBox()
+        self.inactive_mods_search_filter.setParent(self)
         self.inactive_mods_search_filter.setObjectName("MainUI")
         self.inactive_mods_search_filter.setMaximumWidth(140)
         self.inactive_mods_search_filter.addItems(
@@ -3103,6 +3141,7 @@ class ModsPanel(QWidget):
             ]
         )
         self.inactive_mods_sort_combobox: QComboBox = QComboBox()
+        self.inactive_mods_sort_combobox.setParent(self)
         self.inactive_mods_sort_combobox.setObjectName("MainUI")
         self.inactive_mods_sort_combobox.setMaximumWidth(120)
         self.inactive_mods_sort_combobox.setToolTip(self.tr("Sort inactive mods by"))
@@ -3119,6 +3158,7 @@ class ModsPanel(QWidget):
         # Sort order toggle (Asc/Desc)
         self.inactive_sort_descending: bool = True
         self.inactive_mods_sort_order_button: QToolButton = QToolButton()
+        self.inactive_mods_sort_order_button.setParent(self)
         self.inactive_mods_sort_order_button.setObjectName("MainUI")
         self.inactive_mods_sort_order_button.setMaximumWidth(60)
         self.inactive_mods_sort_order_button.setToolTip(self.tr("Toggle sort order"))
@@ -3139,6 +3179,14 @@ class ModsPanel(QWidget):
             self.inactive_mods_sort_combobox, 120
         )
         self.inactive_mods_search_layout.addWidget(self.inactive_mods_sort_order_button)
+
+        # Set initial visibility based on settings
+        self.inactive_mods_sort_combobox.setVisible(
+            self.settings_controller.settings.enable_advanced_filtering
+        )
+        self.inactive_mods_sort_order_button.setVisible(
+            self.settings_controller.settings.enable_advanced_filtering
+        )
 
         # Adding Completer.
         # self.completer = QCompleter(self.active_mods_list.get_list_items())
@@ -3239,6 +3287,8 @@ class ModsPanel(QWidget):
     def on_inactive_mods_sort_changed(self, text: str) -> None:
         """Handle inactive mods sorting selection change."""
         # Determine the sorting key based on the selected text
+        if not self.settings_controller.settings.enable_advanced_filtering:
+            return
         if text == self.tr("Name"):
             sort_key = ModsPanelSortKey.MODNAME
         elif text == self.tr("Modified Time"):

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -1040,10 +1040,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
         size_note = QLabel(
             self.tr(
                 "Min is {MIN_SIZE} and Max is {MAX_SIZE}. Values outside this range will be reset to defaults."
-            ).format(
-                MIN_SIZE=Settings.MIN_SIZE,
-                MAX_SIZE=Settings.MAX_SIZE
-            )
+            ).format(MIN_SIZE=Settings.MIN_SIZE, MAX_SIZE=Settings.MAX_SIZE)
         )
         size_note.setFont(GUIInfo().emphasis_font)
         size_note.setAlignment(Qt.AlignmentFlag.AlignCenter)
@@ -1301,9 +1298,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
         group_layout.addWidget(self.show_duplicate_mods_warning_checkbox)
 
         # Clear button behavior
-        self.clear_moves_dlc_checkbox = QCheckBox(
-            self.tr("Clear also moves DLC")
-        )
+        self.clear_moves_dlc_checkbox = QCheckBox(self.tr("Clear also moves DLC"))
         group_layout.addWidget(self.clear_moves_dlc_checkbox)
 
         self.show_mod_updates_checkbox = QCheckBox(
@@ -1345,6 +1340,17 @@ This basically preserves your mod coloring, user notes etc. for this many second
             )
         )
         group_layout.addWidget(self.consider_alternative_package_ids_checkbox)
+
+        self.enable_advanced_filtering_checkbox = QCheckBox(
+            self.tr("Enable advanced filtering options")
+        )
+        self.enable_advanced_filtering_checkbox.setToolTip(
+            self.tr(
+                "If enabled, additional filtering options like folder size, author, and modified date will be available in the mods panel. "
+                "Disabling this can improve performance by avoiding heavy calculations."
+            )
+        )
+        group_layout.addWidget(self.enable_advanced_filtering_checkbox)
 
         self.update_databases_on_startup_checkbox = QCheckBox(
             self.tr("Update databases on startup")

--- a/tests/views/test_main_content_run.py
+++ b/tests/views/test_main_content_run.py
@@ -111,15 +111,11 @@ def main_content(
     mc.deleteLater()
 
 
-def test_cancel_on_unsaved(
-    patch_dialogue: Mock,
-    patch_launch: List[Tuple[Path, List[str]]],
-    main_content: Tuple[MainContent, List[bool]],
-) -> None:
+def test_cancel_on_unsaved(patch_dialogue: Mock, patch_launch: List[Tuple[Path, List[str]]], main_content: Tuple[MainContent, List[bool]]) -> None:
     mc, save_calls = main_content
     # Set unsaved changes
-    mc.mods_panel.active_mods_list.uuids = ["a", "b"]
-    mc.active_mods_uuids_last_save = ["a"]
+    mc.mods_panel.active_mods_list.uuids = ['a', 'b']
+    mc.active_mods_uuids_last_save = ['a']
     # Simulate Cancel
     patch_dialogue.return_value = QMessageBox.StandardButton.Cancel
     mc._do_run_game()
@@ -127,19 +123,15 @@ def test_cancel_on_unsaved(
     assert patch_launch == []
 
 
-def test_run_anyway_on_unsaved(
-    patch_dialogue: Mock,
-    patch_launch: List[Tuple[Path, List[str]]],
-    main_content: Tuple[MainContent, List[bool]],
-) -> None:
+def test_run_anyway_on_unsaved(patch_dialogue: Mock, patch_launch: List[Tuple[Path, List[str]]], main_content: Tuple[MainContent, List[bool]]) -> None:
     mc, save_calls = main_content
-    mc.mods_panel.active_mods_list.uuids = ["a", "b"]
-    mc.active_mods_uuids_last_save = ["a"]
-    patch_dialogue.return_value = mc.tr("Run Anyway")
+    mc.mods_panel.active_mods_list.uuids = ['a', 'b']
+    mc.active_mods_uuids_last_save = ['a']
+    patch_dialogue.return_value = mc.tr('Run Anyway')
     mc._do_run_game()
     assert save_calls == []
     # launch_game_process with dummy args
-    assert patch_launch == [(Path("/fake/path"), ["--test"])]
+    assert patch_launch == [(Path('/fake/path'), ['--test'])]
 
 
 def test_save_and_run_on_unsaved(

--- a/tests/views/test_main_content_run.py
+++ b/tests/views/test_main_content_run.py
@@ -1,13 +1,13 @@
-
 # tests/views/test_main_content_run.py
 from pathlib import Path
 from types import SimpleNamespace
-from typing import List, Tuple
+from typing import Generator, Iterator, List, Tuple
 from unittest.mock import Mock
 
 import pytest
-from PySide6.QtWidgets import QMessageBox
+from PySide6.QtWidgets import QApplication, QMessageBox
 
+import app.utils.metadata as metadata
 import app.utils.steam.steamcmd.wrapper as steamcmd_wrapper
 import app.views.dialogue as dialogue
 from app.views.main_content_panel import MainContent
@@ -19,59 +19,107 @@ class DummySettings:
         self.current_instance = "inst1"
         # Toggle filter for mod type filtering
         self.mod_type_filter_toggle = False
+        self.enable_advanced_filtering = True
         # Instance data with dummy game_folder and run_args
         self.instances = {
             "inst1": SimpleNamespace(
-                game_folder="/fake/path", run_args=["--test"], steam_client_integration=False
+                game_folder="/fake/path",
+                run_args=["--test"],
+                steam_client_integration=False,
             )
         }
+
 
 class DummySettingsController:
     def __init__(self) -> None:
         self.settings = DummySettings()
 
+
+@pytest.fixture(scope="session", autouse=True)
+def qapp() -> Iterator[QApplication]:
+    """Create QApplication instance for the test session."""
+    app = QApplication.instance()
+    if app is None or not isinstance(app, QApplication):
+        app = QApplication([])
+    yield app
+
+
 @pytest.fixture(autouse=True)
 def patch_dialogue(monkeypatch: pytest.MonkeyPatch) -> Mock:
     mock_dialog = Mock()
     mock_dialog.return_value = None
-    monkeypatch.setattr(dialogue, 'show_dialogue_conditional', mock_dialog)
+    monkeypatch.setattr(dialogue, "show_dialogue_conditional", mock_dialog)
     return mock_dialog
+
 
 @pytest.fixture(autouse=True)
 def patch_launch(monkeypatch: pytest.MonkeyPatch) -> List[Tuple[Path, List[str]]]:
     # Fake launch_game_process in main_content_panel to capture calls
     from app.views import main_content_panel
+
     calls: List[Tuple[Path, List[str]]] = []
+
     def fake_launch_game_process(game_install_path: str, args: List[str]) -> None:
         calls.append((Path(game_install_path), args))
-    monkeypatch.setattr(main_content_panel, 'launch_game_process', fake_launch_game_process)
+
+    monkeypatch.setattr(
+        main_content_panel, "launch_game_process", fake_launch_game_process
+    )
     return calls
+
 
 @pytest.fixture(autouse=True)
 def patch_steamcmd(monkeypatch: pytest.MonkeyPatch) -> None:
     # Prevent SteamcmdInterface __init__ requiring args
     monkeypatch.setattr(
         steamcmd_wrapper.SteamcmdInterface,
-        'instance',
-        classmethod(lambda cls: SimpleNamespace(setup=True, steamcmd_appworkshop_acf_path=""))
+        "instance",
+        classmethod(
+            lambda cls: SimpleNamespace(setup=True, steamcmd_appworkshop_acf_path="")
+        ),
     )
 
+
+@pytest.fixture(autouse=True)
+def patch_metadata_manager(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch MetadataManager to avoid initialization issues."""
+    # Create a mock MetadataManager instance
+    mock_metadata_manager = Mock()
+
+    # Patch the MetadataManager.instance method
+    monkeypatch.setattr(
+        metadata.MetadataManager,
+        "instance",
+        classmethod(lambda cls: mock_metadata_manager),
+    )
+
+
 @pytest.fixture
-def main_content(monkeypatch: pytest.MonkeyPatch) -> Tuple[MainContent, List[bool]]:
+def main_content(
+    monkeypatch: pytest.MonkeyPatch, qapp: QApplication
+) -> Generator[Tuple[MainContent, List[bool]], None, None]:
     # Initialize MainContent with dummy settings
     sc = DummySettingsController()
     mc = MainContent(sc)  # type: ignore[arg-type]
     # Patch _do_save to capture calls
     save_calls: List[bool] = []
-    monkeypatch.setattr(mc, '_do_save', lambda: save_calls.append(True))
-    return mc, save_calls
+    monkeypatch.setattr(mc, "_do_save", lambda: save_calls.append(True))
+
+    yield mc, save_calls
+
+    # Cleanup: delete the widget to avoid Qt object reuse issues
+    mc.deleteLater()
 
 
-def test_cancel_on_unsaved(patch_dialogue: Mock, patch_launch: List[Tuple[Path, List[str]]], main_content: Tuple[MainContent, List[bool]]) -> None:
+def test_cancel_on_unsaved(
+    patch_dialogue: Mock,
+    patch_launch: List[Tuple[Path, List[str]]],
+    main_content: Tuple[MainContent, List[bool]],
+) -> None:
     mc, save_calls = main_content
     # Set unsaved changes
-    mc.mods_panel.active_mods_list.uuids = ['a', 'b']
-    mc.active_mods_uuids_last_save = ['a']
+    mc.mods_panel.active_mods_list.uuids = ["a", "b"]
+    mc.active_mods_uuids_last_save = ["a"]
     # Simulate Cancel
     patch_dialogue.return_value = QMessageBox.StandardButton.Cancel
     mc._do_run_game()
@@ -79,34 +127,46 @@ def test_cancel_on_unsaved(patch_dialogue: Mock, patch_launch: List[Tuple[Path, 
     assert patch_launch == []
 
 
-def test_run_anyway_on_unsaved(patch_dialogue: Mock, patch_launch: List[Tuple[Path, List[str]]], main_content: Tuple[MainContent, List[bool]]) -> None:
+def test_run_anyway_on_unsaved(
+    patch_dialogue: Mock,
+    patch_launch: List[Tuple[Path, List[str]]],
+    main_content: Tuple[MainContent, List[bool]],
+) -> None:
     mc, save_calls = main_content
-    mc.mods_panel.active_mods_list.uuids = ['a', 'b']
-    mc.active_mods_uuids_last_save = ['a']
-    patch_dialogue.return_value = mc.tr('Run Anyway')
+    mc.mods_panel.active_mods_list.uuids = ["a", "b"]
+    mc.active_mods_uuids_last_save = ["a"]
+    patch_dialogue.return_value = mc.tr("Run Anyway")
     mc._do_run_game()
     assert save_calls == []
     # launch_game_process with dummy args
-    assert patch_launch == [(Path('/fake/path'), ['--test'])]
+    assert patch_launch == [(Path("/fake/path"), ["--test"])]
 
 
-def test_save_and_run_on_unsaved(patch_dialogue: Mock, patch_launch: List[Tuple[Path, List[str]]], main_content: Tuple[MainContent, List[bool]]) -> None:
+def test_save_and_run_on_unsaved(
+    patch_dialogue: Mock,
+    patch_launch: List[Tuple[Path, List[str]]],
+    main_content: Tuple[MainContent, List[bool]],
+) -> None:
     mc, save_calls = main_content
-    mc.mods_panel.active_mods_list.uuids = ['a', 'b']
-    mc.active_mods_uuids_last_save = ['a']
-    patch_dialogue.return_value = mc.tr('Save and Run')
+    mc.mods_panel.active_mods_list.uuids = ["a", "b"]
+    mc.active_mods_uuids_last_save = ["a"]
+    patch_dialogue.return_value = mc.tr("Save and Run")
     mc._do_run_game()
     assert save_calls == [True]
-    assert patch_launch == [(Path('/fake/path'), ['--test'])]
+    assert patch_launch == [(Path("/fake/path"), ["--test"])]
 
 
-def test_run_without_unsaved(patch_dialogue: Mock, patch_launch: List[Tuple[Path, List[str]]], main_content: Tuple[MainContent, List[bool]]) -> None:
+def test_run_without_unsaved(
+    patch_dialogue: Mock,
+    patch_launch: List[Tuple[Path, List[str]]],
+    main_content: Tuple[MainContent, List[bool]],
+) -> None:
     mc, save_calls = main_content
     # No unsaved changes
-    mc.mods_panel.active_mods_list.uuids = ['a', 'b']
-    mc.active_mods_uuids_last_save = ['a', 'b']
+    mc.mods_panel.active_mods_list.uuids = ["a", "b"]
+    mc.active_mods_uuids_last_save = ["a", "b"]
     mc._do_run_game()
     # Dialogue not shown
     assert patch_dialogue.return_value is None
     assert save_calls == []
-    assert patch_launch == [(Path('/fake/path'), ['--test'])]
+    assert patch_launch == [(Path("/fake/path"), ["--test"])]


### PR DESCRIPTION
Introduces an option to enable or disable advanced filtering features, allowing users to control whether additional mod data (e.g. folder size, author, modified date) is shown in the mods panel. Disabling advanced filtering hides related UI elements and skips heavy calculations, addressing performance concerns for large mod sets.

(I made this an option because I don’t like it scanning the whole disk and it makes the two mod panels different in size)

https://github.com/RimSort/RimSort/pull/1190#issuecomment-3194035286