### PR TITLE
feat: Add ignore mods functionality

### DIFF
--- a/app/controllers/menu_bar_controller.py
+++ b/app/controllers/menu_bar_controller.py
@@ -113,6 +113,9 @@ class MenuBarController(QObject):
         self.menu_bar.copy_action.triggered.connect(self._on_menu_bar_copy_triggered)
         self.menu_bar.paste_action.triggered.connect(self._on_menu_bar_paste_triggered)
         self.menu_bar.rule_editor_action.triggered.connect(EventBus().do_rule_editor)
+        self.menu_bar.ignore_json_editor_action.triggered.connect(
+            EventBus().do_ignore_json_editor
+        )
         self.menu_bar.reset_all_warnings_action.triggered.connect(
             self._on_menu_bar_reset_warnings_triggered
         )

--- a/app/utils/app_info.py
+++ b/app/utils/app_info.py
@@ -85,6 +85,7 @@ class AppInfo:
         self._theme_data_folder: Path = self._application_folder / "themes"
         self._settings_file: Path = self._app_storage_folder / "settings.json"
         self._user_rules_file = self.databases_folder / "userRules.json"
+        self._ignore_mods_file: Path = self.databases_folder / "ignore.json"
         self._language_data_folder: Path = self._application_folder / "locales"
         self._browser_profile_folder: Path = self._app_storage_folder / "browser"
         self._backup_folder: Path = self._app_storage_folder / "backup"
@@ -185,6 +186,15 @@ class AppInfo:
         May or may not exist.
         """
         return self._user_rules_file
+
+    @property
+    def ignore_mods_file(self) -> Path:
+        """
+        Get the path to the file where ignored mods are stored.
+
+        May or may not exist.
+        """
+        return self._ignore_mods_file
 
     @property
     def user_log_folder(self) -> Path:

--- a/app/utils/event_bus.py
+++ b/app/utils/event_bus.py
@@ -46,6 +46,7 @@ class EventBus(QObject):
 
     # Edit Menu bar signals
     do_rule_editor = Signal()
+    do_ignore_json_editor = Signal()
     reset_warnings_signal = Signal()
     reset_mod_colors_signal = Signal()
 
@@ -110,6 +111,7 @@ class EventBus(QObject):
     refresh_started = Signal()
     refresh_finished = Signal()
     do_metadata_refresh_cache = Signal()
+    do_check_missing_mod_properties = Signal()
 
     # Dialog signals
     reset_settings_file = Signal()

--- a/app/utils/ignore_manager.py
+++ b/app/utils/ignore_manager.py
@@ -1,0 +1,210 @@
+import json
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from app.utils.app_info import AppInfo
+
+
+class IgnoreManager:
+    """
+    Manager for handling ignored mods list.
+
+    This class provides functionality to read and write a list of mods
+    to ignore when checking for missing properties. Ignored mods are
+    identified by their package ID (the stable mod identifier) and
+    stored in a JSON file managed by AppInfo.
+
+    Note: No caching is used to ensure real-time updates when ignore.json
+    is modified during runtime (e.g., when mods are added to ignore list).
+    """
+
+    @staticmethod
+    def get_ignore_file_path() -> Path:
+        """
+        Get the path to the ignore mods file.
+
+        Returns:
+            Path to ignore.json file
+        """
+        return AppInfo().ignore_mods_file
+
+    @staticmethod
+    def load_ignored_mods() -> set[str]:
+        """
+        Load the list of ignored mod package IDs from the ignore file.
+
+        Returns:
+            Set of mod package IDs that should be ignored
+        """
+        ignore_file = IgnoreManager.get_ignore_file_path()
+
+        if not ignore_file.exists():
+            return set()
+
+        try:
+            with open(ignore_file, encoding="utf-8") as f:
+                data = json.load(f)
+
+            # Support both list and dict format with metadata
+            if isinstance(data, dict) and "ignored_mods" in data:
+                return set(data["ignored_mods"])
+            elif isinstance(data, list):
+                return set(data)
+            else:
+                logger.warning(
+                    f"Invalid format in ignore file: {ignore_file}. Expected list or dict with 'ignored_mods' key."
+                )
+                return set()
+        except json.JSONDecodeError as e:
+            logger.error(f"Failed to parse ignore file {ignore_file}: {e}")
+            return set()
+        except Exception as e:
+            logger.error(f"Failed to load ignored mods from {ignore_file}: {e}")
+            return set()
+
+    @staticmethod
+    def save_ignored_mods(ignored_mods: set[str]) -> bool:
+        """
+        Save the list of ignored mod package IDs to the ignore file.
+
+        Args:
+            ignored_mods: Set of mod package IDs to ignore
+
+        Returns:
+            True if successful, False otherwise
+        """
+        ignore_file = IgnoreManager.get_ignore_file_path()
+
+        try:
+            # Create directory if it doesn't exist
+            ignore_file.parent.mkdir(parents=True, exist_ok=True)
+
+            # Save with metadata for future reference
+            data: dict[str, Any] = {
+                "ignored_mods": sorted(ignored_mods),
+                "description": "Mods to ignore when checking for missing properties (identified by packageid)",
+            }
+
+            with open(ignore_file, "w", encoding="utf-8") as f:
+                json.dump(data, f, indent=4)
+
+            logger.info(f"Saved {len(ignored_mods)} ignored mods to {ignore_file}")
+            return True
+        except Exception as e:
+            logger.error(f"Failed to save ignored mods to {ignore_file}: {e}")
+            return False
+
+    @staticmethod
+    def add_ignored_mod(mod_packageid: str) -> bool:
+        """
+        Add a mod package ID to the ignore list.
+
+        Args:
+            mod_packageid: Package ID of the mod to ignore
+
+        Returns:
+            True if successful, False otherwise
+        """
+        ignored_mods = IgnoreManager.load_ignored_mods()
+        if mod_packageid not in ignored_mods:
+            ignored_mods.add(mod_packageid)
+            return IgnoreManager.save_ignored_mods(ignored_mods)
+        return True
+
+    @staticmethod
+    def add_ignored_mods(mod_packageids: list[str] | set[str]) -> bool:
+        """
+        Add multiple mod package IDs to the ignore list.
+
+        Args:
+            mod_packageids: List or set of package IDs to ignore
+
+        Returns:
+            True if successful, False otherwise
+        """
+        if not mod_packageids:
+            return True
+
+        ignored_mods = IgnoreManager.load_ignored_mods()
+        initial_count = len(ignored_mods)
+        ignored_mods.update(mod_packageids)
+
+        # Only save if we actually added something new
+        if len(ignored_mods) > initial_count:
+            return IgnoreManager.save_ignored_mods(ignored_mods)
+        return True
+
+    @staticmethod
+    def remove_ignored_mod(mod_packageid: str) -> bool:
+        """
+        Remove a mod package ID from the ignore list.
+
+        Args:
+            mod_packageid: Package ID of the mod to remove from ignore list
+
+        Returns:
+            True if successful, False otherwise
+        """
+        ignored_mods = IgnoreManager.load_ignored_mods()
+        if mod_packageid in ignored_mods:
+            ignored_mods.discard(mod_packageid)
+            return IgnoreManager.save_ignored_mods(ignored_mods)
+        return True
+
+    @staticmethod
+    def remove_ignored_mods(mod_packageids: list[str] | set[str]) -> bool:
+        """
+        Remove multiple mod package IDs from the ignore list.
+
+        Args:
+            mod_packageids: List or set of package IDs to remove
+
+        Returns:
+            True if successful, False otherwise
+        """
+        if not mod_packageids:
+            return True
+
+        ignored_mods = IgnoreManager.load_ignored_mods()
+        initial_count = len(ignored_mods)
+        ignored_mods.difference_update(mod_packageids)
+
+        # Only save if we actually removed something
+        if len(ignored_mods) < initial_count:
+            return IgnoreManager.save_ignored_mods(ignored_mods)
+        return True
+
+    @staticmethod
+    def clear_ignored_mods() -> bool:
+        """
+        Clear all ignored mods.
+
+        Returns:
+            True if successful, False otherwise
+        """
+        return IgnoreManager.save_ignored_mods(set())
+
+    @staticmethod
+    def is_mod_ignored(mod_packageid: str) -> bool:
+        """
+        Check if a mod package ID is in the ignore list.
+
+        Args:
+            mod_packageid: Package ID to check
+
+        Returns:
+            True if mod is ignored, False otherwise
+        """
+        return mod_packageid in IgnoreManager.load_ignored_mods()
+
+    @staticmethod
+    def get_ignored_mods_count() -> int:
+        """
+        Get the count of ignored mods.
+
+        Returns:
+            Number of ignored mods
+        """
+        return len(IgnoreManager.load_ignored_mods())

--- a/app/views/menu_bar.py
+++ b/app/views/menu_bar.py
@@ -54,6 +54,7 @@ class MenuBar(QObject):
         self.copy_action: QAction
         self.paste_action: QAction
         self.rule_editor_action: QAction
+        self.ignore_json_editor_action: QAction
         self.reset_all_warnings_action: QAction
         self.reset_all_mod_colors_action: QAction
         self.add_git_mod_action: QAction
@@ -254,6 +255,9 @@ class MenuBar(QObject):
         self.paste_action = self._add_action(edit_menu, self.tr("Paste"), "Ctrl+V")
         edit_menu.addSeparator()
         self.rule_editor_action = self._add_action(edit_menu, self.tr("Rule Editor…"))
+        self.ignore_json_editor_action = self._add_action(
+            edit_menu, self.tr("Ignore JSON Editor…")
+        )
         self.reset_all_warnings_action = self._add_action(
             edit_menu, self.tr("Reset Warning Toggles")
         )

--- a/app/windows/ignore_json_editor.py
+++ b/app/windows/ignore_json_editor.py
@@ -1,0 +1,190 @@
+from loguru import logger
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QDialog,
+    QHBoxLayout,
+    QLabel,
+    QListWidget,
+    QListWidgetItem,
+    QMessageBox,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from app.utils.event_bus import EventBus
+from app.utils.ignore_manager import IgnoreManager
+
+# Placeholder text shown when ignore list is empty
+_EMPTY_LIST_PLACEHOLDER = "No mods in ignore list."
+
+
+class IgnoreJsonEditor(QDialog):
+    """
+    Dialog for managing the ignore list of mods.
+
+    Displays ignored mods as a list with checkboxes to remove items,
+    allowing users to easily manage which mods are ignored.
+    """
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        """
+        Initialize the Ignore JSON Editor dialog.
+
+        Args:
+            parent: Parent widget
+        """
+        super().__init__(parent)
+        logger.debug("Initializing IgnoreJsonEditor")
+
+        self.setWindowTitle(self.tr("RimSort - Manage Ignore List"))
+        self.setGeometry(100, 100, 500, 400)
+        self._empty_list_placeholder = self.tr(_EMPTY_LIST_PLACEHOLDER)
+
+        # Create main layout
+        main_layout = QVBoxLayout(self)
+
+        # Add description label
+        description_label = QLabel(
+            self.tr("Mods checked below will be removed from the ignore list.")
+        )
+        main_layout.addWidget(description_label)
+
+        # Create list widget
+        self.list_widget = QListWidget()
+        main_layout.addWidget(self.list_widget)
+
+        # Create button layout
+        button_layout = QHBoxLayout()
+        self._create_buttons(button_layout)
+        main_layout.addLayout(button_layout)
+
+        # Load initial content
+        self._load_ignored_mods()
+
+        logger.debug("Finished IgnoreJsonEditor initialization")
+
+    def _create_buttons(self, button_layout: QHBoxLayout) -> None:
+        """
+        Create and connect dialog buttons.
+
+        Args:
+            button_layout: Layout to add buttons to
+        """
+        # Remove button
+        remove_button = QPushButton(self.tr("Remove Selected"))
+        remove_button.clicked.connect(self._remove_selected)
+        button_layout.addWidget(remove_button)
+
+        # Save button
+        save_button = QPushButton(self.tr("Save"))
+        save_button.clicked.connect(self._save_changes)
+        button_layout.addWidget(save_button)
+
+        # Cancel button
+        cancel_button = QPushButton(self.tr("Cancel"))
+        cancel_button.clicked.connect(self.close)
+        button_layout.addWidget(cancel_button)
+
+    def _remove_selected(self) -> None:
+        """Remove checked items from the list display."""
+        # Collect indices to remove (in reverse order to maintain correct indices)
+        indices_to_remove = [
+            i
+            for i in range(self.list_widget.count())
+            if (item := self.list_widget.item(i))
+            and item.checkState() == Qt.CheckState.Checked
+        ]
+
+        # Remove in reverse order to maintain correct indices
+        for i in reversed(indices_to_remove):
+            self.list_widget.takeItem(i)
+
+        logger.debug(f"Removed {len(indices_to_remove)} item(s) from list")
+
+    def _load_ignored_mods(self) -> None:
+        """Load the ignore list and display as checkbox items."""
+        try:
+            ignored_mods = IgnoreManager.load_ignored_mods()
+
+            if not ignored_mods:
+                self._add_empty_placeholder()
+                logger.info("No ignored mods found")
+                return
+
+            # Add each ignored mod as a checkbox item (sorted for consistency)
+            for mod_packageid in sorted(ignored_mods):
+                self._add_mod_item(mod_packageid)
+
+            logger.info(f"Loaded {len(ignored_mods)} ignored mods")
+        except Exception as e:
+            logger.error(f"Failed to load ignored mods: {e}")
+            QMessageBox.critical(
+                self,
+                self.tr("Error"),
+                self.tr(f"Failed to load ignored mods: {e}"),
+            )
+
+    def _add_empty_placeholder(self) -> None:
+        """Add placeholder item when list is empty."""
+        item = QListWidgetItem(self._empty_list_placeholder)
+        item.setFlags(item.flags() & ~Qt.ItemFlag.ItemIsSelectable)
+        self.list_widget.addItem(item)
+
+    def _add_mod_item(self, mod_packageid: str) -> None:
+        """
+        Add a mod item to the list as a checkbox.
+
+        Args:
+            mod_packageid: Package ID of the mod to add
+        """
+        item = QListWidgetItem(mod_packageid)
+        item.setFlags(item.flags() | Qt.ItemFlag.ItemIsUserCheckable)
+        item.setCheckState(Qt.CheckState.Unchecked)
+        self.list_widget.addItem(item)
+
+    def _save_changes(self) -> None:
+        """Save changes by saving the current list to ignore.json."""
+        try:
+            # Collect remaining items (those not marked for removal)
+            remaining_mods = self._collect_remaining_mods()
+
+            # Save updated list
+            if IgnoreManager.save_ignored_mods(remaining_mods):
+                logger.info(f"Saved {len(remaining_mods)} mod(s) to ignore list")
+                QMessageBox.information(
+                    self,
+                    self.tr("Success"),
+                    self.tr("Ignore list has been saved successfully."),
+                )
+                self.close()
+                # Emit event to check and warn about missing mod properties after closing the panel
+                EventBus().do_check_missing_mod_properties.emit()
+            else:
+                logger.error("Failed to save changes to ignore list")
+                QMessageBox.critical(
+                    self,
+                    self.tr("Error"),
+                    self.tr("Failed to save changes to ignore list."),
+                )
+        except Exception as e:
+            logger.error(f"Error saving changes: {e}")
+            QMessageBox.critical(
+                self,
+                self.tr("Error"),
+                self.tr(f"Error saving changes: {e}"),
+            )
+
+    def _collect_remaining_mods(self) -> set[str]:
+        """
+        Collect mods that should be kept (not removed).
+
+        Returns:
+            Set of remaining mod package IDs
+        """
+        remaining_mods = set()
+        for i in range(self.list_widget.count()):
+            item = self.list_widget.item(i)
+            if item and item.text() and item.text() != self._empty_list_placeholder:
+                remaining_mods.add(item.text())
+        return remaining_mods

--- a/app/windows/missing_mod_properties_panel.py
+++ b/app/windows/missing_mod_properties_panel.py
@@ -1,17 +1,23 @@
-from typing import Any
+from typing import Any, Iterable
 
 from loguru import logger
+from PySide6.QtWidgets import QMessageBox
 
+import app.utils.metadata as metadata
 from app.controllers.settings_controller import SettingsController
-from app.windows.base_mods_panel import BaseModsPanel
+from app.utils.event_bus import EventBus
+from app.utils.ignore_manager import IgnoreManager
+from app.utils.mod_info import ModInfo
+from app.windows.base_mods_panel import BaseModsPanel, ButtonConfig, ButtonType
 
 
 class MissingModPropertiesPanel(BaseModsPanel):
     """
     A unified panel for displaying mods with missing properties.
 
-    This panel displays mods that lack either a valid Package ID (in About.xml) or a valid Publish Field ID (Steam Workshop ID).
-    Users can view detailed information for each mod and access Steam Workshop links, if available
+    This panel displays mods that lack either a valid Package ID (in About.xml)
+    or a valid Publish Field ID (Steam Workshop ID). Users can view detailed
+    information for each mod and add them to the ignore list.
 
     Attributes:
         missing_packageid_mods (list[str]): List of UUIDs for mods with missing Package ID.
@@ -52,8 +58,27 @@ class MissingModPropertiesPanel(BaseModsPanel):
             additional_columns=self._get_standard_mod_columns(),
         )
 
+        # Build button configurations
         button_configs = self._get_base_button_configs()
         self._extend_button_configs_with_steam_actions(button_configs)
+
+        # Add delete button
+        button_configs.append(
+            self._create_delete_button_config(
+                menu_title=self.tr("Delete Mods"),
+                enable_delete_and_unsubscribe=False,
+            )
+        )
+
+        # Add button to add selected mods to ignore list
+        button_configs.append(
+            ButtonConfig(
+                button_type=ButtonType.CUSTOM,
+                text=self.tr("Add to Ignore List"),
+                custom_callback=self._add_to_ignore_list,
+            )
+        )
+
         self._setup_buttons_from_config(button_configs)
 
         # Populate the table with missing properties mod data
@@ -64,6 +89,192 @@ class MissingModPropertiesPanel(BaseModsPanel):
 
         # TODO: let user configure window launch state and size from settings controller
         self.showNormal()
+
+    def _add_to_ignore_list(self) -> None:
+        """
+        Add selected mods to the ignore list.
+
+        Allows users to ignore mods with missing properties so they won't
+        trigger warnings on future refresh operations.
+        """
+        # Get selected mod indices
+        selected_indices = self._get_selected_row_indices()
+
+        if not selected_indices:
+            self._show_message(
+                "No Selection",
+                "Please select mods to add to the ignore list.",
+                "information",
+            )
+            return
+
+        try:
+            if self._process_ignore_list_addition(selected_indices):
+                self.close()
+                # Emit event to check and warn about missing mod properties after closing the panel
+                EventBus().do_check_missing_mod_properties.emit()
+        except Exception as e:
+            logger.error(f"Error adding mods to ignore list: {e}")
+            self._show_message(
+                "Error",
+                f"Error adding mods to ignore list: {str(e)}",
+                "critical",
+            )
+
+    def _process_ignore_list_addition(self, selected_indices: Iterable[int]) -> bool:
+        """
+        Process adding selected mods to ignore list.
+
+        Args:
+            selected_indices: Indices of selected rows
+
+        Returns:
+            True if addition was successful, False otherwise
+        """
+        # Extract package IDs and categorize by validity
+        packageids_to_add, skipped_mods = self._extract_and_validate_packageids(
+            selected_indices
+        )
+
+        if not packageids_to_add:
+            self._show_no_valid_packageids_warning(skipped_mods)
+            return False
+
+        # Add mods to ignore list
+        if not IgnoreManager.add_ignored_mods(packageids_to_add):
+            logger.error("Failed to save changes to ignore list file")
+            self._show_message(
+                "Error",
+                "Failed to add mods to ignore list.",
+                "critical",
+            )
+            return False
+
+        mod_count = len(packageids_to_add)
+        logger.info(f"Added {mod_count} mod(s) to ignore list")
+
+        # Show success message
+        # Parent will re-check and reload panel with fresh ignore.json data
+        self._show_message(
+            "Success",
+            "Mods added to ignore list. Panel will refresh.",
+            "information",
+        )
+        return True
+
+    def _get_valid_mod_metadata(self, uuid: str) -> ModInfo | None:
+        """
+        Get validated mod info from UUID.
+
+        Args:
+            uuid: The UUID to lookup
+
+        Returns:
+            ModInfo instance if valid, None otherwise
+        """
+        mod_metadata = self.metadata_manager.internal_local_metadata.get(uuid)
+        if not mod_metadata:
+            return None
+
+        try:
+            return ModInfo.from_metadata(uuid, mod_metadata)
+        except ValueError as e:
+            logger.warning(f"Failed to extract mod info for UUID {uuid}: {e}")
+            return None
+
+    def _extract_and_validate_packageids(
+        self, row_indices: Iterable[int]
+    ) -> tuple[list[str], list[str]]:
+        """
+        Extract and validate package IDs from selected rows.
+
+        Separates valid package IDs from mods with missing/placeholder IDs.
+
+        Args:
+            row_indices: Iterable of row indices to process
+
+        Returns:
+            Tuple of (valid_packageids, skipped_mod_names)
+        """
+        valid_packageids = []
+        skipped_mods = []
+
+        for row in row_indices:
+            uuid = self._get_uuid_from_row(row)
+            if not uuid:
+                continue
+
+            mod_info = self._get_valid_mod_metadata(uuid)
+            if not mod_info:
+                continue
+
+            packageid = mod_info.packageid
+
+            # Validate package ID
+            if packageid and packageid != metadata.DEFAULT_MISSING_PACKAGEID:
+                valid_packageids.append(packageid)
+            elif packageid == metadata.DEFAULT_MISSING_PACKAGEID:
+                # Collect for warning
+                skipped_mods.append(mod_info.name)
+
+        return valid_packageids, skipped_mods
+
+    def _show_no_valid_packageids_warning(self, skipped_mods: list[str]) -> None:
+        """
+        Show warning when no valid package IDs can be added.
+
+        Args:
+            skipped_mods: List of mod names that were skipped
+        """
+        if skipped_mods:
+            skipped_list = "\n".join([f"• {m}" for m in skipped_mods])
+            message = (
+                "Cannot add mods with missing Package IDs to the ignore list.\n"
+                "These mods need valid Package IDs first:\n" + skipped_list
+            )
+            self._show_message("Cannot Add", message, "warning")
+        else:
+            self._show_message(
+                "Error",
+                "Could not extract package IDs from selected mods.",
+                "warning",
+            )
+
+    def _show_message(
+        self, title: str, message: str, message_type: str = "information"
+    ) -> None:
+        """
+        Show a message dialog with configurable type.
+
+        Args:
+            title: Dialog title
+            message: Message to display
+            message_type: Type of message ('information', 'warning', 'critical')
+        """
+        translated_title = self.tr(title)
+        translated_message = self.tr(message)
+
+        if message_type == "warning":
+            QMessageBox.warning(
+                self,
+                translated_title,
+                translated_message,
+                QMessageBox.StandardButton.Ok,
+            )
+        elif message_type == "critical":
+            QMessageBox.critical(
+                self,
+                translated_title,
+                translated_message,
+                QMessageBox.StandardButton.Ok,
+            )
+        else:
+            QMessageBox.information(
+                self,
+                translated_title,
+                translated_message,
+                QMessageBox.StandardButton.Ok,
+            )
 
     def _populate_from_metadata(self) -> None:
         """
@@ -78,37 +289,45 @@ class MissingModPropertiesPanel(BaseModsPanel):
         process, ensuring partial data is still displayed to the user.
         """
         try:
-            # Initialize dictionary to store categorized mods
-            # Structure: {category_name: [(uuid, metadata_dict), ...]}
-            grouped_mods: dict[str, list[tuple[str, dict[str, Any]]]] = {}
-
-            # Process mods by category, checking only non-empty UUID lists
-            for category, uuids in [
-                ("Mods with Missing Package ID", self.missing_packageid_mods),
-                (
-                    "Mods with Missing Publish Field ID",
-                    self.missing_publishfieldid_mods,
-                ),
-            ]:
-                # Skip empty categories to avoid creating empty groups in the table
-                if uuids:
-                    grouped_mods[category] = []
-                    # Retrieve and pair each UUID with its corresponding metadata
-                    for uuid in uuids:
-                        metadata = self.metadata_manager.internal_local_metadata.get(
-                            uuid
-                        )
-                        if metadata:
-                            # Successfully found metadata for this UUID
-                            grouped_mods[category].append((uuid, metadata))
-                        else:
-                            # Log warning if metadata is missing (data inconsistency)
-                            logger.warning(f"Metadata not found for UUID: {uuid}")
+            # Build grouped mods dict efficiently
+            grouped_mods = self._build_grouped_mods()
 
             # Use base class method to populate the table with grouped mods
-            # Group headers are enabled to visually separate the two categories
             if grouped_mods:
                 self._populate_mods(grouped_mods, add_group_headers=True)
         except Exception as e:
             # Log errors but don't raise - allow graceful degradation
             logger.error(f"Error populating table from metadata: {e}")
+
+    def _build_grouped_mods(
+        self,
+    ) -> dict[str, list[tuple[str, dict[str, Any]]]]:
+        """
+        Build dictionary of grouped mods from UUID lists.
+
+        Returns:
+            Dictionary mapping category names to list of (uuid, metadata) tuples
+        """
+        grouped_mods: dict[str, list[tuple[str, dict[str, Any]]]] = {}
+
+        categories = [
+            ("Mods with Missing Package ID", self.missing_packageid_mods),
+            ("Mods with Missing Publish Field ID", self.missing_publishfieldid_mods),
+        ]
+
+        for category_name, uuids in categories:
+            if not uuids:
+                continue
+
+            category_mods: list[tuple[str, dict[str, Any]]] = []
+            for uuid in uuids:
+                mod_metadata = self.metadata_manager.internal_local_metadata.get(uuid)
+                if mod_metadata:
+                    category_mods.append((uuid, mod_metadata))
+                else:
+                    logger.warning(f"Metadata not found for UUID: {uuid}")
+
+            if category_mods:
+                grouped_mods[category_name] = category_mods
+
+        return grouped_mods


### PR DESCRIPTION
- Added functionality to ignore mods with missing properties in RimSort.
- Introduced IgnoreManager class for managing the list of ignored mods.
- Created IgnoreJsonEditor window for editing the ignore list.
- Added ignore_mods_file property to AppInfo.
- Extended EventBus with signals for ignore json editor and missing mod properties check.
- Updated menu bar to include ignore json editor action.
- Modified main content panel to filter mods using ignore list and open ignore editor.
- Enhanced missing mod properties panel to allow adding mods to ignore list.

<img width="902" height="632" alt="image" src="https://github.com/user-attachments/assets/99f30b99-6987-45ea-a878-d8669ff86545" />

<img width="1291" height="794" alt="image" src="https://github.com/user-attachments/assets/fa2b8697-addd-402f-ad8f-6882a3e371f9" />

