### PR TITLE
Add UUID existence check in ModsPanel

### DIFF
--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -3857,6 +3857,9 @@ class ModsPanel(QWidget):
             )
             if item is None:
                 continue
+            # Check if UUID exists in metadata before accessing
+            if uuid not in self.metadata_manager.internal_local_metadata:
+                continue
             item_data = item.data(Qt.ItemDataRole.UserRole)
             metadata = self.metadata_manager.internal_local_metadata[uuid]
             if pattern != "":


### PR DESCRIPTION
- Prevent potential KeyError by checking if UUID exists in internal_local_metadata before accessing it.
- This ensures the code handles cases where the UUID might not be present, improving robustness.