### PR TITLE
Fix SystemInfo architecture detection on ARM64 (#1251)

### DIFF
--- a/app/utils/system_info.py
+++ b/app/utils/system_info.py
@@ -77,9 +77,12 @@ class SystemInfo:
                 f"Unsupported operating system detected: {platform.system()}."
             )
 
-        if platform.machine() in ["x86_64", "AMD64"]:
+        arch = platform.machine().lower()
+        if arch in ["x86_64", "amd64"]:
             self._architecture = SystemInfo.Architecture.X64
-        elif platform.machine() in ["arm64", "aarch64"]:
+        elif arch in ["x86", "i386", "i686"]:
+            self._architecture = SystemInfo.Architecture.X86
+        elif arch in ["arm64", "aarch64", "arm64e"]:
             self._architecture = SystemInfo.Architecture.ARM64
         else:
             raise UnsupportedArchitectureError(


### PR DESCRIPTION
RimSort already runs fine under Windows on ARM over the emulation layer; the only blocker was the architecture guard rejecting ARM64. Relaxing the check to recognize common ARM64 identifiers (and lowercase aliases), so Win on ARM devices can start the x64 app normally without affecting its behavior.