### PR TITLE
Update Nuitka build configuration to use app/ module

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,31 +45,31 @@ jobs:
             platform: "Darwin"
             arch: "i386"
             env:
-              BUILD_OUTPUT: "__main__.app"
+              BUILD_OUTPUT: "app.app"
               Executable: RimSort
           - os: macos-latest
             platform: "Darwin"
             arch: "arm"
             env:
-              BUILD_OUTPUT: "__main__.app"
+              BUILD_OUTPUT: "app.app"
               Executable: RimSort
           - os: ubuntu-22.04
             platform: "Ubuntu-22.04"
             arch: "x86_64"
             env:
-              BUILD_OUTPUT: "__main__.dist"
+              BUILD_OUTPUT: "app.dist"
               Executable: "RimSort"
           - os: ubuntu-24.04
             platform: "Ubuntu-24.04"
             arch: "x86_64"
             env:
-              BUILD_OUTPUT: "__main__.dist"
+              BUILD_OUTPUT: "app.dist"
               Executable: RimSort
           - os: windows-latest
             platform: "Windows"
             arch: "x86_64"
             env:
-              BUILD_OUTPUT: "__main__.dist"
+              BUILD_OUTPUT: "app.dist"
               Executable: RimSort.exe
     steps:
       - name: Check-out repository
@@ -151,7 +151,8 @@ jobs:
         uses: Nuitka/Nuitka-Action@main
         with:
           nuitka-version: main
-          script-name: app/__main__.py
+          script-name: app/
+          python-flag: -m
           mode: ${{ runner.os == 'macos' && 'app' || 'standalone' }}
           static-libpython: auto
           product-version: >-

--- a/distribute.py
+++ b/distribute.py
@@ -40,7 +40,8 @@ _NUITKA_CMD = [
     PY_CMD,
     "-m",
     "nuitka",
-    "app/__main__.py",
+    "app/",
+    "--python-flag=-m",
     f"--include-data-dir={glob.glob('.venv/**/qtwebengine_locales', recursive=True)[0]}=qtwebengine_locales",
 ]
 


### PR DESCRIPTION
- Modified .github/workflows/build.yml and distribute.py
- Changed the Nuitka script-name from 'app/__main__.py' to 'app/' with '--python-flag=-m'
- updated BUILD_OUTPUT values for macos from '__main__.app' to 'app.app'
- updated BUILD_OUTPUT values for linux and windows from  '__main__.dist' to 'app.dist' for consistency.