### PR TITLE
Default Text Editor: Event Bus / File Menu Bar for Logs

### DIFF
--- a/app/controllers/menu_bar_controller.py
+++ b/app/controllers/menu_bar_controller.py
@@ -65,15 +65,30 @@ class MenuBarController(QObject):
         self.menu_bar.export_to_rentry_action.triggered.connect(
             EventBus().do_export_mod_list_to_rentry
         )
-        self.menu_bar.upload_rimsort_log_action.triggered.connect(
-            EventBus().do_upload_rimsort_log
-        )
-        self.menu_bar.upload_rimsort_old_log_action.triggered.connect(
-            EventBus().do_upload_rimsort_old_log
-        )
-        self.menu_bar.upload_rimworld_log_action.triggered.connect(
-            EventBus().do_upload_rimworld_log
-        )
+        # self.menu_bar.upload_rimsort_log_action.triggered.connect(
+        #     EventBus().do_upload_rimsort_log
+        # )
+        # self.menu_bar.upload_rimsort_old_log_action.triggered.connect(
+        #     EventBus().do_upload_rimsort_old_log
+        # )
+        # self.menu_bar.upload_rimworld_log_action.triggered.connect(
+        #     EventBus().do_upload_rimworld_log
+        # )
+        for action in self.menu_bar.upload_log_actions:
+            action.triggered.connect(
+                partial(
+                    lambda a: EventBus().do_upload_log.emit(a.data()),
+                    a=action,
+                )
+            )
+
+        for action in self.menu_bar.default_open_log_actions:
+            action.triggered.connect(
+                partial(
+                    lambda a: EventBus().do_open_default_editor.emit(a.data()),
+                    a=action,
+                )
+            )
 
         # Shortcuts SubMenu
         self.menu_bar.open_app_directory_action.triggered.connect(

--- a/app/controllers/menu_bar_controller.py
+++ b/app/controllers/menu_bar_controller.py
@@ -65,15 +65,7 @@ class MenuBarController(QObject):
         self.menu_bar.export_to_rentry_action.triggered.connect(
             EventBus().do_export_mod_list_to_rentry
         )
-        # self.menu_bar.upload_rimsort_log_action.triggered.connect(
-        #     EventBus().do_upload_rimsort_log
-        # )
-        # self.menu_bar.upload_rimsort_old_log_action.triggered.connect(
-        #     EventBus().do_upload_rimsort_old_log
-        # )
-        # self.menu_bar.upload_rimworld_log_action.triggered.connect(
-        #     EventBus().do_upload_rimworld_log
-        # )
+
         for action in self.menu_bar.upload_log_actions:
             action.triggered.connect(
                 partial(

--- a/app/utils/event_bus.py
+++ b/app/utils/event_bus.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Self
 
 from PySide6.QtCore import QObject, Signal
@@ -78,9 +79,8 @@ class EventBus(QObject):
     do_download_no_version_warning_db_from_github = Signal()
     do_upload_use_this_instead_db_to_github = Signal()
     do_download_use_this_instead_db_from_github = Signal()
-    do_upload_rimsort_log = Signal()
-    do_upload_rimsort_old_log = Signal()
-    do_upload_rimworld_log = Signal()
+    do_upload_log = Signal(Path)
+    do_open_default_editor = Signal(Path)
     do_download_all_mods_via_steamcmd = Signal()
     do_download_all_mods_via_steam = Signal()
     do_compare_steam_workshop_databases = Signal()

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -58,6 +58,7 @@ from app.utils.generic import (
     chunks,
     copy_to_clipboard_safely,
     launch_game_process,
+    launch_process,
     open_url_browser,
     platform_specific_open,
     upload_data_to_0x0_st,
@@ -143,11 +144,8 @@ class MainContent(QObject):
                 self._do_export_list_clipboard
             )
             EventBus().do_export_mod_list_to_rentry.connect(self._do_upload_list_rentry)
-            EventBus().do_upload_rimsort_log.connect(self._on_do_upload_rimsort_log)
-            EventBus().do_upload_rimsort_old_log.connect(
-                self._on_do_upload_rimsort_old_log
-            )
-            EventBus().do_upload_rimworld_log.connect(self._on_do_upload_rimworld_log)
+            EventBus().do_upload_log.connect(self._on_do_upload_log)
+            EventBus().do_open_default_editor.connect(self._open_in_default_editor)
             EventBus().do_download_all_mods_via_steamcmd.connect(
                 self._on_do_download_all_mods_via_steamcmd
             )
@@ -2098,6 +2096,7 @@ class MainContent(QObject):
 
         self._upload_log(player_log_path)
 
+    @Slot()
     def _upload_log(self, path: Path) -> None:
         if not os.path.exists(path):
             dialogue.show_warning(
@@ -2130,6 +2129,17 @@ class MainContent(QObject):
                 title=self.tr("Failed to upload file."),
                 text=self.tr("Failed to upload the file to 0x0.st"),
                 information=ret,
+            )
+
+    @Slot()
+    def _open_in_default_editor(self, path: Path) -> None:
+        if path.exists():
+            logger.info(f"Opening file in default editor: {path}")
+            launch_process(
+                self.settings_controller.settings.text_editor_location,
+                self.settings_controller.settings.text_editor_folder_arg.split(" ")
+                + [str(path)],
+                str(AppInfo().application_folder),
             )
 
     def _do_save(self) -> None:

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -210,7 +210,9 @@ class MainWindow(QMainWindow):
             settings_controller=self.settings_controller,
         )
 
-        self.menu_bar = MenuBar(menu_bar=self.menuBar())
+        self.menu_bar = MenuBar(
+            menu_bar=self.menuBar(), settings_controller=self.settings_controller
+        )
         self.menu_bar_controller = MenuBarController(
             view=self.menu_bar,
             settings_controller=self.settings_controller,


### PR DESCRIPTION
* Creates a Signal and action pair to open a path in the default text editor
  * Out of scope for this PR: circle back to #1269 - I want to do that when I tackle the file search menu UI elements. Both will likely use this Signal
* Creates a Signal and action pair to upload a path to the fileshare. 
* Refactor the existing upload menu bar submenu to also include Player-prev.log 
* Refactor the existing upload menu bar submenu to generate all four entries via `_create_logfile_submenu` and attach as many actions to the signal as there are logfiles in that menu.
* If the default text editor is set, show a similar menu that opens locally rather than uploading.