### PR TITLE
Add Steam integration validation

### DIFF
--- a/app/utils/acf_utils.py
+++ b/app/utils/acf_utils.py
@@ -14,6 +14,7 @@ Key functions:
 - refresh_acf_metadata: Load ACF data into MetadataManager
 - load_and_merge_acf_data: Merge ACF data from multiple sources
 - steamcmd_purge_mods: Remove mods from SteamCMD ACF metadata
+- validate_acf_file_exists: Validate that appworkshop_294100.acf exists
 """
 
 from pathlib import Path
@@ -463,3 +464,45 @@ def steamcmd_purge_mods(
                 manifest_path.unlink()
             except Exception as e:
                 logger.error(f"Failed to remove manifest file {manifest_path}: {e}")
+
+
+def validate_acf_file_exists(steam_mods_location: str) -> bool:
+    """
+    Validate that the appworkshop_294100.acf file exists for the Steam Workshop location.
+
+    Checks if the Steam Workshop ACF metadata file exists at the expected location
+    relative to the provided steam mods folder path. This file is required for
+    Steam Workshop integration to function properly.
+
+    Args:
+        steam_mods_location: Path to the Steam Workshop mods folder (typically
+                           steamapps/workshop/content/294100). The ACF file is expected
+                           at parent.parent/appworkshop_294100.acf
+
+    Returns:
+        True if the ACF file exists and is accessible, False if missing or empty path.
+
+    Example:
+        >>> is_valid = validate_acf_file_exists("C:\\Steam\\steamapps\\workshop\\content\\294100")
+        >>> # Checks for C:\\Steam\\steamapps\\appworkshop_294100.acf
+    """
+    # Validate input
+    if not steam_mods_location or not steam_mods_location.strip():
+        logger.debug("Steam mods location is empty or None, ACF validation skipped")
+        return False
+
+    try:
+        acf_file_path = (
+            Path(steam_mods_location).parent.parent / "appworkshop_294100.acf"
+        )
+        exists = acf_file_path.exists() and acf_file_path.is_file()
+
+        if exists:
+            logger.debug(f"ACF file validated at: {acf_file_path}")
+        else:
+            logger.debug(f"ACF file not found at expected location: {acf_file_path}")
+
+        return exists
+    except Exception as e:
+        logger.warning(f"Error validating ACF file path for {steam_mods_location}: {e}")
+        return False


### PR DESCRIPTION
Implement validation for Steam client integration settings to ensure proper configuration.

- Added _check_steam_integration_validity and _validate_steam_integration methods in SettingsController to validate Steam mods location and ACF file existence before saving settings.
- Added _validate_steam_integration_config method in Settings model to automatically fix invalid configurations on load.
- Added validate_acf_file_exists function in acf_utils to check for the presence of appworkshop_294100.acf file.

This prevents invalid Steam integration setups and provides user feedback for missing configurations.