### PR TITLE
Remove unused argument from refresh_cache call

### DIFF
--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -362,7 +362,7 @@ class MainContent(QObject):
 
     def do_metadata_refresh_cache(self) -> None:
         """Force Refresh metadata cache"""
-        self.metadata_manager.refresh_cache(is_initial=False)
+        self.metadata_manager.refresh_cache()
 
     def check_if_essential_paths_are_set(self, prompt: bool = True) -> bool:
         """


### PR DESCRIPTION
Updated the do_metadata_refresh_cache method to call refresh_cache without the is_initial argument, reflecting a change in the metadata_manager API.