### PR TITLE
Add mod list options and refactor settings

### DIFF
--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -679,7 +679,6 @@ class SettingsController(QObject):
             self.settings_dialog.sorting_alphabetical_radio.setChecked(True)
         elif self.settings.sorting_algorithm == SortMethod.TOPOLOGICAL:
             self.settings_dialog.sorting_topological_radio.setChecked(True)
-
         # Use dependencies for sorting checkbox
         if self.settings.use_moddependencies_as_loadTheseBefore:
             (
@@ -687,21 +686,38 @@ class SettingsController(QObject):
                     True
                 )
             )
-
         # Use alternativePackageIds as satisfying dependencies
         if self.settings.use_alternative_package_ids_as_satisfying_dependencies:
             self.settings_dialog.use_alternative_package_ids_as_satisfying_dependencies_checkbox.setChecked(
                 True
             )
-
         # Set dependencies checkbox
         self.settings_dialog.check_deps_checkbox.setChecked(
             self.settings.check_dependencies_on_sort
         )
-
         # Prefer versioned About.xml tags over base tags
         if self.settings.prefer_versioned_about_tags:
             self.settings_dialog.prefer_versioned_about_tags_checkbox.setChecked(True)
+        # Download missing mods checkbox
+        self.settings_dialog.download_missing_mods_checkbox.setChecked(
+            self.settings.try_download_missing_mods
+        )
+        # Duplicate mod notification checkbox
+        self.settings_dialog.show_duplicate_mods_warning_checkbox.setChecked(
+            self.settings.duplicate_mods_warning
+        )
+        # Mod type filter checkbox
+        self.settings_dialog.mod_type_filter_checkbox.setChecked(
+            self.settings.mod_type_filter
+        )
+        # Hide invalid mod filtering checkbox
+        self.settings_dialog.hide_invalid_mods_when_filtering_checkbox.setChecked(
+            self.settings.hide_invalid_mods_when_filtering
+        )
+        # Inactive mods sorting options checkbox
+        self.settings_dialog.enable_inactive_mods_sorting_checkbox.setChecked(
+            self.settings.inactive_mods_sorting
+        )
 
         # Database Builder tab
         if self.settings.db_builder_include == "all_mods":
@@ -870,17 +886,8 @@ class SettingsController(QObject):
         self.settings_dialog.auto_backup_compression_count_spinbox.setValue(
             self.settings.auto_backup_compression_count
         )
-        self.settings_dialog.mod_type_filter_checkbox.setChecked(
-            self.settings.mod_type_filter_toggle
-        )
-        self.settings_dialog.hide_invalid_mods_when_filtering_checkbox.setChecked(
-            self.settings.hide_invalid_mods_when_filtering_toggle
-        )
         self.settings_dialog.color_background_instead_of_text_checkbox.setChecked(
             self.settings.color_background_instead_of_text_toggle
-        )
-        self.settings_dialog.show_duplicate_mods_warning_checkbox.setChecked(
-            self.settings.duplicate_mods_warning
         )
         # Clear button behavior
         self.settings_dialog.clear_moves_dlc_checkbox.setChecked(
@@ -894,9 +901,6 @@ class SettingsController(QObject):
                 self.settings.current_instance
             ].steam_client_integration
         )
-        self.settings_dialog.download_missing_mods_checkbox.setChecked(
-            self.settings.try_download_missing_mods
-        )
         self.settings_dialog.render_unity_rich_text_checkbox.setChecked(
             self.settings.render_unity_rich_text
         )
@@ -908,13 +912,6 @@ class SettingsController(QObject):
             self.settings.enable_backup_before_update
         )
         self.settings_dialog.max_backups_spinbox.setValue(self.settings.max_backups)
-        # Advanced: enable advanced filtering toggle
-        try:
-            self.settings_dialog.enable_advanced_filtering_checkbox.setChecked(
-                self.settings.enable_advanced_filtering
-            )
-        except Exception:
-            pass
         self.settings_dialog.enable_aux_db_behavior_editing.setChecked(
             self.settings.enable_aux_db_behavior_editing
         )
@@ -1042,18 +1039,35 @@ class SettingsController(QObject):
         self.settings.use_moddependencies_as_loadTheseBefore = (
             self.settings_dialog.use_moddependencies_as_loadTheseBefore.isChecked()
         )
-
         # Use alternativePackageIds as satisfying dependencies
         self.settings.use_alternative_package_ids_as_satisfying_dependencies = self.settings_dialog.use_alternative_package_ids_as_satisfying_dependencies_checkbox.isChecked()
-
         # Set dependencies checkbox
         self.settings.check_dependencies_on_sort = (
             self.settings_dialog.check_deps_checkbox.isChecked()
         )
-
         # Prefer versioned About.xml tags over base tags
         self.settings.prefer_versioned_about_tags = (
             self.settings_dialog.prefer_versioned_about_tags_checkbox.isChecked()
+        )
+        # Download missing mods checkbox
+        self.settings.try_download_missing_mods = (
+            self.settings_dialog.download_missing_mods_checkbox.isChecked()
+        )
+        # Duplicate mod notification checkbox
+        self.settings.duplicate_mods_warning = (
+            self.settings_dialog.show_duplicate_mods_warning_checkbox.isChecked()
+        )
+        # Mod type filter checkbox
+        self.settings.mod_type_filter = (
+            self.settings_dialog.mod_type_filter_checkbox.isChecked()
+        )
+        # Hide invalid mod filtering checkbox
+        self.settings.hide_invalid_mods_when_filtering = (
+            self.settings_dialog.hide_invalid_mods_when_filtering_checkbox.isChecked()
+        )
+        # Inactive mods sorting options checkbox
+        self.settings.inactive_mods_sorting = (
+            self.settings_dialog.enable_inactive_mods_sorting_checkbox.isChecked()
         )
 
         # Database Builder tab
@@ -1188,17 +1202,8 @@ class SettingsController(QObject):
         self.settings.auto_backup_compression_count = (
             self.settings_dialog.auto_backup_compression_count_spinbox.value()
         )
-        self.settings.mod_type_filter_toggle = (
-            self.settings_dialog.mod_type_filter_checkbox.isChecked()
-        )
-        self.settings.hide_invalid_mods_when_filtering_toggle = (
-            self.settings_dialog.hide_invalid_mods_when_filtering_checkbox.isChecked()
-        )
         self.settings.color_background_instead_of_text_toggle = (
             self.settings_dialog.color_background_instead_of_text_checkbox.isChecked()
-        )
-        self.settings.duplicate_mods_warning = (
-            self.settings_dialog.show_duplicate_mods_warning_checkbox.isChecked()
         )
         # Clear button behavior
         self.settings.clear_moves_dlc = (
@@ -1212,9 +1217,6 @@ class SettingsController(QObject):
         ].steam_client_integration = (
             self.settings_dialog.steam_client_integration_checkbox.isChecked()
         )
-        self.settings.try_download_missing_mods = (
-            self.settings_dialog.download_missing_mods_checkbox.isChecked()
-        )
         self.settings.render_unity_rich_text = (
             self.settings_dialog.render_unity_rich_text_checkbox.isChecked()
         )
@@ -1226,13 +1228,6 @@ class SettingsController(QObject):
             self.settings_dialog.enable_backup_before_update_checkbox.isChecked()
         )
         self.settings.max_backups = self.settings_dialog.max_backups_spinbox.value()
-        # Advanced: enable advanced filtering toggle
-        try:
-            self.settings.enable_advanced_filtering = (
-                self.settings_dialog.enable_advanced_filtering_checkbox.isChecked()
-            )
-        except Exception:
-            pass
         self.settings.enable_aux_db_behavior_editing = (
             self.settings_dialog.enable_aux_db_behavior_editing.isChecked()
         )

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -94,6 +94,17 @@ class Settings(QObject):
         # e.g., modDependenciesByVersion, loadAfterByVersion, loadBeforeByVersion, incompatibleWithByVersion, descriptionsByVersion
         self.prefer_versioned_about_tags: bool = True
 
+        # Whether to notify user about missing mods
+        self.try_download_missing_mods: bool = True
+        # Whether to notify user about duplicate mods
+        self.duplicate_mods_warning: bool = True
+        # Whether to enable Mod type filter
+        self.mod_type_filter: bool = True
+        # Whether to hide invalid mods
+        self.hide_invalid_mods_when_filtering: bool = False
+        # Whether to enable inactive mods sorting options
+        self.inactive_mods_sorting: bool = True
+
         # DB Builder
         self.db_builder_include: str = "all_mods"
         self.build_steam_database_dlc_data: bool = True
@@ -152,21 +163,14 @@ class Settings(QObject):
         self.last_backup_date: str = ""
         self.auto_backup_retention_count: int = 10
         self.auto_backup_compression_count: int = 10
-
-        self.mod_type_filter_toggle: bool = True
-        self.hide_invalid_mods_when_filtering_toggle: bool = False
         self.color_background_instead_of_text_toggle: bool = True
-        self.duplicate_mods_warning: bool = True
         self.steam_mods_update_check: bool = False
-        self.try_download_missing_mods: bool = True
         self.render_unity_rich_text: bool = True
         self.update_databases_on_startup: bool = True
         # UI: Save-comparison labels and icons
         self.show_save_comparison_indicators: bool = True
         # Clear button behavior
         self.clear_moves_dlc: bool = False
-        # Advanced filtering options
-        self.enable_advanced_filtering: bool = True
 
         # Update backup settings
         self.enable_backup_before_update: bool = True

--- a/app/views/mod_info_panel.py
+++ b/app/views/mod_info_panel.py
@@ -466,7 +466,7 @@ class ModInfo:
 
             # Set folder size
             try:
-                if self.settings_controller.settings.enable_advanced_filtering:
+                if self.settings_controller.settings.inactive_mods_sorting:
                     size_bytes = uuid_to_folder_size(uuid)
                     self.mod_info_folder_size_value.setText(
                         format_file_size(size_bytes)
@@ -492,7 +492,7 @@ class ModInfo:
             # Set filesystem modification time
             mod_path = mod_info.get("path")
             if (
-                self.settings_controller.settings.enable_advanced_filtering
+                self.settings_controller.settings.inactive_mods_sorting
                 and mod_path
                 and os.path.exists(mod_path)
             ):

--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -376,7 +376,7 @@ class ModListItemInner(QWidget):
         # Icons that are conditional
         self.csharp_icon = None
         self.xml_icon = None
-        if self.settings_controller.settings.mod_type_filter_toggle:
+        if self.settings_controller.settings.mod_type_filter:
             if (
                 self.metadata_manager.internal_local_metadata.get(self.uuid, {}).get(
                     "csharp"
@@ -626,7 +626,7 @@ class ModListItemInner(QWidget):
         mod_path = metadata.get("path")
         # Folder size: read from in-memory cache only; avoid computing on tooltip
         folder_size_line = "Folder Size: Not available\n"
-        if self.settings_controller.settings.enable_advanced_filtering:
+        if self.settings_controller.settings.inactive_mods_sorting:
             if isinstance(mod_path, str):
                 cached = _FOLDER_SIZE_CACHE.get(mod_path)
                 if cached:
@@ -2716,7 +2716,7 @@ class ModListWidget(QListWidget):
         Returns:
             None
         """
-        filtering = self.settings_controller.settings.enable_advanced_filtering
+        filtering = self.settings_controller.settings.inactive_mods_sorting
 
         if filtering:
             sorted_uuids = sort_uuids(uuids, key=key)
@@ -3082,7 +3082,7 @@ class ModsPanel(QWidget):
         self.active_mods_search_layout.addWidget(
             self.active_mods_filter_data_source_button
         )
-        if self.settings_controller.settings.mod_type_filter_toggle:
+        if self.settings_controller.settings.mod_type_filter:
             self.active_mods_search_layout.addWidget(
                 self.active_data_source_filter_type_button
             )
@@ -3247,7 +3247,7 @@ class ModsPanel(QWidget):
         self.inactive_mods_search_layout.addWidget(
             self.inactive_mods_filter_data_source_button
         )
-        if self.settings_controller.settings.mod_type_filter_toggle:
+        if self.settings_controller.settings.mod_type_filter:
             self.inactive_mods_search_layout.addWidget(
                 self.inactive_data_source_filter_type_button
             )
@@ -3263,10 +3263,10 @@ class ModsPanel(QWidget):
 
         # Set initial visibility based on settings
         self.inactive_mods_sort_combobox.setVisible(
-            self.settings_controller.settings.enable_advanced_filtering
+            self.settings_controller.settings.inactive_mods_sorting
         )
         self.inactive_mods_sort_order_button.setVisible(
-            self.settings_controller.settings.enable_advanced_filtering
+            self.settings_controller.settings.inactive_mods_sorting
         )
 
         # Adding Completer.
@@ -3368,7 +3368,7 @@ class ModsPanel(QWidget):
     def on_inactive_mods_sort_changed(self, text: str) -> None:
         """Handle inactive mods sorting selection change."""
         # Determine the sorting key based on the selected text
-        if not self.settings_controller.settings.enable_advanced_filtering:
+        if not self.settings_controller.settings.inactive_mods_sorting:
             return
         if text == self.tr("Name"):
             sort_key = ModsPanelSortKey.MODNAME
@@ -3737,7 +3737,7 @@ class ModsPanel(QWidget):
             if pattern != "":
                 filters_active = True
             # Hide invalid items if enabled in settings
-            if self.settings_controller.settings.hide_invalid_mods_when_filtering_toggle:
+            if self.settings_controller.settings.hide_invalid_mods_when_filtering:
                 invalid = item_data["invalid"]
                 # TODO: I dont think filtered should be set at all for invalid items... I misunderstood what it represents
                 if invalid and filters_active:

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -686,11 +686,6 @@ This basically preserves your mod coloring, user notes etc. for this many second
         xml_parsing_group_box.setLayout(xml_parsing_group_box_layout)
 
         # Prefer versioned About.xml tags over base tags
-        xml_parsing_explanatory_text = (
-            "When enabled, *ByVersion tags (e.g., modDependenciesByVersion, loadAfterByVersion, "
-            "loadBeforeByVersion, incompatibleWithByVersion, descriptionsByVersion) take precedence "
-            "over the base tags. If a matching version tag exists but is empty, the base tag is ignored."
-        )
         xml_parsing_explanatory_label = QLabel(self.tr("XML Parsing Behavior"))
         xml_parsing_explanatory_label.setFont(GUIInfo().emphasis_font)
         xml_parsing_group_box_layout.addWidget(xml_parsing_explanatory_label)
@@ -698,10 +693,82 @@ This basically preserves your mod coloring, user notes etc. for this many second
             self.tr("Prefer versioned About.xml tags over base tags")
         )
         self.prefer_versioned_about_tags_checkbox.setToolTip(
-            self.tr(xml_parsing_explanatory_text)
+            self.tr(
+                "When enabled, *ByVersion tags take precedence over the base tags, \n"
+                "If a matching version tag exists but is empty, the base tag is ignored. \n"
+                "e.g.(modDependenciesByVersion, loadAfterByVersion, loadBeforeByVersion, incompatibleWithByVersion, descriptionsByVersion)"
+            )
         )
+
         xml_parsing_group_box_layout.addWidget(
             self.prefer_versioned_about_tags_checkbox
+        )
+
+        # Mod list options group
+        modlist_option_group_box = QGroupBox()
+        tab_layout.addWidget(modlist_option_group_box)
+
+        modlist_option_group_box_layout = QVBoxLayout()
+        modlist_option_group_box.setLayout(modlist_option_group_box_layout)
+
+        modlist_option_label = QLabel(self.tr("Mod list options"))
+        modlist_option_label.setFont(GUIInfo().emphasis_font)
+        modlist_option_group_box_layout.addWidget(modlist_option_label)
+
+        # Download missing mods checkbox
+        self.download_missing_mods_checkbox = QCheckBox(
+            self.tr("Download missing mods automatically")
+        )
+        self.download_missing_mods_checkbox.setToolTip(
+            self.tr(
+                "Notifies to download mods that may be missing in the active modlist"
+            )
+        )
+        modlist_option_group_box_layout.addWidget(self.download_missing_mods_checkbox)
+
+        # Duplicate mod notification checkbox
+        self.show_duplicate_mods_warning_checkbox = QCheckBox(
+            self.tr("Show duplicate mods warning")
+        )
+        self.show_duplicate_mods_warning_checkbox.setToolTip(
+            self.tr("Notifies and displays the mods that have the same packageid")
+        )
+        modlist_option_group_box_layout.addWidget(
+            self.show_duplicate_mods_warning_checkbox
+        )
+
+        # Mod type filter checkbox
+        self.mod_type_filter_checkbox = QCheckBox(self.tr("Enable mod type filter"))
+        self.mod_type_filter_checkbox.setToolTip(
+            self.tr(
+                "Add icons and filtering options for easy mods identification and grouping"
+            )
+        )
+        modlist_option_group_box_layout.addWidget(self.mod_type_filter_checkbox)
+
+        # Hide invalid mod filtering checkbox
+        self.hide_invalid_mods_when_filtering_checkbox = QCheckBox(
+            self.tr("Hide invalid mods when filtering")
+        )
+        self.hide_invalid_mods_when_filtering_checkbox.setToolTip(
+            self.tr("Hides invalid mods, not recommended to enable")
+        )
+        modlist_option_group_box_layout.addWidget(
+            self.hide_invalid_mods_when_filtering_checkbox
+        )
+
+        # Inactive mods sorting options checkbox
+        self.enable_inactive_mods_sorting_checkbox = QCheckBox(
+            self.tr("Enable inactive mods sorting")
+        )
+        self.enable_inactive_mods_sorting_checkbox.setToolTip(
+            self.tr(
+                "Additional options like name, author, folder size, modified date will be available in the mods panel for sorting inactive mods \n"
+                "Disabling this can improve performance by avoiding heavy calculations."
+            )
+        )
+        modlist_option_group_box_layout.addWidget(
+            self.enable_inactive_mods_sorting_checkbox
         )
 
         tab_layout.addStretch()
@@ -1458,21 +1525,6 @@ This basically preserves your mod coloring, user notes etc. for this many second
         )
         group_layout.addWidget(self.watchdog_checkbox)
 
-        self.mod_type_filter_checkbox = QCheckBox(self.tr("Enable mod type filter"))
-        group_layout.addWidget(self.mod_type_filter_checkbox)
-
-        self.hide_invalid_mods_when_filtering_checkbox = QCheckBox(
-            self.tr("Hide invalid mods when filtering")
-        )
-        group_layout.addWidget(self.hide_invalid_mods_when_filtering_checkbox)
-
-        # Moved to Performance tab under "Integration with recent save"
-
-        self.show_duplicate_mods_warning_checkbox = QCheckBox(
-            self.tr("Show duplicate mods warning")
-        )
-        group_layout.addWidget(self.show_duplicate_mods_warning_checkbox)
-
         # Clear button behavior
         self.clear_moves_dlc_checkbox = QCheckBox(self.tr("Clear also moves DLC"))
         group_layout.addWidget(self.clear_moves_dlc_checkbox)
@@ -1487,11 +1539,6 @@ This basically preserves your mod coloring, user notes etc. for this many second
         )
         group_layout.addWidget(self.steam_client_integration_checkbox)
 
-        self.download_missing_mods_checkbox = QCheckBox(
-            self.tr("Download missing mods automatically")
-        )
-        group_layout.addWidget(self.download_missing_mods_checkbox)
-
         self.render_unity_rich_text_checkbox = QCheckBox(
             self.tr("Render Unity Rich Text in mod descriptions")
         )
@@ -1505,17 +1552,6 @@ This basically preserves your mod coloring, user notes etc. for this many second
             )
         )
         group_layout.addWidget(self.render_unity_rich_text_checkbox)
-
-        self.enable_advanced_filtering_checkbox = QCheckBox(
-            self.tr("Enable advanced filtering options")
-        )
-        self.enable_advanced_filtering_checkbox.setToolTip(
-            self.tr(
-                "If enabled, additional filtering options like folder size, author, and modified date will be available in the mods panel. "
-                "Disabling this can improve performance by avoiding heavy calculations."
-            )
-        )
-        group_layout.addWidget(self.enable_advanced_filtering_checkbox)
 
         self.update_databases_on_startup_checkbox = QCheckBox(
             self.tr("Update databases on startup")

--- a/tests/views/test_main_content_run.py
+++ b/tests/views/test_main_content_run.py
@@ -17,9 +17,12 @@ from app.views.main_content_panel import MainContent
 class DummySettings:
     def __init__(self) -> None:
         self.current_instance = "inst1"
-        # Toggle filter for mod type filtering
-        self.mod_type_filter_toggle = False
-        self.enable_advanced_filtering = True
+        # Mod list options
+        self.try_download_missing_mods = True
+        self.duplicate_mods_warning = True
+        self.mod_type_filter = True
+        self.hide_invalid_mods_when_filtering = False
+        self.inactive_mods_sorting = True
         self.backup_saves_on_launch = False
         # Instance data with dummy game_folder and run_args
         self.instances = {
@@ -110,6 +113,9 @@ def main_content(
 
     # Cleanup: delete the widget to avoid Qt object reuse issues
     mc.deleteLater()
+    qapp.processEvents()
+    # Reset singleton for next test
+    MainContent._instance = None
 
 
 @pytest.fixture


### PR DESCRIPTION
Refactor and introduce new settings for mod list behavior:

- Add new mod list options: try_download_missing_mods, duplicate_mods_warning, mod_type_filter, hide_invalid_mods_when_filtering, inactive_mods_sorting
- Remove deprecated settings: mod_type_filter_toggle, hide_invalid_mods_when_filtering_toggle, enable_advanced_filtering
- Update settings controller to handle new options in both directions (load/save)
- Update UI components to use new setting names
- Move mod list options to dedicated group in settings dialog
- Update mod info panel and mods panel to use inactive_mods_sorting instead of enable_advanced_filtering
- Fix test_main_content_run.py to match refactored settings structure with proper Qt cleanup