### PR TITLE
Refactor user rules initialization

### DIFF
--- a/app/controllers/app_controller.py
+++ b/app/controllers/app_controller.py
@@ -1,4 +1,3 @@
-import json
 import os
 import sys
 
@@ -10,7 +9,6 @@ from app.controllers.settings_controller import SettingsController
 from app.controllers.theme_controller import ThemeController
 from app.models.settings import Settings
 from app.utils.app_info import AppInfo
-from app.utils.constants import DEFAULT_USER_RULES
 from app.utils.dds_utility import DDSUtility
 from app.utils.gui_info import GUIInfo
 from app.utils.metadata import MetadataManager
@@ -29,8 +27,6 @@ class AppController(QObject):
         self.app = QApplication(sys.argv)
         self.app.setWindowIcon(GUIInfo().app_icon)
 
-        # Initialize user rules.
-        self.initialize_user_rules()
         # Initialize the application settings.
         self.initialize_settings()
         # set the language of the application.
@@ -69,14 +65,6 @@ class AppController(QObject):
             self.settings.enable_themes,
             self.settings.theme_name,
         )
-
-    def initialize_user_rules(self) -> None:
-        """Initializes userRules.json if it does not exist."""
-        user_rules_path = AppInfo().user_rules_file
-        if not user_rules_path.exists():
-            initial_rules_db = DEFAULT_USER_RULES
-            with open(user_rules_path, "w", encoding="utf-8") as output:
-                json.dump(initial_rules_db, output, indent=4)
 
     def initialize_settings(self) -> None:
         """Initializes the settings model, view, and controller."""

--- a/app/utils/app_info.py
+++ b/app/utils/app_info.py
@@ -1,9 +1,12 @@
+import json
 import os
 import sys
 from pathlib import Path
 
 from lxml import etree, objectify
 from platformdirs import PlatformDirs
+
+from app.utils.constants import DEFAULT_USER_RULES
 
 
 class AppInfo:
@@ -99,6 +102,12 @@ class AppInfo:
         self._databases_folder.mkdir(parents=True, exist_ok=True)
         self._theme_storage_folder.mkdir(parents=True, exist_ok=True)
         self._backup_folder.mkdir(parents=True, exist_ok=True)
+
+        # Initialize user rules file if it does not exist
+        if not self._user_rules_file.exists():
+            self._user_rules_file.parent.mkdir(parents=True, exist_ok=True)
+            with open(self._user_rules_file, "w", encoding="utf-8") as output:
+                json.dump(DEFAULT_USER_RULES, output, indent=4)
 
         self._is_initialized: bool = True
 

--- a/app/utils/metadata.py
+++ b/app/utils/metadata.py
@@ -27,7 +27,6 @@ from app.utils.constants import (
     DB_BUILDER_PRUNE_EXCEPTIONS,
     DB_BUILDER_RECURSE_EXCEPTIONS,
     DEFAULT_MISSING_PACKAGEID,
-    DEFAULT_USER_RULES,
     RIMWORLD_DLC_METADATA,
 )
 from app.utils.generic import directories, scanpath
@@ -277,24 +276,6 @@ class MetadataManager(QObject):
             logger.info(
                 f"Loaded {total_entries} additional sorting rules from User Rules"
             )
-        else:
-            logger.info(
-                "Unable to find userRules.json in storage. Creating new user rules db!"
-            )
-            try:
-                path.parent.mkdir(parents=True, exist_ok=True)
-                with open(path, "w", encoding="utf-8") as output:
-                    json.dump(DEFAULT_USER_RULES, output, indent=4)
-            except Exception as e:
-                logger.error(f"Failed to create/write userRules.json: {e}")
-                return
-
-            # Set defaults
-            default_rules: Any = DEFAULT_USER_RULES.get("rules")
-            if isinstance(default_rules, dict):
-                self.external_user_rules = default_rules
-            else:
-                self.external_user_rules = {}
 
     def _load_steam_db(
         self, life: int, path: str


### PR DESCRIPTION
Moved the initialization of userRules.json from AppController and MetadataManager to AppInfo class.
This centralizes the logic for creating the user rules file if it does not exist, improving code organization and reducing duplication.
Removed unused imports and methods accordingly.