### PR TITLE
Update macOS runner to macos-15-intel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-14
+          - os: macos-15-intel
             platform: "Darwin"
             arch: "i386"
             env:

--- a/.github/workflows/test_builds.yml
+++ b/.github/workflows/test_builds.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-14
+          - os: macos-15-intel
             platform: "Darwin"
             arch: "i386"
             env:

--- a/docs/development-guide/development-setup.md
+++ b/docs/development-guide/development-setup.md
@@ -27,7 +27,7 @@ Your OS needs to be one that PySide6 supports. As an example, we use the followi
   - `ubuntu-22.04`
   - `ubuntu-24.04`
 - macOS builds:
-  - `macos-14` (i386)
+  - `macos-15-intel` (i386)
   - `macos-latest` (arm)
 - Windows:
   - `windows-latest` (Windows 2022 at the time of writing)

--- a/docs/development-guide/development-setup.zh-cn.md
+++ b/docs/development-guide/development-setup.zh-cn.md
@@ -31,7 +31,7 @@ RimSort 使用 [PySide6](https://pypi.org/project/PySide6/) 模块以及多个�
     - 最低要求示例：
       - Linux 构建：Ubuntu 22.04 和 24.04
       - macOS 构建：
-        - i386 架构使用 GitHub 的 macos-14 runner
+        - i386 架构使用 GitHub 的 macos-15-intel runner
         - arm 架构使用 GitHub 的 macos-latest（当前为 macos-14）runner
       - Windows 使用 GitHub 的 windows-latest（当前为 Windows 2022）runner
   - 安装对应平台的最新版 [Python](https://python.org/) 3.12（推荐 CPython）


### PR DESCRIPTION
This commit updates the GitHub Actions workflows (build.yml and test_builds.yml) to use the new macOS runner macos-15-intel instead of macos-14 for i386 builds. The development setup documentation in both English and Chinese has been updated to reflect this change.