### PR TITLE
Add auto-clear depot cache setting support to SteamCMD purge

### DIFF
--- a/app/utils/acf_utils.py
+++ b/app/utils/acf_utils.py
@@ -374,7 +374,9 @@ def _extract_manifest_ids_and_remove_pfid(
 
 
 def steamcmd_purge_mods(
-    metadata_manager: "MetadataManager", publishedfileids: set[str]
+    metadata_manager: "MetadataManager",
+    publishedfileids: set[str],
+    auto_clear_enabled: bool = True,
 ) -> None:
     """
     Remove mods from SteamCMD installation and clean up associated files.
@@ -393,9 +395,12 @@ def steamcmd_purge_mods(
                          configured. Must have steamcmd_wrapper with valid paths.
         publishedfileids: Set of published file IDs (PFIDs) as strings to remove
                          from SteamCMD. These correspond to workshop item IDs.
+        auto_clear_enabled: Whether to perform the purge operation. If False,
+                           returns early without making any changes. Defaults to True.
 
     Note:
         The operation is tolerant of missing files and parsing errors:
+        - If auto_clear_enabled is False, returns early without error
         - If ACF file is missing, returns early without error
         - If parsing fails, returns early without error
         - Individual manifest file deletions are logged but don't halt the operation
@@ -405,6 +410,11 @@ def steamcmd_purge_mods(
         >>> steamcmd_purge_mods(metadata_manager, {"123456789", "987654321"})
         # Removes the specified mods from SteamCMD ACF and deletes manifest files
     """
+    # Return early if auto-clear is not enabled
+    if not auto_clear_enabled:
+        logger.debug("SteamCMD auto-clear is disabled, skipping mod purge operation")
+        return
+
     # Load SteamCMD workshop ACF metadata file
     acf_path = metadata_manager.steamcmd_wrapper.steamcmd_appworkshop_acf_path
     acf_metadata = load_acf_from_path(acf_path)

--- a/app/views/deletion_menu.py
+++ b/app/views/deletion_menu.py
@@ -271,11 +271,14 @@ class ModDeletionMenu(QMenu):
 
     def _process_deletion_result(self, result: DeletionResult) -> None:
         """Process the results of a deletion operation."""
-        # Purge SteamCMD metadata for deleted mods
+        # Purge SteamCMD metadata for deleted mods (only if auto-clear depot cache is enabled)
         if result.steamcmd_purge_ids:
             steamcmd_purge_mods(
                 metadata_manager=self.metadata_manager,
                 publishedfileids=result.steamcmd_purge_ids,
+                auto_clear_enabled=self.settings_controller.settings.instances[
+                    self.settings_controller.settings.current_instance
+                ].steamcmd_auto_clear_depot_cache,
             )
 
         # Show success message

--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -1493,11 +1493,14 @@ class ModListWidget(QListWidget):
                             steamcmd_acf_pfid_purge = set(
                                 steamcmd_publishedfileid_to_redownload
                             )
-                        # Purge any deleted SteamCMD mods from acf metadata
+                        # Purge any deleted SteamCMD mods from acf metadata (only if auto-clear depot cache is enabled)
                         if steamcmd_acf_pfid_purge:
                             steamcmd_purge_mods(
                                 metadata_manager=self.metadata_manager,
                                 publishedfileids=steamcmd_acf_pfid_purge,
+                                auto_clear_enabled=self.settings_controller.settings.instances[
+                                    self.settings_controller.settings.current_instance
+                                ].steamcmd_auto_clear_depot_cache,
                             )
                         # Emit signal to steamcmd downloader to re-download
                         logger.debug(


### PR DESCRIPTION
Implement conditional SteamCMD depot cache clearing based on user settings.

- Modified steamcmd_purge_mods() to accept an auto_clear_enabled parameter
- Added early return when auto-clear is disabled to skip purge operations
- Updated deletion_menu.py and mods_panel.py to pass the setting value from current instance settings
- Ensures SteamCMD metadata purge only occurs when steamcmd_auto_clear_depot_cache is enabled