### PR TITLE
Refactor unsaved state setup in run tests

### DIFF
--- a/tests/views/test_main_content_run.py
+++ b/tests/views/test_main_content_run.py
@@ -111,15 +111,23 @@ def main_content(
     mc.deleteLater()
 
 
-def test_cancel_on_unsaved(
-    patch_dialogue: Mock,
-    patch_launch: List[Tuple[Path, List[str]]],
+@pytest.fixture
+def unsaved_main_content(
     main_content: Tuple[MainContent, List[bool]],
-) -> None:
+) -> Tuple[MainContent, List[bool]]:
     mc, save_calls = main_content
     # Set unsaved changes
     mc.mods_panel.active_mods_list.uuids = ["a", "b"]
     mc.active_mods_uuids_last_save = ["a"]
+    return mc, save_calls
+
+
+def test_cancel_on_unsaved(
+    patch_dialogue: Mock,
+    patch_launch: List[Tuple[Path, List[str]]],
+    unsaved_main_content: Tuple[MainContent, List[bool]],
+) -> None:
+    mc, save_calls = unsaved_main_content
     # Simulate Cancel
     patch_dialogue.return_value = QMessageBox.StandardButton.Cancel
     mc._do_run_game()
@@ -130,11 +138,9 @@ def test_cancel_on_unsaved(
 def test_run_anyway_on_unsaved(
     patch_dialogue: Mock,
     patch_launch: List[Tuple[Path, List[str]]],
-    main_content: Tuple[MainContent, List[bool]],
+    unsaved_main_content: Tuple[MainContent, List[bool]],
 ) -> None:
-    mc, save_calls = main_content
-    mc.mods_panel.active_mods_list.uuids = ["a", "b"]
-    mc.active_mods_uuids_last_save = ["a"]
+    mc, save_calls = unsaved_main_content
     patch_dialogue.return_value = mc.tr("Run Anyway")
     mc._do_run_game()
     assert save_calls == []
@@ -145,11 +151,9 @@ def test_run_anyway_on_unsaved(
 def test_save_and_run_on_unsaved(
     patch_dialogue: Mock,
     patch_launch: List[Tuple[Path, List[str]]],
-    main_content: Tuple[MainContent, List[bool]],
+    unsaved_main_content: Tuple[MainContent, List[bool]],
 ) -> None:
-    mc, save_calls = main_content
-    mc.mods_panel.active_mods_list.uuids = ["a", "b"]
-    mc.active_mods_uuids_last_save = ["a"]
+    mc, save_calls = unsaved_main_content
     patch_dialogue.return_value = mc.tr("Save and Run")
     mc._do_run_game()
     assert save_calls == [True]


### PR DESCRIPTION
Introduced an unsaved_main_content fixture to centralize the setup of unsaved changes for tests related to running with unsaved modifications. This reduces code duplication and improves test maintainability.