### PR TITLE
Update submodule URLs to RimSort organization

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "steamfiles"]
 	path = submodules/steamfiles
-	url = https://github.com/twstagg/steamfiles
+	url = https://github.com/RimSort/steamfiles
 	ignore = dirty
 [submodule "SteamworksPy"]
 	path = submodules/SteamworksPy
-	url = https://github.com/twstagg/SteamworksPy
+	url = https://github.com/RimSort/SteamworksPy
 	ignore = dirty
 	branch = master

--- a/docs/development-guide/development-setup.md
+++ b/docs/development-guide/development-setup.md
@@ -40,7 +40,7 @@ Your OS needs to be one that PySide6 supports. As an example, we use the followi
 
 ### Cloning the repository
 RimSort uses submodules that are hosted in other repositories that need to be cloned. 
-- [steamfiles](https://github.com/twstagg/steamfiles): used to parse Steam client acf/appinfo/manifest information
+- [steamfiles](https://github.com/RimSort/steamfiles): used to parse Steam client acf/appinfo/manifest information
 - [SteamworksPy](https://github.com/philippj/SteamworksPy): used for interactions with the local Steam client
   - SteamworksPy is a python module built to interface directly with the [Steamworks API](https://partner.steamgames.com/doc/api)
   - This allows certain interactions with the local Steam client to be initiated through the Steamworks API via Python (such as subscribing/unsubscribing to/from Steam mods via RimSort)

--- a/docs/development-guide/development-setup.zh-cn.md
+++ b/docs/development-guide/development-setup.zh-cn.md
@@ -51,7 +51,7 @@ RimSort 使用 [PySide6](https://pypi.org/project/PySide6/) 模块以及多个�
       - Windows (`powershell`)：`.\Scripts\Activate.ps1`
   - 确保安装构建依赖：`requirements_build.txt`
 - RimSort 还依赖以下必需子模块（执行 `git submodule update --init --recursive` 来初始化/更新）：
-  - [steamfiles](https://github.com/twstagg/steamfiles)：用于解析 Steam 客户端 acf/appinfo/manifest 文件
+  - [steamfiles](https://github.com/RimSort/steamfiles)：用于解析 Steam 客户端 acf/appinfo/manifest 文件
   - [SteamworksPy](https://github.com/philippj/SteamworksPy)：用于实现与本地 Steam 客户端的交互
     - SteamworksPy 是直接对接 [Steamworks API](https://partner.steamgames.com/doc/api) 的 Python 模块
     - 这使 RimSort 可以通过 Python 调用 Steamworks API，与本地 Steam 客户端进行交互（例如通过 RimSort 订阅/取消订阅 Steam Mod）


### PR DESCRIPTION
- Changed steamfiles submodule URL from https://github.com/twstagg/steamfiles to https://github.com/RimSort/steamfiles
- Changed SteamworksPy submodule URL from https://github.com/twstagg/SteamworksPy to https://github.com/RimSort/SteamworksPy
- Updated documentation links in development-setup.md and development-setup.zh-cn.md to reflect the new steamfiles repository URL

This change migrates the submodules to the RimSort organization repositories.