### PR TITLE
Refactor import placement in settings_controller.py

### DIFF
--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -23,6 +23,7 @@ from app.utils.generic import (
     validate_game_executable,
 )
 from app.utils.system_info import SystemInfo
+from app.utils.win_find_steam import find_steam_folder
 from app.views.dialogue import (
     BinaryChoiceDialog,
     show_dialogue_file,
@@ -1811,8 +1812,6 @@ class SettingsController(QObject):
         """
         if sys.platform == "win32":
             user_home = Path.home()
-            from app.utils.win_find_steam import find_steam_folder
-
             steam_folder, found = find_steam_folder()
 
             if not found:


### PR DESCRIPTION
- Moved 'from app.utils.win_find_steam import find_steam_folder' import from inside the __get_windows_paths method to the top-level imports section
- This follows PEP8 guidelines for import placement and improves code organization
- No functional changes, only import reorganization for better code style

This draft is just for me to remember import placement in the middle of the file 
1) find_steam_folder