### PR TITLE
Replace pyperclip with PySide6 clipboard API

### DIFF
--- a/app/utils/generic.py
+++ b/app/utils/generic.py
@@ -14,9 +14,6 @@ from typing import Any, Callable, Generator, Tuple
 
 import requests
 from loguru import logger
-from pyperclip import (  # type: ignore # Stubs don't exist for pyperclip
-    copy as copy_to_clipboard,
-)
 from PySide6.QtCore import QCoreApplication
 from PySide6.QtWidgets import QApplication
 
@@ -44,7 +41,8 @@ def copy_to_clipboard_safely(text: str) -> None:
     :param text: text to copy to clipboard
     """
     try:
-        copy_to_clipboard(text)
+        clipboard = QApplication.clipboard()
+        clipboard.setText(text)
     except Exception as e:
         logger.error(f"Failed to copy to clipboard: {e}")
         dialogue.show_fatal_error(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ dependencies = [
     "psutil==7.0.0",
     "pygit2==1.18.2",
     "pygithub==2.7.0",
-    "pyperclip==1.9.0",
     "pyside6==6.9.2",
     "requests==2.32.5",
     "sqlalchemy==2.0.43",

--- a/uv.lock
+++ b/uv.lock
@@ -599,12 +599,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyperclip"
-version = "1.9.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/30/23/2f0a3efc4d6a32f3b63cdff36cd398d9701d26cda58e3ab97ac79fb5e60d/pyperclip-1.9.0.tar.gz", hash = "sha256:b7de0142ddc81bfc5c7507eea19da920b92252b548b96186caf94a5e2527d310", size = 20961, upload-time = "2024-06-18T20:38:48.401Z" }
-
-[[package]]
 name = "pyside6"
 version = "6.9.2"
 source = { registry = "https://pypi.org/simple" }
@@ -752,7 +746,6 @@ dependencies = [
     { name = "psutil", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "pygit2", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "pygithub", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "pyperclip", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "pyside6", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "requests", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "sqlalchemy", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -805,7 +798,6 @@ requires-dist = [
     { name = "psutil", specifier = "==7.0.0" },
     { name = "pygit2", specifier = "==1.18.2" },
     { name = "pygithub", specifier = "==2.7.0" },
-    { name = "pyperclip", specifier = "==1.9.0" },
     { name = "pyside6", specifier = "==6.9.2" },
     { name = "requests", specifier = "==2.32.5" },
     { name = "sqlalchemy", specifier = "==2.0.43" },


### PR DESCRIPTION
Removed the pyperclip dependency and updated the copy_to_clipboard_safely function in app/utils/generic.py to use QApplication.clipboard() instead of copy_to_clipboard. 
This reduces external dependencies by leveraging PySide6's built-in clipboard functionality. 
Updated pyproject.toml and uv.lock to remove pyperclip references.