### PR TITLE
Fix WorkshopModUpdaterPanel logic for checking mod updates

### DIFF
--- a/app/windows/workshop_mod_updater_panel.py
+++ b/app/windows/workshop_mod_updater_panel.py
@@ -90,12 +90,10 @@ class WorkshopModUpdaterPanel(BaseModsPanel):
             for metadata in self.mm.internal_local_metadata.values()
             if (
                 (metadata.get("steamcmd") or metadata.get("data_source") == "workshop")
+                and metadata.get("internal_time_touched")
                 and metadata.get("external_time_updated")
-                and (
-                    not metadata.get("internal_time_touched")
-                    or metadata["external_time_updated"]
-                    > metadata["internal_time_touched"]
-                )
+                and metadata["external_time_updated"]
+                > metadata["internal_time_touched"]
             )
         ]
 


### PR DESCRIPTION
- Simplified the condition to check for mods that need updating by ensuring 'internal_time_touched' exists and 'external_time_updated' is greater than 'internal_time_touched'.
- Removed redundant check that was causing issues with mod update detection.