### PR TITLE
Ensure packageid and published_file_id are strings in ModInfo

### DIFF
--- a/app/utils/mod_info.py
+++ b/app/utils/mod_info.py
@@ -44,8 +44,12 @@ class ModInfo:
         try:
             name = cls._parse_name(metadata)
             authors = cls._parse_authors(metadata)
-            packageid = metadata.get("packageid", "")
-            published_file_id = metadata.get("publishedfileid", "")
+            packageid = str(
+                metadata.get("packageid", "")
+            )  # make sure packageid is a string
+            published_file_id = str(
+                metadata.get("publishedfileid", "")
+            )  # make sure published_file_id is a string
             supported_versions = cls._parse_supported_versions_static(
                 metadata.get("supportedversions")
             )


### PR DESCRIPTION
Modified the ModInfo class initialization to explicitly convert packageid and published_file_id to strings using str() to ensure they are always string types, preventing potential type-related issues in downstream processing.