### PR TITLE
Set default formatter for XML files in VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -103,5 +103,8 @@
   "editor.defaultFormatter": "charliermarsh.ruff",
   "[yaml]": {
     "editor.defaultFormatter": "redhat.vscode-yaml"
+  },
+  "[xml]": {
+    "editor.defaultFormatter": "redhat.vscode-xml"
   }
 }


### PR DESCRIPTION
Configured VSCode to use the 'redhat.vscode-xml' extension as the default formatter for XML files by updating settings.json.