### PR TITLE
feat: implement saving and loading of inactive mods sort state

### DIFF
--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -124,6 +124,11 @@ class SettingsController(QObject):
         except Exception:
             pass
 
+        # Sorting: wiring for inactive mods sorting checkbox
+        self.settings_dialog.enable_inactive_mods_sorting_checkbox.toggled.connect(
+            self._on_enable_inactive_mods_sorting_checkbox_toggled
+        )
+
         # Locations tab
         self.settings_dialog.game_location.textChanged.connect(
             self._on_game_location_text_changed
@@ -408,6 +413,13 @@ class SettingsController(QObject):
         # Update model immediately for live UI response
         self.settings.show_save_comparison_indicators = checked
         self.settings.save()
+
+    @Slot(bool)
+    def _on_enable_inactive_mods_sorting_checkbox_toggled(self, checked: bool) -> None:
+        """
+        Enable or disable the inactive mods sorting group box based on the checkbox state.
+        """
+        self.settings_dialog.inactive_mods_sorting_group_box.setEnabled(checked)
 
     def create_instance(
         self,
@@ -727,6 +739,14 @@ class SettingsController(QObject):
         # Inactive mods sorting options checkbox
         self.settings_dialog.enable_inactive_mods_sorting_checkbox.setChecked(
             self.settings.inactive_mods_sorting
+        )
+        # Enable/disable the inactive mods sorting group box based on the checkbox state
+        self.settings_dialog.inactive_mods_sorting_group_box.setEnabled(
+            self.settings.inactive_mods_sorting
+        )
+        # Save inactive mods sort state
+        self.settings_dialog.save_inactive_mods_sort_state_checkbox.setChecked(
+            self.settings.save_inactive_mods_sort_state
         )
 
         # Database Builder tab
@@ -1075,6 +1095,10 @@ class SettingsController(QObject):
         # Inactive mods sorting options checkbox
         self.settings.inactive_mods_sorting = (
             self.settings_dialog.enable_inactive_mods_sorting_checkbox.isChecked()
+        )
+        # Save inactive mods sort state
+        self.settings.save_inactive_mods_sort_state = (
+            self.settings_dialog.save_inactive_mods_sort_state_checkbox.isChecked()
         )
 
         # Database Builder tab

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -104,6 +104,10 @@ class Settings(QObject):
         self.hide_invalid_mods_when_filtering: bool = False
         # Whether to enable inactive mods sorting options
         self.inactive_mods_sorting: bool = True
+        # Inactive mods sort state saving
+        self.save_inactive_mods_sort_state: bool = False
+        self.inactive_mods_sort_key: str = "FILESYSTEM_MODIFIED_TIME"
+        self.inactive_mods_sort_descending: bool = True
 
         # DB Builder
         self.db_builder_include: str = "all_mods"

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -531,10 +531,23 @@ class MainContent(QObject):
         self.mods_panel.active_mods_list.recreate_mod_list(
             list_type="active", uuids=active_mods_uuids
         )
+        # Determine sort key and descending for inactive mods
+        if (
+            self.settings_controller.settings.save_inactive_mods_sort_state
+            and self.settings_controller.settings.inactive_mods_sorting
+        ):
+            sort_key = ModsPanelSortKey[
+                self.settings_controller.settings.inactive_mods_sort_key
+            ]
+            descending = self.settings_controller.settings.inactive_mods_sort_descending
+        else:
+            sort_key = ModsPanelSortKey.FILESYSTEM_MODIFIED_TIME
+            descending = True
         self.mods_panel.inactive_mods_list.recreate_mod_list_and_sort(
             list_type="inactive",
             uuids=inactive_mods_uuids,
-            key=ModsPanelSortKey.FILESYSTEM_MODIFIED_TIME,
+            key=sort_key,
+            descending=descending,
         )
         logger.info(
             f"Finished inserting mod data into active [{len(active_mods_uuids)}] and inactive [{len(inactive_mods_uuids)}] mod lists"

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -766,6 +766,19 @@ This basically preserves your mod coloring, user notes etc. for this many second
             self.hide_invalid_mods_when_filtering_checkbox
         )
 
+        # Inactive mods sorting group
+        self.inactive_mods_sorting_group_box = QGroupBox()
+        tab_layout.addWidget(self.inactive_mods_sorting_group_box)
+
+        inactive_mods_sorting_group_box_layout = QVBoxLayout()
+        self.inactive_mods_sorting_group_box.setLayout(
+            inactive_mods_sorting_group_box_layout
+        )
+
+        inactive_mods_sorting_label = QLabel(self.tr("Inactive Mods Sorting"))
+        inactive_mods_sorting_label.setFont(GUIInfo().emphasis_font)
+        inactive_mods_sorting_group_box_layout.addWidget(inactive_mods_sorting_label)
+
         # Inactive mods sorting options checkbox
         self.enable_inactive_mods_sorting_checkbox = QCheckBox(
             self.tr("Enable inactive mods sorting")
@@ -776,8 +789,15 @@ This basically preserves your mod coloring, user notes etc. for this many second
                 "Disabling this can improve performance by avoiding heavy calculations."
             )
         )
-        modlist_option_group_box_layout.addWidget(
+        inactive_mods_sorting_group_box_layout.addWidget(
             self.enable_inactive_mods_sorting_checkbox
+        )
+
+        self.save_inactive_mods_sort_state_checkbox = QCheckBox(
+            self.tr("Save inactive mods sort state")
+        )
+        inactive_mods_sorting_group_box_layout.addWidget(
+            self.save_inactive_mods_sort_state_checkbox
         )
 
         tab_layout.addStretch()

--- a/tests/views/test_main_content_run.py
+++ b/tests/views/test_main_content_run.py
@@ -22,8 +22,12 @@ class DummySettings:
         self.duplicate_mods_warning = True
         self.mod_type_filter = True
         self.hide_invalid_mods_when_filtering = False
-        self.inactive_mods_sorting = True
         self.backup_saves_on_launch = False
+        # Inactive mods sort settings
+        self.inactive_mods_sorting = True
+        self.save_inactive_mods_sort_state = False
+        self.inactive_mods_sort_key = "FILESYSTEM_MODIFIED_TIME"
+        self.inactive_mods_sort_descending = True
         # Instance data with dummy game_folder and run_args
         self.instances = {
             "inst1": SimpleNamespace(


### PR DESCRIPTION
- Add new settings fields: save_inactive_mods_sort_state, inactive_mods_sort_key, inactive_mods_sort_descending
- Add VERSION and PACKAGEID sort options for inactive mods
- Implement conditional saving: only save if inactive_mods_sorting and save_inactive_mods_sort_state are enabled
- On init, apply saved settings if enabled, else default to FILESYSTEM_MODIFIED_TIME descending
- Disable save option UI when inactive_mods_sorting is disabled
- Update tests and ensure application launches without errors

<img width="965" height="679" alt="image" src="https://github.com/user-attachments/assets/c28eb31d-cb73-4433-a46b-27871c68853e" />
