### PR TITLE
Centralize format_file_size utility function

### DIFF
--- a/app/controllers/file_search_controller.py
+++ b/app/controllers/file_search_controller.py
@@ -14,6 +14,7 @@ from app.controllers.settings_controller import SettingsController
 from app.models.search_result import SearchResult
 from app.models.settings import Settings
 from app.utils.file_search import FileSearch
+from app.utils.generic import format_file_size
 from app.utils.ignore_extensions import IGNORE_EXTENSIONS
 from app.utils.metadata import MetadataManager
 from app.utils.mod_utils import get_mod_paths_from_uuids
@@ -167,7 +168,7 @@ class SearchWorker(QThread):
             max_size = 20 * 1024 * 1024  # 20MB
             if file_size > max_size:
                 logger.warning(
-                    f"File too large to read fully: {file_path} ({file_size} bytes)"
+                    f"File too large to read fully: {file_path} ({format_file_size(file_size)})"
                 )
                 # For large files, read only the first part
                 try:
@@ -380,7 +381,7 @@ class SearchWorker(QThread):
 
             # Add a header with file info
             file_size = os.path.getsize(file_path)
-            file_size_str = self._format_file_size(file_size)
+            file_size_str = format_file_size(file_size)
 
             header = f"File: {os.path.basename(file_path)} ({file_size_str})\n"
             header += f"Path: {os.path.dirname(file_path)}\n"
@@ -484,15 +485,6 @@ class SearchWorker(QThread):
             logger.warning(f"Error generating XML preview for {file_path}: {e}")
             # Return empty string to fall back to standard preview
             return ""
-
-    def _format_file_size(self, size_in_bytes: int) -> str:
-        """Format file size in human-readable format"""
-        if size_in_bytes < 1024:
-            return f"{size_in_bytes} B"
-        elif size_in_bytes < 1024 * 1024:
-            return f"{size_in_bytes / 1024:.1f} KB"
-        else:
-            return f"{size_in_bytes / (1024 * 1024):.1f} MB"
 
     def _should_process_mod(self, mod_path: str) -> bool:
         """

--- a/app/sort/mod_sorting.py
+++ b/app/sort/mod_sorting.py
@@ -161,18 +161,6 @@ def get_mod_metadata(uuid: str) -> Optional[ModMetadata]:
     return MetadataManager.instance().internal_local_metadata.get(uuid)
 
 
-def format_file_size(size_in_bytes: int) -> str:
-    """Format bytes to a human-readable string."""
-    if size_in_bytes < 1024:
-        return f"{size_in_bytes} B"
-    elif size_in_bytes < 1024 * 1024:
-        return f"{size_in_bytes / 1024:.1f} KB"
-    elif size_in_bytes < 1024 * 1024 * 1024:
-        return f"{size_in_bytes / (1024 * 1024):.1f} MB"
-    else:
-        return f"{size_in_bytes / (1024 * 1024 * 1024):.2f} GB"
-
-
 class ModsPanelSortKey(Enum):
     """
     Enum class representing different sorting keys for mods.

--- a/app/utils/generic.py
+++ b/app/utils/generic.py
@@ -419,6 +419,18 @@ def flatten_to_list(obj: Any) -> list[Any] | dict[Any, Any] | Any:
         return obj
 
 
+def format_file_size(size_in_bytes: int) -> str:
+    """Format bytes to a human-readable string."""
+    if size_in_bytes < 1024:
+        return f"{size_in_bytes} B"
+    elif size_in_bytes < 1024 * 1024:
+        return f"{size_in_bytes / 1024:.1f} KB"
+    elif size_in_bytes < 1024 * 1024 * 1024:
+        return f"{size_in_bytes / (1024 * 1024):.1f} MB"
+    else:
+        return f"{size_in_bytes / (1024 * 1024 * 1024):.2f} GB"
+
+
 def upload_data_to_0x0_st(path: str) -> tuple[bool, str]:
     """
     Function to upload data to https://0x0.st/

--- a/app/views/mod_info_panel.py
+++ b/app/views/mod_info_panel.py
@@ -19,12 +19,12 @@ from PySide6.QtWidgets import (
 from app.controllers.metadata_db_controller import AuxMetadataController
 from app.controllers.settings_controller import SettingsController
 from app.models.image_label import ImageLabel
+from app.sort.mod_sorting import uuid_to_folder_size
 from app.utils.app_info import AppInfo
 from app.utils.custom_list_widget_item import CustomListWidgetItem
-from app.utils.generic import platform_specific_open
+from app.utils.generic import format_file_size, platform_specific_open
 from app.utils.metadata import MetadataManager
 from app.views.description_widget import DescriptionWidget
-from app.views.mods_panel import format_file_size, uuid_to_folder_size
 
 
 class ClickablePathLabel(QLabel):

--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -60,7 +60,6 @@ from app.sort.mod_sorting import (
     _FOLDER_SIZE_CACHE,
     FolderSizeWorker,
     ModsPanelSortKey,
-    format_file_size,
     sort_uuids,
     uuid_to_folder_size,
 )
@@ -77,6 +76,7 @@ from app.utils.generic import (
     copy_to_clipboard_safely,
     delete_files_except_extension,
     flatten_to_list,
+    format_file_size,
     launch_process,
     open_url_browser,
     platform_specific_open,


### PR DESCRIPTION
Moved the format_file_size function to app/utils/generic.py for reuse across modules. Updated imports and removed duplicate implementations in file_search_controller.py, mod_sorting.py, mod_info_panel.py, and mods_panel.py to use the centralized utility.