### PR TITLE
Refactor steamcmd downloader to use EventBus

### DIFF
--- a/app/utils/steam/steambrowser/browser.py
+++ b/app/utils/steam/steambrowser/browser.py
@@ -36,6 +36,7 @@ from PySide6.QtWidgets import (
 from app.controllers.settings_controller import SettingsController
 from app.models.image_label import ImageLabel
 from app.utils.app_info import AppInfo
+from app.utils.event_bus import EventBus
 from app.utils.generic import extract_page_title_steam_browser
 from app.utils.metadata import MetadataManager
 from app.utils.steam.webapi.wrapper import (
@@ -58,7 +59,6 @@ class SteamBrowser(QWidget):
     A generic panel used to browse Workshop content - downloader included
     """
 
-    steamcmd_downloader_signal = Signal(list)
     steamworks_subscription_signal = Signal(list)
 
     def __init__(
@@ -135,7 +135,8 @@ class SteamBrowser(QWidget):
         )
         self.download_steamcmd_button.clicked.connect(
             partial(
-                self.steamcmd_downloader_signal.emit, self.downloader_list_mods_tracking
+                EventBus().do_steamcmd_download.emit,
+                self.downloader_list_mods_tracking,
             )
         )
         self.download_steamworks_button = QPushButton(

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -301,12 +301,6 @@ class MainContent(QObject):
             self.mods_panel.inactive_mods_list.edit_rules_signal.connect(
                 self._do_open_rule_editor
             )
-            self.mods_panel.active_mods_list.steamcmd_downloader_signal.connect(
-                self._do_download_mods_with_steamcmd
-            )
-            self.mods_panel.inactive_mods_list.steamcmd_downloader_signal.connect(
-                self._do_download_mods_with_steamcmd
-            )
             self.mods_panel.active_mods_list.steamworks_subscription_signal.connect(
                 self._do_steamworks_api_call_animated
             )
@@ -2008,9 +2002,6 @@ class MainContent(QObject):
             self.metadata_manager,
             self.settings_controller,
         )
-        self.steam_browser.steamcmd_downloader_signal.connect(
-            self._do_download_mods_with_steamcmd
-        )
         self.steam_browser.steamworks_subscription_signal.connect(
             self._do_steamworks_api_call_animated
         )
@@ -2137,9 +2128,6 @@ class MainContent(QObject):
             self.steamcmd_runner = RunnerPanel(
                 steamcmd_download_tracking=publishedfileids,
                 steam_db=steam_db,
-            )
-            self.steamcmd_runner.steamcmd_downloader_signal.connect(
-                self._do_download_mods_with_steamcmd
             )
             self.steamcmd_runner.setWindowTitle("RimSort - SteamCMD downloader")
             self.steamcmd_runner.show()

--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -787,7 +787,6 @@ class ModListWidget(QListWidget):
     refresh_signal = Signal()
     update_git_mods_signal = Signal(list)
     steamdb_blacklist_signal = Signal(list)
-    steamcmd_downloader_signal = Signal(list)
     steamworks_subscription_signal = Signal(list)
 
     def __init__(self, list_type: str, settings_controller: SettingsController) -> None:
@@ -1504,9 +1503,9 @@ class ModListWidget(QListWidget):
                             )
                         # Emit signal to steamcmd downloader to re-download
                         logger.debug(
-                            f"Emitting steamcmd_downloader_signal for {list(steamcmd_publishedfileid_to_redownload)}"
+                            f"Emitting do_steamcmd_download for {list(steamcmd_publishedfileid_to_redownload)}"
                         )
-                        self.steamcmd_downloader_signal.emit(
+                        EventBus().do_steamcmd_download.emit(
                             list(steamcmd_publishedfileid_to_redownload)
                         )
                     return True

--- a/app/windows/runner_panel.py
+++ b/app/windows/runner_panel.py
@@ -37,7 +37,6 @@ class RunnerPanel(QWidget):
     """
 
     closing_signal = Signal()
-    steamcmd_downloader_signal = Signal(list)
 
     def __init__(
         self,
@@ -552,7 +551,7 @@ class RunnerPanel(QWidget):
         )
         if answer == QMessageBox.StandardButton.Yes:
             self.redownloading = True
-            self.steamcmd_downloader_signal.emit(self.steamcmd_download_tracking)
+            EventBus().do_steamcmd_download.emit(self.steamcmd_download_tracking)
             self.exit_window()
 
         else:


### PR DESCRIPTION
- Replaced direct steamcmd_downloader_signal emissions with EventBus().do_steamcmd_download.emit in SteamBrowser, ModListWidget, and RunnerPanel classes.
- Removed steamcmd_downloader_signal definitions from the affected classes.
- Updated MainContent to disconnect direct signal connections for steamcmd downloader.
- Added EventBus import in browser.py to support the new emission method.
- This change centralizes steamcmd download triggering through the event bus, improving code decoupling and maintainability.