### PR TITLE
Refactor ModInfoPanel class and update imports

### DIFF
--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -77,7 +77,7 @@ from app.utils.system_info import SystemInfo
 from app.utils.todds.wrapper import ToddsInterface
 from app.utils.update_utils import UpdateManager
 from app.utils.xml import json_to_xml_write
-from app.views.mod_info_panel import ModInfo
+from app.views.mod_info_panel import ModInfoPanel
 from app.views.mods_panel import (
     ModListWidget,
     ModsPanel,
@@ -251,7 +251,7 @@ class MainContent(QObject):
             self.main_layout_frame.setLayout(self.main_layout)
 
             # INSTANTIATE WIDGETS
-            self.mod_info_panel = ModInfo(
+            self.mod_info_panel = ModInfoPanel(
                 settings_controller=self.settings_controller,
             )
             self.mods_panel = ModsPanel(


### PR DESCRIPTION
- Renamed ModInfo class to ModInfoPanel in mod_info_panel.py to distinguish from ModInfo data class in utils
- Added layout proportion constants for better maintainability
- Refactored display_mod_info method into smaller helper methods (_set_mod_version_info, _set_folder_size_info, etc.) for improved code organization and error handling
- Updated main_content_panel.py to import and instantiate ModInfoPanel instead of ModInfo