### PR TITLE
Implement instance folder override feature

### DIFF
--- a/app/models/instance.py
+++ b/app/models/instance.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import msgspec
 
 from app.utils.app_info import AppInfo
+from app.utils.constants import DEFAULT_INSTANCE_NAME, INSTANCE_FOLDER_NAME
 
 
 class Instance(msgspec.Struct):
@@ -13,7 +14,7 @@ class Instance(msgspec.Struct):
     Validation and signal emission handled by controllers and settings management.
     """
 
-    name: str = "Default"
+    name: str = DEFAULT_INSTANCE_NAME
     game_folder: str = ""
     config_folder: str = ""
     local_folder: str = ""
@@ -21,8 +22,13 @@ class Instance(msgspec.Struct):
     run_args: list[str] = msgspec.field(default_factory=list)
     steamcmd_auto_clear_depot_cache: bool = True
     steamcmd_install_path: str = str(
-        Path(AppInfo().app_storage_folder / "instances" / "Default")
+        Path(
+            AppInfo().app_storage_folder / INSTANCE_FOLDER_NAME / DEFAULT_INSTANCE_NAME
+        )
     )
     steamcmd_ignore: bool = False
     steam_client_integration: bool = False
+    instance_folder_override: str = (
+        ""  # Custom instance folder path, empty = use default
+    )
     initial_setup: bool = True

--- a/app/utils/constants.py
+++ b/app/utils/constants.py
@@ -1,6 +1,12 @@
 from enum import Enum
 from typing import Any
 
+# Instance constants
+DEFAULT_INSTANCE_NAME = "Default"
+INSTANCE_FOLDER_NAME = "instances"
+STEAMCMD_FOLDER_NAME = "steamcmd"
+STEAM_FOLDER_NAME = "steam"
+
 
 class SortMethod(str, Enum):
     ALPHABETICAL = "Alphabetical"

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -95,6 +95,7 @@ class SettingsDialog(QDialog):
         self._do_config_folder_location_area(tab_layout)
         self._do_steam_mods_folder_location_area(tab_layout)
         self._do_local_mods_folder_location_area(tab_layout)
+        self._do_instance_folder_location_area(tab_layout)
 
         # Set the tab order:
         # "Game location" → "Config location" → "Steam mods location" → "Local mods location"
@@ -276,6 +277,39 @@ class SettingsDialog(QDialog):
             GUIInfo().default_font_line_height * 2
         )
         group_layout.addWidget(self.local_mods_folder_location)
+
+    def _do_instance_folder_location_area(self, tab_layout: QVBoxLayout) -> None:
+        """Create UI for custom instance folder location selection."""
+        group_box = QGroupBox()
+        tab_layout.addWidget(group_box)
+
+        group_layout = QVBoxLayout(group_box)
+
+        header_layout = QHBoxLayout()
+        group_layout.addLayout(header_layout)
+
+        section_label = QLabel(self.tr("Instance folder location (optional)"))
+        section_label.setFont(GUIInfo().emphasis_font)
+        header_layout.addWidget(section_label)
+
+        self.instance_folder_location_choose_button = QToolButton()
+        self.instance_folder_location_choose_button.setText(self.tr("Choose…"))
+        header_layout.addWidget(self.instance_folder_location_choose_button)
+
+        self.instance_folder_location_clear_button = QToolButton()
+        self.instance_folder_location_clear_button.setText(self.tr("Use Default"))
+        header_layout.addWidget(self.instance_folder_location_clear_button)
+
+        self.instance_folder_location = QLineEdit()
+        self.instance_folder_location.setReadOnly(True)
+        self.instance_folder_location.setPlaceholderText(
+            self.tr("Leave empty to use default location")
+        )
+        self.instance_folder_location.setTextMargins(GUIInfo().text_field_margins)
+        self.instance_folder_location.setFixedHeight(
+            GUIInfo().default_font_line_height * 2
+        )
+        group_layout.addWidget(self.instance_folder_location)
 
     def _do_databases_tab(self) -> None:
         tab = QWidget()


### PR DESCRIPTION
- Adds support for custom instance folder locations, allowing users to specify alternative paths for storing instance data.
- Addresses issues with default folder locations and provides flexibility in managing multiple instances.

Key changes:
- Added instance_folder_override field to Instance model
- Updated InstanceController to handle override paths with validation
- Introduced constants for folder names (DEFAULT_INSTANCE_NAME, INSTANCE_FOLDER_NAME, etc.)
- Modified Settings to use override paths where applicable
- Updated UI in MainWindow and SettingsDialog for folder selection
- Ensured default instance never uses override for consistency

Fixes [#604](https://github.com/RimSort/RimSort/issues/604), [#809](https://github.com/RimSort/RimSort/issues/809), [#945](https://github.com/RimSort/RimSort/issues/945)