### PR TITLE
Add option to auto-delete orphaned DDS files

### DIFF
--- a/app/controllers/app_controller.py
+++ b/app/controllers/app_controller.py
@@ -11,6 +11,7 @@ from app.controllers.theme_controller import ThemeController
 from app.models.settings import Settings
 from app.utils.app_info import AppInfo
 from app.utils.constants import DEFAULT_USER_RULES
+from app.utils.dds_utility import DDSUtility
 from app.utils.gui_info import GUIInfo
 from app.utils.metadata import MetadataManager
 from app.utils.steam.steamcmd.wrapper import SteamcmdInterface
@@ -40,6 +41,8 @@ class AppController(QObject):
         self.set_theme()
         # Initialize the Steamcmd interface
         self.initialize_steamcmd_interface()
+        # Perform cleanup of orphaned DDS files if the setting is enabled
+        self.do_dds_cleanup()
         # Initialize the metadata manager
         self.initialize_metadata_manager()
         # Initialize the main window controller
@@ -115,6 +118,12 @@ class AppController(QObject):
             ].steamcmd_install_path,
             self.settings_controller.settings.steamcmd_validate_downloads,
         )
+
+    def do_dds_cleanup(self) -> None:
+        """Performs cleanup of orphaned DDS files if the setting is enabled."""
+        if self.settings.auto_delete_orphaned_dds:
+            dds_utility = DDSUtility(self.settings_controller)
+            dds_utility.delete_dds_files_without_png()
 
     def initialize_metadata_manager(self) -> None:
         """Initializes the MetadataManager."""

--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -742,6 +742,9 @@ class SettingsController(QObject):
         self.settings_dialog.todds_custom_command_lineedit.setText(
             self.settings.todds_custom_command
         )
+        self.settings_dialog.auto_delete_orphaned_dds_checkbox.setChecked(
+            self.settings.auto_delete_orphaned_dds
+        )
 
         # Themes tab
         self.settings_dialog.enable_themes_checkbox.setChecked(
@@ -1063,6 +1066,9 @@ class SettingsController(QObject):
         )
         self.settings.todds_overwrite = (
             self.settings_dialog.todds_overwrite_checkbox.isChecked()
+        )
+        self.settings.auto_delete_orphaned_dds = (
+            self.settings_dialog.auto_delete_orphaned_dds_checkbox.isChecked()
         )
 
         # Themes tab

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -99,10 +99,11 @@ class Settings(QObject):
 
         # todds
         self.todds_preset: str = "optimized"
+        self.todds_custom_command: str = ""
         self.todds_active_mods_target: bool = True
         self.todds_dry_run: bool = False
         self.todds_overwrite: bool = False
-        self.todds_custom_command: str = ""
+        self.auto_delete_orphaned_dds: bool = False
 
         # Theme
         self.enable_themes: bool = True

--- a/app/utils/dds_utility.py
+++ b/app/utils/dds_utility.py
@@ -1,0 +1,54 @@
+import os
+from glob import glob
+
+from loguru import logger
+
+from app.controllers.settings_controller import SettingsController
+
+
+class DDSUtility:
+    """
+    Utility class for handling DDS files in the application.
+    """
+
+    def __init__(self, settings_controller: SettingsController) -> None:
+        self.settings_controller = settings_controller
+        logger.info("DDSUtility initialized.")
+
+    def delete_dds_files_without_png(self) -> None:
+        """Deletes all DDS files that do not have a corresponding PNG file."""
+        logger.info(
+            "Running checks for deleting DDS files without corresponding PNG files..."
+        )
+        local_mods_target = self.settings_controller.settings.instances[
+            self.settings_controller.settings.current_instance
+        ].local_folder
+        workshop_mods_target = self.settings_controller.settings.instances[
+            self.settings_controller.settings.current_instance
+        ].workshop_folder
+
+        # Combine both paths to search for DDS files
+        combined_paths = [local_mods_target, workshop_mods_target]
+        combined_paths = [
+            path for path in combined_paths if path and os.path.exists(path)
+        ]
+
+        dds_files = []
+        for path in combined_paths:
+            dds_files.extend(glob(os.path.join(path, "**", "*.dds"), recursive=True))
+
+        # Check for corresponding PNG files
+        deleted_count = 0
+        for dds_file in dds_files:
+            png_file = dds_file.replace(".dds", ".png")
+            if not os.path.exists(png_file):
+                logger.warning(f"Deleting DDS file without PNG: {dds_file}")
+                try:
+                    os.remove(dds_file)
+                    deleted_count += 1
+                except OSError as e:
+                    logger.error(f"Failed to delete {dds_file}: {e}")
+
+        logger.info(
+            f"Deleted {deleted_count} DDS files without corresponding PNG files"
+        )

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -914,6 +914,19 @@ This basically preserves your mod coloring, user notes etc. for this many second
         )
         group_layout.addWidget(self.todds_overwrite_checkbox)
 
+        self.auto_delete_orphaned_dds_checkbox = QCheckBox(
+            self.tr(
+                "Automatically delete .dds files if no corresponding .png file exists"
+            )
+        )
+        self.auto_delete_orphaned_dds_checkbox.setToolTip(
+            self.tr(
+                "This will delete .dds files that are not paired with a .png file,\n\n"
+                "This checks may take few seconds depending on the number of .dds files present."
+            )
+        )
+        group_layout.addWidget(self.auto_delete_orphaned_dds_checkbox)
+
         # Connect radio buttons to enable/disable custom command input
         self.todds_preset_optimized_radio.toggled.connect(self._on_preset_radio_toggled)
         self.todds_preset_custom_radio.toggled.connect(self._on_preset_radio_toggled)


### PR DESCRIPTION
1. Introduces a new setting and UI checkbox in settings to automatically delete .dds files that do not have a corresponding .png file
2.  Implements DDSUtility for the cleanup logic and integrates the feature into the app initialization
3.  Disabled by Default and only runs once on app initialization

<img width="902" height="730" alt="image" src="https://github.com/user-attachments/assets/72e95165-73a3-414c-8f9c-92037b48b717" />
