### PR TITLE
Refactor AcfLogReader and add ACF export functionality

### DIFF
--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -206,9 +206,6 @@ class Settings(QObject):
         # Player Log
         self.auto_load_player_log_on_startup: bool = False
 
-        # ACF Log Reader
-        self.enable_acf_log_reader: bool = True
-
         # Instances
         self.current_instance: str = DEFAULT_INSTANCE_NAME
         self.current_instance_path: str = str(

--- a/app/utils/csv_export_utils.py
+++ b/app/utils/csv_export_utils.py
@@ -1,77 +1,102 @@
+"""
+CSV export utility for BaseModsPanel and subclasses.
+
+Provides functionality to export table data to CSV files with:
+- Automatic filename generation with timestamps
+- Metadata headers (export date, total items, source ACF path)
+- Column descriptions
+- Progress logging
+- Comprehensive error handling and user feedback
+"""
+
 from __future__ import annotations
 
 import csv
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional
+from typing import Any, Optional
 
 from loguru import logger
 from PySide6.QtCore import Qt
 
 from app.views.dialogue import show_dialogue_file, show_information, show_warning
+from app.windows.base_mods_panel import BaseModsPanel
 
-if TYPE_CHECKING:
-    from app.views.acf_log_reader import AcfLogReader
-
-# Error messages for CSV export
+# Error message templates
 INVALID_EXPORT_FILE_PATH = "Invalid file path provided for export: {file_path}"
 EXPORT_PERMISSION_DENIED = "Export failed: Permission denied - check file permissions"
 EXPORT_FILESYSTEM_ERROR = "Export failed: File system error: {e}"
 EXPORT_UNKNOWN_ERROR = "Export failed due to an unknown error"
 
 
-def export_to_csv(acf_log_reader: "AcfLogReader") -> None:
+def export_to_csv(panel: BaseModsPanel) -> None:
     """
-    Export table data to CSV file with enhanced error handling and metadata.
+    Export table data to CSV file with metadata and error handling.
 
-    Errors are shown in the status bar and logged with full stack traces.
-    Includes detailed metadata headers in the CSV file.
+    Orchestrates the complete CSV export workflow:
+    1. User selects file path via save dialog
+    2. File path is validated
+    3. CSV is written with metadata, headers, and data rows
+    4. User is notified of success or failure
 
-    Raises:
-        ValueError: If file path is invalid.
-        PermissionError: If file cannot be written due to permissions.
-        OSError: For other file system errors.
-        Exception: For unexpected errors during export.
+    Args:
+        panel: The panel instance (BaseModsPanel or subclass) containing the table to export.
+
+    Error handling:
+        - ValueError: Invalid file path - shown in error dialog
+        - PermissionError: Insufficient write permissions - shown in error dialog
+        - OSError: File system errors - shown in error dialog
+        - Exception: Any other errors - shown in error dialog with details
     """
-    acf_log_reader._set_buttons_enabled(False)
     try:
-        file_path = _prepare_csv_export(acf_log_reader)
+        file_path = _prepare_csv_export(panel)
         if not file_path:
             return
 
-        _write_csv_data(acf_log_reader, file_path)
-        _finalize_csv_export(acf_log_reader, file_path)
+        _write_csv_data(panel, file_path)
+        _finalize_csv_export(panel, file_path)
     except ValueError as e:
-        _handle_csv_export_error(acf_log_reader, str(e), "Invalid File Path")
+        _handle_csv_export_error(panel, str(e), "Invalid File Path")
     except PermissionError:
         _handle_csv_export_error(
-            acf_log_reader,
+            panel,
             EXPORT_PERMISSION_DENIED,
             "Export Permission Denied",
         )
     except OSError as e:
         _handle_csv_export_error(
-            acf_log_reader,
+            panel,
             EXPORT_FILESYSTEM_ERROR.format(e=str(e)),
             "Export File System Error",
         )
     except Exception as e:
         _handle_csv_export_error(
-            acf_log_reader,
+            panel,
             EXPORT_UNKNOWN_ERROR,
             "Export Unknown Error",
             str(e),
         )
-    finally:
-        acf_log_reader._set_buttons_enabled(True)
 
 
-def _prepare_csv_export(acf_log_reader: "AcfLogReader") -> Optional[str]:
+def _prepare_csv_export(panel: BaseModsPanel) -> Optional[str]:
     """
-    Prepare CSV export by selecting file path and validating it.
+    Prepare CSV export by prompting user for file path and validating it.
+
+    Steps:
+    1. Shows file save dialog with default filename (timestamped)
+    2. Validates that the file path is syntactically correct
+    3. Tests that the file can be opened for writing
+
+    Args:
+        panel: The panel instance (BaseModsPanel or subclass).
 
     Returns:
-        The selected file path, or None if canceled or invalid.
+        The selected file path if valid, None if user canceled the dialog.
+
+    Raises:
+        ValueError: If the file path is invalid or cannot be resolved.
+        PermissionError: If the file cannot be written due to permission issues.
+        OSError: If other file system errors occur.
     """
     file_path = show_dialogue_file(
         mode="save",
@@ -80,21 +105,19 @@ def _prepare_csv_export(acf_log_reader: "AcfLogReader") -> Optional[str]:
         _filter="CSV Files (*.csv)",
     )
     if not file_path:
-        acf_log_reader.status_bar.showMessage(
-            acf_log_reader.tr("Export canceled by user.")
-        )
+        logger.debug("User cancelled CSV export")
         return None
 
-    # Validate user-provided path
+    # Validate the file path syntax
     try:
-        Path(file_path).resolve(strict=False)  # Check if path is valid
+        Path(file_path).resolve(strict=False)
     except (OSError, ValueError) as e:
         raise ValueError(INVALID_EXPORT_FILE_PATH.format(file_path=file_path)) from e
 
-    # Check file can be opened before proceeding
+    # Test that we can write to the file (catches permission and path issues)
     try:
         with open(file_path, "w", newline="", encoding="utf-8"):
-            pass  # Just testing file opening, no need for the file object
+            pass  # Just test file opening, don't write anything
     except PermissionError:
         raise
     except OSError:
@@ -103,131 +126,194 @@ def _prepare_csv_export(acf_log_reader: "AcfLogReader") -> Optional[str]:
     return file_path
 
 
-def _write_csv_data(acf_log_reader: "AcfLogReader", file_path: str) -> None:
+def _write_csv_data(panel: BaseModsPanel, file_path: str) -> None:
     """
-    Write CSV data to the specified file path.
+    Write complete CSV data to file including metadata, headers, and table rows.
+
+    CSV structure:
+    - Header section: Title, export date, row count, optional source ACF path
+    - Column headers and descriptions
+    - Blank separator row
+    - Data rows from the table (one row per iteration)
+
+    Progress is logged every 50 rows for large datasets.
 
     Args:
-        acf_log_reader: The AcfLogReader instance.
-        file_path: The path to write the CSV file to.
+        panel: The panel instance containing the table model to export.
+        file_path: The file path to write the CSV to.
     """
-    acf_log_reader.status_bar.showMessage(acf_log_reader.tr("Exporting to CSV..."))
+    logger.debug(f"Starting CSV export to {file_path}")
+    model = _get_table_model(panel)
 
     with open(file_path, "w", newline="", encoding="utf-8-sig") as csvfile:
         writer = csv.writer(csvfile)
 
-        _write_csv_metadata(acf_log_reader, writer)
-        _write_csv_headers(acf_log_reader, writer)
+        _write_csv_metadata(panel, writer)
+        _write_csv_headers(panel, writer)
 
-        # Write data rows with progress feedback
-        for row in range(acf_log_reader.table_view.model().rowCount()):
+        # Write data rows with progress logging
+        row_count = model.rowCount()
+        for row in range(row_count):
             row_data = []
-            for col in range(acf_log_reader.table_view.model().columnCount()):
-                item = acf_log_reader.table_view.model().data(
-                    acf_log_reader.table_view.model().index(row, col),
+            for col in range(model.columnCount()):
+                item = model.data(
+                    model.index(row, col),
                     Qt.ItemDataRole.DisplayRole,
                 )
                 row_data.append(item if item else "")
             writer.writerow(row_data)
 
-            if row % 50 == 0:  # Update progress every 50 rows
-                acf_log_reader.status_bar.showMessage(
-                    f"Exporting row {row + 1} of {acf_log_reader.table_view.model().rowCount()}..."
-                )
+            if row % 50 == 0 and row > 0:  # Log progress every 50 rows (skip row 0)
+                logger.debug(f"Exported {row} / {row_count} rows")
 
 
-def _write_csv_metadata(acf_log_reader: "AcfLogReader", writer: Any) -> None:
+def _write_csv_metadata(panel: BaseModsPanel, writer: Any) -> None:
     """
     Write metadata headers to the CSV file.
 
+    Metadata includes:
+    - Export title
+    - Export timestamp
+    - Total number of rows exported
+    - Source ACF file path (if available in panel)
+
     Args:
-        acf_log_reader: The AcfLogReader instance.
+        panel: The panel instance (BaseModsPanel or subclass).
         writer: The CSV writer object.
     """
+    model = _get_table_model(panel)
+
     writer.writerow(["RimSort Workshop Items Export"])
     writer.writerow([f"Export Date: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}"])
-    writer.writerow([f"Total Items: {acf_log_reader.table_view.model().rowCount()}"])
-    writer.writerow(
-        [
-            f"Source ACF: {acf_log_reader.steamcmd_interface.steamcmd_appworkshop_acf_path}"
-        ]
-    )
-    writer.writerow([])
+    writer.writerow([f"Total Items: {model.rowCount()}"])
+
+    # Add SteamCMD ACF path if available (AcfLogReader has this)
+    acf_path = None
+    if hasattr(panel, "metadata_manager") and hasattr(
+        panel.metadata_manager, "steamcmd_wrapper"
+    ):
+        acf_path = getattr(
+            panel.metadata_manager.steamcmd_wrapper,
+            "steamcmd_appworkshop_acf_path",
+            None,
+        )
+
+    if acf_path:
+        writer.writerow([f"Source ACF: {acf_path}"])
+    writer.writerow([])  # Blank separator
 
 
-def _write_csv_headers(acf_log_reader: "AcfLogReader", writer: Any) -> None:
+def _write_csv_headers(panel: BaseModsPanel, writer: Any) -> None:
     """
     Write column headers and descriptions to the CSV file.
 
+    Writes two rows: one for column headers, one for descriptions.
+
     Args:
-        acf_log_reader: The AcfLogReader instance.
+        panel: The panel instance (BaseModsPanel or subclass).
         writer: The CSV writer object.
     """
+    model = _get_table_model(panel)
+
     headers = []
     descriptions = []
-    for col in range(acf_log_reader.table_view.model().columnCount()):
+    for col in range(model.columnCount()):
         header = (
-            acf_log_reader.table_model.headerData(
+            model.headerData(
                 col, Qt.Orientation.Horizontal, Qt.ItemDataRole.DisplayRole
             )
             or ""
         )
         headers.append(header)
-        descriptions.append(_get_column_description(acf_log_reader, col))
+        descriptions.append(_get_column_description(panel, col))
+
     writer.writerow(headers)
     writer.writerow(descriptions)
-    writer.writerow([])
+    writer.writerow([])  # Blank separator
 
 
-def _finalize_csv_export(acf_log_reader: "AcfLogReader", file_path: str) -> None:
+def _finalize_csv_export(panel: BaseModsPanel, file_path: str) -> None:
     """
-    Finalize the CSV export by updating status and showing success message.
+    Finalize the CSV export by logging success and showing confirmation dialog.
 
     Args:
-        acf_log_reader: The AcfLogReader instance.
-        file_path: The path of the exported file.
+        panel: The panel instance (BaseModsPanel or subclass).
+        file_path: The path of the exported CSV file.
     """
-    acf_log_reader.status_bar.showMessage(
-        f"Successfully exported {acf_log_reader.table_view.model().rowCount()} items to {file_path}"
-    )
+    model = _get_table_model(panel)
+    row_count = model.rowCount()
+
+    logger.info(f"Successfully exported {row_count} items to {file_path}")
     show_information(
-        title=acf_log_reader.tr("Export Success"),
-        text=acf_log_reader.tr(
-            "Successfully exported {count} items to {file_path}"
-        ).format(
-            count=acf_log_reader.table_view.model().rowCount(), file_path=file_path
+        title=panel.tr("Export Success"),
+        text=panel.tr("Successfully exported {count} items to {file_path}").format(
+            count=row_count, file_path=file_path
         ),
     )
 
 
 def _handle_csv_export_error(
-    acf_log_reader: "AcfLogReader",
+    panel: BaseModsPanel,
     message: str,
     title: str,
     details: Optional[str] = None,
 ) -> None:
     """
-    Handle CSV export errors by logging, updating status, and showing dialog.
+    Handle CSV export errors with logging and user notification.
+
+    Logs the error with full stack trace and shows an error dialog to the user.
 
     Args:
-        acf_log_reader: The AcfLogReader instance.
-        message: The error message.
+        panel: The panel instance (BaseModsPanel or subclass).
+        message: The error message to display to the user.
         title: The dialog title.
-        details: Optional additional details.
+        details: Optional additional details (technical info) to show in the dialog.
     """
-    acf_log_reader.status_bar.showMessage(message)
     logger.error(f"CSV Export error: {message}", exc_info=True)
     show_warning(
-        title=acf_log_reader.tr(title),
+        title=panel.tr(title),
         text=message,
         information=details,
     )
 
 
-def _get_column_description(acf_log_reader: "AcfLogReader", col: int) -> str:
-    """Get description for a table column."""
-    try:
-        column = acf_log_reader.TableColumn(col)
-        return column.description
-    except ValueError:
-        return ""
+def _get_table_model(panel: BaseModsPanel) -> Any:
+    """
+    Get the table model from the panel.
+
+    Handles both direct attribute access (editor_model) and property-based access
+    (table_view.model()), making this utility compatible with various panel implementations.
+
+    Args:
+        panel: The panel instance (BaseModsPanel or subclass).
+
+    Returns:
+        The table model object.
+    """
+    return (
+        panel.editor_model
+        if hasattr(panel, "editor_model")
+        else panel.table_view.model()  # type: ignore[attr-defined]
+    )
+
+
+def _get_column_description(panel: BaseModsPanel, col: int) -> str:
+    """
+    Get description for a table column (currently returns the column header).
+
+    This is a placeholder for future column-specific descriptions.
+    Currently, it returns the same as the header.
+
+    Args:
+        panel: The panel instance (BaseModsPanel or subclass).
+        col: The column index.
+
+    Returns:
+        The column header/description string.
+    """
+    model = _get_table_model(panel)
+    header = (
+        model.headerData(col, Qt.Orientation.Horizontal, Qt.ItemDataRole.DisplayRole)
+        or ""
+    )
+    return header

--- a/app/utils/event_bus.py
+++ b/app/utils/event_bus.py
@@ -88,6 +88,7 @@ class EventBus(QObject):
     do_build_steam_workshop_database = Signal()
     do_clear_steamcmd_depot_cache = Signal()
     do_import_acf = Signal()
+    do_export_acf = Signal()
     do_delete_acf = Signal()
     do_install_steamcmd = Signal()
     do_change_mod_coloring_mode = Signal()

--- a/app/windows/base_mods_panel.py
+++ b/app/windows/base_mods_panel.py
@@ -348,7 +348,9 @@ class BaseModsPanel(QWidget):
         if event.type() == QEvent.Type.KeyPress:
             key_event = QKeyEvent(event)  # type: ignore
             if key_event.key() == Qt.Key.Key_Escape:
-                self.close()
+                # Don't close AcfLogReader on Escape key (it's a persistent view)
+                if self.__class__.__name__ != "AcfLogReader":
+                    self.close()
                 return True
 
         return super().eventFilter(watched, event)
@@ -425,7 +427,9 @@ class BaseModsPanel(QWidget):
             completed()
 
         # Close the panel window after triggering operations
-        self.close()
+        # Don't close AcfLogReader (it's a persistent view, not a dialog)
+        if self.__class__.__name__ != "AcfLogReader":
+            self.close()
 
     def _collect_pfids_by_mode(
         self, pfid_column: int, mode: str | int


### PR DESCRIPTION
- Completely rewrote AcfLogReader with search functionality, debounced search input, and improved table handling
- Removed enable_acf_log_reader setting from Settings model
- Refactored csv_export_utils to work with BaseModsPanel instead of AcfLogReader, added comprehensive docstrings and error handling
- Added do_export_acf signal to EventBus for ACF export operations
- Implemented ACF export functionality in MainContentPanel with proper error handling and user dialogs
- Modified BaseModsPanel to treat AcfLogReader as a persistent view, preventing closure on Escape key or operation completion