### PR TITLE
Removed mods from KNOWN_TIER_ONE_MODS except Hugslib

### DIFF
--- a/app/utils/constants.py
+++ b/app/utils/constants.py
@@ -89,9 +89,5 @@ KNOWN_TIER_ZERO_MODS = {
     "ludeon.rimworld.odyssey",
 }
 KNOWN_TIER_ONE_MODS = {
-    "vanillaexpanded.backgrounds",
-    "redmattis.betterprerequisites",
-    "adaptive.storage.framework",
-    "oskarpotocki.vanillafactionsexpanded.core",
     "unlimitedhugs.hugslib",
 }


### PR DESCRIPTION
Removed mods from KNOWN_TIER_ONE_MODS set:
- vanillaexpanded.backgrounds
- redmattis.betterprerequisites
- adaptive.storage.framework
- oskarpotocki.vanillafactionsexpanded.core

Kept only 'unlimitedhugs.hugslib' as the remaining tier one mod.

This removes hard coding of some mods that were forced to load on top of the list 
This results in more reliable sorting by depending on the rules set my mod author in about.xml files or community database