### PR TITLE
Add dialogue monitor constraint setting

### DIFF
--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -886,6 +886,12 @@ class SettingsController(QObject):
         except Exception:
             pass
 
+        # Launch State tab
+        # Dialogue positioning
+        self.settings_dialog.constrain_dialogues_to_main_window_monitor_checkbox.setChecked(
+            self.settings.constrain_dialogues_to_main_window_monitor
+        )
+
         # Windows launch state
         # Main Window
         main_window_launch_state = self.settings.main_window_launch_state
@@ -1227,6 +1233,10 @@ class SettingsController(QObject):
         )
         self.settings.font_size = self.settings_dialog.font_size_spinbox.value()
         self.settings.language = self.settings_dialog.language_combobox.currentData()
+
+        # Launch State tab
+        # Dialogue positioning
+        self.settings.constrain_dialogues_to_main_window_monitor = self.settings_dialog.constrain_dialogues_to_main_window_monitor_checkbox.isChecked()
 
         # Windows launch state
         # Main Window

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -150,6 +150,10 @@ class Settings(QObject):
         # Language
         self.language = "en_US"
 
+        # Launch state
+        # Dialogue positioning
+        self.constrain_dialogues_to_main_window_monitor: bool = False
+
         # Launch state setting: "maximized", "normal", or "custom"
         # Main Window
         self.main_window_launch_state: str = "maximized"

--- a/app/utils/globals.py
+++ b/app/utils/globals.py
@@ -1,0 +1,12 @@
+"""
+Global variables for the application.
+"""
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.controllers.settings_controller import SettingsController
+    from app.views.main_window import MainWindow
+
+MAIN_WINDOW: "MainWindow | None" = None
+SETTINGS_CONTROLLER: "SettingsController | None" = None

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -32,6 +32,7 @@ from app.controllers.metadata_db_controller import AuxMetadataController
 from app.controllers.mods_panel_controller import ModsPanelController
 from app.controllers.settings_controller import SettingsController
 from app.controllers.troubleshooting_controller import TroubleshootingController
+from app.utils import globals
 from app.utils.acf_utils import refresh_acf_metadata
 from app.utils.app_info import AppInfo
 from app.utils.constants import (
@@ -77,6 +78,10 @@ class MainWindow(QMainWindow):
         super(MainWindow, self).__init__()
 
         self.settings_controller = settings_controller
+
+        # Set global references
+        globals.MAIN_WINDOW = self
+        globals.SETTINGS_CONTROLLER = settings_controller
 
         # Create the main application window
         self.DEBUG_MODE = debug_mode

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -1400,6 +1400,11 @@ This basically preserves your mod coloring, user notes etc. for this many second
         user_note.setAlignment(Qt.AlignmentFlag.AlignCenter)
         group_layout.addWidget(user_note)
 
+        self.constrain_dialogues_to_main_window_monitor_checkbox = QCheckBox(
+            self.tr("Constrain dialogues to main window monitor")
+        )
+        group_layout.addWidget(self.constrain_dialogues_to_main_window_monitor_checkbox)
+
         size_note = QLabel(
             self.tr(
                 "Min is {MIN_SIZE} and Max is {MAX_SIZE}. Values outside this range will be reset to defaults."


### PR DESCRIPTION
- Add a new setting to constrain dialogue windows to the main window's monitor.
- Added constrain_dialogues_to_main_window_monitor boolean setting in Settings model.
- Updated SettingsController to load and save the setting from/to the settings dialog.
- Modified dialogue.py to include a helper function that sets dialogue parent to main window when enabled.
- Created app/utils/globals.py to store global references to MAIN_WINDOW and SETTINGS_CONTROLLER.
- Updated MainWindow to set these global references on initialization.
- Added checkbox in settings dialog under Launch State tab for the constraint option. This feature prevents dialogues from appearing on different monitors in multi-monitor setups, improving user experience.

<img width="978" height="673" alt="image" src="https://github.com/user-attachments/assets/f0ed0ed3-acf4-43ee-a7bf-62025a51e338" />
