### PR TITLE
Allow None values in SteamDbEntry gameVersions field

### DIFF
--- a/app/models/metadata/metadata_structure.py
+++ b/app/models/metadata/metadata_structure.py
@@ -544,7 +544,7 @@ class SteamDbEntry(msgspec.Struct, omit_defaults=True):
     unpublished: bool = False
     url: str = msgspec.field(default_factory=str)
     packageId: str = msgspec.field(default_factory=str)
-    gameVersions: list[str] | str = msgspec.field(default_factory=list)
+    gameVersions: list[str | None] | str | None = msgspec.field(default_factory=list)
     steamName: str = msgspec.field(default_factory=str)
     name: str = msgspec.field(default_factory=str)
     authors: list[str] | str | None = msgspec.field(default_factory=str)


### PR DESCRIPTION
- Updated the type annotation for gameVersions in SteamDbEntry to support None values within the list and as the entire field.
- This change enables better handling of incomplete or missing version data from the Steam database, preventing potential errors when parsing entries with null or undefined game versions.