### PR TITLE
Remove unused import and simplify progress messages

### DIFF
--- a/app/utils/db_builder_core.py
+++ b/app/utils/db_builder_core.py
@@ -10,8 +10,6 @@ import os
 from pathlib import Path
 from typing import Any, Callable, Optional
 
-from loguru import logger
-
 from app.utils.constants import (
     DB_BUILDER_PRUNE_EXCEPTIONS,
     DB_BUILDER_RECURSE_EXCEPTIONS,
@@ -104,9 +102,9 @@ class DBBuilderCore:
             return True
         else:  # Otherwise, API key is not valid
             self.progress_callback(
-                f"SteamDatabaseBuilder (no_local): Invalid Steam WebAPI key!"
+                "SteamDatabaseBuilder (no_local): Invalid Steam WebAPI key!"
             )
-            self.progress_callback(f"SteamDatabaseBuilder (no_local): Exiting...")
+            self.progress_callback("SteamDatabaseBuilder (no_local): Exiting...")
             return False
 
     def _init_empty_db_from_publishedfileids(


### PR DESCRIPTION
- Removed unused 'loguru' import from app/utils/db_builder_core.py
- Simplified two progress_callback calls by removing f-string formatting where no variables were interpolated