### PR TITLE
Normalize authors field in metadata parsing

### DIFF
--- a/app/models/metadata/metadata_factory.py
+++ b/app/models/metadata/metadata_factory.py
@@ -296,8 +296,22 @@ def _parse_basic(mod_data: dict[str, Any], mod: AboutXmlMod) -> AboutXmlMod:
     if isinstance(author, str):
         mod.authors.append(author)
 
-    if authors:
-        mod.authors.extend(authors)
+    # Normalize authors to list[str]
+    normalized_authors: list[str] = []
+    if isinstance(authors, dict) and authors.get("li"):
+        li = authors.get("li")
+        if isinstance(li, list):
+            normalized_authors = [str(a) for a in li if a]
+        elif isinstance(li, str):
+            normalized_authors = [li]
+    elif isinstance(authors, list):
+        normalized_authors = [str(a) for a in authors if a]
+    elif isinstance(authors, str):
+        normalized_authors = [authors]
+    else:
+        normalized_authors = []
+
+    mod.authors.extend(normalized_authors)
 
     supported_versions = value_extractor(mod_data.get("supportedVersions", False))
     if isinstance(supported_versions, list):

--- a/app/utils/metadata.py
+++ b/app/utils/metadata.py
@@ -1846,6 +1846,16 @@ class ModParser(QRunnable):
                         ("authors" if key.lower() == "author" else key): value
                         for key, value in mod_metadata.items()
                     }
+                    # Normalize authors to a string
+                    authors = mod_metadata.get("authors")
+                    if isinstance(authors, dict) and authors.get("li"):
+                        mod_metadata["authors"] = ", ".join(authors["li"])
+                    elif isinstance(authors, list):
+                        mod_metadata["authors"] = ", ".join(authors)
+                    elif isinstance(authors, str):
+                        pass  # Keep as is
+                    else:
+                        mod_metadata["authors"] = "Unknown"
                     # Make sure <supportedversions> or <targetversion> is correct format
                     if mod_metadata.get("supportedversions") and not isinstance(
                         mod_metadata.get("supportedversions"), dict
@@ -3116,5 +3126,3 @@ def recursively_update_dict(
         for key in purge_keys:
             if key in a_dict:
                 del a_dict[key]
-
-            # (removed misplaced block: loadBefore byVersion processing belongs in compile_metadata)


### PR DESCRIPTION
- Updated metadata_factory.py to properly handle authors as list of strings
- Modified metadata.py to normalize authors to comma-separated string
- Removed misplaced code block from metadata.py