### PR TITLE
Refactor internet connection check and error dialog

### DIFF
--- a/app/controllers/main_content_controller.py
+++ b/app/controllers/main_content_controller.py
@@ -35,7 +35,6 @@ from app.views.dialogue import (
     BinaryChoiceDialog,
     InformationBox,
     show_dialogue_conditional,
-    show_internet_connection_error,
 )
 from app.views.main_content_panel import MainContent
 
@@ -363,7 +362,6 @@ class MainContentController(QObject):
         """Handle clone request: ask user before starting."""
         # Check internet connection before attempting task
         if not check_internet_connection():
-            show_internet_connection_error()
             return
         repo_folder = git_utils.git_get_repo_name(repo_url)
         full_repo_path = Path(base_path) / repo_folder
@@ -416,7 +414,6 @@ class MainContentController(QObject):
 
         # Check internet connection before attempting task
         if not check_internet_connection():
-            show_internet_connection_error()
             return
 
         # Community Rules database
@@ -589,7 +586,6 @@ class MainContentController(QObject):
         """
         # Check internet connection before attempting task
         if not check_internet_connection():
-            show_internet_connection_error()
             return
 
         if not repo_url or not repo_url.strip():

--- a/app/utils/update_utils.py
+++ b/app/utils/update_utils.py
@@ -421,7 +421,6 @@ class UpdateManager(QObject):
 
         # Check internet connection
         if not check_internet_connection():
-            dialogue.show_internet_connection_error()
             return False
 
         return True

--- a/app/views/dialogue.py
+++ b/app/views/dialogue.py
@@ -260,13 +260,24 @@ def show_fatal_error(
     diag.exec_()
 
 
-def show_internet_connection_error() -> None:
-    """Show a warning dialog for no internet connection, with firewall info and user information for help."""
+def show_internet_connection_error(failed_urls: list[str] | None = None) -> None:
+    """Show a warning dialog for no internet connection, with firewall info and user information for help.
+
+    :param failed_urls: Optional list of URLs that failed to connect
+    """
     logger.info("Showing no internet connection error dialog")
+
+    failed_urls_str = (
+        f"Failed to reach: {', '.join(failed_urls)}"
+        if failed_urls
+        else "Unable to reach internet services"
+    )
+
     show_information(
         title="No Internet Connection",
         text="RimSort requires an active internet connection to perform this operation.",
         information=(
+            f"{failed_urls_str}\n\n"
             "If you are connected but still see this message, your firewall or security software may be blocking RimSort. \n"
             "To resolve this issue: \n\n"
             "Add RimSort to your firewall's allowed applications. \n"

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -1274,7 +1274,6 @@ class MainContent(QObject):
     def _do_import_list_workshop_collection(self) -> None:
         # Check internet connection before attempting task
         if not check_internet_connection():
-            dialogue.show_internet_connection_error()
             return
         # Create an instance of collection_import
         # This also triggers the import dialogue and gets result
@@ -2020,7 +2019,6 @@ class MainContent(QObject):
     def _do_check_for_workshop_updates(self) -> None:
         # Check internet connection before attempting task
         if not check_internet_connection():
-            dialogue.show_internet_connection_error()
             return
         # Query Workshop for update data
         updates_checked = self.do_threaded_loading_animation(
@@ -2325,7 +2323,6 @@ class MainContent(QObject):
             if url and ok:
                 # Check internet connection before attempting task
                 if not check_internet_connection():
-                    dialogue.show_internet_connection_error()
                     return
                 fd, temp_path = tempfile.mkstemp(suffix=".zip")
                 os.close(fd)


### PR DESCRIPTION
- Simplified check_internet_connection() to use requests.head() for checking connectivity to Steam and GitHub URLs instead of socket connections and HTTP requests
- Updated show_internet_connection_error() to accept an optional failed_urls parameter and display the list of failed URLs in the dialog
- Removed redundant calls to show_internet_connection_error() after check_internet_connection() checks, as the function now internally shows the error dialog when no connection is detected
- This centralizes the error handling and provides more informative error messages to users