### PR TITLE
Set steamcmd_auto_clear_depot_cache default to True

### DIFF
--- a/app/models/instance.py
+++ b/app/models/instance.py
@@ -50,7 +50,7 @@ class Instance(msgspec.Struct):
     local_folder: str = ""
     workshop_folder: str = ""
     run_args: list[str] = msgspec.field(default_factory=list)
-    steamcmd_auto_clear_depot_cache: bool = False
+    steamcmd_auto_clear_depot_cache: bool = True
     steamcmd_install_path: str = str(
         Path(AppInfo().app_storage_folder / "instances" / "Default")
     )


### PR DESCRIPTION
Changed the default value of steamcmd_auto_clear_depot_cache from False to True in the Instance model to enable automatic clearing of the depot cache by default.