### PR TITLE
Add 'use_this_instead' flag for alternative mods

### DIFF
--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -2535,6 +2535,7 @@ class ModListWidget(QListWidget):
                 current_item_data["alternative"]
                 and mod_data["packageid"] not in self.ignore_warning_list
             ):
+                mod_errors["use_this_instead"] = True
                 tool_tip_text += self.tr(
                     "\nAn alternative updated mod is recommended:\n{alternative}"
                 ).format(alternative=current_item_data["alternative"])


### PR DESCRIPTION
Sets 'use_this_instead' in mod_errors when an alternative mod is recommended, improving error reporting and tooltip messaging for outdated mods.
Also, now shows warning and error panel correctly with proper mods count

Before
<img width="1316" height="794" alt="image" src="https://github.com/user-attachments/assets/6a8df79e-b9d3-4d6a-8152-b1c99977321c" />

Now
<img width="1289" height="794" alt="image" src="https://github.com/user-attachments/assets/58e9b276-efc0-44bb-afc3-1d52fd0f1c14" />
