### PR TITLE
Handling for custom Python temp path

### DIFF
--- a/update.bat
+++ b/update.bat
@@ -14,7 +14,11 @@ set "current_dir_no_slash=%current_dir:~0,-1%"
 set "executable_path=%current_dir%RimSort.exe"
 
 REM Path to the update files (should be copied here externally)
+if "%TMPDIR%" == "" (
 set "update_source_folder=%TEMP%\RimSort"
+) else (
+set "update_source_folder=%TMPDIR%\RimSort"
+)
 
 REM Attempt to stop RimSort if it's already running
 call :KillRimSort


### PR DESCRIPTION
On Windows, Python can have a custom temporary folder set by using the system Environment Variable %TMPDIR%, this change checks if %TMPDIR% exists and if so uses it as the update_source_folder, otherwise use the regular %TEMP% path.

Resolves the issue I was having with https://github.com/RimSort/RimSort/issues/1083