### PR TITLE
Add support for missing package ID detection and warning

### DIFF
--- a/app/utils/metadata.py
+++ b/app/utils/metadata.py
@@ -43,6 +43,8 @@ from app.views.dialogue import (
 )
 
 # Locally installed mod metadata
+# Default packageId for mods with missing or invalid packageId
+DEFAULT_MISSING_PACKAGEID = "missing.packageid"
 
 
 class ModReplacement:
@@ -1767,6 +1769,8 @@ class ModParser(QRunnable):
         data_malformed = None
         # Any pfid parsed will be stored here locally
         pfid = None
+        # Use module-level constant for default packageId
+        default_packageid = DEFAULT_MISSING_PACKAGEID
         # Define defaults for scenario
         scenario_rsc_found = False
         scenario_rsc_file = ""
@@ -1940,21 +1944,34 @@ class ModParser(QRunnable):
                         # ...check type of packageid, use first packageid parsed
                         if isinstance(mod_metadata["packageid"], list):
                             # Loop through the list and find str. If we find one, use it.
+                            found = False
                             for potential_packageid in mod_metadata["packageid"]:
                                 if potential_packageid and isinstance(
                                     potential_packageid, str
                                 ):
                                     mod_metadata["packageid"] = potential_packageid
+                                    found = True
                                     break
+                            # If no string found in list, set to error packageid
+                            if not found:
+                                mod_metadata["packageid"] = default_packageid
                         # Normalize package ID in metadata
                         if isinstance(mod_metadata["packageid"], str):
                             mod_metadata["packageid"] = mod_metadata[
                                 "packageid"
                             ].lower()
+                        elif isinstance(mod_metadata["packageid"], dict):
+                            # Handle dict packageid (from malformed XML), try to extract text
+                            if mod_metadata["packageid"].get("#text"):
+                                mod_metadata["packageid"] = mod_metadata["packageid"][
+                                    "#text"
+                                ].lower()
+                                if not mod_metadata["packageid"]:
+                                    mod_metadata["packageid"] = default_packageid
+                            else:
+                                mod_metadata["packageid"] = default_packageid
                         else:
-                            mod_metadata["packageid"] = (
-                                "packageid error in mod about.xml"
-                            )
+                            mod_metadata["packageid"] = default_packageid
                     else:  # ...otherwise, we don't have one from About.xml, and we can check Steam DB...
                         # ...this can be needed if a mod depends on a RW generated packageid via built-in hashing mechanism.
                         if (
@@ -1970,7 +1987,11 @@ class ModParser(QRunnable):
                                 ].lower()
                             )
                         else:
-                            mod_metadata.setdefault("packageid", "missing.packageid")
+                            # Ensure packageid is always set, default to missing.packageid
+                            mod_metadata.setdefault("packageid", default_packageid)
+                    # Log warning if packageid is missing
+                    if mod_metadata.get("packageid") == default_packageid:
+                        logger.warning(f"Invalid packageId in mod: {mod_data_path}")
                     # Track pfid if we parsed one earlier
                     if pfid:  # Make some assumptions if we have a pfid
                         mod_metadata["publishedfileid"] = pfid
@@ -2199,6 +2220,13 @@ class ModParser(QRunnable):
                 self.data_source, self.mod_directory, self.metadata_manager, self.uuid
             )
             packageid = mod_metadata[self.uuid].get("packageid")
+            # Ensure packageid is always a string, never a dict
+            if isinstance(packageid, dict):
+                packageid = packageid.get("#text", DEFAULT_MISSING_PACKAGEID)
+                mod_metadata[self.uuid]["packageid"] = packageid
+            elif not isinstance(packageid, str):
+                packageid = DEFAULT_MISSING_PACKAGEID
+                mod_metadata[self.uuid]["packageid"] = packageid
             self.metadata_manager.internal_local_metadata.update(mod_metadata)
             # Track packageid -> uuid relationships for future uses
             self.metadata_manager.packageid_to_uuids.setdefault(packageid, set()).add(

--- a/app/windows/missing_packageid_panel.py
+++ b/app/windows/missing_packageid_panel.py
@@ -1,0 +1,87 @@
+from loguru import logger
+
+from app.controllers.settings_controller import SettingsController
+from app.windows.base_mods_panel import BaseModsPanel
+
+
+class MissingPackageIdPanel(BaseModsPanel):
+    """
+    A panel used when mods with missing Package ID are detected.
+
+    This panel displays mods that lack a valid Package ID defined in their
+    About.xml file, showing detailed information for each mod. Users can
+    view mod details and access Steam Workshop links if available.
+
+    Attributes:
+        missing_packageid_mods (list[str]): List of UUIDs for mods with missing Package ID.
+        settings_controller (SettingsController): Controller for application settings.
+        metadata_manager: MetadataManager instance from base class for accessing mod data.
+    """
+
+    def __init__(
+        self,
+        missing_packageid_mods: list[str],
+        settings_controller: SettingsController,
+    ) -> None:
+        """
+        Initialize the MissingPackageIdPanel with mods data.
+
+        Args:
+            missing_packageid_mods: List of UUIDs for mods with missing Package ID.
+            settings_controller: Controller for managing application settings.
+        """
+        logger.debug("Initializing MissingPackageIdPanel")
+        self.missing_packageid_mods = missing_packageid_mods
+        self.settings_controller = settings_controller
+
+        super().__init__(
+            object_name="missingPackageIdPanel",
+            window_title=self.tr("RimSort - Mods with Missing Package ID"),
+            title_text=self.tr("Mods with Missing Package ID detected!"),
+            details_text=self.tr(
+                "The following mods do not have a valid Package ID defined in their About.xml file. "
+                "This may cause issues with mod dependencies and compatibility checking.\n\n"
+                "For Workshop mods, you can identify them by the Published File ID column. "
+                "Please contact the mod authors to add a Package ID to their About.xml file."
+            ),
+            additional_columns=self._get_standard_mod_columns(),
+        )
+
+        button_configs = self._get_base_button_configs()
+        self._extend_button_configs_with_steam_actions(button_configs)
+        self._setup_buttons_from_config(button_configs)
+
+        # Populate the table with missing packageid mod data
+        self._populate_from_metadata()
+
+        # Configure table settings
+        self._setup_table_configuration(sorting_enabled=False)
+
+        # TODO: let user configure window launch state and size from settings controller
+        self.showNormal()
+
+    def _populate_from_metadata(self) -> None:
+        """
+        Populate the table with missing packageid mod data.
+        Displays all mod metadata in the table, with Published File ID column
+        showing Workshop IDs for Workshop mods.
+        """
+        try:
+            # Convert list of UUIDs to the format expected by _populate_mods
+            mod_list = []
+            for uuid in self.missing_packageid_mods:
+                metadata = self.metadata_manager.internal_local_metadata.get(uuid)
+                if metadata:
+                    mod_list.append((uuid, metadata))
+                else:
+                    logger.warning(
+                        f"Metadata not found for UUID: {uuid} in missing packageid mods"
+                    )
+
+            # Use the refactored base class method to populate mods
+            if mod_list:
+                self._populate_mods(
+                    {"Mods with Missing Package ID": mod_list}, add_group_headers=True
+                )
+        except Exception as e:
+            logger.error(f"Error populating table from metadata: {e}")


### PR DESCRIPTION
Implement detection of mods with missing or invalid package IDs, add a new panel to display such mods, and update metadata parsing to handle various package ID formats.