### PR TITLE
Add default formatter for GitHub Actions workflow files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -106,5 +106,8 @@
   },
   "[xml]": {
     "editor.defaultFormatter": "redhat.vscode-xml"
+  },
+  "[github-actions-workflow]": {
+    "editor.defaultFormatter": "redhat.vscode-yaml"
   }
 }


### PR DESCRIPTION
Configure VSCode to use redhat.vscode-yaml as the default formatter for GitHub Actions workflow files in .vscode/settings.json.