### PR TITLE
Refactor DEFAULT_MISSING_PACKAGEID constant placement

### DIFF
--- a/app/utils/constants.py
+++ b/app/utils/constants.py
@@ -7,6 +7,9 @@ INSTANCE_FOLDER_NAME = "instances"
 STEAMCMD_FOLDER_NAME = "steamcmd"
 STEAM_FOLDER_NAME = "steam"
 
+# Default packageId for mods with missing or invalid packageId
+DEFAULT_MISSING_PACKAGEID = "missing.packageid"
+
 
 class SortMethod(str, Enum):
     ALPHABETICAL = "Alphabetical"

--- a/app/utils/metadata.py
+++ b/app/utils/metadata.py
@@ -26,6 +26,7 @@ from app.utils.app_info import AppInfo
 from app.utils.constants import (
     DB_BUILDER_PRUNE_EXCEPTIONS,
     DB_BUILDER_RECURSE_EXCEPTIONS,
+    DEFAULT_MISSING_PACKAGEID,
     DEFAULT_USER_RULES,
     RIMWORLD_DLC_METADATA,
 )
@@ -43,10 +44,6 @@ from app.views.dialogue import (
     show_dialogue_file,
     show_warning,
 )
-
-# Locally installed mod metadata
-# Default packageId for mods with missing or invalid packageId
-DEFAULT_MISSING_PACKAGEID = "missing.packageid"
 
 # Metadata loader source constants
 SOURCE_FILE_PATH = "Configured file path"

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -619,7 +619,7 @@ class MainContent(QObject):
         return [
             uuid
             for uuid, mod_metadata in self.metadata_manager.internal_local_metadata.items()
-            if mod_metadata.get("packageid") == metadata.DEFAULT_MISSING_PACKAGEID
+            if mod_metadata.get("packageid") == app_constants.DEFAULT_MISSING_PACKAGEID
         ]
 
     def _get_missing_publishfieldid_uuids(self) -> list[str]:

--- a/app/windows/missing_mod_properties_panel.py
+++ b/app/windows/missing_mod_properties_panel.py
@@ -3,8 +3,8 @@ from typing import Any, Iterable
 from loguru import logger
 from PySide6.QtWidgets import QMessageBox
 
-import app.utils.metadata as metadata
 from app.controllers.settings_controller import SettingsController
+from app.utils.constants import DEFAULT_MISSING_PACKAGEID
 from app.utils.event_bus import EventBus
 from app.utils.ignore_manager import IgnoreManager
 from app.utils.mod_info import ModInfo
@@ -211,9 +211,9 @@ class MissingModPropertiesPanel(BaseModsPanel):
             packageid = mod_info.packageid
 
             # Validate package ID
-            if packageid and packageid != metadata.DEFAULT_MISSING_PACKAGEID:
+            if packageid and packageid != DEFAULT_MISSING_PACKAGEID:
                 valid_packageids.append(packageid)
-            elif packageid == metadata.DEFAULT_MISSING_PACKAGEID:
+            elif packageid == DEFAULT_MISSING_PACKAGEID:
                 # Collect for warning
                 skipped_mods.append(mod_info.name)
 


### PR DESCRIPTION
- Moved DEFAULT_MISSING_PACKAGEID from app/utils/metadata.py to app/utils/constants.py for better organization of constants.
- Updated imports and references in app/utils/metadata.py, app/views/main_content_panel.py, and app/windows/missing_mod_properties_panel.py to use the constant from constants.py.