### PR TITLE
Add toggle functionality for ACF Log Reader

### DIFF
--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -202,6 +202,9 @@ class Settings(QObject):
         # Player Log
         self.auto_load_player_log_on_startup: bool = False
 
+        # ACF Log Reader
+        self.enable_acf_log_reader: bool = True
+
         # Instances
         self.current_instance: str = DEFAULT_INSTANCE_NAME
         self.current_instance_path: str = str(


### PR DESCRIPTION
- Added enable_acf_log_reader setting in Settings model to control ACF reader state
- Implemented toggle button in AcfLogReader view to enable/disable the feature
- Added methods to update UI state, start/stop auto-refresh, and clear caches based on toggle
- Enhanced TableResizer class with improved documentation and proportional resizing logic
- Improved code comments and organization throughout the AcfLogReader class