### PR TITLE
Launch xdg-open with a clean environment

### DIFF
--- a/app/utils/generic.py
+++ b/app/utils/generic.py
@@ -370,7 +370,7 @@ def platform_specific_open(path: str | Path) -> None:
                 raise
     elif sys.platform == "linux":
         logger.info(f"Opening {path} with xdg-open on Linux")
-        subprocess.Popen(["xdg-open", path])
+        subprocess.Popen(["xdg-open", path], env=dict(os.environ, LD_LIBRARY_PATH=""))
     else:
         logger.error("Attempting to open directory on an unknown system")
 


### PR DESCRIPTION
Closes #998 

---

Similar to [PyInstaller](https://pyinstaller.org/en/stable/common-issues-and-pitfalls.html#launching-external-programs-from-the-frozen-application), Nuitka will also set `LD_LIBRARY_PATH` to the running application directory.

When launching applications from `subprocess.Popen`, they'll inherit RimSort's environment, including the changed `LD_LIBRARY_PATH`.

This can cause issues when launching external applications (like KDE's xdg-open) due to conflicts with system Qt6 and PySide bundled Qt6, since applications will try to load libQt6Core (and other libs) from RimSorts directory instead.

Unlike PyInstaller however, there's not a "backup" `LD_LIBRARY_PATH_ORIG` to resture the value from, so we just reset it to empty when launching xdg-open