### PR TITLE
Add jikulopo.prepatcher to Harmony mod replacements

### DIFF
--- a/app/utils/constants.py
+++ b/app/utils/constants.py
@@ -77,7 +77,7 @@ SEARCH_DATA_SOURCE_FILTER_INDEXES = [
     "xml",
 ]
 KNOWN_MOD_REPLACEMENTS = {
-    "brrainz.harmony": {"zetrith.prepatcher"},
+    "brrainz.harmony": {"zetrith.prepatcher", "jikulopo.prepatcher"},
     "aoba.motorization.engine": {"rimthunder.core"},
 }
 KNOWN_TIER_ZERO_MODS = {


### PR DESCRIPTION
Expanded the KNOWN_MOD_REPLACEMENTS for 'brrainz.harmony' to include 'jikulopo.prepatcher' alongside 'zetrith.prepatcher'. This helps improve mod compatibility handling.