### PR TITLE
Implement mod replacement logic for dependency sorting

### DIFF
--- a/app/utils/constants.py
+++ b/app/utils/constants.py
@@ -77,6 +77,7 @@ SEARCH_DATA_SOURCE_FILTER_INDEXES = [
     "xml",
 ]
 KNOWN_MOD_REPLACEMENTS = {
+    "zetrith.prepatcher": {"jikulopo.prepatcher"},
     "brrainz.harmony": {"zetrith.prepatcher", "jikulopo.prepatcher"},
     "aoba.motorization.engine": {"rimthunder.core"},
 }


### PR DESCRIPTION
- Added 'jikulopo.prepatcher' as a replacement for 'zetrith.prepatcher'
- Implements a mod replacement system that allows certain mods to substitute for others in RimSort's dependency resolution and sorting logic. 
- This feature improves compatibility and load ordering when users have alternative implementations of the same functionality.