### PR TITLE
Handle edge releases in update check logic

### DIFF
--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -820,6 +820,15 @@ class MainContent(QObject):
 
         logger.debug(f"Latest RimSort version: {latest_version}")
 
+        # Special handling for edge releases
+        current_version_str = str(current_version).lower()
+        latest_version_str = str(latest_version).lower()
+        if "edge" in current_version_str and "edge" in latest_version_str:
+            logger.warning(
+                "Both current and latest versions are edge releases. Skipping update prompt."
+            )
+            return
+
         # Compare versions
         try:
             current_version_parsed = version.parse(current_version)
@@ -871,7 +880,10 @@ class MainContent(QObject):
 
             # Parse version
             try:
-                latest_version = version.parse(normalized_tag)
+                if "edge" in normalized_tag.lower():
+                    latest_version = version.parse("999.999.999")
+                else:
+                    latest_version = version.parse(normalized_tag)
             except Exception as e:
                 logger.warning(f"Failed to parse version from tag {tag_name}: {e}")
                 self.show_update_error()

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -307,7 +307,7 @@ class MainWindow(QMainWindow):
             self.settings_controller.settings.save()
         # IF CHECK FOR UPDATE ON STARTUP...
         if self.settings_controller.settings.check_for_update_startup:
-            self.main_content_panel.actions_slot("check_for_update")
+            self.main_content_panel._do_check_for_update()
         # Delete outdated entries in aux DB
         EventBus().do_delete_outdated_entries_in_aux_db.emit()
 


### PR DESCRIPTION
Adds special handling to skip update prompts when both current and latest versions are edge releases. 
Also ensures edge tags are parsed as a high version to avoid incorrect update notifications. 
Updates the update check call in main_window.py to use the correct method.