### PR TITLE
Support compressed files in "File -> Import -> From Save File" for loading modlists

### DIFF
--- a/app/utils/xml.py
+++ b/app/utils/xml.py
@@ -276,7 +276,7 @@ def using_zstd(fp: str) -> bool:
 
 def __open_file_maybe_compressed(path: str) -> Any:
     """
-    Open a file which may be comprssed.
+    Open a file which may be compressed.
     Mostly intended for savefiles but can be other compressed text files too.
 
     Compatible with gzip and zstd. (RimKeeper and Save File Compression)


### PR DESCRIPTION
Work following https://github.com/RimSort/RimSort/pull/1190, https://github.com/RimSort/RimSort/pull/1313, and https://github.com/RimSort/RimSort/issues/1377

Now ``File -> Import -> From Save File...`` can load compressed (GZip/Zstandard) save files.

Not heavily tested, just tried it locally by following [Development Setup & Building](https://rimsort.github.io/RimSort/development-guide/development-setup) on Windows and it seem to work.

To test it:
1. Save a modded game using any one of these mods: [Save File Compression](https://steamcommunity.com/sharedfiles/filedetails/?id=3562729067) (Supports zstd/GZip), [RimKeeper - Save Compressor](https://steamcommunity.com/sharedfiles/filedetails/?id=3243386716) (Supports GZip), [Savegame Compressor (Continued)](https://steamcommunity.com/sharedfiles/filedetails/?id=3413768309) (Supports GZip)
2. Try ``File -> Import -> From Save File...`` on the compressed save file, which should fail before this PR and succeed with this PR.

I also renamed ``__open_save_file`` to ``__open_file_maybe_compressed`` since it can handle any compressed text file, not just game saves.

Currently ``ET.parse(f)`` parses the entire save file in memory, which is both memory-intensive (may consume up to hundreds of megabytes for large saves) and slow. I think a solution with a streaming approach using ``iterparse`` like that in ``fast_rimworld_xml_save_validation`` would massively improve its performance.