### PR TITLE
Enable Ruff format fixes in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -58,6 +58,7 @@ jobs:
             /github/workflow/.venv/lib/python3.12/site-packages"
           VALIDATE_PYTHON_MYPY: true
           VALIDATE_PYTHON_RUFF: true
+          VALIDATE_PYTHON_RUFF_FORMAT: true
           VALIDATE_GITHUB_ACTIONS: true
           VALIDATE_GITLEAKS: true
           VALIDATE_JSON: true


### PR DESCRIPTION
- Add VALIDATE_PYTHON_RUFF_FORMAT: true to enable FIX_PYTHON_RUFF_FORMAT.
- Add FIX_PYTHON_RUFF_FORMAT: true to allow automatic formatting fixes during linting.