### PR TITLE
Close RunnerPanel after initiating redownload

### DIFF
--- a/app/windows/runner_panel.py
+++ b/app/windows/runner_panel.py
@@ -552,6 +552,7 @@ class RunnerPanel(QWidget):
         if answer == QMessageBox.StandardButton.Yes:
             self.redownloading = True
             self.steamcmd_downloader_signal.emit(self.steamcmd_download_tracking)
+            self.close()
 
         else:
             self.redownloading = False


### PR DESCRIPTION
Add self.close() call in _handle_steamcmd_completion method to close the runner panel immediately after emitting the redownload signal. This prevents user interaction with the panel during the ongoing download process.