### PR TITLE
Add "Delete" shortcut, mod list download and steam path

### DIFF
--- a/app/utils/steam/steambrowser/browser.py
+++ b/app/utils/steam/steambrowser/browser.py
@@ -19,6 +19,7 @@ from PySide6.QtWebEngineCore import (
 )
 from PySide6.QtWebEngineWidgets import QWebEngineView
 from PySide6.QtWidgets import (
+    QDialog,
     QHBoxLayout,
     QLabel,
     QLayout,
@@ -29,10 +30,12 @@ from PySide6.QtWidgets import (
     QProgressBar,
     QPushButton,
     QSizePolicy,
+    QTextEdit,
     QToolBar,
     QVBoxLayout,
     QWidget,
 )
+from PySide6.QtWidgets import QDialogButtonBox as ButtonBox
 
 from app.controllers.settings_controller import SettingsController
 from app.models.image_label import ImageLabel
@@ -259,29 +262,31 @@ class SteamBrowser(QWidget):
         self._launch_browser_window()
         logger.debug("Finished Browser Window initialization")
 
-    def _show_add_mods_by_id_dialog(self):
-        from PySide6.QtWidgets import QDialog, QVBoxLayout, QTextEdit, QDialogButtonBox, QLabel
-        from PySide6.QtWidgets import QDialogButtonBox as ButtonBox
-
+    def _show_add_mods_by_id_dialog(self) -> None:
         dialog = QDialog(self)
         dialog.setWindowTitle(self.tr("Add Mods by Workshop ID"))
         layout = QVBoxLayout(dialog)
-        label = QLabel(self.tr("Enter one or more Workshop IDs (one per line or separated by commas):"))
+        label = QLabel(
+            self.tr(
+                "Enter one or more Workshop IDs (one per line or separated by commas):"
+            )
+        )
         layout.addWidget(label)
         text_edit = QTextEdit()
         layout.addWidget(text_edit)
-        buttons = ButtonBox(ButtonBox.StandardButton.Ok | ButtonBox.StandardButton.Cancel)
+        buttons = ButtonBox(
+            ButtonBox.StandardButton.Ok | ButtonBox.StandardButton.Cancel
+        )
         layout.addWidget(buttons)
         buttons.accepted.connect(dialog.accept)
         buttons.rejected.connect(dialog.reject)
 
         if dialog.exec() == QDialog.DialogCode.Accepted:
             ids_text = text_edit.toPlainText()
-            ids = re.split(r'[\s,]+', ids_text.strip())
+            ids = re.split(r"[\s,]+", ids_text.strip())
             ids = [id_.strip() for id_ in ids if id_.strip()]
             for workshop_id in ids:
                 self._add_mod_to_list(publishedfileid=workshop_id)
-
 
     def _launch_browser_window(self) -> None:
         """Apply browser window launch state from settings"""

--- a/app/utils/steam/steambrowser/browser.py
+++ b/app/utils/steam/steambrowser/browser.py
@@ -86,6 +86,11 @@ class SteamBrowser(QWidget):
             logger.info("Setting QTWEBENGINE_DISABLE_SANDBOX for non-Windows platform")
             os.environ["QTWEBENGINE_DISABLE_SANDBOX"] = "1"
 
+        # Add Mods by Workshop ID Button (always create, not just non-Windows)
+        self.add_mods_by_id_button = QPushButton(self.tr("Add Mods by Workshop ID"))
+        self.add_mods_by_id_button.setObjectName("browserPanelAddModsByID")
+        self.add_mods_by_id_button.clicked.connect(self._show_add_mods_by_id_dialog)
+
         # VARIABLES
         profile_dir = Path(AppInfo()._browser_profile_folder)
         profile_dir.mkdir(parents=True, exist_ok=True)
@@ -229,6 +234,7 @@ class SteamBrowser(QWidget):
         self.downloader_layout.addWidget(self.downloader_label)
         self.downloader_layout.addWidget(self.downloader_list)
         self.downloader_layout.addWidget(self.add_to_list2_button)
+        self.downloader_layout.addWidget(self.add_mods_by_id_button)
         self.downloader_layout.addWidget(self.download_steamcmd_button)
         self.downloader_layout.addWidget(self.download_steamworks_button)
         self.downloader_layout.addWidget(self.clear_list_button)
@@ -252,6 +258,30 @@ class SteamBrowser(QWidget):
         # launch the browser window
         self._launch_browser_window()
         logger.debug("Finished Browser Window initialization")
+
+    def _show_add_mods_by_id_dialog(self):
+        from PySide6.QtWidgets import QDialog, QVBoxLayout, QTextEdit, QDialogButtonBox, QLabel
+        from PySide6.QtWidgets import QDialogButtonBox as ButtonBox
+
+        dialog = QDialog(self)
+        dialog.setWindowTitle(self.tr("Add Mods by Workshop ID"))
+        layout = QVBoxLayout(dialog)
+        label = QLabel(self.tr("Enter one or more Workshop IDs (one per line or separated by commas):"))
+        layout.addWidget(label)
+        text_edit = QTextEdit()
+        layout.addWidget(text_edit)
+        buttons = ButtonBox(ButtonBox.StandardButton.Ok | ButtonBox.StandardButton.Cancel)
+        layout.addWidget(buttons)
+        buttons.accepted.connect(dialog.accept)
+        buttons.rejected.connect(dialog.reject)
+
+        if dialog.exec() == QDialog.DialogCode.Accepted:
+            ids_text = text_edit.toPlainText()
+            ids = re.split(r'[\s,]+', ids_text.strip())
+            ids = [id_.strip() for id_ in ids if id_.strip()]
+            for workshop_id in ids:
+                self._add_mod_to_list(publishedfileid=workshop_id)
+
 
     def _launch_browser_window(self) -> None:
         """Apply browser window launch state from settings"""

--- a/app/views/mod_info_panel.py
+++ b/app/views/mod_info_panel.py
@@ -71,20 +71,29 @@ class ClickablePathLabel(QLabel):
             self.setCursor(Qt.CursorShape.ArrowCursor)
 
     def mousePressEvent(self, event: QMouseEvent) -> None:
-        """Handle mouse click to open the folder if clickable."""
+        """Handle mouse click to open the folder or URL if clickable."""
         if event.button() == Qt.MouseButton.LeftButton and self.path and self.clickable:
-            try:
-                path_obj = Path(self.path)
-                if path_obj.exists():
-                    if path_obj.is_dir():
-                        platform_specific_open(self.path)
-                        logger.info(f"Opening mod folder: {self.path}")
+            # If path looks like a URL, open in browser
+            if self.path.startswith("http://") or self.path.startswith("https://"):
+                import webbrowser
+                try:
+                    webbrowser.open(self.path)
+                    logger.info(f"Opening URL: {self.path}")
+                except Exception as e:
+                    logger.error(f"Failed to open URL {self.path}: {e}")
+            else:
+                try:
+                    path_obj = Path(self.path)
+                    if path_obj.exists():
+                        if path_obj.is_dir():
+                            platform_specific_open(self.path)
+                            logger.info(f"Opening mod folder: {self.path}")
+                        else:
+                            logger.warning(f"Path is not a directory: {self.path}")
                     else:
-                        logger.warning(f"Path is not a directory: {self.path}")
-                else:
-                    logger.warning(f"Mod folder does not exist: {self.path}")
-            except Exception as e:
-                logger.error(f"Failed to open mod folder {self.path}: {e}")
+                        logger.warning(f"Mod folder does not exist: {self.path}")
+                except Exception as e:
+                    logger.error(f"Failed to open mod folder {self.path}: {e}")
         super().mousePressEvent(event)
 
 
@@ -229,6 +238,13 @@ class ModInfoPanel:
             Qt.TextInteractionFlag.TextSelectableByMouse
         )
         self.mod_info_path_value.setWordWrap(True)
+        # Add Steam URL label and value
+        self.mod_info_steam_url_label = QLabel(self.tr("Steam URL:"))
+        self.mod_info_steam_url_label.setObjectName("summaryLabel")
+        self.mod_info_steam_url_value = ClickablePathLabel()
+        self.mod_info_steam_url_value.setObjectName("summaryValue")
+        self.mod_info_steam_url_value.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
+        self.mod_info_steam_url_value.setWordWrap(True)
         self.mod_info_last_touched_label = QLabel(self.tr("Last Touched:"))
         self.mod_info_last_touched_label.setObjectName("summaryLabel")
         self.mod_info_last_touched_value = QLabel()
@@ -331,6 +347,10 @@ class ModInfoPanel:
         self.mod_info_layout.addLayout(self.mod_info_supported_versions)
         self.mod_info_layout.addLayout(self.mod_info_folder_size)
         self.mod_info_layout.addLayout(self.mod_info_path)
+        self.mod_info_steam_url_layout = QHBoxLayout()
+        self.mod_info_steam_url_layout.addWidget(self.mod_info_steam_url_label, 20)
+        self.mod_info_steam_url_layout.addWidget(self.mod_info_steam_url_value, 80)
+        self.mod_info_layout.addLayout(self.mod_info_steam_url_layout)
         self.notes_layout.addWidget(self.notes)
         self.mod_info_layout.addLayout(self.mod_info_last_touched)
         self.mod_info_layout.addLayout(self.mod_info_filesystem_time)
@@ -343,6 +363,8 @@ class ModInfoPanel:
             self.mod_info_name_value,
             self.mod_info_path_label,
             self.mod_info_path_value,
+                self.mod_info_steam_url_label,
+                self.mod_info_steam_url_value,
         ]
 
         self.base_mod_info_widgets = [
@@ -624,6 +646,22 @@ class ModInfoPanel:
         self, mod_metadata: dict[str, Any], render_unity_rt: bool
     ) -> None:
         """Set the mod description with version-specific handling."""
+        self.mod_info_path_value.setPath(mod_info.get("path"))
+        # Set Steam URL value
+        steam_url = None
+        pfid = mod_info.get("pfid")
+        if pfid:
+            steam_url = f"https://steamcommunity.com/sharedfiles/filedetails/?id={pfid}"
+        elif mod_info.get("steam_url"):
+            steam_url = mod_info.get("steam_url")
+        elif mod_info.get("url"):
+            steam_url = mod_info.get("url")
+        self.mod_info_steam_url_value.setPath(steam_url)
+        if steam_url:
+            self.mod_info_steam_url_value.setToolTip(f"Click to open Steam Workshop: {steam_url}")
+        else:
+            self.mod_info_steam_url_value.setToolTip("")
+        # Set the scrolling description for the Mod Info Panel
         self.description.setText("")
         if "description" in mod_metadata:
             if mod_metadata["description"] is not None:

--- a/app/views/mod_info_panel.py
+++ b/app/views/mod_info_panel.py
@@ -76,6 +76,7 @@ class ClickablePathLabel(QLabel):
             # If path looks like a URL, open in browser
             if self.path.startswith("http://") or self.path.startswith("https://"):
                 import webbrowser
+
                 try:
                     webbrowser.open(self.path)
                     logger.info(f"Opening URL: {self.path}")
@@ -243,7 +244,9 @@ class ModInfoPanel:
         self.mod_info_steam_url_label.setObjectName("summaryLabel")
         self.mod_info_steam_url_value = ClickablePathLabel()
         self.mod_info_steam_url_value.setObjectName("summaryValue")
-        self.mod_info_steam_url_value.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
+        self.mod_info_steam_url_value.setTextInteractionFlags(
+            Qt.TextInteractionFlag.TextSelectableByMouse
+        )
         self.mod_info_steam_url_value.setWordWrap(True)
         self.mod_info_last_touched_label = QLabel(self.tr("Last Touched:"))
         self.mod_info_last_touched_label.setObjectName("summaryLabel")
@@ -363,8 +366,8 @@ class ModInfoPanel:
             self.mod_info_name_value,
             self.mod_info_path_label,
             self.mod_info_path_value,
-                self.mod_info_steam_url_label,
-                self.mod_info_steam_url_value,
+            self.mod_info_steam_url_label,
+            self.mod_info_steam_url_value,
         ]
 
         self.base_mod_info_widgets = [
@@ -646,19 +649,24 @@ class ModInfoPanel:
         self, mod_metadata: dict[str, Any], render_unity_rt: bool
     ) -> None:
         """Set the mod description with version-specific handling."""
-        self.mod_info_path_value.setPath(mod_info.get("path"))
+        self.mod_info_path_value.setPath(mod_metadata.get("path"))
         # Set Steam URL value
-        steam_url = None
-        pfid = mod_info.get("pfid")
-        if pfid:
-            steam_url = f"https://steamcommunity.com/sharedfiles/filedetails/?id={pfid}"
-        elif mod_info.get("steam_url"):
-            steam_url = mod_info.get("steam_url")
-        elif mod_info.get("url"):
-            steam_url = mod_info.get("url")
+        steam_url: str | None = None
+        pfid = mod_metadata.get("pfid")
+        if isinstance(pfid, str) and pfid:
+            steam_url = "https://steamcommunity.com/sharedfiles/filedetails/?id=" + pfid
+        else:
+            steam_url_candidate = mod_metadata.get("steam_url") or mod_metadata.get(
+                "url"
+            )
+            if isinstance(steam_url_candidate, str) and steam_url_candidate:
+                steam_url = steam_url_candidate
         self.mod_info_steam_url_value.setPath(steam_url)
+
         if steam_url:
-            self.mod_info_steam_url_value.setToolTip(f"Click to open Steam Workshop: {steam_url}")
+            self.mod_info_steam_url_value.setToolTip(
+                f"Click to open Steam Workshop: {steam_url}"
+            )
         else:
             self.mod_info_steam_url_value.setToolTip("")
         # Set the scrolling description for the Mod Info Panel

--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -2675,6 +2675,12 @@ class ModListWidget(QListWidget):
             ):
                 self.key_press_signal.emit(key_pressed)
             else:
+                # Handle Delete key for mod deletion
+                if event.key() == Qt.Key.Key_Delete:
+                    # Only trigger if there are selected mods
+                    if self.selectedItems():
+                        self.deletion_sub_menu.delete_mod_completely()
+                    return
                 return super().keyPressEvent(event)
 
     def resizeEvent(self, e: QResizeEvent) -> None:


### PR DESCRIPTION
Hello

These are some things that I really needed to exist. I'm not very experienced with python though, so I apologize in advance. 


1. Add the ability to press "Delete" Key on the keyboard to invoke a delete command similar to selecting "Delete mod completely" from the context menu. 
<img width="571" height="486" alt="image" src="https://github.com/user-attachments/assets/802a8fd2-5095-4a61-89c2-8c5490398b59" />



2. Add the ability to view the steam url and click directly from the mod panel instead of selecting "Open URL in browser" from the contextt menu, and similar to the path. 
<img width="754" height="320" alt="image" src="https://github.com/user-attachments/assets/fff34510-66b8-411f-b65f-ff51f953e610" />

3. Add the ability to add a comma-seperated list of mod ids to the steam browser to download. 
(I needed this because I already had a list from long ago that I wanted to add and sometimes I'm browsing mods from a different laptop and create a list and want to automatically download all of them instead of browsing one by one.) 
<img width="1585" height="1367" alt="image" src="https://github.com/user-attachments/assets/bd7327e4-12c6-4a31-83aa-6cbbaa3cfb77" />
<img width="241" height="260" alt="image" src="https://github.com/user-attachments/assets/17ebb889-e64b-477b-9022-1092ef517f34" />
