### PR TITLE
Fix exit window cleanup order in RunnerPanel

### DIFF
--- a/app/windows/runner_panel.py
+++ b/app/windows/runner_panel.py
@@ -614,5 +614,5 @@ class RunnerPanel(QWidget):
 
     def exit_window(self) -> None:
         """Clean up resources when the process window is closed."""
-        self.close()
         EventBus().do_metadata_refresh_cache.emit()
+        self.close()


### PR DESCRIPTION
Ensure metadata refresh cache is emitted before closing the window to prevent potential issues.