### PR TITLE
Update README.md Releases link

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,7 @@ If you have an issue, make sure you **checked the [wiki][Wiki]** for a solution.
 
 [![Join us on Discord](https://github-production-user-asset-6210df.s3.amazonaws.com/2766946/248529301-486f4f8c-fed5-4fe1-832f-6461b7ce3a55.png)][Discord]
 
-
 [Wiki]: https://rimsort.github.io/RimSort/
-[Repo]: https://github.com/RimSort/RimSort
 [Issues]: https://github.com/RimSort/RimSort/issues
-[Releases]: https://github.com/oceancabbage/RimSort/releases
+[Releases]: https://github.com/RimSort/RimSort/releases
 [Discord]: https://discord.gg/aV7g69JmR2


### PR DESCRIPTION
Correct the Releases link from the old oceancabbage repository to the current RimSort repository.