### PR TITLE
Fix alphabetical sort dependency ordering

### DIFF
--- a/app/sort/alphabetical_sort.py
+++ b/app/sort/alphabetical_sort.py
@@ -87,7 +87,7 @@ def recursively_force_insert(
                     metadata_manager.internal_local_metadata[uuid]["name"]
                 )
     deps_of_package_alphabetized = sorted(
-        deps_id_to_name.items(), key=lambda x: x[1], reverse=True
+        deps_id_to_name.items(), key=lambda x: x[1], reverse=False
     )
 
     # Iterate through the list of reverse alphabetized dependencies


### PR DESCRIPTION
- Changed dependency sorting from reverse alphabetical to alphabetical order in recursively_force_insert function
- Ensures dependencies are inserted in correct order respecting both alphabetical sorting and dependency hierarchy
- Fixes issue where mods with dependencies were not loaded in the expected sequence