### PR TITLE
Refactor & add toggle for Steam client integration checkbox

### DIFF
--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -462,7 +462,6 @@ class SettingsController(QObject):
         self.settings_dialog.game_location_open_button.setEnabled(
             self.settings_dialog.game_location.text() != ""
         )
-
         self.settings_dialog.config_folder_location.setText(
             str(self.settings.instances[self.settings.current_instance].config_folder)
         )
@@ -470,7 +469,6 @@ class SettingsController(QObject):
         self.settings_dialog.config_folder_location_open_button.setEnabled(
             self.settings_dialog.config_folder_location.text() != ""
         )
-
         self.settings_dialog.steam_mods_folder_location.setText(
             str(self.settings.instances[self.settings.current_instance].workshop_folder)
         )
@@ -478,7 +476,6 @@ class SettingsController(QObject):
         self.settings_dialog.steam_mods_folder_location_open_button.setEnabled(
             self.settings_dialog.steam_mods_folder_location.text() != ""
         )
-
         self.settings_dialog.local_mods_folder_location.setText(
             str(self.settings.instances[self.settings.current_instance].local_folder)
         )
@@ -486,6 +483,19 @@ class SettingsController(QObject):
         self.settings_dialog.local_mods_folder_location_open_button.setEnabled(
             self.settings_dialog.local_mods_folder_location.text() != ""
         )
+        self.settings_dialog.steam_client_integration_checkbox.setChecked(
+            self.settings.instances[
+                self.settings.current_instance
+            ].steam_client_integration
+        )
+        # Enable/disable Steam mods location fields based on checkbox state
+        checked = self.settings_dialog.steam_client_integration_checkbox.isChecked()
+        self.settings_dialog.steam_mods_folder_location.setEnabled(checked)
+        self.settings_dialog.steam_mods_folder_location_open_button.setEnabled(checked)
+        self.settings_dialog.steam_mods_folder_location_choose_button.setEnabled(
+            checked
+        )
+        self.settings_dialog.steam_mods_folder_location_clear_button.setEnabled(checked)
 
         # Databases tab
         if self.settings.external_community_rules_metadata_source == "None":
@@ -896,11 +906,6 @@ class SettingsController(QObject):
         self.settings_dialog.show_mod_updates_checkbox.setChecked(
             self.settings.steam_mods_update_check
         )
-        self.settings_dialog.steam_client_integration_checkbox.setChecked(
-            self.settings.instances[
-                self.settings.current_instance
-            ].steam_client_integration
-        )
         self.settings_dialog.render_unity_rich_text_checkbox.setChecked(
             self.settings.render_unity_rich_text
         )
@@ -943,18 +948,20 @@ class SettingsController(QObject):
         self.settings.instances[
             self.settings.current_instance
         ].game_folder = self.settings_dialog.game_location.text()
-
         self.settings.instances[
             self.settings.current_instance
         ].config_folder = self.settings_dialog.config_folder_location.text()
-
         self.settings.instances[
             self.settings.current_instance
         ].workshop_folder = self.settings_dialog.steam_mods_folder_location.text()
-
         self.settings.instances[
             self.settings.current_instance
         ].local_folder = self.settings_dialog.local_mods_folder_location.text()
+        self.settings.instances[
+            self.settings.current_instance
+        ].steam_client_integration = (
+            self.settings_dialog.steam_client_integration_checkbox.isChecked()
+        )
 
         # Databases tab
         if self.settings_dialog.community_rules_db_none_radio.isChecked():
@@ -1211,11 +1218,6 @@ class SettingsController(QObject):
         )
         self.settings.steam_mods_update_check = (
             self.settings_dialog.show_mod_updates_checkbox.isChecked()
-        )
-        self.settings.instances[
-            self.settings.current_instance
-        ].steam_client_integration = (
-            self.settings_dialog.steam_client_integration_checkbox.isChecked()
         )
         self.settings.render_unity_rich_text = (
             self.settings_dialog.render_unity_rich_text_checkbox.isChecked()

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -203,6 +203,15 @@ class SettingsDialog(QDialog):
         header_layout = QHBoxLayout()
         group_layout.addLayout(header_layout)
 
+        self.steam_client_integration_checkbox = QCheckBox(
+            self.tr("Enable Steam client integration")
+        )
+        group_layout.addWidget(self.steam_client_integration_checkbox)
+
+        self.steam_client_integration_checkbox.stateChanged.connect(
+            self._on_steam_integration_toggled
+        )
+
         section_label = QLabel(self.tr("Steam mods location"))
         section_label.setFont(GUIInfo().emphasis_font)
         header_layout.addWidget(section_label)
@@ -1137,6 +1146,13 @@ This basically preserves your mod coloring, user notes etc. for this many second
         else:
             self.todds_custom_command_lineedit.setEnabled(False)
 
+    def _on_steam_integration_toggled(self) -> None:
+        checked = self.steam_client_integration_checkbox.isChecked()
+        self.steam_mods_folder_location.setEnabled(checked)
+        self.steam_mods_folder_location_open_button.setEnabled(checked)
+        self.steam_mods_folder_location_choose_button.setEnabled(checked)
+        self.steam_mods_folder_location_clear_button.setEnabled(checked)
+
     def _do_themes_tab(self) -> None:
         tab = QWidget()
         self.tab_widget.addTab(tab, self.tr("Theme"))
@@ -1533,11 +1549,6 @@ This basically preserves your mod coloring, user notes etc. for this many second
             self.tr("Check for mod updates on refresh")
         )
         group_layout.addWidget(self.show_mod_updates_checkbox)
-
-        self.steam_client_integration_checkbox = QCheckBox(
-            self.tr("Enable Steam client integration")
-        )
-        group_layout.addWidget(self.steam_client_integration_checkbox)
 
         self.render_unity_rich_text_checkbox = QCheckBox(
             self.tr("Render Unity Rich Text in mod descriptions")


### PR DESCRIPTION
This improves the UI responsiveness and code organization.
- Moved the Steam client integration checkbox setup to the correct location in the settings dialog
- Added logic to enable/disable Steam mods location fields based on the checkbox state.