### PR TITLE
Handle Zstandard (zstd) save files

### DIFF
--- a/app/utils/xml.py
+++ b/app/utils/xml.py
@@ -1,9 +1,9 @@
 import gzip
-import zstandard as zstd
 import os
 from typing import Any
 
 import xmltodict
+import zstandard as zstd
 from bs4 import BeautifulSoup
 from loguru import logger
 from lxml import etree

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "toposort==1.10",
     "watchdog==6.0.0",
     "xmltodict==0.15.1",
+    "zstandard==0.23.0",
 ]
 
 [tool.uv.sources]
@@ -80,7 +81,7 @@ warn_unused_ignores = true
 exclude = ['venv', '.venv', 'submodules']
 
 [[tool.mypy.overrides]]
-module = ['steam.*', 'steamfiles.*', 'pytestqt.qtbot']
+module = ['steam.*', 'steamfiles.*', 'pytestqt.qtbot', 'zstandard']
 ignore_missing_imports = true
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -754,6 +754,7 @@ dependencies = [
     { name = "toposort", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "watchdog", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "xmltodict", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "zstandard", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 
 [package.dev-dependencies]
@@ -806,6 +807,7 @@ requires-dist = [
     { name = "toposort", specifier = "==1.10" },
     { name = "watchdog", specifier = "==6.0.0" },
     { name = "xmltodict", specifier = "==0.15.1" },
+    { name = "zstandard", specifier = "==0.23.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Based off of PR https://github.com/RimSort/RimSort/pull/1190 for GZip, but adding Zstandard support to support save files produced by my mod [Save File Compression](https://github.com/AmCh-Q/RimWorldMod_SaveFileCompression).
Reference: https://github.com/RimSort/RimSort/pull/1190#issuecomment-3273658567

This PR requires [Zstandard bindings for Python](https://pypi.org/project/zstandard/) as a dependency -- Python 3.14 adds native ZStandard support, but I presume there won't be an upgrade to 3.14 soon.
I did not add the dependency myself because I don't know how.

Sample test save file compressed with Zstandard: [test1.6-zstd.zip](https://github.com/user-attachments/files/22306036/test1.6-zstd.zip) (the actual zstd-compressed save file is inside the zip package, unzip it first)

I am not very familiar with Python programming and the contribution rules here, so please forgive me if I am making any mistakes.