### PR TITLE
Add missing comma in language dictionary

### DIFF
--- a/app/controllers/language_controller.py
+++ b/app/controllers/language_controller.py
@@ -66,7 +66,7 @@ class LanguageController:
             "ru_RU": "Русский",
             "tr_TR": "Türkçe",
             "pt_BR": "Português (Brasil)",
-            "zh_TW": "正體中文"
+            "zh_TW": "正體中文",
         }
         available_languages = self.languages
         for lang_code in available_languages:


### PR DESCRIPTION
Added a trailing comma after the 'zh_TW' entry in the language dictionary to maintain consistency and prevent potential syntax errors.