### PR TITLE
Fix broken links in rule editor docs

### DIFF
--- a/docs/user-guide/rule-editor.md
+++ b/docs/user-guide/rule-editor.md
@@ -147,6 +147,4 @@ Use the search bar above the mods list to quickly find specific mods by name. Th
 
 ## Related Topics
 
-- [Databases](databases.md): Learn about the Community Rules and User Rules databases
-- [Sorting](sorting.md): Understand how rules affect mod sorting
-- [Mod Management](mod-management.md): General mod handling in RimSort
+- [Databases](../user-guide/databases): Learn about the Community Rules and User Rules databases

--- a/docs/user-guide/rule-editor.zh-cn.md
+++ b/docs/user-guide/rule-editor.zh-cn.md
@@ -148,7 +148,5 @@ lang: zh-cn
 
 ## 相关主题
 
-- [数据库](databases.zh-cn.md)：了解社区规则和用户规则数据库
-- [排序](sorting.zh-cn.md)：了解规则如何影响 Mod 排序
-- [Mod 管理](mod-management.zh-cn.md)：RimSort 中的一般 Mod 处理
+- [数据库](../user-guide/databases.zh-cn)：了解社区规则和用户规则数据库
 


### PR DESCRIPTION
Updated related topics links in both English and Chinese rule editor documentation to use correct relative paths, ensuring proper navigation.