### PR TITLE
Remove qtwebengine_locales inclusion from Nuitka build

### DIFF
--- a/distribute.py
+++ b/distribute.py
@@ -40,7 +40,6 @@ _NUITKA_CMD = [
     "-m",
     "nuitka",
     "app/__main__.py",
-    "--include-data-dir=.venv/Lib/site-packages/PySide6/translations/qtwebengine_locales=qtwebengine_locales",
 ]
 
 if _SYSTEM == "Darwin" and _PROCESSOR in ["i386", "arm"]:

--- a/github_conf/branch_protection_rules.json
+++ b/github_conf/branch_protection_rules.json
@@ -1,0 +1,5 @@
+{
+    "message": "Not Found",
+    "documentation_url": "https://docs.github.com/rest",
+    "status": "404"
+}


### PR DESCRIPTION
Removed the --include-data-dir option for PySide6 qtwebengine_locales translations to fix build issues or optimize the bundle.