### PR TITLE
Fix AttributeError in RunnerPanel.finished method

### DIFF
--- a/app/windows/runner_panel.py
+++ b/app/windows/runner_panel.py
@@ -72,6 +72,7 @@ class RunnerPanel(QWidget):
         self.process_last_args: Sequence[str] = []
         self.steamcmd_current_pfid: Optional[str] = None
         self.login_error = False
+        self.redownloading = False
 
         # Set up UI components
         self._setup_text_display()


### PR DESCRIPTION
Added self.redownloading = False to the process-related variables in init 
This prevents AttributeError when finished() method tries to access self.redownloading 
This attribute is used to track if a redownload process is in progress