### PR TITLE
Ruff: Remove 'include' directive from Ruff config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,6 @@ line-length = 88
 indent-width = 4
 lint.extend-select = ["I"]
 exclude = ["submodules"]
-include = ["distribute.py"]
 
 [tool.ruff.format]
 quote-style = "double"


### PR DESCRIPTION
Deleted the 'include' option specifying 'distribute.py' in the Ruff configuration within pyproject.toml, likely to simplify or correct the linting scope.
This fixes Ruff which was broken due to this change