### PR TITLE
Refactor Use This Instead to use JSON/GZ instead of XML/Folders

### DIFF
--- a/app/controllers/main_window_controller.py
+++ b/app/controllers/main_window_controller.py
@@ -61,9 +61,6 @@ class MainWindowController(QObject):
         )  # Save btn animation
         EventBus().refresh_started.connect(self.on_refresh_started)
         EventBus().refresh_finished.connect(self.on_refresh_finished)
-        EventBus().reset_use_this_instead_cache.connect(
-            self.on_reset_use_this_instead_cache
-        )
 
     def _parse_workshop_id(self, url: str) -> str | None:
         """Extract a Steam Workshop ID from a dependency URL."""
@@ -416,10 +413,3 @@ class MainWindowController(QObject):
     def set_buttons_enabled(self, enabled: bool) -> None:
         for btn in self.buttons:
             btn.setEnabled(enabled)
-
-    @Slot()
-    def on_reset_use_this_instead_cache(self) -> None:
-        logger.warning(
-            'Resetting "Use This Instead" cache - performance may be impacted until xml is re-cached'
-        )
-        MetadataManager.instance().has_alternative_mod.cache_clear()

--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -653,7 +653,6 @@ class SettingsController(QObject):
         self.settings_dialog.no_version_warning_db_github_url.setCursorPosition(0)
 
         if self.settings.external_use_this_instead_metadata_source == "None":
-            EventBus().reset_use_this_instead_cache.emit()
             self.settings_dialog.use_this_instead_db_none_radio.setChecked(True)
             self.settings_dialog.use_this_instead_db_github_url.setEnabled(False)
             self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(
@@ -667,7 +666,6 @@ class SettingsController(QObject):
             self.settings.external_use_this_instead_metadata_source
             == "Configured git repository"
         ):
-            EventBus().reset_use_this_instead_cache.emit()
             self.settings_dialog.use_this_instead_db_github_radio.setChecked(True)
             self.settings_dialog.use_this_instead_db_github_url.setEnabled(True)
             self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(
@@ -681,7 +679,6 @@ class SettingsController(QObject):
             self.settings.external_use_this_instead_metadata_source
             == "Configured file path"
         ):
-            EventBus().reset_use_this_instead_cache.emit()
             self.settings_dialog.use_this_instead_db_local_file_radio.setChecked(True)
             self.settings_dialog.use_this_instead_db_github_url.setEnabled(False)
             self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(
@@ -692,7 +689,7 @@ class SettingsController(QObject):
                 True
             )
         self.settings_dialog.use_this_instead_db_local_file.setText(
-            self.settings.external_use_this_instead_folder_path
+            self.settings.external_use_this_instead_file_path
         )
         self.settings_dialog.use_this_instead_db_local_file.setCursorPosition(0)
         self.settings_dialog.use_this_instead_db_github_url.setText(
@@ -1046,7 +1043,7 @@ class SettingsController(QObject):
             self.settings.external_use_this_instead_metadata_source = (
                 "Configured git repository"
             )
-        self.settings.external_use_this_instead_folder_path = (
+        self.settings.external_use_this_instead_file_path = (
             self.settings_dialog.use_this_instead_db_local_file.text()
         )
         self.settings.external_use_this_instead_repo_path = (
@@ -1361,6 +1358,8 @@ class SettingsController(QObject):
             self.settings.enable_themes,
             self.settings.theme_name,
         )
+        # Do a full refresh after updating the settings
+        EventBus().do_refresh_mods_lists.emit()
 
     @Slot()
     def _on_game_location_text_changed(self) -> None:
@@ -1965,12 +1964,13 @@ class SettingsController(QObject):
     @Slot()
     def _on_use_this_instead_db_local_file_choose_button_clicked(self) -> None:
         """
-        Open a file dialog to select the "Use This Instead" folder and handle the result.
+        Open a file dialog to select the "Use This Instead" replacements file and handle the result.
         """
         use_this_instead_db_location = show_dialogue_file(
-            mode="open_dir",
-            caption='Select "Use This Instead" Folder',
+            mode="open",
+            caption='Select "Use This Instead" Replacements File',
             _dir=str(self._last_file_dialog_path),
+            _filter="JSON Files (*.json *.json.gz)",
         )
         if not use_this_instead_db_location:
             return

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -73,8 +73,8 @@ class Settings(QObject):
         )
 
         self.external_use_this_instead_metadata_source: str = "None"
-        self.external_use_this_instead_folder_path: str = str(
-            AppInfo().app_storage_folder / "UseThisInstead" / "Replacements"
+        self.external_use_this_instead_file_path: str = str(
+            AppInfo().app_storage_folder / "UseThisInstead" / "replacements.json.gz"
         )
         self.external_use_this_instead_repo_path: str = (
             "https://github.com/emipa606/UseThisInstead"

--- a/app/utils/event_bus.py
+++ b/app/utils/event_bus.py
@@ -119,7 +119,6 @@ class EventBus(QObject):
     filters_changed_in_active_modlist = Signal()
     filters_changed_in_inactive_modlist = Signal()
     use_this_instead_clicked = Signal()
-    reset_use_this_instead_cache = Signal()
 
     # Help Menu bar signals
     do_check_for_application_update = Signal()

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -3170,13 +3170,22 @@ class MainContent(QObject):
         """
         When clicked, opens the Use This Instead panel.
         """
+        if (
+            self.settings_controller.settings.external_use_this_instead_metadata_source
+            == "None"
+        ):
+            dialogue.show_warning(
+                title=self.tr("Use This Instead"),
+                text=self.tr(
+                    'Please configure "Use This Instead" database in settings.'
+                ),
+            )
+            return
+
         self.use_this_instead_dialog = UseThisInsteadPanel(
             mod_metadata=self.metadata_manager.internal_local_metadata
         )
-        self.use_this_instead_dialog._populate_from_metadata()
-        if self.use_this_instead_dialog.editor_model.rowCount() > 0:
-            self.use_this_instead_dialog.show()
-        else:
+        if not self.use_this_instead_dialog.show_if_has_alternatives():
             dialogue.show_information(
                 title=self.tr("Use This Instead"),
                 text=self.tr(

--- a/app/windows/use_this_instead_panel.py
+++ b/app/windows/use_this_instead_panel.py
@@ -138,13 +138,20 @@ class UseThisInsteadPanel(BaseModsPanel):
         self._original_rows: set[int] = set()
         self._replacement_rows: set[int] = set()
 
-        self._populate_from_metadata()
+    def show_if_has_alternatives(self) -> bool:
+        """
+        Populate the panel and show it if alternatives exist.
 
-        # Configure table settings
+        Returns:
+            True if alternatives were found and panel was shown, False otherwise.
+        """
+        self._populate_from_metadata()
         self._setup_table_configuration(sorting_enabled=False)
 
-        # TODO: let user configure window launch state and size from settings controller
-        self.showNormal()
+        if self.editor_model.rowCount() > 0:
+            self.showNormal()
+            return True
+        return False
 
     def _on_mod_action_completed(self, action: str, count: int) -> None:
         """Handle successful mod action completion."""


### PR DESCRIPTION
- Changed external_use_this_instead_folder_path to external_use_this_instead_file_path in settings
- Updated MetadataManager to load JSON/GZ files instead of XML for replacements
- Removed reset_use_this_instead_cache signal and related cache clearing code
- Modified has_alternative_mod method to search JSON rules array instead of XML files
- Updated Use This Instead panel to check for configured database before opening
- Added full refresh after settings update to ensure changes take effect