### PR TITLE
Refactor steamworks subscription to use EventBus

### DIFF
--- a/app/utils/steam/steambrowser/browser.py
+++ b/app/utils/steam/steambrowser/browser.py
@@ -9,7 +9,7 @@ from string import Template
 from typing import Any
 
 from loguru import logger
-from PySide6.QtCore import QPoint, Qt, QUrl, Signal
+from PySide6.QtCore import QPoint, Qt, QUrl
 from PySide6.QtGui import QAction, QPixmap
 from PySide6.QtWebChannel import QWebChannel
 from PySide6.QtWebEngineCore import (
@@ -58,8 +58,6 @@ class SteamBrowser(QWidget):
     """
     A generic panel used to browse Workshop content - downloader included
     """
-
-    steamworks_subscription_signal = Signal(list)
 
     def __init__(
         self,
@@ -501,7 +499,7 @@ class SteamBrowser(QWidget):
         logger.debug(
             f"Signaling Steamworks subscription handler with {len(self.downloader_list_mods_tracking)} mods"
         )
-        self.steamworks_subscription_signal.emit(
+        EventBus().do_steamworks_api_call.emit(
             [
                 "subscribe",
                 [eval(str_pfid) for str_pfid in self.downloader_list_mods_tracking],

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -301,12 +301,6 @@ class MainContent(QObject):
             self.mods_panel.inactive_mods_list.edit_rules_signal.connect(
                 self._do_open_rule_editor
             )
-            self.mods_panel.active_mods_list.steamworks_subscription_signal.connect(
-                self._do_steamworks_api_call_animated
-            )
-            self.mods_panel.inactive_mods_list.steamworks_subscription_signal.connect(
-                self._do_steamworks_api_call_animated
-            )
             self.mods_panel.active_mods_list.steamdb_blacklist_signal.connect(
                 self._do_blacklist_action_steamdb
             )
@@ -2001,9 +1995,6 @@ class MainContent(QObject):
             "https://steamcommunity.com/app/294100/workshop/",
             self.metadata_manager,
             self.settings_controller,
-        )
-        self.steam_browser.steamworks_subscription_signal.connect(
-            self._do_steamworks_api_call_animated
         )
         self.steam_browser.show()
 

--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -787,7 +787,6 @@ class ModListWidget(QListWidget):
     refresh_signal = Signal()
     update_git_mods_signal = Signal(list)
     steamdb_blacklist_signal = Signal(list)
-    steamworks_subscription_signal = Signal(list)
 
     def __init__(self, list_type: str, settings_controller: SettingsController) -> None:
         """
@@ -1586,7 +1585,7 @@ class ModListWidget(QListWidget):
                             delete_files_except_extension(
                                 directory=path, extension=".dds"
                             )
-                        self.steamworks_subscription_signal.emit(
+                        EventBus().do_steamworks_api_call.emit(
                             [
                                 "resubscribe",
                                 [eval(str_pfid) for str_pfid in publishedfileids],
@@ -1610,7 +1609,7 @@ class ModListWidget(QListWidget):
                         logger.debug(
                             f"Unsubscribing from {len(publishedfileids)} mod(s)"
                         )
-                        self.steamworks_subscription_signal.emit(
+                        EventBus().do_steamworks_api_call.emit(
                             [
                                 "unsubscribe",
                                 [eval(str_pfid) for str_pfid in publishedfileids],


### PR DESCRIPTION
- Remove steamworks_subscription_signal from SteamBrowser, ModListWidget, and related connections in MainContent
- Replace direct signal emissions with EventBus().do_steamworks_api_call.emit for subscribe, resubscribe, and unsubscribe operations
- Update imports in browser.py to remove unused Signal import

This refactoring centralizes steamworks API calls through the EventBus, improving decoupling and maintainability.