### PR TITLE
Only validate Steam integration when checkbox is enabled

### DIFF
--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -1501,8 +1501,9 @@ class SettingsController(QObject):
             return
 
         # Validate Steam integration if enabled
-        if not self._validate_steam_integration():
-            return
+        if self.settings_dialog.steam_client_integration_checkbox.isChecked():
+            if not self._validate_steam_integration():
+                return
 
         self.settings_dialog.close()
         self._update_model_from_view()


### PR DESCRIPTION
- Modified the validation logic in _on_global_ok_button_clicked method to only validate Steam integration if the steam_client_integration_checkbox is checked.
- This prevents unnecessary validation attempts when Steam client integration is disabled, improving user experience by avoiding irrelevant error messages and potential false positives.