### PR TITLE
Add backup cleanup in update process and settings UI

### DIFF
--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -894,6 +894,11 @@ class SettingsController(QObject):
         self.settings_dialog.update_databases_on_startup_checkbox.setChecked(
             self.settings.update_databases_on_startup
         )
+
+        self.settings_dialog.enable_backup_before_update_checkbox.setChecked(
+            self.settings.enable_backup_before_update
+        )
+        self.settings_dialog.max_backups_spinbox.setValue(self.settings.max_backups)
         # Advanced: enable advanced filtering toggle
         try:
             self.settings_dialog.enable_advanced_filtering_checkbox.setChecked(
@@ -1198,6 +1203,11 @@ class SettingsController(QObject):
         self.settings.update_databases_on_startup = (
             self.settings_dialog.update_databases_on_startup_checkbox.isChecked()
         )
+
+        self.settings.enable_backup_before_update = (
+            self.settings_dialog.enable_backup_before_update_checkbox.isChecked()
+        )
+        self.settings.max_backups = self.settings_dialog.max_backups_spinbox.value()
         # Advanced: enable advanced filtering toggle
         try:
             self.settings.enable_advanced_filtering = (

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -161,6 +161,10 @@ class Settings(QObject):
         # Advanced filtering options
         self.enable_advanced_filtering: bool = True
 
+        # Update backup settings
+        self.enable_backup_before_update: bool = True
+        self.max_backups: int = 3
+
         # Authentication
         self.rentry_auth_code: str = ""
         self.github_username: str = ""

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -1476,6 +1476,29 @@ This basically preserves your mod coloring, user notes etc. for this many second
         )
         group_layout.addWidget(self.update_databases_on_startup_checkbox)
 
+        # Put checkbox, label and spinbox on the same horizontal line
+        backup_layout = QHBoxLayout()
+        self.enable_backup_before_update_checkbox = QCheckBox(
+            self.tr("Create backup before RimSort update")
+        )
+        self.enable_backup_before_update_checkbox.setToolTip(
+            self.tr(
+                "Recommended to keep this enabled as it creates a backup before updating RimSort, "
+                "This helps prevent any unwanted changes or data getting deleted."
+            )
+        )
+        backup_layout.addWidget(self.enable_backup_before_update_checkbox)
+
+        max_backups_label = QLabel(self.tr("Maximum number of backups to keep:"))
+        backup_layout.addWidget(max_backups_label)
+
+        self.max_backups_spinbox = QSpinBox()
+        self.max_backups_spinbox.setRange(1, 10)
+        self.max_backups_spinbox.setValue(3)
+        backup_layout.addWidget(self.max_backups_spinbox)
+
+        group_layout.addLayout(backup_layout)
+
         run_args_group = QGroupBox()
         tab_layout.addWidget(run_args_group)
 


### PR DESCRIPTION
- Call _cleanup_old_backups at start of do_check_for_update to remove old backups before update check.
- Add enable_backup_before_update and max_backups settings with UI controls in settings dialog.
- Update settings controller to sync new backup settings.
- Remove user prompt for backup creation; use settings flag instead.
- Keep only max_backups most recent backups, deleting older ones automatically.