### PR TITLE
Refactor all mod panels now depend on base_mods_panel

### DIFF
--- a/app/utils/button_factory.py
+++ b/app/utils/button_factory.py
@@ -1,0 +1,96 @@
+"""
+Button factory utilities for creating standardized buttons in mod panels.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from PySide6.QtGui import QAction
+from PySide6.QtWidgets import QMenu, QPushButton, QToolButton
+
+
+@dataclass
+class MenuItem:
+    """Represents a menu item for button configurations."""
+
+    text: str
+    callback: Callable[[], None]
+
+
+class ButtonFactory:
+    """Factory class for creating standardized buttons."""
+
+    def __init__(self, panel: Any):
+        self.panel = panel
+
+    def create_refresh_button(
+        self, callback: Callable[[], None] | None = None
+    ) -> QPushButton:
+        """Create a refresh button."""
+        return self.panel._create_refresh_button(callback)
+
+    def create_steamcmd_button(self, pfid_column: int) -> QPushButton:
+        """Create a SteamCMD download button."""
+        return self.panel._create_steamcmd_button(pfid_column)
+
+    def create_subscribe_button(
+        self,
+        pfid_column: int,
+        completion_callback: Callable[[], None] | None = None,
+    ) -> QPushButton:
+        """Create a subscribe button."""
+        return self.panel._create_subscribe_button(pfid_column, completion_callback)
+
+    def create_unsubscribe_button(
+        self,
+        pfid_column: int,
+        completion_callback: Callable[[], None] | None = None,
+    ) -> QPushButton:
+        """Create an unsubscribe button."""
+        return self.panel._create_unsubscribe_button(pfid_column, completion_callback)
+
+    def create_delete_button(
+        self,
+        menu_title: str,
+        completion_callback: Callable[[], None] | None = None,
+        enable_delete_mod: bool = True,
+        enable_delete_keep_dds: bool = False,
+        enable_delete_dds_only: bool = False,
+        enable_delete_and_unsubscribe: bool = False,
+        enable_delete_and_resubscribe: bool = False,
+    ) -> QPushButton:
+        """Create a deletion button with menu."""
+        return self.panel._create_deletion_button(
+            self.panel.settings_controller,
+            self.panel._get_selected_mod_metadata,
+            completion_callback,
+            menu_title,
+            enable_delete_mod,
+            enable_delete_keep_dds,
+            enable_delete_dds_only,
+            enable_delete_and_unsubscribe,
+            enable_delete_and_resubscribe,
+        )
+
+    def create_custom_button(
+        self, text: str, callback: Callable[[], None]
+    ) -> QPushButton:
+        """Create a custom button."""
+        button = QPushButton(text)
+        button.clicked.connect(callback)
+        return button
+
+    def create_select_button(
+        self, text: str, menu_items: list[MenuItem]
+    ) -> QToolButton:
+        """Create a select button with dropdown menu."""
+        button = QToolButton()
+        button.setText(text)
+        menu = QMenu(button)
+        for menu_item in menu_items:
+            action = QAction(menu_item.text, self.panel)
+            action.triggered.connect(menu_item.callback)
+            menu.addAction(action)
+        button.setMenu(menu)
+        button.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
+        return button

--- a/app/utils/metadata.py
+++ b/app/utils/metadata.py
@@ -47,13 +47,20 @@ from app.views.dialogue import (
 
 class ModReplacement:
     def __init__(
-        self, name: str, author: str, packageid: str, pfid: str, supportedversions: str
+        self,
+        name: str,
+        author: str,
+        packageid: str,
+        pfid: str,
+        supportedversions: str,
+        source: str = "database",
     ):
         self.name = name
         self.author = author
         self.packageid = packageid
         self.pfid = pfid
         self.supportedversions = supportedversions
+        self.source = source
 
 
 # TODO: Someday, it is probably worth typing out the keys

--- a/app/utils/mod_info.py
+++ b/app/utils/mod_info.py
@@ -1,0 +1,200 @@
+from dataclasses import dataclass
+from typing import Any
+
+from loguru import logger
+
+from app.utils.generic import format_time_display
+
+# Module-level constants for better access
+UNKNOWN = "Unknown"
+STEAM_CMD = "SteamCMD"
+STEAM = "Steam"
+LOCAL = "Local"
+DATABASE = "database"
+
+
+@dataclass
+class ModInfo:
+    """Standardized mod information structure."""
+
+    uuid: str | None
+    name: str
+    authors: str
+    packageid: str
+    published_file_id: str
+    supported_versions: str
+    source: str
+    path: str
+    downloaded_time_raw: float | None
+    updated_time_raw: float | None
+    workshop_url: str
+    type: str  # Type of mod (e.g., "Original", "Replacement")
+    installed_status: str  # Installation status (e.g., "Installed", "Not Installed")
+
+    def __post_init__(self) -> None:
+        """Validate required fields after initialization."""
+        if not self.packageid or not self.packageid.strip():
+            raise ValueError("packageid cannot be empty or whitespace-only")
+        if not self.name or not self.name.strip():
+            self.name = UNKNOWN  # Set to UNKNOWN if empty, but allow it
+
+    @classmethod
+    def from_metadata(cls, uuid: str | None, metadata: dict[str, Any]) -> "ModInfo":
+        """Create ModInfo from metadata dictionary."""
+        try:
+            name = cls._parse_name(metadata)
+            authors = cls._parse_authors(metadata)
+            packageid = metadata.get("packageid", "")
+            published_file_id = metadata.get("publishedfileid", "")
+            supported_versions = cls._parse_supported_versions_static(
+                metadata.get("supportedversions")
+            )
+            source = ""
+            if metadata.get("steamcmd"):
+                source = STEAM_CMD
+            elif metadata.get("data_source") == "workshop":
+                source = STEAM
+            elif metadata.get("data_source") == "local" and not metadata.get(
+                "steamcmd"
+            ):
+                source = LOCAL
+            else:
+                source = DATABASE
+            path = metadata.get("path", "")
+            downloaded_time_raw = metadata.get("internal_time_touched")
+            updated_time_raw = metadata.get("external_time_updated")
+            workshop_url = cls._generate_workshop_url(published_file_id)
+            type = metadata.get("type", "")
+            installed_status = metadata.get("installed_status", "")
+
+            # Input validation for required fields
+            if not isinstance(packageid, str) or not packageid.strip():
+                logger.warning(
+                    f"Invalid or missing packageid in metadata for UUID {uuid}"
+                )
+            if not isinstance(name, str) or not name.strip():
+                logger.warning(f"Invalid or missing name in metadata for UUID {uuid}")
+            if not isinstance(published_file_id, str):
+                logger.warning(f"Invalid published_file_id in metadata for UUID {uuid}")
+
+            return cls(
+                uuid,
+                name,
+                authors,
+                packageid,
+                published_file_id,
+                supported_versions,
+                source,
+                path,
+                downloaded_time_raw,
+                updated_time_raw,
+                workshop_url,
+                type,
+                installed_status,
+            )
+        except Exception as e:
+            # Log detailed error information and raise exception instead of returning minimal ModInfo
+            metadata_keys = (
+                list(metadata.keys())
+                if isinstance(metadata, dict)
+                else "Invalid metadata type"
+            )
+            logger.error(
+                f"Error creating ModInfo from metadata for UUID {uuid}: {e}. Metadata keys: {metadata_keys}"
+            )
+            raise ValueError(f"Failed to create ModInfo from metadata: {e}") from e
+
+    @staticmethod
+    def _parse_name(metadata: dict[str, Any]) -> str:
+        """Parse mod name from metadata with fallbacks."""
+        try:
+            return metadata.get("name", metadata.get("steamName", ""))
+        except Exception:
+            return UNKNOWN
+
+    @staticmethod
+    def _parse_authors(metadata: dict[str, Any]) -> str:
+        """Parse authors from metadata, handling different formats."""
+        try:
+            authors = metadata.get("authors", "")
+            if isinstance(authors, list):
+                return ", ".join(str(author) for author in authors)
+            elif isinstance(authors, str):
+                return authors
+            return UNKNOWN
+        except Exception:
+            return UNKNOWN
+
+    @staticmethod
+    def _normalize_version(version: str) -> str:
+        """Normalize a version string to major.minor format if it has more parts."""
+        if not isinstance(version, str):
+            return str(version)
+        parts = version.split(".")
+        if len(parts) > 2:
+            return ".".join(parts[:2])
+        return version.strip()
+
+    @staticmethod
+    def _parse_supported_versions_static(
+        supported_versions: dict[str, Any] | list[str] | str | None,
+    ) -> str:
+        """
+        Parse supported versions from metadata into a normalized, sorted, comma-separated string.
+
+        Args:
+            supported_versions: The supported versions data from metadata.
+                - dict: Expected to have 'li' key with list of versions or single version string.
+                - list: List of version strings.
+                - str: Single version string.
+                - None: No versions specified.
+
+        Returns:
+            str: Comma-separated string of normalized versions, or "Unknown" if None or empty.
+        """
+        if supported_versions is None:
+            return UNKNOWN
+
+        versions = []
+        if isinstance(supported_versions, dict):
+            if "li" in supported_versions:
+                li = supported_versions["li"]
+                if isinstance(li, list):
+                    versions = [ModInfo._normalize_version(v) for v in li if v]
+                elif isinstance(li, str):
+                    normalized = ModInfo._normalize_version(li)
+                    if normalized:
+                        versions = [normalized]
+        elif isinstance(supported_versions, list):
+            versions = [ModInfo._normalize_version(v) for v in supported_versions if v]
+        elif isinstance(supported_versions, str):
+            normalized = ModInfo._normalize_version(supported_versions)
+            if normalized:
+                versions = [normalized]
+
+        if versions:
+            # Remove duplicates, sort for consistency, and join
+            unique_versions = sorted(set(versions), key=str)
+            return ", ".join(unique_versions)
+        return UNKNOWN
+
+    @staticmethod
+    def _generate_workshop_url(published_file_id: str) -> str:
+        """Generate workshop URL from published file ID."""
+        if published_file_id and published_file_id.isdigit():
+            return f"https://steamcommunity.com/sharedfiles/filedetails/?id={published_file_id}"
+        return ""
+
+    @property
+    def downloaded_time(self) -> str:
+        """Get formatted downloaded time."""
+        if self.downloaded_time_raw is not None:
+            return format_time_display(int(self.downloaded_time_raw))[0]
+        return UNKNOWN
+
+    @property
+    def updated_on_workshop(self) -> str:
+        """Get formatted workshop update time."""
+        if self.updated_time_raw is not None:
+            return format_time_display(int(self.updated_time_raw))[0]
+        return UNKNOWN

--- a/app/utils/mod_utils.py
+++ b/app/utils/mod_utils.py
@@ -1,4 +1,5 @@
 import os
+from typing import Any
 
 from app.utils.metadata import MetadataManager
 
@@ -77,3 +78,27 @@ def get_mod_paths_from_uuids(uuids: list[str]) -> list[str]:
                 mod_paths.append(mod_path)
 
     return mod_paths
+
+
+def filter_eligible_mods_for_update(
+    internal_local_metadata: dict[str, dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """
+    Filter mods that are eligible for update.
+
+    Args:
+        internal_local_metadata: Dictionary of internal local metadata.
+
+    Returns:
+        List of metadata dictionaries for mods eligible for update.
+    """
+    return [
+        metadata
+        for metadata in internal_local_metadata.values()
+        if (
+            (metadata.get("steamcmd") or metadata.get("data_source") == "workshop")
+            and metadata.get("internal_time_touched")
+            and metadata.get("external_time_updated")
+            and metadata["external_time_updated"] > metadata["internal_time_touched"]
+        )
+    ]

--- a/app/windows/base_mods_panel.py
+++ b/app/windows/base_mods_panel.py
@@ -1,10 +1,15 @@
+from __future__ import annotations
+
 import os
 import shutil
+from dataclasses import dataclass
+from enum import Enum
 from functools import partial
-from typing import Callable, Self, TypeVar, Union
+from typing import Any, Callable, Sequence, TypeVar
 
+from loguru import logger
 from PySide6.QtCore import QEvent, QObject, Qt
-from PySide6.QtGui import QStandardItem, QStandardItemModel
+from PySide6.QtGui import QAction, QKeyEvent, QStandardItem, QStandardItemModel
 from PySide6.QtWidgets import (
     QAbstractItemView,
     QCheckBox,
@@ -13,28 +18,102 @@ from PySide6.QtWidgets import (
     QHeaderView,
     QLabel,
     QLayout,
+    QMenu,
     QPushButton,
     QTableView,
+    QToolButton,
     QVBoxLayout,
     QWidget,
 )
 
+from app.utils.button_factory import ButtonFactory, MenuItem
 from app.utils.event_bus import EventBus
+from app.utils.generic import platform_specific_open
 from app.utils.metadata import MetadataManager
+from app.utils.mod_info import ModInfo
 from app.utils.mod_utils import get_mod_path_from_pfid
+from app.views.deletion_menu import ModDeletionMenu
+from app.views.mod_info_panel import ClickablePathLabel
 
 # By default, we assume Stretch for all columns.
 # Tuples should be used if this should be overridden
 HeaderColumn = str | tuple[str, QHeaderView.ResizeMode]
 
 
-# class BaseModPanelCheckbox(QStandardItem):
-#     def __init__(self, uuid: str, default_checkbox_state: bool = False) -> None:
-#         super().__init__()
-#         self.uuid = uuid
-#         self.checkbox = QCheckBox()
-#         self.checkbox.setObjectName("selectCheckbox")
-#         self.checkbox.setChecked(default_checkbox_state)
+@dataclass
+class UIElements:
+    """Dataclass to group UI elements for better organization."""
+
+    title: QLabel
+    details_label: QLabel
+    editor_deselect_all_button: QPushButton
+    editor_select_all_button: QPushButton
+    editor_cancel_button: QPushButton
+
+
+@dataclass
+class Layouts:
+    """Dataclass to group layout elements for better organization."""
+
+    upper_layout: QVBoxLayout
+    lower_layout: QVBoxLayout
+    details_layout: QVBoxLayout
+    editor_layout: QVBoxLayout
+    editor_actions_layout: QHBoxLayout
+    editor_checkbox_actions_layout: QHBoxLayout
+    editor_main_actions_layout: QHBoxLayout
+    editor_exit_actions_layout: QHBoxLayout
+
+
+class ColumnIndex(Enum):
+    """Enumeration for table column indices to eliminate magic numbers."""
+
+    CHECKBOX = 0
+    NAME = 1
+    AUTHOR = 2
+    PACKAGE_ID = 3
+    PUBLISHED_FILE_ID = 4
+    SUPPORTED_VERSIONS = 5
+    MOD_DOWNLOADED = 6
+    UPDATED_ON_WORKSHOP = 7
+    SOURCE = 8
+    PATH = 9
+    WORKSHOP_PAGE = 10
+
+
+class ButtonType(Enum):
+    """Enumeration of button types for standardized button creation."""
+
+    REFRESH = "refresh"
+    STEAMCMD = "steamcmd"
+    SUBSCRIBE = "subscribe"
+    UNSUBSCRIBE = "unsubscribe"
+    DELETE = "delete"
+    SELECT = "select"
+    CUSTOM = "custom"
+
+
+@dataclass
+class ButtonConfig:
+    """Configuration for creating standardized buttons."""
+
+    button_type: ButtonType
+    text: str = ""
+    pfid_column: int | None = None
+    # Callbacks to refresh the panel after deletion
+    completion_callback: Callable[[], None] | None = None
+    menu_items: list[MenuItem] | None = None
+    # For delete buttons
+    get_selected_mod_metadata: Callable[[], list[dict[str, Any]]] | None = None
+    # deletion menu
+    menu_title: str | None = None
+    enable_delete_mod: bool = True
+    enable_delete_keep_dds: bool = False
+    enable_delete_dds_only: bool = False
+    enable_delete_and_unsubscribe: bool = True
+    enable_delete_and_resubscribe: bool = False
+    # For custom buttons
+    custom_callback: Callable[[], None] | None = None
 
 
 class BaseModsPanel(QWidget):
@@ -42,69 +121,90 @@ class BaseModsPanel(QWidget):
     Base class used for multiple panels that display a list of mods.
     """
 
-    def __init__(
+    # Type hints for instance variables
+    metadata_manager: MetadataManager
+    settings_controller: Any
+    editor_model: QStandardItemModel
+    editor_table_view: QTableView
+    ui_elements: UIElements
+    layouts: Layouts
+
+    # Common column definitions for standardization
+    COL_MOD_NAME = "Name"
+    COL_AUTHOR = "Author"
+    COL_PACKAGE_ID = "Package ID"
+    COL_PUBLISHED_FILE_ID = "Published File Id"
+    COL_SUPPORTED_VERSIONS = "Supported Versions"
+    COL_MOD_DOWNLOADED = "Mod Downloaded"
+    COL_UPDATED_ON_WORKSHOP = "Updated on Workshop"
+    COL_SOURCE = "Source"
+    COL_PATH = "Path"
+    COL_WORKSHOP_PAGE = "Workshop Page"
+
+    def _setup_metadata(self) -> None:
+        """Set up metadata manager and settings controller."""
+        self.metadata_manager = MetadataManager.instance()
+        self.settings_controller = self.metadata_manager.settings_controller
+
+    def _get_steam_client_integration_enabled(self) -> bool:
+        """
+        Get whether Steam client integration is enabled.
+
+        Returns:
+            True if Steam client integration is enabled, False otherwise.
+        """
+        return self.settings_controller.settings.instances[
+            self.settings_controller.settings.current_instance
+        ].steam_client_integration
+
+    def _setup_ui_elements(
         self,
         object_name: str,
         window_title: str,
         title_text: str,
         details_text: str,
-        additional_columns: list[HeaderColumn],
-    ):
-        super().__init__()
-        # Utility and Setup
-        self.metadata_manager = MetadataManager.instance()
-        self.settings_controller = self.metadata_manager.settings_controller
-
-        # Start of UI
+    ) -> None:
+        """Set up basic UI elements like title and details."""
         self.installEventFilter(self)
         self.setObjectName(object_name)
-        self.title = QLabel(title_text)
-        self.title.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.ui_elements.title = QLabel(title_text)
+        self.ui_elements.title.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
-        self.editor_model: QStandardItemModel
+        self.ui_elements.details_label = QLabel(details_text)
+        self.ui_elements.details_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
-        # CONTAINER LAYOUTS
-        self.upper_layout = QVBoxLayout()
-        self.lower_layout = QVBoxLayout()
-        layout = QVBoxLayout()
+        self.setWindowTitle(window_title)
 
-        # SUB LAYOUTS
-        self.details_layout = QVBoxLayout()
-        self.editor_layout = QVBoxLayout()
-        self.editor_actions_layout = QHBoxLayout()
-        self.editor_checkbox_actions_layout = QHBoxLayout()
-        self.editor_main_actions_layout = QHBoxLayout()
-        self.editor_exit_actions_layout = QHBoxLayout()
+    def _setup_layout_structure(self) -> None:
+        """Set up the main layout structure."""
+        self.layouts.details_layout.addWidget(self.ui_elements.details_label)
+        self.layouts.upper_layout.addLayout(self.layouts.details_layout)
 
-        self.editor_actions_layout.addLayout(self.editor_checkbox_actions_layout)
-        self.editor_actions_layout.addStretch(25)
-        self.editor_actions_layout.addLayout(self.editor_main_actions_layout)
-        self.editor_actions_layout.addStretch(25)
-        self.editor_actions_layout.addLayout(self.editor_exit_actions_layout)
-
-        # DETAILS WIDGETS
-        self.details_label = QLabel(details_text)
-        self.details_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-
-        # EDITOR MODEL
+    def _setup_model(self, additional_columns: Sequence[HeaderColumn]) -> None:
+        """Set up the table model."""
         self.editor_model = QStandardItemModel(0, len(additional_columns) + 1)
         editor_header_labels = [
             "✔",
         ] + list(map(lambda x: x[0] if isinstance(x, tuple) else x, additional_columns))
         self.editor_model.setHorizontalHeaderLabels(editor_header_labels)
 
-        # EDITOR WIDGETS
-        # Create the table view and set the model
+    def _setup_table_view(self) -> None:
+        """Set up the table view."""
         self.editor_table_view = QTableView()
         self.editor_table_view.setModel(self.editor_model)
-        self.editor_table_view.setSortingEnabled(True)  # Enable sorting on the columns
+        self.editor_table_view.setSortingEnabled(False)
         self.editor_table_view.setEditTriggers(
             QAbstractItemView.EditTrigger.NoEditTriggers
         )
         self.editor_table_view.setSelectionMode(
             QAbstractItemView.SelectionMode.NoSelection
         )
+        self.editor_table_view.setHorizontalScrollBarPolicy(
+            Qt.ScrollBarPolicy.ScrollBarAsNeeded
+        )
 
+    def _setup_headers(self, additional_columns: Sequence[HeaderColumn]) -> None:
+        """Set up table headers."""
         self.editor_table_view.horizontalHeader().setSectionResizeMode(
             0, QHeaderView.ResizeMode.ResizeToContents
         )
@@ -112,61 +212,151 @@ class BaseModsPanel(QWidget):
         for column_index, column in enumerate(additional_columns):
             self.editor_table_view.horizontalHeader().setSectionResizeMode(
                 column_index + 1,
-                column[1]
-                if isinstance(column, tuple)
-                else QHeaderView.ResizeMode.Stretch,
+                QHeaderView.ResizeMode.Stretch,
             )
 
-        self.editor_deselect_all_button = QPushButton(self.tr("Deselect all"))
-        self.editor_deselect_all_button.clicked.connect(
+        # Set vertical header to resize to contents
+        self.editor_table_view.verticalHeader().setSectionResizeMode(
+            QHeaderView.ResizeMode.ResizeToContents
+        )
+
+    def _setup_table_and_model(
+        self, additional_columns: Sequence[HeaderColumn]
+    ) -> None:
+        """Set up the table configuration."""
+        self._setup_model(additional_columns)
+        self._setup_table_view()
+        self._setup_headers(additional_columns)
+
+    def _setup_action_buttons(self) -> None:
+        """Set up the action buttons layout."""
+        self.layouts.editor_actions_layout.addLayout(
+            self.layouts.editor_checkbox_actions_layout
+        )
+        self.layouts.editor_actions_layout.addStretch(25)
+        self.layouts.editor_actions_layout.addLayout(
+            self.layouts.editor_main_actions_layout
+        )
+        self.layouts.editor_actions_layout.addStretch(25)
+        self.layouts.editor_actions_layout.addLayout(
+            self.layouts.editor_exit_actions_layout
+        )
+
+        self.ui_elements.editor_deselect_all_button.clicked.connect(
             partial(self._set_all_checkbox_rows, False)
         )
-        self.editor_checkbox_actions_layout.addWidget(self.editor_deselect_all_button)
+        self.layouts.editor_checkbox_actions_layout.addWidget(
+            self.ui_elements.editor_deselect_all_button
+        )
 
-        self.editor_select_all_button = QPushButton(self.tr("Select all"))
-        self.editor_select_all_button.clicked.connect(
+        self.ui_elements.editor_select_all_button.clicked.connect(
             partial(self._set_all_checkbox_rows, True)
         )
-        self.editor_checkbox_actions_layout.addWidget(self.editor_select_all_button)
+        self.layouts.editor_checkbox_actions_layout.addWidget(
+            self.ui_elements.editor_select_all_button
+        )
 
-        self.editor_cancel_button = QPushButton(self.tr("Do nothing and exit"))
-        self.editor_cancel_button.clicked.connect(self.close)
-        self.editor_exit_actions_layout.addWidget(self.editor_cancel_button)
+        self.ui_elements.editor_cancel_button.clicked.connect(self.close)
+        self.layouts.editor_exit_actions_layout.addWidget(
+            self.ui_elements.editor_cancel_button
+        )
 
-        # Build the details layout
-        self.details_layout.addWidget(self.details_label)
+        self.layouts.editor_layout.addWidget(self.editor_table_view)
+        self.layouts.editor_layout.addLayout(self.layouts.editor_actions_layout)
 
-        # Build the editor layouts
-        self.editor_layout.addWidget(self.editor_table_view)
-        self.editor_layout.addLayout(self.editor_actions_layout)
+    def _setup_main_layout(self) -> None:
+        """Set up the main layout structure."""
+        layout = QVBoxLayout()
+        layout.addWidget(self.ui_elements.title)
+        layout.addLayout(self.layouts.upper_layout)
+        layout.addLayout(self.layouts.lower_layout)
 
-        # Add our widget layouts to the containers
-        self.upper_layout.addLayout(self.details_layout)
-        self.lower_layout.addLayout(self.editor_layout)
-
-        # Add our layouts to the main layout
-        layout.addWidget(self.title)
-        layout.addLayout(self.upper_layout)
-        layout.addLayout(self.lower_layout)
-
-        # Put it all together
-        self.setWindowTitle(window_title)
+        self.layouts.lower_layout.addLayout(self.layouts.editor_layout)
         self.setLayout(layout)
-
-        # Set the window size
+        # TODO: let user configure window launch state and size from settings controller
         self.resize(900, 600)
 
+    def _setup_table(self, additional_columns: Sequence[HeaderColumn]) -> None:
+        """Set up the table configuration."""
+        pass  # Table setup is already done in _setup_ui
+
+    def _setup_buttons(self) -> None:
+        """Set up buttons if needed."""
+        pass  # Buttons are set up in _setup_ui
+
+    def _initialize_components(self) -> None:
+        """Initialize core components."""
+        self._setup_metadata()
+
+    def _setup_components(
+        self,
+        object_name: str,
+        window_title: str,
+        title_text: str,
+        details_text: str,
+        additional_columns: Sequence[HeaderColumn],
+    ) -> None:
+        """Set up UI and table components."""
+        self._setup_ui_elements(object_name, window_title, title_text, details_text)
+        self._setup_layout_structure()
+        self._setup_table_and_model(additional_columns)
+        self._setup_action_buttons()
+        self._setup_main_layout()
+        self._setup_table(additional_columns)
+        self._setup_buttons()
+
+    def _initialize_ui_elements(self) -> None:
+        """Initialize UI elements dataclasses."""
+        self.ui_elements = UIElements(
+            title=QLabel(),
+            details_label=QLabel(),
+            editor_deselect_all_button=QPushButton(self.tr("Deselect all")),
+            editor_select_all_button=QPushButton(self.tr("Select all")),
+            editor_cancel_button=QPushButton(self.tr("Do nothing and exit")),
+        )
+
+    def _initialize_layouts(self) -> None:
+        """Initialize layout dataclasses."""
+        self.layouts = Layouts(
+            upper_layout=QVBoxLayout(),
+            lower_layout=QVBoxLayout(),
+            details_layout=QVBoxLayout(),
+            editor_layout=QVBoxLayout(),
+            editor_actions_layout=QHBoxLayout(),
+            editor_checkbox_actions_layout=QHBoxLayout(),
+            editor_main_actions_layout=QHBoxLayout(),
+            editor_exit_actions_layout=QHBoxLayout(),
+        )
+
+    def __init__(
+        self,
+        object_name: str,
+        window_title: str,
+        title_text: str,
+        details_text: str,
+        additional_columns: Sequence[HeaderColumn],
+    ):
+        super().__init__()
+        self._initialize_ui_elements()
+        self._initialize_layouts()
+        self._initialize_components()
+        self._setup_components(
+            object_name, window_title, title_text, details_text, additional_columns
+        )
+
     def eventFilter(self, watched: QObject, event: QEvent) -> bool:
-        if event.type() == QEvent.Type.KeyPress and event.type() == Qt.Key.Key_Escape:
-            self.close()
-            return True
+        if event.type() == QEvent.Type.KeyPress:
+            key_event = QKeyEvent(event)  # type: ignore
+            if key_event.key() == Qt.Key.Key_Escape:
+                self.close()
+                return True
 
         return super().eventFilter(watched, event)
 
     def _add_row(
         self,
         items: list[QStandardItem],
-        defaultCheckboxState: bool = False,
+        default_checkbox_state: bool = False,
     ) -> None:
         items = [
             QStandardItem(),
@@ -175,69 +365,86 @@ class BaseModsPanel(QWidget):
         checkbox_index = items[0].index()
         checkbox = QCheckBox()
         checkbox.setObjectName("selectCheckbox")
-        checkbox.setChecked(defaultCheckboxState)
+        checkbox.setChecked(default_checkbox_state)
         # Set the checkbox as the index widget
         self.editor_table_view.setIndexWidget(checkbox_index, checkbox)
 
     def _set_all_checkbox_rows(self, value: bool) -> None:
         # Iterate through the editor's rows
         for row in range(self.editor_model.rowCount()):
-            if self.editor_model.item(row):  # If there is a row at current index
-                # If an existing row is found, setChecked the value
-                checkbox = self.editor_table_view.indexWidget(
-                    self.editor_model.item(row, 0).index()
-                )
-                if isinstance(checkbox, QCheckBox):
-                    checkbox.setChecked(value)
+            # If an existing row is found, setChecked the value
+            checkbox = self.editor_table_view.indexWidget(
+                self.editor_model.item(row, 0).index()
+            )
+            if isinstance(checkbox, QCheckBox):
+                checkbox.setChecked(value)
 
     def _row_count(self) -> int:
         return self.editor_model.rowCount()
 
+    def _clear_table_model(self) -> None:
+        """Clear all rows from the table model."""
+        self.editor_model.removeRows(0, self.editor_model.rowCount())
+
     def _update_mods_from_table(
         self,
         pfid_column: int,
-        mode: Union[str, int],
+        mode: str | int,
         steamworks_cmd: str = "resubscribe",
-        completed: Callable[[Self], None] = lambda self: (self.close(), None)[1],
+        completed: Callable[[], None] | None = None,
     ) -> None:
-        steamcmd_publishedfileids = []
-        steam_publishedfileids = []
-        pfids: list[tuple[str, str]]
+        """
+        filter out empty strings using
+        len(str_pfid) > 0
+        happens when MissingModsPrompt does not have published_file_id for mods in the table
+        passes empty string to steamcmd download command
+        causes crash in steamworks api call when passing empty string
+        this approach works because it will just skip over any missing published_file_ids
+        """
+        steamcmd_pfids, steam_pfids = self._collect_pfids_by_mode(pfid_column, mode)
+        # filter out empty strings happens when MissingModsPrompt does not have published_file_id for mods in the table
+        filtered_steamcmd_pfids = [
+            str_pfid for str_pfid in steamcmd_pfids if len(str_pfid) > 0
+        ]
+        if filtered_steamcmd_pfids:
+            self._delete_selected_mods(pfid_column, "SteamCMD")
+            EventBus().do_steamcmd_download.emit(filtered_steamcmd_pfids)
+
+        if steam_pfids:
+            EventBus().do_steamworks_api_call.emit(
+                [
+                    steamworks_cmd,
+                    [eval(str_pfid) for str_pfid in steam_pfids if len(str_pfid) > 0],
+                ]
+            )
+
+        if completed:
+            completed()
+
+        # Close the panel window after triggering operations
+        self.close()
+
+    def _collect_pfids_by_mode(
+        self, pfid_column: int, mode: str | int
+    ) -> tuple[list[str], list[str]]:
         pfid_fn = self._get_selected_text_by_column(pfid_column)
         if isinstance(mode, str):
             pfids = [(pfid, mode) for pfid in self._run_for_selected_rows(pfid_fn)]
-        elif isinstance(mode, int):
+        else:
             mode_fn = self._get_selected_text_by_column(mode)
             pfids = self._run_for_selected_rows(
                 lambda row: (pfid_fn(row), mode_fn(row))
             )
 
-        for publishedfileid, mode in pfids:
-            if mode == "SteamCMD":
-                steamcmd_publishedfileids.append(publishedfileid)
-                # Call to delete selected mods before update
-                self._delete_selected_mods(pfid_column, mode)
-            elif mode == "Steam":
-                steam_publishedfileids.append(publishedfileid)
-
-        # If we have any SteamCMD mods designated to be updated
-        if len(steamcmd_publishedfileids) > 0:
-            EventBus().do_steamcmd_download.emit(steamcmd_publishedfileids)
-        # If we have any Steam mods designated to be updated
-        if len(steam_publishedfileids) > 0:
-            EventBus().do_steamworks_api_call.emit(
-                [
-                    steamworks_cmd,
-                    [eval(str_pfid) for str_pfid in steam_publishedfileids],
-                ]
-            )
-        completed(self)
+        steamcmd_pfids = [pfid for pfid, m in pfids if m == "SteamCMD"]
+        steam_pfids = [pfid for pfid, m in pfids if m == "Steam"]
+        return steamcmd_pfids, steam_pfids
 
     def _steamworks_cmd_for_all(
         self,
         pfid_column: int,
         steamworks_cmd: str = "resubscribe",
-        completed: Callable[[Self], None] = lambda self: (self.close(), None)[1],
+        completed: Callable[[], None] | None = None,
     ) -> None:
         self._set_all_checkbox_rows(True)
         self._update_mods_from_table(pfid_column, "Steam", steamworks_cmd, completed)
@@ -247,7 +454,7 @@ class BaseModsPanel(QWidget):
             child = layout.takeAt(0)
             widget = child.widget()
             if widget is not None:
-                widget.setParent(None)
+                widget.deleteLater()
 
     def _row_is_checked(self, row: int) -> bool:
         checkbox = self.editor_table_view.indexWidget(
@@ -255,22 +462,32 @@ class BaseModsPanel(QWidget):
         )
         return isinstance(checkbox, QCheckBox) and checkbox.isChecked()
 
+    def _get_selected_row_indices(self) -> set[int]:
+        """
+        Get the set of selected row indices.
+
+        Returns:
+            Set of row indices that are checked.
+        """
+        return {
+            row
+            for row in range(self.editor_model.rowCount())
+            if self._row_is_checked(row)
+        }
+
     T = TypeVar("T")
 
     def _run_for_selected_rows(self, fn: Callable[[int], T]) -> list[T]:
-        ret = []
-        for row in range(self.editor_model.rowCount()):
-            if self._row_is_checked(row):
-                ret.append(fn(row))
-        return ret
+        return [fn(row) for row in self._get_selected_row_indices()]
 
     def _get_selected_text_by_column(self, column: int) -> Callable[[int], str]:
         def __selected_text_by_column(row: int) -> str:
-            combo_box = self.editor_table_view.indexWidget(
-                self.editor_model.item(row, column).index()
-            )
+            item = self.editor_model.item(row, column)
+            if item is None:
+                return ""
+            combo_box = self.editor_table_view.indexWidget(item.index())
             if not isinstance(combo_box, QComboBox):
-                return self.editor_model.item(row, column).text()
+                return item.text()
             else:
                 return combo_box.currentText()
 
@@ -298,3 +515,758 @@ class BaseModsPanel(QWidget):
                             shutil.rmtree(mod_path)
                         except Exception as e:
                             print(f"Error deleting mod directory {mod_path}: {e}")
+
+    def _configure_button(
+        self,
+        button: QPushButton,
+        text: str,
+        object_name: str,
+        callback: Callable[[], None] | None = None,
+    ) -> None:
+        """
+        Configure a button with common properties.
+
+        Args:
+            button: The button to configure.
+            text: Button text.
+            object_name: Object name for the button.
+            callback: Optional callback for the clicked signal.
+        """
+        button.setText(text)
+        button.setObjectName(object_name)
+        if callback is not None:
+            button.clicked.connect(callback)
+
+    def _create_workshop_button(
+        self, url: str, object_name: str = "workshopButton"
+    ) -> QPushButton:
+        """
+        Create a standardized workshop button that opens the Steam Workshop page.
+
+        Args:
+            url: The full URL to the Steam Workshop page.
+            object_name: The object name for the button widget (default: "workshopButton").
+
+        Returns:
+            QPushButton: Configured button that opens the workshop page when clicked.
+        """
+        button = QPushButton()
+        self._configure_button(
+            button,
+            self.tr("Open Page"),
+            object_name,
+            partial(platform_specific_open, url),
+        )
+        return button
+
+    def _create_path_link(self, path: str, object_name: str = "pathLink") -> QLabel:
+        """
+        Create a clickable label that opens the mod path when clicked.
+
+        Args:
+            path: The file system path to open.
+            object_name: The object name for the label widget (default: "pathLink").
+
+        Returns:
+            QLabel: Configured label that displays the path as clickable text.
+        """
+        label = ClickablePathLabel()
+        label.setPath(path)
+        label.setObjectName(object_name)
+        return label
+
+    def _create_button(
+        self,
+        text: str,
+        callback: Callable[[], None] | None = None,
+        object_name: str = "",
+    ) -> QPushButton:
+        """
+        Create a standardized button.
+
+        Args:
+            text: Button text.
+            callback: Optional callback function.
+            object_name: Optional object name for the button.
+
+        Returns:
+            QPushButton: Configured button.
+        """
+        button = QPushButton()
+        button.setText(text)
+        if object_name:
+            button.setObjectName(object_name)
+        if callback is not None:
+            button.clicked.connect(callback)
+        return button
+
+    def _create_standardized_button(
+        self,
+        button_type: ButtonType,
+        pfid_column: int | None = None,
+        completion_callback: Callable[[], None] | None = None,
+        custom_callback: Callable[[], None] | None = None,
+        text: str = "",
+    ) -> QPushButton:
+        """
+        Create a standardized button based on type.
+
+        Args:
+            button_type: Type of button to create.
+            pfid_column: Column index for published file ID (for Steam-related buttons).
+            completion_callback: Callback after operation completes.
+            custom_callback: Custom callback for custom buttons.
+            text: Custom text for the button.
+
+        Returns:
+            Configured QPushButton.
+        """
+        if button_type == ButtonType.REFRESH:
+            return self._create_button(self.tr("Refresh"), custom_callback)
+        elif button_type == ButtonType.STEAMCMD:
+            if pfid_column is not None:
+                return self._create_button(
+                    self.tr("Download selected with SteamCMD"),
+                    partial(self._update_mods_from_table, pfid_column, "SteamCMD"),
+                )
+        elif button_type == ButtonType.SUBSCRIBE:
+            if pfid_column is not None:
+                return self._create_button(
+                    self.tr("Subscribe selected"),
+                    partial(
+                        self._update_mods_from_table,
+                        pfid_column,
+                        "Steam",
+                        completed=completion_callback,
+                    ),
+                )
+        elif button_type == ButtonType.UNSUBSCRIBE:
+            if pfid_column is not None:
+                return self._create_button(
+                    self.tr("Unsubscribe selected"),
+                    partial(
+                        self._update_mods_from_table,
+                        pfid_column,
+                        "Steam",
+                        "unsubscribe",
+                        completed=completion_callback,
+                    ),
+                )
+        elif button_type == ButtonType.CUSTOM:
+            return self._create_button(text, custom_callback)
+
+        # Fallback
+        return self._create_button(text or "Button", custom_callback)
+
+    def _create_refresh_button(
+        self, callback: Callable[[], None] | None
+    ) -> QPushButton:
+        """Create a standardized refresh button."""
+        return self._create_standardized_button(
+            ButtonType.REFRESH, custom_callback=callback
+        )
+
+    def _create_steamcmd_button(self, pfid_column: int) -> QPushButton:
+        """Create a standardized SteamCMD button."""
+        return self._create_standardized_button(
+            ButtonType.STEAMCMD, pfid_column=pfid_column
+        )
+
+    def _create_subscribe_button(
+        self, pfid_column: int, completion_callback: Callable[[], None] | None = None
+    ) -> QPushButton:
+        """Create a standardized subscribe button."""
+        return self._create_standardized_button(
+            ButtonType.SUBSCRIBE,
+            pfid_column=pfid_column,
+            completion_callback=completion_callback,
+        )
+
+    def _create_unsubscribe_button(
+        self, pfid_column: int, completion_callback: Callable[[], None] | None = None
+    ) -> QPushButton:
+        """Create a standardized unsubscribe button."""
+        return self._create_standardized_button(
+            ButtonType.UNSUBSCRIBE,
+            pfid_column=pfid_column,
+            completion_callback=completion_callback,
+        )
+
+    def _create_deletion_button(
+        self,
+        settings_controller: Any,
+        get_selected_mod_metadata: Callable[[], list[dict[str, Any]]],
+        completion_callback: Callable[[], None] | None,
+        menu_title: str,
+        enable_delete_mod: bool = True,
+        enable_delete_keep_dds: bool = False,
+        enable_delete_dds_only: bool = False,
+        enable_delete_and_unsubscribe: bool = False,
+        enable_delete_and_resubscribe: bool = False,
+    ) -> QPushButton:
+        """
+        Create a standardized deletion button with menu.
+
+        Args:
+            settings_controller: The settings controller instance.
+            get_selected_mod_metadata: Function to get selected mod metadata.
+            menu_title: Title for the deletion menu.
+            completion_callback: Callback after deletion completes.
+            enable_delete_mod: Enable delete mod option.
+            enable_delete_keep_dds: Enable delete mod but keep DDS option.
+            enable_delete_dds_only: Enable delete DDS only option.
+            enable_delete_and_unsubscribe: Enable delete and unsubscribe option.
+            enable_delete_and_resubscribe: Enable delete and resubscribe option.
+
+        Returns:
+            QPushButton: Configured deletion button with dropdown menu.
+        """
+        # Check if Steam client integration is enabled
+        steam_client_integration_enabled = settings_controller.settings.instances[
+            settings_controller.settings.current_instance
+        ].steam_client_integration
+
+        button = QPushButton()
+        button.setText(self.tr("Delete"))
+        deletion_menu = ModDeletionMenu(
+            settings_controller=settings_controller,
+            get_selected_mod_metadata=get_selected_mod_metadata,
+            completion_callback=completion_callback,
+            menu_title=menu_title,
+            enable_delete_mod=enable_delete_mod,
+            enable_delete_keep_dds=enable_delete_keep_dds,
+            enable_delete_dds_only=enable_delete_dds_only,
+            enable_delete_and_unsubscribe=steam_client_integration_enabled,
+            enable_delete_and_resubscribe=steam_client_integration_enabled,
+        )
+        button.setMenu(deletion_menu)
+        button.clicked.connect(
+            lambda: deletion_menu.exec(button.mapToGlobal(button.rect().bottomLeft()))
+        )
+        return button
+
+    def _setup_buttons_from_config(self, button_configs: list[ButtonConfig]) -> None:
+        """
+        Set up buttons from a list of button configurations.
+
+        Args:
+            button_configs: List of ButtonConfig objects defining the buttons to create.
+        """
+        factory = self.get_button_factory()
+        for config in button_configs:
+            button = self._create_button_from_config_with_factory(config, factory)
+            if button:
+                self.layouts.editor_main_actions_layout.addWidget(button)
+
+    def _create_button_from_config(self, config: ButtonConfig) -> QWidget | None:
+        """
+        Create a button from a single button configuration.
+
+        Args:
+            config: ButtonConfig object defining the button to create.
+
+        Returns:
+            The created button widget, or None if creation failed.
+        """
+        factory = self.get_button_factory()
+        return self._create_button_from_config_with_factory(config, factory)
+
+    def _create_button_from_config_with_factory(
+        self, config: ButtonConfig, factory: ButtonFactory
+    ) -> QWidget | None:
+        """
+        Create a button from a single button configuration using a factory.
+
+        Args:
+            config: ButtonConfig object defining the button to create.
+            factory: ButtonFactory instance to create buttons.
+
+        Returns:
+            The created button widget, or None if creation failed.
+        """
+        if config.button_type == ButtonType.REFRESH:
+            return self._create_refresh_button_from_config(config, factory)
+        elif config.button_type == ButtonType.STEAMCMD:
+            return self._create_steamcmd_button_from_config(config, factory)
+        elif config.button_type == ButtonType.SUBSCRIBE:
+            return self._create_subscribe_button_from_config(config, factory)
+        elif config.button_type == ButtonType.UNSUBSCRIBE:
+            return self._create_unsubscribe_button_from_config(config, factory)
+        elif config.button_type == ButtonType.DELETE:
+            return self._create_delete_button_from_config(config, factory)
+        elif config.button_type == ButtonType.CUSTOM:
+            return self._create_custom_button_from_config(config, factory)
+        elif config.button_type == ButtonType.SELECT:
+            return self._create_select_button_from_config(config, factory)
+        return None
+
+    def _create_refresh_button_from_config(
+        self, config: ButtonConfig, factory: ButtonFactory
+    ) -> QWidget | None:
+        """Create a refresh button from config."""
+        return factory.create_refresh_button(config.custom_callback)
+
+    def _create_steamcmd_button_from_config(
+        self, config: ButtonConfig, factory: ButtonFactory
+    ) -> QWidget | None:
+        """Create a SteamCMD button from config."""
+        if config.pfid_column is not None:
+            return factory.create_steamcmd_button(config.pfid_column)
+        return None
+
+    def _create_subscribe_button_from_config(
+        self, config: ButtonConfig, factory: ButtonFactory
+    ) -> QWidget | None:
+        """Create a subscribe button from config."""
+        if config.pfid_column is not None:
+            return factory.create_subscribe_button(
+                config.pfid_column, config.completion_callback
+            )
+        return None
+
+    def _create_unsubscribe_button_from_config(
+        self, config: ButtonConfig, factory: ButtonFactory
+    ) -> QWidget | None:
+        """Create an unsubscribe button from config."""
+        if config.pfid_column is not None:
+            return factory.create_unsubscribe_button(
+                config.pfid_column, config.completion_callback
+            )
+        return None
+
+    def _create_delete_button_from_config(
+        self, config: ButtonConfig, factory: ButtonFactory
+    ) -> QWidget | None:
+        """Create a delete button from config."""
+        if config.menu_title is not None:
+            return factory.create_delete_button(
+                config.menu_title,
+                config.completion_callback,
+                config.enable_delete_mod,
+                config.enable_delete_keep_dds,
+                config.enable_delete_dds_only,
+                config.enable_delete_and_unsubscribe,
+                config.enable_delete_and_resubscribe,
+            )
+        return None
+
+    def _create_custom_button_from_config(
+        self, config: ButtonConfig, factory: ButtonFactory
+    ) -> QWidget | None:
+        """Create a custom button from config."""
+        if config.custom_callback is not None:
+            return factory.create_custom_button(config.text, config.custom_callback)
+        return None
+
+    def _create_select_button_from_config(
+        self, config: ButtonConfig, factory: ButtonFactory
+    ) -> QWidget | None:
+        """Create a select button from config."""
+        if config.menu_items:
+            return factory.create_select_button(config.text, config.menu_items)
+        return None
+
+    def _create_custom_button(
+        self, text: str, callback: Callable[[], None]
+    ) -> QPushButton:
+        """
+        Create a custom button with text and callback.
+
+        Args:
+            text: Button text
+            callback: Function to call when button is clicked
+
+        Returns:
+            Configured custom button
+        """
+        button = QPushButton(text)
+        button.clicked.connect(callback)
+        return button
+
+    def _create_select_button(
+        self, text: str, menu_items: list[MenuItem]
+    ) -> QToolButton:
+        """
+        Create a select button with dropdown menu.
+
+        Args:
+            text: Button text
+            menu_items: List of menu items for the dropdown
+
+        Returns:
+            Configured select button with menu
+        """
+        button = QToolButton()
+        button.setText(text)
+        menu = QMenu(button)
+        for menu_item in menu_items:
+            action = QAction(menu_item.text, self)
+            action.triggered.connect(menu_item.callback)
+            menu.addAction(action)
+        button.setMenu(menu)
+        button.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
+        return button
+
+    # ===== CENTRALIZED METADATA HANDLING =====
+
+    def _get_uuid_from_row(self, row: int, name_column: int = 1) -> str | None:
+        """
+        Extract UUID from a table row's name column.
+
+        Args:
+            row: Row index to extract UUID from
+            name_column: Column index containing the name item with UUID data
+
+        Returns:
+            UUID string if found, None otherwise
+        """
+        try:
+            if row >= self.editor_model.rowCount():
+                return None
+
+            name_item = self.editor_model.item(row, name_column)
+            if name_item is None:
+                return None
+
+            return name_item.data(Qt.ItemDataRole.UserRole)
+        except Exception as e:
+            logger.warning(f"Error accessing UUID from row {row}: {e}")
+            return None
+
+    def _get_selected_mod_metadata(self) -> list[dict[str, Any]]:
+        """
+        Get metadata for selected mods in the table.
+
+        Returns:
+            List of ModMetadata objects for selected mods
+        """
+        selected_mods = []
+        try:
+            for row in range(self.editor_model.rowCount()):
+                if self._row_is_checked(row):
+                    uuid = self._get_uuid_from_row(row)
+                    if uuid and uuid in self.metadata_manager.internal_local_metadata:
+                        selected_mods.append(
+                            self.metadata_manager.internal_local_metadata[uuid]
+                        )
+        except Exception as e:
+            logger.warning(f"Error getting selected mod metadata: {e}")
+        return selected_mods
+
+    def _refresh_metadata_and_panel(self) -> None:
+        """
+        Standard refresh method called manually or after deletion operations.
+        Refreshes the metadata cache and repopulates the table.
+
+        This refreshes the metadata cache and repopulates the table with the updated mod data.
+        """
+        logger.warning("Refreshing metadata cache and repopulating table")
+        # Refresh the metadata cache to reflect deletion changes
+        self.metadata_manager.refresh_cache(is_initial=False)
+        # Repopulate the table with updated data
+        self._populate_from_metadata()
+
+    def get_button_factory(self) -> ButtonFactory:
+        """Get a button factory instance for this panel."""
+        return ButtonFactory(self)
+
+    # ===== UTILITY METHOD CONSOLIDATION =====
+
+    def _add_workshop_button_to_row(
+        self, row_items: list[QStandardItem], pfid: str, workshop_column: int
+    ) -> QPushButton:
+        """
+        Add a workshop button to a specific column in a row.
+
+        Args:
+            row_items: List of QStandardItem for the row
+            pfid: Published file ID for the workshop URL
+            workshop_column: Column index for the workshop button
+
+        Returns:
+            The created workshop button
+        """
+        workshop_item = row_items[workshop_column]
+        workshop_button = self._create_workshop_button(
+            f"https://steamcommunity.com/sharedfiles/filedetails/?id={pfid}",
+            "workshopButton",
+        )
+        self.editor_table_view.setIndexWidget(workshop_item.index(), workshop_button)
+        return workshop_button
+
+    def _add_combo_box_to_row(
+        self,
+        row_items: list[QStandardItem],
+        combo_column: int,
+        items: list[str] | None = None,
+    ) -> QComboBox:
+        """
+        Add a combo box to a specific column in a row.
+
+        Args:
+            row_items: List of QStandardItem for the row
+            combo_column: Column index for the combo box
+            items: Optional list of items to add to the combo box
+
+        Returns:
+            The created combo box
+        """
+        combo_item = row_items[combo_column]
+        combo_box = QComboBox()
+        combo_box.setEditable(True)
+        combo_box.setObjectName("variantComboBox")
+        if items:
+            combo_box.addItems(items)
+        self.editor_table_view.setIndexWidget(combo_item.index(), combo_box)
+        return combo_box
+
+    # ===== NEW HELPER METHODS FOR REFACTORING =====
+
+    def _add_mod_row(
+        self,
+        mod_info: "ModInfo",
+        additional_items: list[QStandardItem] | None = None,
+        default_checkbox_state: bool = False,
+    ) -> None:
+        """
+        Standardized method to add a mod row to the table.
+
+        Args:
+            mod_info: ModInfo object containing mod data
+            additional_items: Optional additional QStandardItem objects for extra columns
+            default_checkbox_state: Default state for the checkbox
+        """
+        # Base columns that all panels use
+        base_items = [
+            QStandardItem(mod_info.name),
+            QStandardItem(mod_info.authors),
+            QStandardItem(mod_info.packageid),
+            QStandardItem(mod_info.published_file_id),
+            QStandardItem(mod_info.supported_versions),
+            QStandardItem(mod_info.downloaded_time),
+            QStandardItem(mod_info.updated_on_workshop),
+            QStandardItem(mod_info.source),
+            QStandardItem(""),  # Path will be displayed via widget
+        ]
+
+        # Add workshop page column
+        workshop_item = QStandardItem()
+        base_items.append(workshop_item)
+
+        # Add any additional columns specific to the panel
+        if additional_items:
+            base_items.extend(additional_items)
+
+        # Set UUID data on name item for metadata lookup
+        if mod_info.uuid:
+            base_items[0].setData(mod_info.uuid, Qt.ItemDataRole.UserRole)
+
+        self._add_row(base_items, default_checkbox_state)
+
+        # Add path link to the path column (index 9) only if path exists and row is not blank
+        if mod_info.path and mod_info.path.strip():
+            path_link = self._create_path_link(mod_info.path, "pathLink")
+            self.editor_table_view.setIndexWidget(base_items[8].index(), path_link)
+
+        # Add workshop button to the workshop column only if published_file_id exists
+        if mod_info.published_file_id and mod_info.published_file_id.strip():
+            workshop_button = self._create_workshop_button(
+                mod_info.workshop_url, "workshopButton"
+            )
+            self.editor_table_view.setIndexWidget(
+                workshop_item.index(), workshop_button
+            )
+
+    def _add_group_header_row(self, header_text: str) -> None:
+        """
+        Add a group header row to the table.
+
+        Args:
+            header_text: Text for the header row
+        """
+        header_item = QStandardItem(header_text)
+        header_item.setData(None, Qt.ItemDataRole.UserRole)
+
+        # Create empty items for other columns
+        empty_items = [
+            QStandardItem("") for _ in range(self.editor_model.columnCount() - 1)
+        ]
+        items = [header_item] + empty_items
+
+        self.editor_model.appendRow(items)
+
+    def _extract_mod_info_from_metadata(
+        self, uuid: str | None, metadata: dict[str, Any]
+    ) -> ModInfo:
+        """
+        Extract ModInfo from metadata dictionary.
+
+        Args:
+            uuid: UUID of the mod
+            metadata: Metadata dictionary
+
+        Returns:
+            ModInfo object
+        """
+        return ModInfo.from_metadata(uuid, metadata)
+
+    def _extract_uuid_from_path(self, path: str) -> str | None:
+        """
+        Extract UUID from mod path using metadata manager.
+
+        Args:
+            path: Mod path
+
+        Returns:
+            UUID if found, None otherwise
+        """
+        return self.metadata_manager.mod_metadata_dir_mapper.get(path)
+
+    def _setup_table_configuration(
+        self,
+        sorting_enabled: bool = True,
+        stretch_columns: list[int] | None = None,
+        resize_to_contents_columns: list[int] | None = None,
+    ) -> None:
+        """
+        Configure table settings.
+
+        Args:
+            sorting_enabled: Whether sorting is enabled
+            stretch_columns: List of column indices to set to Stretch mode
+            resize_to_contents_columns: List of column indices to resize to contents
+        """
+        self.editor_table_view.setSortingEnabled(sorting_enabled)
+
+        # Set Stretch for specified columns
+        if stretch_columns is not None:
+            for col in stretch_columns:
+                self.editor_table_view.horizontalHeader().setSectionResizeMode(
+                    col, QHeaderView.ResizeMode.Stretch
+                )
+
+        # Default all columns to ResizeToContents if not specified
+        if resize_to_contents_columns is None:
+            resize_to_contents_columns = list(range(self.editor_model.columnCount()))
+
+    def _populate_from_metadata(self) -> None:
+        """Populate the table from metadata. Must be implemented by subclasses."""
+        raise NotImplementedError("Subclasses must implement _populate_from_metadata")
+
+    def _populate_mods(
+        self,
+        groups: dict[str, list[tuple[str, dict[str, Any]]]],
+        add_group_headers: bool = False,
+    ) -> None:
+        """
+        Populate the table with mod groups.
+
+        Args:
+            groups: Dictionary of groups, where key is group name, value is list of (uuid, metadata) tuples.
+            add_group_headers: Whether to add header rows for each group.
+        """
+        self._clear_table_model()
+
+        for group_key, mod_list in groups.items():
+            if add_group_headers and group_key:
+                self._add_group_header_row(group_key)
+
+            for uuid, metadata in mod_list:
+                mod_info = self._extract_mod_info_from_metadata(uuid, metadata)
+                self._add_mod_row(mod_info)
+
+    def _get_standard_mod_columns(self) -> list[HeaderColumn]:
+        """
+        Get the standard list of columns for displaying mod information.
+
+        Returns:
+            List of standard column definitions.
+        """
+        return [
+            self.tr(self.COL_MOD_NAME),
+            self.tr(self.COL_AUTHOR),
+            self.tr(self.COL_PACKAGE_ID),
+            self.tr(self.COL_PUBLISHED_FILE_ID),
+            self.tr(self.COL_SUPPORTED_VERSIONS),
+            self.tr(self.COL_MOD_DOWNLOADED),
+            self.tr(self.COL_UPDATED_ON_WORKSHOP),
+            self.tr(self.COL_SOURCE),
+            self.tr(self.COL_PATH),
+            self.tr(self.COL_WORKSHOP_PAGE),
+        ]
+
+    def _get_base_button_configs(self) -> list[ButtonConfig]:
+        """
+        Get base button configurations that are common across panels.
+
+        Returns:
+            List of base ButtonConfig objects for refresh and SteamCMD.
+        """
+        return [
+            ButtonConfig(
+                button_type=ButtonType.REFRESH,
+                custom_callback=self._refresh_metadata_and_panel,
+            ),
+            ButtonConfig(
+                button_type=ButtonType.STEAMCMD,
+                pfid_column=ColumnIndex.PUBLISHED_FILE_ID.value,
+            ),
+        ]
+
+    def _extend_button_configs_with_steam_actions(
+        self, button_configs: list[ButtonConfig]
+    ) -> list[ButtonConfig]:
+        """
+        Extend button configurations with Steam client actions if integration is enabled.
+
+        Args:
+            button_configs: List of button configurations to extend.
+
+        Returns:
+            Extended list of button configurations.
+        """
+        steam_client_integration_enabled = self._get_steam_client_integration_enabled()
+        if steam_client_integration_enabled:
+            button_configs.extend(
+                [
+                    ButtonConfig(
+                        button_type=ButtonType.SUBSCRIBE,
+                        pfid_column=ColumnIndex.PUBLISHED_FILE_ID.value,
+                    ),
+                    ButtonConfig(
+                        button_type=ButtonType.UNSUBSCRIBE,
+                        pfid_column=ColumnIndex.PUBLISHED_FILE_ID.value,
+                    ),
+                ]
+            )
+        return button_configs
+
+    def _create_delete_button_config(
+        self, menu_title: str, enable_delete_and_unsubscribe: bool = True
+    ) -> ButtonConfig:
+        """
+        Create a delete button configuration with standard settings.
+
+        Args:
+            menu_title: Title for the deletion menu.
+            enable_delete_and_unsubscribe: Whether to enable delete and unsubscribe option.
+
+        Returns:
+            ButtonConfig for delete button.
+        """
+        steam_client_integration_enabled = self._get_steam_client_integration_enabled()
+        return ButtonConfig(
+            button_type=ButtonType.DELETE,
+            text=self.tr("Delete"),
+            pfid_column=ColumnIndex.PUBLISHED_FILE_ID.value,
+            get_selected_mod_metadata=self._get_selected_mod_metadata,
+            completion_callback=self._refresh_metadata_and_panel,
+            menu_title=menu_title,
+            enable_delete_mod=True,
+            enable_delete_keep_dds=False,
+            enable_delete_dds_only=False,
+            enable_delete_and_unsubscribe=enable_delete_and_unsubscribe
+            and steam_client_integration_enabled,
+            enable_delete_and_resubscribe=enable_delete_and_unsubscribe
+            and steam_client_integration_enabled,
+        )

--- a/app/windows/duplicate_mods_panel.py
+++ b/app/windows/duplicate_mods_panel.py
@@ -1,16 +1,11 @@
-from functools import partial
-from typing import Dict, List
+from typing import Any
 
 from loguru import logger
-from PySide6.QtCore import Qt
-from PySide6.QtGui import QStandardItem
-from PySide6.QtWidgets import QHeaderView, QPushButton, QToolButton
 
 from app.controllers.settings_controller import SettingsController
-from app.utils.generic import format_time_display, platform_specific_open
-from app.utils.metadata import MetadataManager, ModMetadata
-from app.views.deletion_menu import ModDeletionMenu
-from app.windows.base_mods_panel import BaseModsPanel, HeaderColumn
+from app.windows.base_mods_panel import (
+    BaseModsPanel,
+)
 
 
 class DuplicateModsPanel(BaseModsPanel):
@@ -22,15 +17,15 @@ class DuplicateModsPanel(BaseModsPanel):
     use the deletion menu to remove unwanted duplicates.
 
     Attributes:
-        duplicate_mods (Dict[str, List[str]]): Dictionary mapping package IDs to lists of UUIDs
+        duplicate_mods (dict[str, list[str]]): Dictionary mapping package IDs to lists of UUIDs
             of duplicate mods.
         settings_controller (SettingsController): Controller for application settings.
-        mm (MetadataManager): Instance of the metadata manager for accessing mod data.
+        metadata_manager: MetadataManager instance from base class for accessing mod data.
     """
 
     def __init__(
         self,
-        duplicate_mods: Dict[str, List[str]],
+        duplicate_mods: dict[str, list[str]],
         settings_controller: SettingsController,
     ) -> None:
         """
@@ -43,19 +38,6 @@ class DuplicateModsPanel(BaseModsPanel):
         logger.debug("Initializing DuplicateModsPanel")
         self.duplicate_mods = duplicate_mods
         self.settings_controller = settings_controller
-        self.mm = MetadataManager.instance()
-
-        # Define table columns for displaying duplicate mod information
-        additional_columns: list[HeaderColumn] = [
-            self.tr("Mod Name"),
-            self.tr("Author"),
-            self.tr("Package ID"),
-            self.tr("PublishedFileId"),
-            self.tr("Source"),
-            self.tr("Mod Downloaded"),
-            self.tr("Path"),
-            self.tr("Workshop Page"),
-        ]
 
         super().__init__(
             object_name="duplicateModsPanel",
@@ -65,208 +47,46 @@ class DuplicateModsPanel(BaseModsPanel):
                 "\nThe following table displays duplicate mods grouped by package ID. "
                 "Select which versions to keep and choose an action."
             ),
-            additional_columns=additional_columns,
+            additional_columns=self._get_standard_mod_columns(),
         )
 
-        # Set up the deletion button and menu for managing duplicate mods
-        self._setup_deletion_button()
+        button_configs = self._get_base_button_configs()
+        self._extend_button_configs_with_steam_actions(button_configs)
+        button_configs.append(
+            self._create_delete_button_config(self.tr("Delete Selected Mods"))
+        )
+        self._setup_buttons_from_config(button_configs)
 
         # Populate the table with duplicate mod data
         self._populate_from_metadata()
 
-        # Set all columns to Stretch
-        for i in range(self.editor_model.columnCount()):
-            self.editor_table_view.horizontalHeader().setSectionResizeMode(
-                i, QHeaderView.ResizeMode.Stretch
-            )
-        # Set all rows to auto-resize to content
-        self.editor_table_view.verticalHeader().setSectionResizeMode(
-            QHeaderView.ResizeMode.ResizeToContents
-        )
-
-        # Disable sorting to maintain mod grouping by package ID
-        self.editor_table_view.setSortingEnabled(False)
+        # Configure table settings
+        self._setup_table_configuration(sorting_enabled=False)
 
         # TODO: let user configure window launch state and size from settings controller
         self.showNormal()
 
-    def _setup_deletion_button(self) -> None:
-        """
-        Set up the deletion menu button for managing duplicate mods.
-
-        Creates a tool button with a dropdown menu that provides various deletion
-        options for selected duplicate mods, including unsubscribing from Steam
-        Workshop items and refreshing the panel after deletion.
-        """
-        # Create the tool button for the deletion menu
-        self.deletion_tool_button = QToolButton()
-        self.deletion_tool_button.setText(self.tr("Delete"))
-
-        # Create the deletion menu with specific options for duplicate mods
-        self.deletion_menu = ModDeletionMenu(
-            settings_controller=self.settings_controller,
-            get_selected_mod_metadata=self._get_selected_mod_metadata,
-            menu_title=self.tr("Delete Selected Duplicates..."),
-            enable_delete_mod=True,  # Allow deleting the entire mod
-            enable_delete_keep_dds=False,  # Not applicable for duplicates
-            enable_delete_dds_only=False,  # Not applicable for duplicates
-            enable_delete_and_unsubscribe=True,  # Allow unsubscribing from Workshop
-            enable_delete_and_resubscribe=False,  # Not applicable for duplicates
-            completion_callback=self._refresh_after_deletion,
-        )
-
-        # Configure the button to show the menu on click
-        self.deletion_tool_button.setMenu(self.deletion_menu)
-        self.deletion_tool_button.setPopupMode(
-            QToolButton.ToolButtonPopupMode.InstantPopup
-        )
-
-        # Add the button to the panel's action layout
-        self.editor_main_actions_layout.addWidget(self.deletion_tool_button)
-
     def _populate_from_metadata(self) -> None:
         """
-        Populate the table with duplicate mod data, grouped by package ID.
-
-        Iterates through the duplicate mods dictionary, creating header rows for each
-        package ID group and individual rows for each mod version within the group.
-        Each mod row displays comprehensive information including name, author,
-        package ID, published file ID, source, download time, path, and workshop link.
+        Populate the table with duplicate mod data.
         """
-        # Clear existing table data
-        self.editor_model.removeRows(0, self.editor_model.rowCount())
+        try:
+            # Convert duplicate_mods dict to the format expected by _populate_mods
+            groups: dict[str, list[tuple[str, dict[str, Any]]]] = {}
+            for packageid, uuids in self.duplicate_mods.items():
+                mod_list = []
+                for uuid in uuids:
+                    metadata = self.metadata_manager.internal_local_metadata.get(uuid)
+                    if metadata:
+                        mod_list.append((uuid, metadata))
+                    else:
+                        logger.warning(
+                            f"Metadata not found for UUID: {uuid} in package group {packageid}"
+                        )
+                if mod_list:  # Only add groups that have mods
+                    groups[packageid] = mod_list
 
-        # Process each package ID group
-        for packageid, uuids in self.duplicate_mods.items():
-            # Create header row for the current package ID group
-            group_item = QStandardItem(packageid)
-            group_item.setData(
-                None, Qt.ItemDataRole.UserRole
-            )  # No UUID for header rows
-
-            # Add the header row with empty cells for other columns
-            self.editor_model.appendRow(
-                [
-                    group_item,  # Package ID as group header
-                    QStandardItem(""),  # Empty Mod Name
-                    QStandardItem(""),  # Empty Author
-                    QStandardItem(""),  # Empty Package ID
-                    QStandardItem(""),  # Empty PublishedFileId
-                    QStandardItem(""),  # Empty Source
-                    QStandardItem(""),  # Empty Mod Downloaded
-                    QStandardItem(""),  # Empty Path
-                    QStandardItem(""),  # Empty Workshop Page
-                ]
-            )
-
-            # Add individual mod rows for this package ID group
-            for uuid in uuids:
-                # Retrieve mod metadata using UUID
-                mod_data = self.mm.internal_local_metadata.get(uuid)
-                if not mod_data:
-                    continue  # Skip if metadata is not available
-
-                # Extract mod information from metadata
-                name = mod_data.get("name", "")
-                authors = mod_data.get("authors", "")
-                path = mod_data.get("path", "")
-                pfid = mod_data.get("publishedfileid", "")
-                mod_source = "SteamCMD" if mod_data.get("steamcmd") else "Steam"
-
-                # Format the download time for display
-                touched_text, internal_time_touched = format_time_display(
-                    mod_data.get("internal_time_touched")
-                )
-
-                # Create table items for each column
-                name_item = QStandardItem(name)
-                name_item.setData(
-                    uuid, Qt.ItemDataRole.UserRole
-                )  # Store UUID for selection
-                authors_item = QStandardItem(authors)
-                packageid_item = QStandardItem(packageid)
-                pfid_item = QStandardItem(pfid)
-                source_item = QStandardItem(mod_source)
-                path_item = QStandardItem(path)
-                downloaded_item = QStandardItem(touched_text)
-                downloaded_item.setData(internal_time_touched)  # Store raw timestamp
-
-                # Create workshop button for opening the mod's Steam Workshop page
-                workshop_btn_item = QStandardItem(pfid)
-                workshop_btn = self._create_workshop_button(
-                    f"https://steamcommunity.com/sharedfiles/filedetails/?id={pfid}",
-                    "workshopButton",
-                )
-
-                # Add the complete mod row to the table
-                self._add_row(
-                    [
-                        name_item,
-                        authors_item,
-                        packageid_item,
-                        pfid_item,
-                        source_item,
-                        downloaded_item,
-                        path_item,
-                        workshop_btn_item,
-                    ]
-                )
-
-                # Set the workshop button as the widget for the last column
-                self.editor_table_view.setIndexWidget(
-                    workshop_btn_item.index(), workshop_btn
-                )
-
-    def _create_workshop_button(self, url: str, object_name: str) -> QPushButton:
-        """
-        Create a button that opens the Steam Workshop page for a mod.
-
-        Args:
-            url: The full URL to the Steam Workshop page.
-            object_name: The object name for the button widget.
-
-        Returns:
-            QPushButton: Configured button that opens the workshop page when clicked.
-        """
-        button = QPushButton()
-        button.setObjectName(object_name)
-        button.setText(self.tr("Open Workshop Page"))
-        button.clicked.connect(partial(platform_specific_open, url))
-        return button
-
-    def _get_selected_mod_metadata(self) -> List[ModMetadata]:
-        """
-        Retrieve metadata for mods selected in the table via checkboxes.
-
-        Iterates through all table rows, checking which ones are selected via
-        the checkbox state. For selected rows, extracts the UUID from the Mod Name
-        column and retrieves the corresponding metadata from the metadata manager.
-
-        Returns:
-            List[ModMetadata]: List of metadata objects for selected mods.
-        """
-        selected_mods = []
-        for row in range(self.editor_model.rowCount()):
-            if self._row_is_checked(row):
-                # UUID is stored in the Mod Name column (index 1)
-                uuid = self.editor_model.item(row, 1).data(Qt.ItemDataRole.UserRole)
-                if uuid and uuid in self.mm.internal_local_metadata:
-                    selected_mods.append(self.mm.internal_local_metadata[uuid])
-
-        return selected_mods
-
-    def _refresh_after_deletion(self) -> None:
-        """
-        Refresh the metadata cache and repopulate the table after deletion operations.
-
-        This method is called as a callback after mods are deleted. It refreshes
-        the metadata cache to reflect the changes and repopulates the table with
-        the updated duplicate mod data.
-        """
-        logger.debug(
-            "Refreshing mod list and closing DuplicateModsPanel after deletion"
-        )
-        # Refresh the metadata cache to reflect deletion changes
-        self.mm.refresh_cache(is_initial=False)
-        # Repopulate the table with updated data
-        self._populate_from_metadata()
+            # Use the refactored base class method to populate grouped mods
+            self._populate_mods(groups, add_group_headers=True)
+        except Exception as e:
+            logger.error(f"Error populating table from metadata: {e}")

--- a/app/windows/missing_mods_panel.py
+++ b/app/windows/missing_mods_panel.py
@@ -5,22 +5,35 @@ from loguru import logger
 from PySide6.QtGui import QStandardItem
 from PySide6.QtWidgets import (
     QComboBox,
-    QPushButton,
 )
 
 from app.utils.constants import RIMWORLD_DLC_METADATA
-from app.windows.base_mods_panel import BaseModsPanel
+from app.windows.base_mods_panel import (
+    BaseModsPanel,
+    ButtonConfig,
+    ButtonType,
+)
 
 
 class MissingModsPrompt(BaseModsPanel):
     """
-    A generic panel used to prompt a user to download missing mods
+    A panel for prompting users to download missing mods from their active mods list.
+
+    This panel queries the SteamDB database to find available variants for missing package IDs,
+    allowing users to select and download preferred mod variants. It handles multiple variants
+    per package ID and provides options for downloading via SteamCMD or the Steam client.
     """
 
     def __init__(
         self,
         packageids: list[str],
-    ):
+    ) -> None:
+        """
+        Initialize the MissingModsPrompt.
+
+        Args:
+            packageids: List of package IDs for missing mods.
+        """
         logger.debug("Initializing MissingModsPrompt")
 
         super().__init__(
@@ -33,94 +46,146 @@ class MissingModsPrompt(BaseModsPanel):
                 + "\n\nPlease select your preferred mod variant in the table below. You can also open each variant in Steam/Web browser to verify."
             ),
             additional_columns=[
-                self.tr("Name"),
-                self.tr("PackageId"),
-                self.tr("Game Versions"),
+                self.tr(self.COL_MOD_NAME),
+                self.tr(self.COL_PACKAGE_ID),
+                self.tr(self.COL_SUPPORTED_VERSIONS),
                 self.tr("# Variants"),
-                self.tr("PublishedFileID"),
-                # "Open page",
+                self.tr(self.COL_PUBLISHED_FILE_ID),
+                self.tr(self.COL_WORKSHOP_PAGE),
             ],
         )
 
-        self.data_by_variants: dict[str, Any] = {}
+        self.data_by_variants: dict[str, dict[str, Any]] = {}
         self.DEPENDENCY_TAG = "_-_DEPENDENCY_-_"
-        self.packageids = packageids
+        self.DEFAULT_NOT_FOUND = "Not found in steam database"
+        # Validate and filter package IDs
+        self.packageids = self._validate_packageids(packageids)
+        self.packageid_to_row: dict[str, int] = {}
 
-        self.editor_download_steamcmd_button = QPushButton(
-            self.tr("Download with SteamCMD")
-        )
-        self.editor_download_steamcmd_button.clicked.connect(
-            partial(
-                self._update_mods_from_table,
-                pfid_column=5,
-                mode="SteamCMD",
-            )
-        )
-        self.editor_download_steamworks_button = QPushButton(
-            self.tr("Download with Steam client")
-        )
-        self.editor_download_steamworks_button.clicked.connect(
-            partial(
-                self._update_mods_from_table,
-                pfid_column=5,
-                mode="Steam",
-            )
-        )
-        self.editor_main_actions_layout.addWidget(self.editor_download_steamcmd_button)
-        self.editor_main_actions_layout.addWidget(
-            self.editor_download_steamworks_button
-        )
+        # Check if Steam client integration is enabled
+        steam_client_integration_enabled = self._get_steam_client_integration_enabled()
 
-    def _mm_add_row(
+        # Set up buttons using standardized configuration
+        button_configs = [
+            ButtonConfig(
+                button_type=ButtonType.REFRESH,
+                custom_callback=self._refresh_metadata_and_panel,
+            ),
+            ButtonConfig(
+                button_type=ButtonType.CUSTOM,
+                text=self.tr("Download with SteamCMD"),
+                custom_callback=partial(
+                    self._update_mods_from_table,
+                    pfid_column=5,
+                    mode="SteamCMD",
+                ),
+            ),
+        ]
+
+        # Only add Steam client download button if Steam client integration is enabled
+        if steam_client_integration_enabled:
+            button_configs.append(
+                ButtonConfig(
+                    button_type=ButtonType.CUSTOM,
+                    text=self.tr("Download with Steam client"),
+                    custom_callback=partial(
+                        self._update_mods_from_table,
+                        pfid_column=5,
+                        mode="Steam",
+                    ),
+                )
+            )
+        self._setup_buttons_from_config(button_configs)
+
+        # Configure table settings
+        self._setup_table_configuration(sorting_enabled=True)
+
+        # TODO: let user configure window launch state and size from settings controller
+        self.showNormal()
+
+    def _validate_packageids(self, packageids: list[str]) -> list[str]:
+        """
+        Validate and filter package IDs to prevent empty or invalid IDs.
+
+        Args:
+            packageids: List of package IDs to validate.
+
+        Returns:
+            List of validated and filtered package IDs.
+        """
+        validated = []
+        for pid in packageids:
+            if pid and isinstance(pid, str):
+                stripped = pid.strip()
+                if stripped:
+                    validated.append(stripped)
+        return validated
+
+    def _missing_mods_add_row(
         self,
         name: str,
         packageid: str,
         game_versions: list[str],
         mod_variants: str,
-        publishedfileid: str,
+        published_file_id: str,
     ) -> None:
+        """
+        Add a row for a missing mod, handling variants.
+
+        Args:
+            name: Mod name
+            packageid: Package ID
+            game_versions: List of supported game versions
+            mod_variants: Number of variants as string
+            published_file_id: Published file ID
+        """
         # Check if a row with the given packageid already exists
-        for row in range(self.editor_model.rowCount()):
-            if self.editor_model.item(row, 2).text() == packageid:
-                # If an existing row is found, add the new publishedfileid
-                existing_item = self.editor_model.item(row, 5)
-                combo_box = self.editor_table_view.indexWidget(existing_item.index())
-                if not isinstance(combo_box, QComboBox):
-                    raise Exception(f"Combo box is not a QComboBox!: {combo_box}")
+        existing_row = self._find_existing_row_by_packageid(packageid)
+        if existing_row is not None:
+            # If an existing row is found, add the new published_file_id
+            self._add_variant_to_existing_row(existing_row, published_file_id)
+            return  # Return here to exit function
 
-                combo_box.addItem(publishedfileid)
-                return  # Return here to exit function
         # If we're still here, we need to actually create a new row
-        name_item = QStandardItem(name)
-        name_item.setToolTip(name)
-        items = [
-            name_item,
-            QStandardItem(packageid),
-            QStandardItem(str(game_versions)),
-            QStandardItem(mod_variants if publishedfileid != "" else "0"),
-            QStandardItem(),
-        ]
-        self._add_row(items)
-        combo_box_index = items[4].index()
-        combo_box = QComboBox()
-        combo_box.setEditable(True)
-        combo_box.setObjectName("missing_mods_variant_cb")
-        combo_box.addItem(publishedfileid)
-        # Connect the currentTextChanged signal
-        combo_box.currentTextChanged.connect(self._update_mod_info)
-        # Set the combo_box as the index widget
-        self.editor_table_view.setIndexWidget(combo_box_index, combo_box)
+        self._create_new_missing_mod_row(
+            name, packageid, game_versions, mod_variants, published_file_id
+        )
 
-    def _populate_from_metadata(self) -> None:
-        # Build a dict of missing mod variant(s)
-        steam_metadata = self.metadata_manager.external_steam_metadata
-        if steam_metadata and len(steam_metadata.keys()) > 0:
-            # Generate a list of all missing mods + any missing mod dependencies listed
-            # in the user-configured Steam metadata.
-            for publishedfileid, metadata in steam_metadata.items():
-                name = metadata.get("steamName", metadata.get("name", "Not found"))
-                packageid = metadata.get("packageId", "None").lower()
-                game_versions = metadata.get("gameVersions", ["None listed"])
+    def _filter_eligible_mods(self) -> list[str]:
+        """
+        Filter package IDs that are eligible for missing mod processing.
+
+        Returns:
+            List of package IDs that need to be processed.
+        """
+        return self.packageids
+
+    def _build_variant_data_from_steam_metadata(self) -> dict[str, dict[str, Any]]:
+        """
+        Build variant data from Steam metadata, grouping by package ID.
+
+        Returns:
+            Dictionary mapping package IDs to their variant data.
+        """
+        if not hasattr(self, "_cached_steam_metadata"):
+            self._cached_steam_metadata = self.metadata_manager.external_steam_metadata
+
+        steam_metadata = self._cached_steam_metadata
+        if steam_metadata and len(steam_metadata) > 500:
+            logger.info(
+                f"Processing large Steam metadata set with {len(steam_metadata)} items"
+            )
+
+        variants_by_packageid: dict[str, dict[str, Any]] = {}
+        if steam_metadata:
+            for published_file_id, metadata in steam_metadata.items():
+                name = metadata.get(
+                    "steamName", metadata.get("name", "Not found in steam database")
+                )
+                packageid = metadata.get("packageId", "").lower()
+                game_versions = metadata.get(
+                    "gameVersions", ["Not found in steam database"]
+                )
 
                 # Remove AppId dependencies from this dict. They cannot be subscribed like mods.
                 dependencies = {
@@ -129,37 +194,180 @@ class MissingModsPrompt(BaseModsPanel):
                     if key not in RIMWORLD_DLC_METADATA.keys()
                 }
 
-                # Populate data_by_variants dict
+                # Populate variants_by_packageid dict
                 if packageid in self.packageids:
-                    variants = self.data_by_variants.setdefault(packageid, {})
-                    variants[publishedfileid] = {
+                    variants = variants_by_packageid.setdefault(packageid, {})
+                    variants[published_file_id] = {
                         "name": name,
                         "gameVersions": game_versions,
                         "dependencies": dependencies,
                     }
+        return variants_by_packageid
 
-            # If we couldn't find any from Steam metadata, we still want to populate a blank row for user input
-            for packageid in self.packageids:
-                if packageid not in self.data_by_variants.keys():
-                    self.data_by_variants[packageid] = {
-                        "": {
-                            "name": "Not found",
-                            "gameVersions": ["None listed"],
-                        }
+    def _add_default_entries_for_missing_packageids(
+        self, variants_by_packageid: dict[str, dict[str, Any]]
+    ) -> None:
+        """
+        Add default entries for package IDs not found in Steam metadata.
+
+        Args:
+            variants_by_packageid: Dictionary of variants by package ID to update.
+        """
+        for packageid in self.packageids:
+            if packageid not in variants_by_packageid:
+                variants_by_packageid[packageid] = {
+                    "": {
+                        "name": self.DEFAULT_NOT_FOUND,
+                        "gameVersions": self.DEFAULT_NOT_FOUND,
                     }
+                }
 
-            # Add a row for each mod variant
-            for packageid, variants in self.data_by_variants.items():
-                for publishedfileid, variant_data in variants.items():
-                    self._mm_add_row(
-                        name=variant_data["name"],
-                        packageid=packageid,
-                        game_versions=variant_data["gameVersions"],
-                        mod_variants=str(len(variants.keys())),
-                        publishedfileid=publishedfileid,
-                    )
+    def _populate_table_from_variants(
+        self, variants_by_packageid: dict[str, dict[str, Any]]
+    ) -> None:
+        """
+        Populate the table with mod variants.
 
-    def _update_mod_info(self, publishedfileid: str) -> None:
+        Args:
+            variants_by_packageid: Dictionary of variants grouped by package ID.
+        """
+        for packageid, variants in variants_by_packageid.items():
+            for published_file_id, variant_data in variants.items():
+                self._missing_mods_add_row(
+                    name=variant_data["name"],
+                    packageid=packageid,
+                    game_versions=variant_data["gameVersions"],
+                    mod_variants=str(len(variants.keys())),
+                    published_file_id=published_file_id,
+                )
+
+    def _find_existing_row_by_packageid(self, packageid: str) -> int | None:
+        """
+        Find the row index for an existing packageid.
+
+        Args:
+            packageid: The package ID to search for.
+
+        Returns:
+            Row index if found, None otherwise.
+        """
+        return self.packageid_to_row.get(packageid)
+
+    def _add_variant_to_existing_row(self, row: int, published_file_id: str) -> None:
+        """
+        Add a new variant to an existing row's combo box.
+
+        Args:
+            row: Row index to update.
+            published_file_id: Published file ID to add to the combo box.
+        """
+        existing_item = self.editor_model.item(row, 5)
+        if existing_item is None:
+            logger.error(f"No item found at row {row}, column 5")
+            return
+
+        combo_box = self.editor_table_view.indexWidget(existing_item.index())
+        if not isinstance(combo_box, QComboBox):
+            logger.error(
+                f"Expected QComboBox at row {row}, column 5, but found {type(combo_box)}"
+            )
+            return
+
+        combo_box.addItem(published_file_id)
+
+    def _create_new_missing_mod_row(
+        self,
+        name: str,
+        packageid: str,
+        game_versions: list[str],
+        mod_variants: str,
+        published_file_id: str,
+    ) -> None:
+        """
+        Create a new row for a missing mod.
+
+        Args:
+            name: Mod name.
+            packageid: Package ID.
+            game_versions: List of supported game versions.
+            mod_variants: Number of variants as string.
+            published_file_id: Published file ID.
+        """
+        # Create items for the custom columns in this panel
+        name_item = QStandardItem(name)
+        packageid_item = QStandardItem(packageid)
+        game_versions_item = QStandardItem(str(game_versions))
+        variants_item = QStandardItem(mod_variants if published_file_id != "" else "0")
+        published_file_id_combo_item = QStandardItem()  # PublishedFileId (combo box)
+        workshop_item = QStandardItem()  # Workshop Page (button)
+
+        items = [
+            name_item,
+            packageid_item,
+            game_versions_item,
+            variants_item,
+            published_file_id_combo_item,
+            workshop_item,
+        ]
+        self._add_row(items)
+        self._setup_variant_combo_box(items, published_file_id)
+        # Generate workshop button only if published_file_id exists
+        if published_file_id:
+            self._add_workshop_button_to_row(items, published_file_id, 5)
+        # Track the row index for this packageid
+        self.packageid_to_row[packageid] = self.editor_model.rowCount() - 1
+
+    def _setup_variant_combo_box(
+        self, items: list[QStandardItem], published_file_id: str
+    ) -> None:
+        """
+        Set up the combo box for variant selection.
+
+        Args:
+            items: List of QStandardItem for the row.
+            published_file_id: Initial published file ID for the combo box.
+        """
+        combo_box = QComboBox()
+        combo_box.setEditable(True)
+        combo_box.setObjectName("missing_mods_variant_cb")
+        combo_box.addItem(published_file_id)
+        # Connect the currentTextChanged signal
+        combo_box.currentTextChanged.connect(self._update_mod_info)
+        # Set the combo_box as the index widget
+        self.editor_table_view.setIndexWidget(items[4].index(), combo_box)
+
+    def _populate_from_metadata(self) -> None:
+        """
+        Populate the table with missing mod variants.
+        """
+        try:
+            # Cache Steam metadata to avoid repeated access
+            self._cached_steam_metadata = self.metadata_manager.external_steam_metadata
+            if (
+                self._cached_steam_metadata
+                and len(self._cached_steam_metadata.keys()) > 0
+            ):
+                # Group mods by package ID from Steam metadata
+                variants_by_packageid = self._build_variant_data_from_steam_metadata()
+
+                # Add default entries for package IDs not found in Steam metadata
+                self._add_default_entries_for_missing_packageids(variants_by_packageid)
+
+                # Populate the table with all variants
+                self._populate_table_from_variants(variants_by_packageid)
+
+                # Update the instance variable for compatibility with existing methods
+                self.data_by_variants = variants_by_packageid
+        except Exception as e:
+            logger.error(f"Error populating table from metadata: {e}")
+
+    def _update_mod_info(self, published_file_id: str) -> None:
+        """
+        Update mod information when variant selection changes.
+
+        Args:
+            published_file_id: The selected published file ID.
+        """
         combo_box = self.sender()
         if not isinstance(combo_box, QComboBox):
             raise ValueError(f"Sender is not a QComboBox!: {combo_box}")
@@ -167,15 +375,12 @@ class MissingModsPrompt(BaseModsPanel):
         if index.isValid():
             row = index.row()
             packageid = self.editor_model.item(row, 1).text()
+            variant_data = self.data_by_variants.get(packageid, {}).get(
+                published_file_id, {}
+            )
             self.editor_model.item(row, 0).setText(
-                self.data_by_variants.get(packageid, {})
-                .get(publishedfileid, {})
-                .get("name", "No variant found!")
+                variant_data.get("name", self.DEFAULT_NOT_FOUND)
             )
             self.editor_model.item(row, 2).setText(
-                str(
-                    self.data_by_variants.get(packageid, {})
-                    .get(publishedfileid, {})
-                    .get("gameVersions", "No variant found!")
-                )
+                str(variant_data.get("gameVersions", self.DEFAULT_NOT_FOUND))
             )

--- a/app/windows/use_this_instead_panel.py
+++ b/app/windows/use_this_instead_panel.py
@@ -1,18 +1,29 @@
 from collections import defaultdict
 from dataclasses import dataclass
-from functools import partial
-from typing import Any, Dict, List, Optional
+from enum import Enum
+from typing import Any, Generator, Optional
 
 from loguru import logger
-from PySide6.QtCore import Qt
-from PySide6.QtGui import QAction, QStandardItem
-from PySide6.QtWidgets import QCheckBox, QHeaderView, QMenu, QPushButton, QToolButton
+from PySide6.QtGui import QStandardItem
+from PySide6.QtWidgets import QCheckBox
 
-from app.utils.generic import format_time_display, platform_specific_open
-from app.utils.metadata import MetadataManager, ModMetadata
+from app.utils.metadata import MetadataManager
+from app.utils.mod_info import ModInfo
 from app.views import dialogue
-from app.views.deletion_menu import ModDeletionMenu
-from app.windows.base_mods_panel import BaseModsPanel, HeaderColumn
+from app.windows.base_mods_panel import (
+    BaseModsPanel,
+    ButtonConfig,
+    ButtonType,
+    ColumnIndex,
+    MenuItem,
+)
+
+
+class InstallationStatus(Enum):
+    """Enumeration for installation status."""
+
+    INSTALLED = "Installed"
+    NOT_INSTALLED = "Not Installed"
 
 
 @dataclass
@@ -33,6 +44,7 @@ class ReplacementInfo:
     packageid: str
     pfid: str
     supportedversions: Any
+    source: str
 
 
 @dataclass
@@ -47,7 +59,7 @@ class ModGroupItem:
     """
 
     mod_id: str
-    metadata: Dict[str, Any]
+    metadata: dict[str, Any]
     replacement: Optional[ReplacementInfo] = None
 
 
@@ -57,7 +69,7 @@ class UseThisInsteadPanel(BaseModsPanel):
     Groups mods by replacement mod and provides actions for subscription, unsubscription, and deletion.
     """
 
-    def __init__(self, mod_metadata: Dict[str, Any]) -> None:
+    def __init__(self, mod_metadata: dict[str, Any]) -> None:
         """
         Initialize the UseThisInsteadPanel with mod metadata.
 
@@ -66,20 +78,6 @@ class UseThisInsteadPanel(BaseModsPanel):
         """
         logger.debug("Initializing UseThisInsteadPanel")
         self.mod_metadata = mod_metadata
-        self.mm = MetadataManager.instance()
-
-        # Define table columns for displaying mod information
-        additional_columns: list[HeaderColumn] = [
-            self.tr("Mod Name"),
-            self.tr("Author"),
-            self.tr("Package ID"),
-            self.tr("PublishedFileId"),
-            self.tr("Supported Versions"),
-            self.tr("Source"),
-            self.tr("Mod Downloaded"),
-            self.tr("Path"),
-            self.tr("Workshop Page"),
-        ]
 
         super().__init__(
             object_name="useThisInsteadModsPanel",
@@ -89,169 +87,64 @@ class UseThisInsteadPanel(BaseModsPanel):
                 "The following table displays Workshop mods with suggested replacements "
                 'according to the "Use This Instead" database, grouped by replacement mod.'
             ),
-            additional_columns=additional_columns,
+            additional_columns=self._get_standard_mod_columns(),
         )
 
-        self._setup_buttons()
+        steam_client_integration_enabled = self._get_steam_client_integration_enabled()
+
+        button_configs = [
+            ButtonConfig(
+                button_type=ButtonType.SELECT,
+                text=self.tr("Select"),
+                menu_items=[
+                    MenuItem(
+                        text=self.tr("Select all Originals"),
+                        callback=self._select_all_originals,
+                    ),
+                    MenuItem(
+                        text=self.tr("Select all Replacements"),
+                        callback=self._select_all_replacements,
+                    ),
+                ],
+            ),
+        ]
+        button_configs.extend(self._get_base_button_configs())
+
+        if steam_client_integration_enabled:
+            button_configs.extend(
+                [
+                    ButtonConfig(
+                        button_type=ButtonType.SUBSCRIBE,
+                        pfid_column=ColumnIndex.PUBLISHED_FILE_ID.value,
+                        completion_callback=self._on_subscribe_completed,
+                    ),
+                    ButtonConfig(
+                        button_type=ButtonType.UNSUBSCRIBE,
+                        pfid_column=ColumnIndex.PUBLISHED_FILE_ID.value,
+                        completion_callback=self._on_unsubscribe_completed,
+                    ),
+                ]
+            )
+
+        button_configs.append(
+            self._create_delete_button_config(
+                self.tr("Delete Selected Mods"),
+                enable_delete_and_unsubscribe=steam_client_integration_enabled,
+            )
+        )
+        self._setup_buttons_from_config(button_configs)
+
+        # Initialize row index trackers for bulk selection operations
+        self._original_rows: set[int] = set()
+        self._replacement_rows: set[int] = set()
+
         self._populate_from_metadata()
 
-        # Set all rows to auto-resize to content
-        self.editor_table_view.verticalHeader().setSectionResizeMode(
-            QHeaderView.ResizeMode.ResizeToContents
-        )
-
-        # Disable sorting to maintain mod grouping by package ID
-        self.editor_table_view.setSortingEnabled(False)
+        # Configure table settings
+        self._setup_table_configuration(sorting_enabled=False)
 
         # TODO: let user configure window launch state and size from settings controller
         self.showNormal()
-
-    def _setup_buttons(self) -> None:
-        """Set up action buttons for the panel."""
-        self._add_select_buttons()
-        self._add_refresh_button()
-        self._add_steamcmd_button()
-        self._add_subscribe_button()
-        self._add_unsubscribe_button()
-        self._add_deletion_button()
-
-    def _add_select_buttons(self) -> None:
-        """Add select buttons for originals and replacements."""
-        button = QToolButton()
-        button.setText(self.tr("Select"))
-        menu = QMenu(button)
-
-        # Select all originals
-        action = QAction(self.tr("Select all Originals"), self)
-        action.triggered.connect(self._select_all_originals)
-        menu.addAction(action)
-
-        # Select all replacements
-        action = QAction(self.tr("Select all Replacements"), self)
-        action.triggered.connect(self._select_all_replacements)
-        menu.addAction(action)
-
-        button.setMenu(menu)
-        button.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
-        self.editor_main_actions_layout.addWidget(button)
-
-    def _add_refresh_button(self) -> None:
-        """Add refresh button."""
-        self.refresh_button = QPushButton()
-        self.refresh_button.setText(self.tr("Refresh"))
-        self.refresh_button.clicked.connect(self._refresh_use_this_instead_panel)
-        self.editor_main_actions_layout.addWidget(self.refresh_button)
-
-    def _add_steamcmd_button(self) -> None:
-        """Add SteamCMD button with menu options."""
-        button = QToolButton()
-        button.setText(self.tr("SteamCMD"))
-        menu = QMenu(button)
-
-        # Download selected mods with SteamCMD
-        action = QAction(self.tr("Download selected with SteamCMD"), self)
-        action.triggered.connect(
-            partial(
-                self._update_mods_from_table,
-                4,  # COL_PUBLISHED_FILE_ID
-                "SteamCMD",
-            )
-        )
-        menu.addAction(action)
-
-        # Download all replacements with SteamCMD
-        action = QAction(self.tr("Download all replacements with SteamCMD"), self)
-        action.triggered.connect(
-            partial(
-                self._steamcmd_for_all_replacements,
-                4,  # COL_PUBLISHED_FILE_ID
-            )
-        )
-        menu.addAction(action)
-
-        button.setMenu(menu)
-        button.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
-        self.editor_main_actions_layout.addWidget(button)
-
-    def _add_subscribe_button(self) -> None:
-        """Add subscribe button with menu options."""
-        button = QToolButton()
-        button.setText(self.tr("Subscribe"))
-        menu = QMenu(button)
-
-        # Subscribe selected mods
-        action = QAction(self.tr("Subscribe selected"), self)
-        action.triggered.connect(
-            partial(
-                self._update_mods_from_table,
-                4,  # COL_PUBLISHED_FILE_ID
-                "Steam",
-                completed=lambda self: self._on_mod_action_completed(
-                    "subscribe", self._get_selected_count()
-                ),
-            )
-        )
-        menu.addAction(action)
-
-        # Subscribe all replacements
-        action = QAction(self.tr("Subscribe all replacements"), self)
-        action.triggered.connect(self._subscribe_all_replacements)
-        menu.addAction(action)
-
-        button.setMenu(menu)
-        button.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
-        self.editor_main_actions_layout.addWidget(button)
-
-    def _add_unsubscribe_button(self) -> None:
-        """Add unsubscribe button with menu options."""
-        button = QToolButton()
-        button.setText(self.tr("Unsubscribe"))
-        menu = QMenu(button)
-
-        # Unsubscribe selected mods
-        action = QAction(self.tr("Unsubscribe selected"), self)
-        action.triggered.connect(
-            partial(
-                self._update_mods_from_table,
-                4,  # COL_PUBLISHED_FILE_ID
-                "Steam",
-                "unsubscribe",
-                completed=lambda self: self._on_mod_action_completed(
-                    "unsubscribe", self._get_selected_count()
-                ),
-            )
-        )
-        menu.addAction(action)
-
-        # Unsubscribe all original mods
-        action = QAction(self.tr("Unsubscribe all originals"), self)
-        action.triggered.connect(self._unsubscribe_all_originals)
-        menu.addAction(action)
-
-        button.setMenu(menu)
-        button.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
-        self.editor_main_actions_layout.addWidget(button)
-
-    def _add_deletion_button(self) -> None:
-        """Add deletion button with menu."""
-        self.deletion_tool_button = QToolButton()
-        self.deletion_tool_button.setText(self.tr("Delete"))
-        self.deletion_menu = ModDeletionMenu(
-            settings_controller=self.settings_controller,
-            get_selected_mod_metadata=self._get_selected_mod_metadata,
-            menu_title=self.tr("Delete Selected Original Mods..."),
-            enable_delete_mod=True,
-            enable_delete_keep_dds=False,
-            enable_delete_dds_only=False,
-            enable_delete_and_unsubscribe=True,
-            enable_delete_and_resubscribe=False,
-            completion_callback=self._refresh_use_this_instead_panel,
-        )
-        self.deletion_tool_button.setMenu(self.deletion_menu)
-        self.deletion_tool_button.setPopupMode(
-            QToolButton.ToolButtonPopupMode.InstantPopup
-        )
-        self.editor_main_actions_layout.addWidget(self.deletion_tool_button)
 
     def _on_mod_action_completed(self, action: str, count: int) -> None:
         """Handle successful mod action completion."""
@@ -259,6 +152,16 @@ class UseThisInsteadPanel(BaseModsPanel):
             self.tr("Use This Instead"),
             self.tr(f"Successfully {action}d {count} mods"),
         )
+
+    def _on_subscribe_completed(self) -> None:
+        """Handle subscribe completion."""
+        count = self._get_selected_count()
+        self._on_mod_action_completed("subscribe", count)
+
+    def _on_unsubscribe_completed(self) -> None:
+        """Handle unsubscribe completion."""
+        count = self._get_selected_count()
+        self._on_mod_action_completed("unsubscribe", count)
 
     def _get_selected_count(self) -> int:
         """Get the count of selected mods."""
@@ -272,53 +175,358 @@ class UseThisInsteadPanel(BaseModsPanel):
         """
         Populate the table with mod data grouped by replacement mod.
 
-        This method clears the existing table, computes mod groups based on
-        replacement suggestions, and populates the table with headers, original
-        mods, and replacement mods.
+        This method computes mod groups based on replacement suggestions,
+        and populates the table with headers, original mods, and replacement mods.
         """
-        # Clear the existing table content
-        self.editor_model.removeRows(0, self.editor_model.rowCount())
-        mm = MetadataManager.instance()
+        try:
+            # Clear the table before populating
+            self._clear_table_model()
 
-        # Pre-filter alternatives to avoid repeated database lookups
-        # This creates a cache of mod alternatives for efficient access
-        alternatives: Dict[str, Any] = {}
-        for mod in self.mod_metadata:
-            alt = mm.has_alternative_mod(mod)
-            if alt is not None:
-                alternatives[mod] = alt
+            # Filter and group mods
+            groups = self._filter_and_group_mods()
 
-        # Precompute groups: group mods by their package_id, each group contains
-        # original mods that can be replaced by the same replacement mod
-        groups = defaultdict(list)
-        for mod, mv in self.mod_metadata.items():
-            mr = alternatives.get(mod)
-            if mr is None or mv is None:
-                continue
-            package_id: str = mv.get("packageid", "")
-            groups[package_id].append(ModGroupItem(mod, mv, mr))
+            if not groups:
+                logger.debug("No groups found to populate the use this instead panel.")
+                return
 
-        # Initialize row index trackers for bulk selection operations
-        self._original_rows: List[int] = []
-        self._replacement_rows: List[int] = []
-        current_row: int = 0
+            # Add groups to table
+            self._add_groups_to_table(groups)
 
-        # Process each group: add header, originals, and replacement
-        group_counter: int = 1
+            # Track row indices for selection during population to avoid double iteration
+            self._track_row_indices_during_population(groups)
+        except Exception as e:
+            logger.error(f"Error populating metadata: {e}")
+            # Graceful degradation: clear table if error occurs
+            self._clear_table_model()
+
+    def _track_row_indices_during_population(
+        self, groups: dict[str, list[ModGroupItem]]
+    ) -> None:
+        """
+        Track row indices for originals and replacements during population.
+
+        Args:
+            groups: Dictionary of groups by package ID.
+        """
+        current_row = 0
         for package_id, originals in groups.items():
-            # Add group header row
-            self._add_group_header(group_counter, current_row)
+            # Skip header row
+            current_row += 1
+            # Add original rows to tracking
+            for _ in originals:
+                self._original_rows.add(current_row)
+                current_row += 1
+            # Add replacement row to tracking
+            self._replacement_rows.add(current_row)
             current_row += 1
 
-            # Add all original mods in this group
-            self._add_original_mods(originals, package_id, current_row)
-            current_row += len(originals)
+    def _prepare_formatted_groups(
+        self, groups: dict[str, list[ModGroupItem]]
+    ) -> dict[str, list[tuple[str | None, dict[str, Any]]]]:
+        """
+        Prepare formatted groups for population.
 
-            # Add the replacement mod for this group
-            self._add_replacement_mod(originals[0].replacement, package_id, current_row)
-            current_row += 1
+        Args:
+            groups: Dictionary of groups by package ID.
 
+        Returns:
+            Formatted groups dictionary.
+        """
+        formatted_groups: dict[str, list[tuple[str | None, dict[str, Any]]]] = {}
+        for package_id, originals in groups.items():
+            mod_list = self._prepare_mod_list_for_group(originals)
+            formatted_groups[package_id] = mod_list
+        return formatted_groups
+
+    def _prepare_mod_list_for_group(
+        self, originals: list[ModGroupItem]
+    ) -> list[tuple[str | None, dict[str, Any]]]:
+        """
+        Prepare mod list for a group, including originals and replacement.
+
+        Args:
+            originals: List of original mod group items.
+
+        Returns:
+            List of (uuid, metadata) tuples.
+        """
+        mod_list = []
+        for mod_item in originals:
+            metadata_copy = self._create_original_metadata(mod_item)
+            path = mod_item.metadata.get("path")
+            uuid = self._extract_uuid_from_path(path) if isinstance(path, str) else None
+            mod_list.append((uuid, metadata_copy))
+
+        # Add replacement mod
+        mod_replacement = originals[0].replacement if originals else None
+        if mod_replacement is not None:
+            uuid, fake_metadata = self._create_replacement_metadata(mod_replacement)
+            mod_list.append((uuid, fake_metadata))
+        return mod_list
+
+    def _create_original_metadata(self, mod_item: ModGroupItem) -> dict[str, Any]:
+        """
+        Create metadata for an original mod with type.
+
+        Args:
+            mod_item: The mod group item.
+
+        Returns:
+            Metadata dictionary with type.
+        """
+        metadata_copy = mod_item.metadata.copy()
+        metadata_copy["type"] = "Original"
+        return metadata_copy
+
+    def _create_replacement_metadata(
+        self, mod_replacement: ReplacementInfo
+    ) -> tuple[str | None, dict[str, Any]]:
+        """
+        Create metadata for a replacement mod.
+
+        Args:
+            mod_replacement: The replacement mod information.
+
+        Returns:
+            Tuple of (uuid, metadata).
+        """
+        # Check if the replacement mod already exists locally
+        exists_locally, uuid = self._check_replacement_exists_locally(
+            mod_replacement.pfid
+        )
+
+        fake_metadata = self._build_replacement_metadata(
+            mod_replacement, exists_locally, uuid
+        )
+        return uuid, fake_metadata
+
+    def _check_replacement_exists_locally(self, pfid: str) -> tuple[bool, str | None]:
+        """
+        Check if replacement mod exists locally and get its UUID.
+
+        Args:
+            pfid: Published file ID.
+
+        Returns:
+            Tuple of (exists_locally, uuid).
+        """
+        exists_locally = any(
+            mod.get("publishedfileid") == pfid
+            for mod in self.metadata_manager.internal_local_metadata.values()
+        )
+        uuid = None
+        if exists_locally:
+            for (
+                mod_uuid,
+                mod_metadata,
+            ) in self.metadata_manager.internal_local_metadata.items():
+                if mod_metadata.get("publishedfileid") == pfid:
+                    uuid = mod_uuid
+                    break
+        return exists_locally, uuid
+
+    def _get_local_metadata_for_replacement(
+        self, uuid: str | None
+    ) -> dict[str, Any] | None:
+        """
+        Retrieve local metadata for a replacement mod if it exists.
+
+        Args:
+            uuid: UUID of the replacement mod.
+
+        Returns:
+            Local metadata dictionary or None if not found.
+        """
+        if uuid and uuid in self.metadata_manager.internal_local_metadata:
+            return self.metadata_manager.internal_local_metadata[uuid]
+        return None
+
+    def _merge_local_and_external_metadata(
+        self, external_metadata: dict[str, Any], local_metadata: dict[str, Any] | None
+    ) -> dict[str, Any]:
+        """
+        Merge local and external metadata for a replacement mod.
+
+        Args:
+            external_metadata: Metadata from external source.
+            local_metadata: Local metadata if available.
+
+        Returns:
+            Merged metadata dictionary.
+        """
+        if local_metadata:
+            external_metadata.update(
+                {
+                    "supportedversions": local_metadata.get(
+                        "supportedversions", external_metadata["supportedversions"]
+                    ),
+                    "path": local_metadata.get("path", ""),
+                    "internal_time_touched": local_metadata.get(
+                        "internal_time_touched"
+                    ),
+                    "external_time_updated": local_metadata.get(
+                        "external_time_updated"
+                    ),
+                    "data_source": local_metadata.get("source"),
+                }
+            )
+        return external_metadata
+
+    def _create_base_replacement_metadata(
+        self, mod_replacement: ReplacementInfo, exists_locally: bool
+    ) -> dict[str, Any]:
+        """
+        Create base metadata dictionary for replacement mod.
+
+        Args:
+            mod_replacement: Replacement mod info.
+            exists_locally: Whether it exists locally.
+
+        Returns:
+            Metadata dictionary.
+        """
+        return {
+            "name": mod_replacement.name,
+            "authors": mod_replacement.author,
+            "packageid": mod_replacement.packageid,
+            "publishedfileid": mod_replacement.pfid,
+            "supportedversions": mod_replacement.supportedversions,
+            "internal_time_touched": None,
+            "external_time_updated": None,
+            "data_source": mod_replacement.source,
+            "path": None,
+            "type": "Replacement",
+            "installed_status": (
+                self.tr("Installed") if exists_locally else self.tr("Not Installed")
+            ),
+        }
+
+    def _build_replacement_metadata(
+        self, mod_replacement: ReplacementInfo, exists_locally: bool, uuid: str | None
+    ) -> dict[str, Any]:
+        """
+        Build metadata dictionary for replacement mod.
+
+        Args:
+            mod_replacement: Replacement mod info.
+            exists_locally: Whether it exists locally.
+            uuid: UUID if exists locally.
+
+        Returns:
+            Metadata dictionary.
+        """
+        fake_metadata = self._create_base_replacement_metadata(
+            mod_replacement, exists_locally
+        )
+        local_metadata = self._get_local_metadata_for_replacement(uuid)
+        return self._merge_local_and_external_metadata(fake_metadata, local_metadata)
+
+    def _filter_and_group_mods(self) -> dict[str, list[ModGroupItem]]:
+        """
+        Filter mods that have alternatives and group them by package ID.
+
+        Returns:
+            Dictionary grouping mods by package ID.
+        """
+        # Pre-filter alternatives and compute groups
+        alternatives = self._filter_alternatives()
+        groups = self._group_mods_by_package_id(alternatives)
+        return groups
+
+    def _add_groups_to_table(self, groups: dict[str, list[ModGroupItem]]) -> None:
+        """
+        Add all groups to the table.
+
+        Args:
+            groups: Dictionary of groups by package ID.
+        """
+        for group_counter, package_id, originals, current_row in self._process_groups(
+            groups
+        ):
+            self._add_group_to_table(group_counter, package_id, originals, current_row)
+
+    def _process_groups(
+        self, groups: dict[str, list[ModGroupItem]]
+    ) -> Generator[tuple[int, str, list[ModGroupItem], int], None, None]:
+        """
+        Process and yield each group to the table.
+
+        Args:
+            groups: Dictionary of groups by package ID.
+        """
+        current_row = 0
+        group_counter = 1
+        for package_id, originals in groups.items():
+            yield group_counter, package_id, originals, current_row
+            current_row += 1 + len(originals) + 1  # header + originals + replacement
             group_counter += 1
+
+    def _filter_alternatives(self) -> dict[str, Any]:
+        """
+        Filter mods that have alternatives.
+
+        Returns:
+            Dictionary of mods with their alternatives.
+        """
+        try:
+            metadata_manager = MetadataManager.instance()
+            alternatives: dict[str, Any] = {}
+            for mod in self.mod_metadata:
+                alt = metadata_manager.has_alternative_mod(mod)
+                if alt is not None:
+                    alternatives[mod] = alt
+            return alternatives
+        except Exception as e:
+            logger.error(f"Error filtering alternatives: {e}")
+            return {}
+
+    def _group_mods_by_package_id(
+        self, alternatives: dict[str, Any]
+    ) -> dict[str, list[ModGroupItem]]:
+        """
+        Group mods by their replacement's package ID.
+
+        Args:
+            alternatives: Dictionary of mods with alternatives.
+
+        Returns:
+            Dictionary grouping mods by replacement's package ID.
+        """
+        groups = defaultdict(list)
+        for mod, mod_orignal in self.mod_metadata.items():
+            mod_replacement = alternatives.get(mod)
+            if mod_replacement is None or mod_orignal is None:
+                continue
+            package_id: str = mod_replacement.packageid
+            groups[package_id].append(ModGroupItem(mod, mod_orignal, mod_replacement))
+        return groups
+
+    def _add_group_to_table(
+        self,
+        group_counter: int,
+        package_id: str,
+        originals: list[ModGroupItem],
+        current_row: int,
+    ) -> None:
+        """
+        Add a complete group (header, originals, replacement) to the table.
+
+        Args:
+            group_counter: The group number.
+            package_id: The package ID for the group.
+            originals: List of original mods in the group.
+            current_row: The starting row index.
+        """
+        # Add group header row
+        self._add_group_header(group_counter, current_row)
+
+        # Add all original mods in this group
+        self._add_original_mods(originals, package_id, current_row + 1)
+
+        # Add the replacement mod for this group
+        self._add_replacement_mod(
+            originals[0].replacement, package_id, current_row + 1 + len(originals)
+        )
 
     def _add_group_header(self, group_number: int, current_row: int) -> None:
         """
@@ -328,26 +536,114 @@ class UseThisInsteadPanel(BaseModsPanel):
             group_number: The number of the group.
             current_row: The current row index.
         """
-        header_item = QStandardItem("")
-        header_item.setData(None, Qt.ItemDataRole.UserRole)
-        group_name_item = QStandardItem(f"Group {group_number}")
-        self.editor_model.appendRow(
-            [
-                header_item,
-                group_name_item,
-                QStandardItem(""),
-                QStandardItem(""),
-                QStandardItem(""),
-                QStandardItem(""),
-                QStandardItem(""),
-                QStandardItem(""),
-                QStandardItem(""),
-                QStandardItem(""),
-            ]
+        self._add_group_header_row(self.tr("Group {0}").format(group_number))
+
+    def _add_mod_to_group(
+        self,
+        mod_item: ModGroupItem,
+        package_id: str,
+        current_row: int,
+        is_original: bool,
+    ) -> None:
+        """
+        Add a mod to a group in the table.
+
+        Args:
+            mod_item: The mod group item to add.
+            package_id: The package ID for the group.
+            current_row: The row index for adding the mod.
+            is_original: Whether this is an original mod or a replacement.
+        """
+        try:
+            # Use modified metadata for originals to include type
+            if is_original:
+                metadata = self._create_original_metadata(mod_item)
+            else:
+                metadata = mod_item.metadata
+
+            # Retrieve UUID for the mod from the directory mapper
+            path = metadata.get("path")
+            uuid = (
+                self.metadata_manager.mod_metadata_dir_mapper.get(path)
+                if isinstance(path, str)
+                else None
+            )
+
+            # Create ModInfo from metadata
+            mod_info = self._extract_mod_info_from_metadata(uuid, metadata)
+
+            mod_info.name = mod_info.name
+
+            # Use base class method to add the mod row
+            self._add_mod_row(mod_info)
+            if is_original:
+                self._original_rows.add(current_row)
+        except Exception as e:
+            logger.error(f"Error accessing metadata for mod in group {package_id}: {e}")
+
+    def _check_and_get_replacement_local_metadata(
+        self, pfid: str
+    ) -> tuple[bool, str | None, dict[str, Any] | None]:
+        """
+        Check if replacement mod exists locally by published file ID and retrieve local metadata.
+
+        Args:
+            pfid: Published file ID for replacement mod.
+
+        Returns:
+            tuple:
+                - exists_locally (bool): True if exists locally.
+                - uuid (str | None): UUID if exists locally.
+                - local_metadata (dict | None): Local metadata dict or None.
+        """
+        exists_locally = False
+        uuid = None
+        local_metadata = None
+        try:
+            exists_locally = any(
+                mod.get("publishedfileid") == pfid
+                for mod in self.metadata_manager.internal_local_metadata.values()
+            )
+            if exists_locally:
+                for (
+                    mod_uuid,
+                    mod_metadata,
+                ) in self.metadata_manager.internal_local_metadata.items():
+                    if mod_metadata.get("publishedfileid") == pfid:
+                        uuid = mod_uuid
+                        local_metadata = mod_metadata
+                        break
+        except Exception as e:
+            logger.error(
+                f"Error checking local replacement metadata for pfid {pfid}: {e}"
+            )
+        return exists_locally, uuid, local_metadata
+
+    def _create_replacement_mod_info(self, mod_replacement: Any) -> "ModInfo":
+        """
+        Create ModInfo for a replacement mod.
+
+        Args:
+            mod_replacement: The replacement mod information.
+
+        Returns:
+            ModInfo object for the replacement mod.
+        """
+        exists_locally, uuid, local_metadata = (
+            self._check_and_get_replacement_local_metadata(mod_replacement.pfid)
         )
 
+        if exists_locally and uuid and local_metadata is not None:
+            local_metadata_copy = dict(local_metadata)
+            local_metadata_copy["type"] = "Replacement"
+            local_metadata_copy["installed_status"] = self.tr("Installed")
+            return ModInfo.from_metadata(uuid, local_metadata_copy)
+        else:
+            metadata = self._create_base_replacement_metadata(mod_replacement, False)
+            return ModInfo.from_metadata(None, metadata)
+
     def _add_original_mods(
-        self, originals: List[ModGroupItem], package_id: str, current_row: int
+        self, originals: list[ModGroupItem], package_id: str, current_row: int
     ) -> None:
         """
         Add original mods to the table.
@@ -358,214 +654,27 @@ class UseThisInsteadPanel(BaseModsPanel):
             current_row: The starting row index for adding mods.
         """
         for i, original in enumerate(originals):
-            mod = original.mod_id
-            mv = original.metadata
-            name = self._get_string_from_metadata(mv, "name", mod)
-            authors = self._get_string_from_metadata(mv, "authors", mod)
-
-            # Retrieve UUID for the mod from the directory mapper
-            path = mv.get("path")
-            uuid = (
-                self.mm.mod_metadata_dir_mapper.get(path)
-                if isinstance(path, str)
-                else None
+            self._add_mod_to_group(
+                original, package_id, current_row + i, is_original=True
             )
 
-            # Create table items for each column
-            name_item = QStandardItem(f"[Original] {name}")
-            name_item.setData(uuid, Qt.ItemDataRole.UserRole)
-
-            author_item = QStandardItem(authors)
-            packageid_item = QStandardItem(package_id)
-            pfid_item = QStandardItem(mv["publishedfileid"])
-
-            supported_versions = self._parse_supported_versions(
-                mv.get("supportedversions")
-            )
-            supported_versions_item = QStandardItem(supported_versions)
-
-            workshop_item = QStandardItem("")
-            source_item = QStandardItem("SteamCMD" if mv.get("steamcmd") else "Steam")
-
-            touched_text, _ = format_time_display(mv.get("internal_time_touched"))
-            downloaded_item = QStandardItem(touched_text)
-            path_item = QStandardItem(mv.get("path", ""))
-
-            # Add the row to the table
-            items = [
-                name_item,
-                author_item,
-                packageid_item,
-                pfid_item,
-                supported_versions_item,
-                source_item,
-                downloaded_item,
-                path_item,
-                workshop_item,
-            ]
-            self._add_row(items)
-            self._original_rows.append(current_row + i)
-
-            # Add workshop button to the last column
-            workshop_button = self._create_workshop_button(
-                f"https://steamcommunity.com/sharedfiles/filedetails/?id={mv['publishedfileid']}",
-                "originalWorkshopButton",
-            )
-            self.editor_table_view.setIndexWidget(
-                workshop_item.index(), workshop_button
-            )
-
-    def _add_replacement_mod(self, mr: Any, package_id: str, current_row: int) -> None:
+    def _add_replacement_mod(
+        self, mod_replacement: Any, package_id: str, current_row: int
+    ) -> None:
         """
         Add a replacement mod to the table.
 
         Args:
-            mr: The replacement mod information.
+            mod_replacement: The replacement mod information.
             package_id: The package ID for the group.
             current_row: The row index for adding the mod.
         """
-        # Check if the replacement mod already exists locally by comparing published file IDs
-        exists_locally = any(
-            mod.get("publishedfileid") == mr.pfid
-            for mod in self.mm.internal_local_metadata.values()
-        )
-        status_indicator = " [Installed]" if exists_locally else ""
+        # Create ModInfo for the replacement mod using consolidated check method
+        mod_info = self._create_replacement_mod_info(mod_replacement)
 
-        # Retrieve UUID for the replacement mod if it exists locally
-        uuid = None
-        if exists_locally:
-            for mod_uuid, mod_metadata in self.mm.internal_local_metadata.items():
-                if mod_metadata.get("publishedfileid") == mr.pfid:
-                    uuid = mod_uuid
-                    break
-
-        # Create table items for each column
-        name_item = QStandardItem(f"[Replacement]{status_indicator} {mr.name}")
-        name_item.setData(uuid, Qt.ItemDataRole.UserRole)
-
-        author_item = QStandardItem(mr.author)
-        packageid_item = QStandardItem(mr.packageid)
-        pfid_item = QStandardItem(mr.pfid)
-
-        # Parse supported versions into a string
-        supported_versions = (
-            mr.supportedversions
-            if isinstance(mr.supportedversions, str)
-            else ", ".join(mr.supportedversions.keys())
-            if isinstance(mr.supportedversions, dict) and mr.supportedversions
-            else ""
-        )
-        supported_versions_item = QStandardItem(supported_versions)
-
-        workshop_item = QStandardItem("")
-
-        # Populate source, downloaded, and path columns if the replacement is installed locally
-        if exists_locally and uuid:
-            local_metadata = self.mm.internal_local_metadata[uuid]
-            source_item = QStandardItem(
-                "SteamCMD" if local_metadata.get("steamcmd") else "Steam"
-            )
-            touched_text, _ = format_time_display(
-                local_metadata.get("internal_time_touched")
-            )
-            downloaded_item = QStandardItem(touched_text)
-            path_item = QStandardItem(local_metadata.get("path", ""))
-        else:
-            source_item = QStandardItem("")
-            downloaded_item = QStandardItem("")
-            path_item = QStandardItem("")
-
-        # Add the row to the table
-        items = [
-            name_item,
-            author_item,
-            packageid_item,
-            pfid_item,
-            supported_versions_item,
-            source_item,
-            downloaded_item,
-            path_item,
-            workshop_item,
-        ]
-        self._add_row(items)
-        self._replacement_rows.append(current_row)
-
-        # Add workshop button to the last column
-        workshop_button = self._create_workshop_button(
-            f"https://steamcommunity.com/sharedfiles/filedetails/?id={mr.pfid}",
-            "replacementWorkshopButton",
-        )
-        self.editor_table_view.setIndexWidget(workshop_item.index(), workshop_button)
-
-    def _create_workshop_button(self, url: str, object_name: str) -> QPushButton:
-        """
-        Create a button to open a Steam Workshop page.
-
-        Args:
-            url: The URL to open.
-            object_name: Object name for the button.
-
-        Returns:
-            Configured QPushButton.
-        """
-        button = QPushButton()
-        button.setObjectName(object_name)
-        button.setText(self.tr("Open Workshop Page"))
-        button.clicked.connect(partial(platform_specific_open, url))
-        return button
-
-    def _get_string_from_metadata(
-        self, metadata: Dict[str, Any], key: str, mod: str
-    ) -> str:
-        """
-        Extract a string value from metadata, handling different types.
-
-        Args:
-            metadata: Metadata dictionary.
-            key: Key to extract.
-            mod: Mod identifier for error logging.
-
-        Returns:
-            String representation of the value.
-        """
-        value = metadata.get(key)
-        if value is None:
-            logger.error(f"Missing '{key}' key in metadata for mod: {mod}")
-            return f"Unknown {key.capitalize()}"
-        if isinstance(value, str):
-            return value
-        if isinstance(value, list):
-            return ", ".join(str(v) for v in value)
-        return str(value)
-
-    def _parse_supported_versions(self, supported_versions: Any) -> str:
-        """
-        Parse supported versions from metadata into a string.
-
-        Args:
-            supported_versions: The supported versions data from metadata.
-
-        Returns:
-            A string representation of supported versions.
-        """
-        if supported_versions is None:
-            return ""
-        if isinstance(supported_versions, dict) and "li" in supported_versions:
-            return ", ".join(supported_versions["li"])
-        return ""
-
-    def _get_selected_mod_metadata(self) -> List[ModMetadata]:
-        """
-        Get metadata for selected mods in the table based on checkbox states.
-        """
-        selected_mods = []
-        for row in range(self.editor_model.rowCount()):
-            if self._row_is_checked(row):
-                uuid = self.editor_model.item(row, 1).data(Qt.ItemDataRole.UserRole)
-                if uuid and uuid in self.mm.internal_local_metadata:
-                    selected_mods.append(self.mm.internal_local_metadata[uuid])
-
-        return selected_mods
+        # Add the row to the table using base class method
+        self._add_mod_row(mod_info)
+        self._replacement_rows.add(current_row)
 
     def _clear_all_checkboxes(self) -> None:
         """Clear all checkboxes in the table."""
@@ -576,65 +685,53 @@ class UseThisInsteadPanel(BaseModsPanel):
             if isinstance(widget, QCheckBox):
                 widget.setChecked(False)
 
-    def _select_all_originals(self) -> None:
-        """Select all original mods in the table."""
-        # Clear all checkboxes first
-        self._clear_all_checkboxes()
-        # Then select all originals
-        for row in self._original_rows:
+    def _select_rows_by_indices(self, row_indices: set[int]) -> None:
+        """
+        Select rows by their indices using set operations for bulk selections.
+
+        Args:
+            row_indices: Set of row indices to select.
+        """
+        for row in range(self.editor_model.rowCount()):
             checkbox = self.editor_table_view.indexWidget(
                 self.editor_model.item(row, 0).index()
             )
             if isinstance(checkbox, QCheckBox):
-                checkbox.setChecked(True)
+                checkbox.setChecked(row in row_indices)
+
+    def _select_all_originals(self) -> None:
+        """Select all original mods in the table."""
+        self._select_rows_by_indices(self._original_rows)
 
     def _select_all_replacements(self) -> None:
         """Select all replacement mods in the table."""
-        # Clear all checkboxes first
-        self._clear_all_checkboxes()
-        # Then select all replacements
-        for row in self._replacement_rows:
-            widget = self.editor_table_view.indexWidget(
-                self.editor_model.item(row, 0).index()
-            )
-            if isinstance(widget, QCheckBox):
-                widget.setChecked(True)
+        self._select_rows_by_indices(self._replacement_rows)
 
-    def _steamcmd_for_all_replacements(self, pfid_column: int) -> None:
-        """Download all replacement mods with SteamCMD."""
-        self._select_all_replacements()
-        self._update_mods_from_table(pfid_column, "SteamCMD")
-
-    def _subscribe_all_replacements(self) -> None:
-        """Subscribe to all replacement mods."""
-        self._select_all_replacements()
-        self._update_mods_from_table(
-            4,  # COL_PUBLISHED_FILE_ID
-            "Steam",
-            completed=lambda self: self._on_mod_action_completed(
-                "subscribe", self._get_selected_count()
-            ),
-        )
-
-    def _unsubscribe_all_originals(self) -> None:
-        """Unsubscribe from all original mods."""
-        self._select_all_originals()
-        self._update_mods_from_table(
-            4,  # COL_PUBLISHED_FILE_ID
-            "Steam",
-            "unsubscribe",
-            completed=lambda self: self._on_mod_action_completed(
-                "unsubscribe", self._get_selected_count()
-            ),
-        )
-
-    def _refresh_use_this_instead_panel(self) -> None:
+    def _add_mod_row(
+        self,
+        mod_info: "ModInfo",
+        additional_items: list[QStandardItem] | None = None,
+        default_checkbox_state: bool = False,
+    ) -> None:
         """
-        Refresh metadata cache and use this instead panel after deletion operations.
+        Override to set checkbox text based on mod type.
+
+        Args:
+            mod_info: ModInfo object containing mod data
+            additional_items: Optional additional QStandardItem objects for extra columns
+            default_checkbox_state: Default state for the checkbox
         """
-        logger.debug("Refreshing UseThisInsteadPanel after deletion")
-        # Refresh internal metadata to reflect deletions
-        self.mm = MetadataManager.instance()
-        self.mm.refresh_cache(is_initial=False)
-        # Repopulate the table with updated metadata
-        self._populate_from_metadata()
+        super()._add_mod_row(mod_info, additional_items, default_checkbox_state)
+
+        # Set checkbox text based on type
+        row = self.editor_model.rowCount() - 1  # Last added row
+        checkbox = self.editor_table_view.indexWidget(
+            self.editor_model.item(row, 0).index()
+        )
+        if isinstance(checkbox, QCheckBox):
+            if mod_info.type == "Original":
+                checkbox.setText(self.tr("Original"))
+            elif mod_info.type == "Replacement":
+                checkbox.setText(
+                    self.tr("Replacement [{0}]").format(mod_info.installed_status)
+                )

--- a/app/windows/workshop_mod_updater_panel.py
+++ b/app/windows/workshop_mod_updater_panel.py
@@ -1,38 +1,34 @@
 from functools import partial
+from typing import Any
 
 from loguru import logger
-from PySide6.QtGui import QStandardItem
-from PySide6.QtWidgets import (
-    QPushButton,
-)
 
-from app.utils.generic import format_time_display, platform_specific_open
 from app.utils.metadata import MetadataManager
-from app.windows.base_mods_panel import BaseModsPanel
+from app.utils.mod_info import ModInfo
+from app.utils.mod_utils import filter_eligible_mods_for_update
+from app.windows.base_mods_panel import (
+    BaseModsPanel,
+    ButtonConfig,
+    ButtonType,
+    ColumnIndex,
+)
 
 
 class WorkshopModUpdaterPanel(BaseModsPanel):
     """
-    A panel used to prompt a user to update eligible Workshop mods.
+    A panel for updating Workshop mods that have newer versions available.
 
-    This panel displays a table of Workshop mods that have updates available,
-    showing information like mod name, source, last local access time, and
-    last update time on the Workshop. Users can select mods to update individually
-    or update all at once. Each mod row includes a button to open the Workshop page.
-
-    Attributes:
-        mm (MetadataManager): Instance of MetadataManager for accessing mod metadata.
+    This panel displays mods that can be updated, showing current and available versions,
+    and provides options to update mods via SteamCMD or the Steam client. It helps users
+    keep their mods up-to-date with the latest versions from the Workshop.
     """
 
     def __init__(self) -> None:
         """
         Initialize the WorkshopModUpdaterPanel.
-
-        Sets up the panel with translated UI elements, buttons for updating mods,
-        and loads ACF data for timestamp handling.
         """
         logger.debug("Initializing WorkshopModUpdaterPanel")
-        self.mm = MetadataManager.instance()
+        self.metadata_manager = MetadataManager.instance()
 
         super().__init__(
             object_name="updateModsPanel",
@@ -41,129 +37,91 @@ class WorkshopModUpdaterPanel(BaseModsPanel):
             details_text=self.tr(
                 "\nThe following table displays Workshop mods available for update from Steam."
             ),
-            additional_columns=[
-                self.tr("Name"),
-                self.tr("PublishedFileID"),
-                self.tr("Mod Source"),
-                self.tr("Mod Downloaded"),
-                self.tr("Updated on Workshop"),
-                self.tr("Workshop Page"),
-            ],
+            additional_columns=self._get_standard_mod_columns(),
         )
 
-        # EDITOR WIDGETS
-        # Create buttons for updating mods
-        self.editor_update_mods_button = QPushButton(self.tr("Update Selected Mods"))
-        self.editor_update_mods_button.clicked.connect(
-            partial(self._update_mods_from_table, 2, 3)
+        button_configs = [
+            ButtonConfig(
+                button_type=ButtonType.CUSTOM,
+                text=self.tr("Update with SteamCMD"),
+                custom_callback=partial(
+                    self._update_mods_from_table,
+                    pfid_column=ColumnIndex.PUBLISHED_FILE_ID.value,
+                    mode="SteamCMD",
+                ),
+            ),
+        ]
+
+        steam_client_integration_enabled = self._get_steam_client_integration_enabled()
+        if steam_client_integration_enabled:
+            button_configs.append(
+                ButtonConfig(
+                    button_type=ButtonType.CUSTOM,
+                    text=self.tr("Update with Steam client"),
+                    custom_callback=partial(
+                        self._update_mods_from_table,
+                        pfid_column=ColumnIndex.PUBLISHED_FILE_ID.value,
+                        mode="Steam",
+                    ),
+                )
+            )
+        self._setup_buttons_from_config(button_configs)
+
+        # Populate the table with mods that have updates available
+        self._populate_from_metadata()
+
+        # Configure table settings
+        self._setup_table_configuration(sorting_enabled=True)
+
+        # TODO: let user configure window launch state and size from settings controller
+        self.showNormal()
+
+    def _filter_eligible_mods(self) -> list[dict[str, Any]]:
+        """
+        Filter mods that are eligible for update.
+
+        Returns:
+            List of metadata dictionaries for mods eligible for update.
+        """
+        return filter_eligible_mods_for_update(
+            self.metadata_manager.internal_local_metadata
         )
-        self.editor_update_all_button = QPushButton(self.tr("Update All Mods"))
-        self.editor_update_all_button.clicked.connect(partial(self._update_all_mods))
-
-        # Add buttons to the main actions layout
-        self.editor_main_actions_layout.addWidget(self.editor_update_mods_button)
-        self.editor_main_actions_layout.addWidget(self.editor_update_all_button)
-
-    def _update_all_mods(self) -> None:
-        """
-        Update all mods in the table.
-
-        Selects all checkboxes and triggers the update process for all mods.
-        """
-        self._set_all_checkbox_rows(True)
-        self._update_mods_from_table(2, 3)
 
     def _populate_from_metadata(self) -> None:
         """
         Populate the table with mods that have available updates.
-
-        Iterates through internal local metadata to find mods with updates available.
-        For each eligible mod, creates table rows with mod information, timestamps,
-        and workshop page buttons.
         """
-        logger.debug("Starting to populate table with mods that have updates available")
-        start_time = __import__("time").time()
-
-        # Pre-filter eligible metadata to improve performance
-        eligible_metadata = [
-            metadata
-            for metadata in self.mm.internal_local_metadata.values()
-            if (
-                (metadata.get("steamcmd") or metadata.get("data_source") == "workshop")
-                and metadata.get("internal_time_touched")
-                and metadata.get("external_time_updated")
-                and metadata["external_time_updated"]
-                > metadata["internal_time_touched"]
-            )
-        ]
-
-        logger.debug(f"Found {len(eligible_metadata)} eligible mods for update")
-
-        # Check our metadata for available updates, append row if found by data source
-        for metadata in eligible_metadata:
-            # Retrieve values from metadata
-            name = metadata.get("name")
-            publishedfileid = metadata.get("publishedfileid")
-            mod_source = "SteamCMD" if metadata.get("steamcmd") else "Steam"
-
-            # Use new format_time_display function
-            touched_text, internal_time_touched = format_time_display(
-                metadata.get("internal_time_touched")
-            )
-            updated_text, external_time_updated = format_time_display(
-                metadata.get("external_time_updated")
+        try:
+            logger.debug(
+                "Starting to populate table with mods that have updates available"
             )
 
-            # Create table items
-            name_item = QStandardItem(name)
-            name_item.setToolTip(name)
-            pfid_item = QStandardItem(publishedfileid)
-            source_item = QStandardItem(mod_source)
-            touched_item = QStandardItem(touched_text)
-            touched_item.setData(internal_time_touched)
-            updated_item = QStandardItem(updated_text)
-            updated_item.setData(external_time_updated)
+            # Clear existing table data before populating since it shows duplicate rows if not cleared
+            self._clear_table_model()
 
-            # Create workshop button item and button
-            workshop_btn_item = QStandardItem(publishedfileid)
-            workshop_btn = self._create_workshop_button(
-                f"https://steamcommunity.com/sharedfiles/filedetails/?id={publishedfileid}",
-                "workshopButton",
-            )
+            eligible_metadata = self._filter_eligible_mods()
+            logger.debug(f"Found {len(eligible_metadata)} eligible mods for update")
 
-            # Prepare items list for row addition
-            items = [
-                name_item,
-                pfid_item,
-                source_item,
-                touched_item,
-                updated_item,
-                workshop_btn_item,
-            ]
-            # Add row to table
-            self._add_row(items)
+            for metadata in eligible_metadata:
+                self._add_update_mod_row(metadata)
+        except Exception as e:
+            logger.error(f"Error populating table from metadata: {e}")
 
-            # Set the workshop button as the widget for the last column
-            self.editor_table_view.setIndexWidget(
-                workshop_btn_item.index(), workshop_btn
-            )
-
-        end_time = __import__("time").time()
-        logger.debug(f"Populated table in {end_time - start_time:.2f} seconds")
-
-    def _create_workshop_button(self, url: str, object_name: str) -> QPushButton:
+    def _add_update_mod_row(self, metadata: dict[str, Any]) -> None:
         """
-        Create a QPushButton that opens a Steam Workshop page.
+        Add a mod row to the table.
 
         Args:
-            url (str): The URL of the Steam Workshop page to open.
-            object_name (str): The object name for the button (for styling).
-
-        Returns:
-            QPushButton: The configured button that opens the workshop page when clicked.
+            metadata: Metadata dictionary for the mod.
         """
-        button = QPushButton()
-        button.setObjectName(object_name)
-        button.setText(self.tr("Open Workshop Page"))
-        button.clicked.connect(partial(platform_specific_open, url))
-        return button
+        # Get UUID for the mod
+        uuid = None
+        path = metadata.get("path")
+        if isinstance(path, str):
+            uuid = self.metadata_manager.mod_metadata_dir_mapper.get(path)
+
+        # Create ModInfo from metadata
+        mod_info = ModInfo.from_metadata(uuid, metadata)
+
+        # Use the base class method to add the mod row
+        self._add_mod_row(mod_info)


### PR DESCRIPTION
- Adds a ModInfo dataclass for consistent mod metadata handling.
- Adds a button_factory utility for standardized button creation across mod panels.
- Refactors base_mods_panel.py to use dataclasses for UI/layout grouping, enums for columns and button types, and centralizes button creation logic.
- Moved filter_eligible_mods_for_update from WorkshopModUpdaterPanel to mod utils for improved mod update filtering and metadata handling.
- Extends metadata.py's ModReplacement to include a source field.
- Refactored various mod/window panels for consistent button usage and enhanced functionality (DuplicateModsPanel, WorkshopModUpdaterPanel, MissingModsPrompt, UseThisInsteadPanel) 