### PR TITLE
Refactor input dialogs to use QInputDialog.getText

### DIFF
--- a/app/utils/rentry/wrapper.py
+++ b/app/utils/rentry/wrapper.py
@@ -6,12 +6,11 @@ from typing import Any
 import requests
 from loguru import logger
 from PySide6.QtCore import QCoreApplication
-from PySide6.QtWidgets import QMessageBox
+from PySide6.QtWidgets import QInputDialog, QMessageBox
 
 from app.controllers.settings_controller import SettingsController
 from app.views.dialogue import (
     InformationBox,
-    show_dialogue_input,
     show_fatal_error,
     show_warning,
 )
@@ -188,9 +187,10 @@ class RentryImport:
 
     def input_dialog(self) -> None:
         """Initialize the UI for entering Rentry.co links."""
-        self.link_input = show_dialogue_input(
-            title=translate("RentryImport", "Enter Rentry.co link"),
-            label=translate("RentryImport", "Enter the Rentry.co link:"),
+        self.link_input = QInputDialog.getText(
+            None,
+            translate("RentryImport", "Enter Rentry.co link"),
+            translate("RentryImport", "Enter the Rentry.co link:"),
         )
         logger.info("Rentry link Input UI initialized successfully!")
         if self.link_input[1]:

--- a/app/utils/steam/webapi/wrapper.py
+++ b/app/utils/steam/webapi/wrapper.py
@@ -10,13 +10,14 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
 import requests
 from loguru import logger
 from PySide6.QtCore import QCoreApplication, QObject, Signal
+from PySide6.QtWidgets import QInputDialog
 from steam.webapi import WebAPI
 
 from app.utils.app_info import AppInfo
 from app.utils.constants import RIMWORLD_DLC_METADATA
 from app.utils.generic import chunks
 from app.utils.steam.steamworks.wrapper import SteamworksAppDependenciesQuery
-from app.views.dialogue import show_dialogue_input, show_warning
+from app.views.dialogue import show_warning
 
 STEAM_THERE_WAS_A_PROBLEM_FLAG = "There was a problem accessing the item. "
 
@@ -58,9 +59,10 @@ class CollectionImport:
 
     def input_dialog(self) -> None:
         # Initialize the UI for entering collection links
-        self.link_input = show_dialogue_input(
-            title=self.translate("CollectionImport", "Add Workshop collection link"),
-            label=self.translate("CollectionImport", "Add Workshop collection link"),
+        self.link_input = QInputDialog.getText(
+            None,
+            self.translate("CollectionImport", "Add Workshop collection link"),
+            self.translate("CollectionImport", "Add Workshop collection link"),
         )
         logger.info("Workshop collection link Input UI initialized successfully!")
         if self.link_input[1]:

--- a/app/views/dialogue.py
+++ b/app/views/dialogue.py
@@ -1,7 +1,7 @@
 import os
 import sys
 from pathlib import Path
-from typing import Tuple, Union
+from typing import Union
 
 from loguru import logger
 from PySide6.QtCore import (
@@ -17,7 +17,6 @@ from PySide6.QtWidgets import (
     QDialog,
     QFileDialog,
     QHBoxLayout,
-    QInputDialog,
     QLabel,
     QMessageBox,
     QPlainTextEdit,
@@ -29,7 +28,6 @@ from PySide6.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-from typing_extensions import deprecated
 
 import app.utils.generic as generic
 from app.utils.app_info import AppInfo
@@ -106,17 +104,6 @@ def show_dialogue_conditional(
             return std_button
     # Fallback to return button text if no match found
     return response.text()
-
-
-@deprecated("Just use QInputDialog().getText() instead")
-def show_dialogue_input(
-    title: str = "",
-    label: str = "",
-    text: str = "",
-    parent: QWidget | None = None,
-) -> Tuple[str, bool]:
-    actual_parent = parent if parent is not None else QWidget()
-    return QInputDialog().getText(actual_parent, title, label, text=text)
 
 
 def show_dialogue_file(

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -27,6 +27,7 @@ from PySide6.QtWidgets import (
     QApplication,
     QFrame,
     QHBoxLayout,
+    QInputDialog,
     QLabel,
     QMessageBox,
     QSplitter,
@@ -2358,11 +2359,10 @@ class MainContent(QObject):
         )
 
         if answer == "Download":
-            url, ok = dialogue.show_dialogue_input(
-                title=self.tr("Enter zip file url"),
-                label=self.tr(
-                    "Enter a zip file url (http/https) to download to local mods:"
-                ),
+            url, ok = QInputDialog.getText(
+                None,
+                self.tr("Enter zip file url"),
+                self.tr("Enter a zip file url (http/https) to download to local mods:"),
             )
             if url and ok:
                 # Check internet connection before attempting task
@@ -2716,9 +2716,10 @@ class MainContent(QObject):
         Opens a QDialogInput that allows user to edit their Steam DB repo
         This URL is used for Steam DB repo related actions.
         """
-        args, ok = dialogue.show_dialogue_input(
-            title=self.tr("Edit Steam DB repo"),
-            label=self.tr("Enter URL (https://github.com/AccountName/RepositoryName):"),
+        args, ok = QInputDialog.getText(
+            None,
+            self.tr("Edit Steam DB repo"),
+            self.tr("Enter URL (https://github.com/AccountName/RepositoryName):"),
             text=self.settings_controller.settings.external_steam_metadata_repo,
         )
         if ok:
@@ -2730,9 +2731,10 @@ class MainContent(QObject):
         Opens a QDialogInput that allows user to edit their Community Rules
         DB repo. This URL is used for Steam DB repo related actions.
         """
-        args, ok = dialogue.show_dialogue_input(
-            title=self.tr("Edit Community Rules DB repo"),
-            label=self.tr("Enter URL (https://github.com/AccountName/RepositoryName):"),
+        args, ok = QInputDialog.getText(
+            None,
+            self.tr("Edit Community Rules DB repo"),
+            self.tr("Enter URL (https://github.com/AccountName/RepositoryName):"),
             text=self.settings_controller.settings.external_community_rules_repo,
         )
         if ok:
@@ -2941,9 +2943,10 @@ class MainContent(QObject):
         that are configured to be passed to the "Dynamic Query" feature for
         the Steam Workshop metadata needed for sorting
         """
-        args, ok = dialogue.show_dialogue_input(
-            title=self.tr("Edit Steam WebAPI key"),
-            label=self.tr("Enter your personal 32 character Steam WebAPI key here:"),
+        args, ok = QInputDialog.getText(
+            None,
+            self.tr("Edit Steam WebAPI key"),
+            self.tr("Enter your personal 32 character Steam WebAPI key here:"),
             text=self.settings_controller.settings.steam_apikey,
         )
         if ok:
@@ -3221,9 +3224,10 @@ class MainContent(QObject):
         Opens a QDialogInput that allows the user to edit their preferred
         WebAPI Query Expiry (in seconds)
         """
-        args, ok = dialogue.show_dialogue_input(
-            title=self.tr("Edit SteamDB expiry:"),
-            label=self.tr(
+        args, ok = QInputDialog.getText(
+            None,
+            self.tr("Edit SteamDB expiry:"),
+            self.tr(
                 "Enter your preferred expiry duration in seconds (default 1 week/604800 sec):"
             ),
             text=str(self.settings_controller.settings.database_expiry),

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -11,6 +11,7 @@ from PySide6.QtGui import QShowEvent
 from PySide6.QtWidgets import (
     QApplication,
     QHBoxLayout,
+    QInputDialog,
     QLabel,
     QMainWindow,
     QMessageBox,
@@ -49,7 +50,6 @@ from app.views.dialogue import (
     BinaryChoiceDialog,
     show_dialogue_conditional,
     show_dialogue_file,
-    show_dialogue_input,
     show_fatal_error,
     show_warning,
 )
@@ -342,19 +342,19 @@ class MainWindow(QMainWindow):
         return
 
     def __ask_for_new_instance_name(self) -> str | None:
-        instance_name, ok = show_dialogue_input(
-            title=self.tr("Create new instance"),
-            label=self.tr(
-                "Input a unique name of new instance that is not already used:"
-            ),
+        instance_name, ok = QInputDialog.getText(
+            self,
+            self.tr("Create new instance"),
+            self.tr("Input a unique name of new instance that is not already used:"),
         )
         return instance_name.strip() if ok else None
 
     def __ask_for_non_default_instance_name(self) -> str | None:
         while True:
-            instance_name, ok = show_dialogue_input(
-                title=self.tr("Provide instance name"),
-                label=self.tr(
+            instance_name, ok = QInputDialog.getText(
+                self,
+                self.tr("Provide instance name"),
+                self.tr(
                     'Input a unique name for the backed up instance that is not "{name}"'
                 ).format(name=DEFAULT_INSTANCE_NAME),
             )

--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -43,6 +43,7 @@ from PySide6.QtWidgets import (
     QComboBox,
     QFrame,
     QHBoxLayout,
+    QInputDialog,
     QLabel,
     QLineEdit,
     QListWidget,
@@ -88,7 +89,6 @@ from app.utils.xml import extract_xml_package_ids, fast_rimworld_xml_save_valida
 from app.views.deletion_menu import ModDeletionMenu
 from app.views.dialogue import (
     show_dialogue_conditional,
-    show_dialogue_input,
     show_warning,
 )
 
@@ -1634,9 +1634,10 @@ class ModListWidget(QListWidget):
                         )
                         return False
 
-                    args, ok = show_dialogue_input(
-                        title=self.tr("Add comment"),
-                        label=self.tr(
+                    args, ok = QInputDialog.getText(
+                        self,
+                        self.tr("Add comment"),
+                        self.tr(
                             "Enter a comment providing your reasoning for wanting to blacklist this mod: "
                         )
                         + f"{self.metadata_manager.external_steam_metadata.get(steamdb_add_blacklist, {}).get('steamName', steamdb_add_blacklist)}",

--- a/app/windows/rule_editor_panel.py
+++ b/app/windows/rule_editor_panel.py
@@ -15,6 +15,7 @@ from PySide6.QtWidgets import (
     QCheckBox,
     QHBoxLayout,
     QHeaderView,
+    QInputDialog,
     QItemDelegate,
     QLabel,
     QLineEdit,
@@ -31,7 +32,7 @@ from PySide6.QtWidgets import (
 
 from app.utils.app_info import AppInfo
 from app.utils.metadata import MetadataManager
-from app.views.dialogue import show_dialogue_input, show_warning
+from app.views.dialogue import show_warning
 
 
 class EditableDelegate(QItemDelegate):
@@ -670,10 +671,12 @@ class RuleEditor(QWidget):
                 destination_list.addItem(copied_item)
                 destination_list.setItemWidget(copied_item, QLabel(item_label_text))
                 # Add a new row in the editor - prompt user to enter a comment for their rule addition
-                args, ok = show_dialogue_input(
-                    title=self.tr("Enter comment"),
-                    label=self.tr("""Enter a comment to annotate why this rule exists.
+                args, ok = QInputDialog().getText(
+                    self,
+                    self.tr("Enter comment"),
+                    self.tr("""Enter a comment to annotate why this rule exists.
                       This is useful for your own records, as well as others."""),
+                    text="",
                 )
                 if ok:
                     comment = args
@@ -1186,13 +1189,14 @@ class RuleEditor(QWidget):
                 comment = ""
                 if not self.block_comment_prompt:
                     # Add a new row in the editor - prompt user to enter a comment for their rule addition
-                    args, ok = show_dialogue_input(
-                        title=self.tr("Enter comment"),
-                        label=self.tr(
+                    args, ok = QInputDialog().getText(
+                        self,
+                        self.tr("Enter comment"),
+                        self.tr(
                             "Enter a comment to annotate why this rule exists."
                             "This is useful for your own records, as well as others."
                         ),
-                        parent=self,
+                        text="",
                     )
                     if ok:
                         comment = args
@@ -1260,13 +1264,14 @@ class RuleEditor(QWidget):
                 comment = ""
                 if not self.block_comment_prompt:
                     # Add a new row in the editor - prompt user to enter a comment for their rule addition
-                    args, ok = show_dialogue_input(
-                        title=self.tr("Enter comment"),
-                        label=self.tr(
+                    args, ok = QInputDialog().getText(
+                        self,
+                        self.tr("Enter comment"),
+                        self.tr(
                             "Enter a comment to annotate why this rule exists."
                             "This is useful for your own records, as well as others."
                         ),
-                        parent=self,
+                        text="",
                     )
                     if ok:
                         comment = args
@@ -1325,16 +1330,17 @@ class RuleEditor(QWidget):
         Returns:
             str: The comment entered by the user if dialogue is accepted, otherwise an empty string.
         """
-        item, ok = show_dialogue_input(
-            title=self.tr("Enter comment"),
-            label=self.tr(
+        args, ok = QInputDialog().getText(
+            self,
+            self.tr("Enter comment"),
+            self.tr(
                 "Enter a comment to annotate why this rule exists."
                 " This is useful for your own records, as well as others."
             ),
-            parent=self,
+            text="",
         )
         if ok:
-            return item
+            return args
         return ""
 
     def modItemContextMenuEvent(self, point: QPoint) -> None:


### PR DESCRIPTION
Replace custom show_dialogue_input function with standard QInputDialog.getText across the application.

This change removes the deprecated show_dialogue_input function from app/views/dialogue.py and updates all usages in:
- app/utils/rentry/wrapper.py
- app/utils/steam/webapi/wrapper.py
- app/views/main_content_panel.py
- app/views/main_window.py
- app/views/mods_panel.py
- app/windows/rule_editor_panel.py

The refactoring improves consistency by using Qt's built-in input dialog instead of a custom wrapper.