### PR TITLE
Add metadata cache refresh signal and handler

### DIFF
--- a/app/utils/event_bus.py
+++ b/app/utils/event_bus.py
@@ -109,6 +109,7 @@ class EventBus(QObject):
 
     refresh_started = Signal()
     refresh_finished = Signal()
+    do_metadata_refresh_cache = Signal()
 
     # Dialog signals
     reset_settings_file = Signal()

--- a/app/utils/metadata.py
+++ b/app/utils/metadata.py
@@ -1573,7 +1573,7 @@ class MetadataManager(QObject):
         somehow, e.g. re-setting workshop path, mods config path, or downloading another mod,
         but also after ModsConfig.xml path has been changed).
         """
-        logger.info("Refreshing metadata cache...")
+        logger.warning("Refreshing metadata cache...")
 
         # If we are refreshing cache from user action, update user paths as well in case of change
         if not is_initial:

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -327,6 +327,8 @@ class MainContent(QObject):
                 self.do_threaded_loading_animation
             )
 
+            EventBus().do_metadata_refresh_cache.connect(self.do_metadata_refresh_cache)
+
             # Restore cache initially set to empty
             self.active_mods_uuids_last_save: list[str] = []
             self.active_mods_uuids_restore_state: list[str] = []
@@ -357,6 +359,10 @@ class MainContent(QObject):
         elif args or kwargs:
             raise ValueError("MainContent instance has already been initialized.")
         return cls._instance
+
+    def do_metadata_refresh_cache(self) -> None:
+        """Force Refresh metadata cache"""
+        self.metadata_manager.refresh_cache(is_initial=False)
 
     def check_if_essential_paths_are_set(self, prompt: bool = True) -> bool:
         """

--- a/app/windows/runner_panel.py
+++ b/app/windows/runner_panel.py
@@ -18,6 +18,7 @@ from PySide6.QtWidgets import (
 )
 
 from app.utils.app_info import AppInfo
+from app.utils.event_bus import EventBus
 from app.utils.steam.webapi.wrapper import (
     ISteamRemoteStorage_GetPublishedFileDetails,
 )
@@ -610,3 +611,4 @@ class RunnerPanel(QWidget):
         )
         if diag.exec_is_positive():
             self.close()
+            EventBus().do_metadata_refresh_cache.emit()


### PR DESCRIPTION
Introduces a new do_metadata_refresh_cache signal to EventBus and connects it to MainContent for triggering metadata cache refreshes. RunnerPanel now emits this signal after closing a dialog, and logging for cache refresh is changed to warning level for better visibility.