### PR TITLE
Refactor XML utilities to use standard library xml.etree.ElementTree instead of xmltodict

### DIFF
--- a/app/utils/xml.py
+++ b/app/utils/xml.py
@@ -1,35 +1,111 @@
 import gzip
 import os
+import xml.dom.minidom as minidom
+import xml.etree.ElementTree as ET
 from typing import Any
 
-import xmltodict
 import zstandard as zstd
 from bs4 import BeautifulSoup
 from loguru import logger
-from lxml import etree
+
+
+def etree_to_dict(t: Any) -> dict[str, Any]:
+    """
+    Convert xml.etree.ElementTree element to a dictionary.
+    """
+    d: dict[str, Any] = {str(t.tag): {}}
+    children = list(t)
+    if children:
+        dd: dict[str, Any] = {}
+        for dc in map(etree_to_dict, children):
+            for k, v in dc.items():
+                if k in dd:
+                    if not isinstance(dd[k], list):
+                        dd[k] = [dd[k]]
+                    dd[k].append(v)
+                else:
+                    dd[k] = v
+        d[str(t.tag)] = dd
+    if t.attrib:
+        d[str(t.tag)].update(("@" + str(k), str(v)) for k, v in t.attrib.items())
+    if t.text:
+        text = str(t.text or "").strip()
+        if children or t.attrib:
+            if text:
+                d[str(t.tag)]["#text"] = text
+        else:
+            d[str(t.tag)] = text
+    return d
+
+
+def bs4_to_dict(soup: Any) -> Any:
+    """
+    Convert BeautifulSoup object to dictionary.
+    """
+    if soup.name is None:
+        return str(soup.string or "")
+    if soup.name == "[document]":
+        result = {}
+        for child in soup.children:
+            if child.name is not None:
+                result.update(bs4_to_dict(child))
+        return result
+    result = {}
+    for child in soup.children:
+        if child.name is not None:
+            result[str(child.name)] = bs4_to_dict(child)
+    return {str(soup.name): result} if result else str(soup.string or "")
+
+
+def dict_to_etree(d: dict[str, Any]) -> Any:
+    """
+    Convert dictionary to xml.etree.ElementTree element.
+    """
+
+    def _to_etree(d: Any, root: Any) -> None:
+        if isinstance(d, dict):
+            for k, v in d.items():
+                if k.startswith("@"):
+                    root.set(k[1:], v)
+                elif k == "#text":
+                    root.text = v
+                elif isinstance(v, list):
+                    for e in v:
+                        _to_etree(e, ET.SubElement(root, k))
+                else:
+                    _to_etree(v, ET.SubElement(root, k))
+        else:
+            root.text = str(d)
+
+    assert isinstance(d, dict) and len(d) == 1
+    tag, body = next(iter(d.items()))
+    node = ET.Element(tag)
+    _to_etree(body, node)
+    return node
 
 
 def xml_path_to_json(path: str) -> dict[str, Any]:
     """
-    Return the contents of an XML file as JSON.
+    Return the contents of an XML file as a dictionary.
     If the file does not exist, return an empty dict.
 
     :param path: Path to the XML file.
-    :return: JSON dict of XML file contents.
+    :return: Dictionary of XML file contents.
     """
     data: dict[str, Any] = {}
     if not os.path.exists(path):
         logger.error(f"XML file does not exist at: {path}")
         return data
     try:
+        # Parse XML file using xml.etree.ElementTree for standard library parsing
+        tree = ET.parse(path)
+        root = tree.getroot()
+        data = etree_to_dict(root)
+    except Exception as e:
+        # If ET parsing fails, attempt parsing with BeautifulSoup
+        logger.debug(f"Error parsing XML file with xml.etree.ElementTree: {e}")
+        logger.debug("Trying to parse with BeautifulSoup as a fallback")
         try:
-            # Try parsing the XML file using xmltodict
-            with open(path, "rb") as file:
-                data = xmltodict.parse(file.read(), dict_constructor=dict)
-        except Exception as e:
-            # If xmltodict parsing fails, attempt parsing with BeautifulSoup
-            logger.debug(f"Error parsing XML file with xmltodict: {e}")
-            logger.debug("Trying to parse with BeautifulSoup as a fallback")
             with open(path, "rb") as f:
                 soup = BeautifulSoup(f.read(), "lxml-xml")
                 # Find and remove empty tags
@@ -38,39 +114,43 @@ def xml_path_to_json(path: str) -> dict[str, Any]:
                 )
                 for empty_tag in empty_tags:
                     empty_tag.extract()
-                # Convert the BeautifulSoup object to a dictionary using xmltodict
-                data = xmltodict.parse(str(soup), dict_constructor=dict)
-        # Return the parsed data
-        return data
-    except Exception as e:
-        logger.debug(f"Error parsing XML file with BeautifulSoup: {e}")
-        logger.error(f"Error parsing XML file: {path}")
-        return data
+                # Convert the BeautifulSoup object to a dictionary
+                data = bs4_to_dict(soup)
+        except Exception as e2:
+            logger.debug(f"Error parsing XML file with BeautifulSoup: {e2}")
+            logger.error(f"Error parsing XML file: {path}")
+            return data
+    if isinstance(data, dict) and "[document]" in data:
+        data = data["[document]"]
+    # Return the parsed data
+    return data
 
 
 def json_to_xml_write(
     data: dict[str, Any], path: str, raise_errs: bool = False
 ) -> None:
     """
-    Write JSON data to an XML file.
+    Write dictionary data to an XML file.
 
-    :param data: JSON data to write.
+    :param data: Dictionary data to write.
     :param path: Path to write the XML file to.
     """
-    logger.debug("Started writing JSON to XML")
+    logger.debug("Started writing dictionary to XML")
     try:
-        # Convert JSON data to XML format using xmltodict
-        xml_data = xmltodict.unparse(data, pretty=True)
-        # Write the XML data to the specified file path
-        with open(path, "w", encoding="utf-8") as file:
-            file.write(xml_data)
+        # Convert dictionary data to XML format using xml.etree.ElementTree
+        root = dict_to_etree(data)
+        rough_string = ET.tostring(root, encoding="utf-8")
+        # Use minidom for pretty printing since ET doesn't have pretty_print
+        reparsed = minidom.parseString(rough_string)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(reparsed.toprettyxml(indent="  ", encoding=None))
     except Exception as e:
         if raise_errs:
             raise e
         logger.error(f"Error writing XML file: {e}")
         return
 
-    logger.debug("Finished writing JSON to XML")
+    logger.debug("Finished writing dictionary to XML")
 
 
 def extract_xml_package_ids(path: str) -> set[str]:
@@ -91,7 +171,7 @@ def extract_xml_package_ids(path: str) -> set[str]:
 
     try:
         with __open_save_file(path) as file:
-            context = etree.iterparse(file, events=("start", "end"))
+            context = ET.iterparse(file, events=("start", "end"))
             for event, elem in context:
                 if not found_modIds and event == "start" and elem.tag == "modIds":
                     found_modIds = True
@@ -139,7 +219,7 @@ def fast_rimworld_xml_save_validation(path: str) -> bool:
 
     try:
         with __open_save_file(path) as file:
-            context = etree.iterparse(file, events=("start", "end"))
+            context = ET.iterparse(file, events=("start", "end"))
             for event, elem in context:
                 if event == "start":
                     stack.append(elem.tag)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "steamfiles",
     "toposort==1.10",
     "watchdog==6.0.0",
-    "xmltodict==1.0.2",
+
     "zstandard==0.25.0",
 ]
 
@@ -54,7 +54,7 @@ dev = [
     "types-pygments>=2.19.0.20250715",
     "types-requests>=2.32.4.20250611",
     "types-toposort>=1.10.0.20250401",
-    "types-xmltodict>=0.14.0.20241009",
+
 ]
 
 build = [

--- a/uv.lock
+++ b/uv.lock
@@ -754,7 +754,6 @@ dependencies = [
     { name = "steamfiles", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "toposort", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "watchdog", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "xmltodict", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "zstandard", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 
@@ -781,7 +780,6 @@ dev = [
     { name = "types-pygments", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "types-requests", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "types-toposort", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "types-xmltodict", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 
 [package.metadata]
@@ -807,7 +805,6 @@ requires-dist = [
     { name = "steamfiles", git = "https://github.com/RimSort/steamfiles" },
     { name = "toposort", specifier = "==1.10" },
     { name = "watchdog", specifier = "==6.0.0" },
-    { name = "xmltodict", specifier = "==1.0.2" },
     { name = "zstandard", specifier = "==0.25.0" },
 ]
 
@@ -832,7 +829,6 @@ dev = [
     { name = "types-pygments", specifier = ">=2.19.0.20250715" },
     { name = "types-requests", specifier = ">=2.32.4.20250611" },
     { name = "types-toposort", specifier = ">=1.10.0.20250401" },
-    { name = "types-xmltodict", specifier = ">=0.14.0.20241009" },
 ]
 
 [[package]]
@@ -1094,15 +1090,6 @@ wheels = [
 ]
 
 [[package]]
-name = "types-xmltodict"
-version = "1.0.1.20250920"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f0/a7/a3bd65abc7ca906c4d658140c63ce1def95dcd25497726d0eed05c45d245/types_xmltodict-1.0.1.20250920.tar.gz", hash = "sha256:3a2a97b7c3247251d715452e7bd86b9f0567fb91e407164344c93390d9bbbe88", size = 8705, upload-time = "2025-09-20T02:45:14.34Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/de/fd8b3ad5ef409bdb796b70e66d46a795785ece05823a2fffc916d8e166ba/types_xmltodict-1.0.1.20250920-py3-none-any.whl", hash = "sha256:2acd1bd50e226f4939507165e5bbbd3a3f69718439ba31c142755ce353343ff3", size = 8380, upload-time = "2025-09-20T02:45:13.629Z" },
-]
-
-[[package]]
 name = "typing-extensions"
 version = "4.14.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1157,15 +1144,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/705086c9d734d3b663af0e9bb3d4de6578d08f46b1b101c2442fd9aecaa2/win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0", size = 4867, upload-time = "2024-12-07T15:28:28.314Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390", size = 4083, upload-time = "2024-12-07T15:28:26.465Z" },
-]
-
-[[package]]
-name = "xmltodict"
-version = "1.0.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6a/aa/917ceeed4dbb80d2f04dbd0c784b7ee7bba8ae5a54837ef0e5e062cd3cfb/xmltodict-1.0.2.tar.gz", hash = "sha256:54306780b7c2175a3967cad1db92f218207e5bc1aba697d887807c0fb68b7649", size = 25725, upload-time = "2025-09-17T21:59:26.459Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/20/69a0e6058bc5ea74892d089d64dfc3a62ba78917ec5e2cfa70f7c92ba3a5/xmltodict-1.0.2-py3-none-any.whl", hash = "sha256:62d0fddb0dcbc9f642745d8bbf4d81fd17d6dfaec5a15b5c1876300aad92af0d", size = 13893, upload-time = "2025-09-17T21:59:24.859Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Remove xmltodict dependency from pyproject.toml and uv.lock
- Implement custom etree_to_dict and dict_to_etree functions for XML/dict conversion
- Update xml_path_to_json and json_to_xml_write to use xml.etree.ElementTree
- Keep BeautifulSoup as fallback for complex XML parsing
- Update docstrings to accurately reflect dictionary handling
- Maintain compatibility with gzip and zstd compressed files