### PR TITLE
Remove duplicate and unused update check signals from EventBus

### DIFF
--- a/app/utils/event_bus.py
+++ b/app/utils/event_bus.py
@@ -25,7 +25,6 @@ class EventBus(QObject):
     _instance: Union[None, "EventBus"] = None
 
     # Menu bar signals
-    do_check_for_application_update = Signal()
     do_open_mod_list = Signal()
     do_save_mod_list_as = Signal()
     do_import_mod_list_from_rentry = Signal()
@@ -124,7 +123,6 @@ class EventBus(QObject):
 
     # Help Menu bar signals
     do_check_for_application_update = Signal()
-    do_check_for_update_startup = Signal()
 
     # Performance settings signals
     enable_aux_db_performance_mode = Signal()


### PR DESCRIPTION
Removed 'do_check_for_application_update' from Menu bar signals section and 'do_check_for_update_startup' from Help Menu bar signals section in the EventBus class.
This cleanup eliminates redundant or unused signals to streamline the event handling system.