### PR TITLE
Disable immediate UI refresh after mod action

### DIFF
--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -2253,7 +2253,12 @@ class MainContent(QObject):
             ),
         )
         # Do a full refresh of metadata and UI
-        self._do_refresh()
+        # self._do_refresh()
+        # TODO  check if this is necessary
+        """       
+        Disabled refresh since steam downloads are not instant and in the background in its own time
+        Refreshing metadata and UI here could tag mods as invalid or cause crashes due to key errors etc
+        """
 
         # GIT MOD ACTIONS
 


### PR DESCRIPTION
- Commented out the call to _do_refresh() after mod actions to prevent potential issues caused by Steam downloads not being instant.
- This avoids tagging mods as invalid or causing crashes due to key errors when metadata is refreshed prematurely.