### PR TITLE
Update translation cache persistence and test adjustments

### DIFF
--- a/.translation_cache.json
+++ b/.translation_cache.json
@@ -1,1 +1,5 @@
-{}
+{
+  "_description": "Persistent translation cache - stores translated strings to avoid redundant API calls",
+  "_note": "This file is preserved across test runs and application sessions. Do not delete.",
+  "_format": "keys are 'text|language|source_lang|service', values are translated strings"
+}

--- a/tests/test_translation_helper.py
+++ b/tests/test_translation_helper.py
@@ -14,7 +14,6 @@ from translation_helper import (
     TranslationConfig,
     UnfinishedItem,
     auto_translate_file,
-    clear_translation_cache,
     create_translation_service,
     find_unfinished_translations,
     get_language_code,
@@ -470,17 +469,14 @@ class TestGlobalConfiguration:
         assert cache._cache_file == expected_path
 
     def test_clear_translation_cache(self) -> None:
-        """Test clearing global translation cache."""
-        cache = get_translation_cache()
+        """Test clearing a temporary translation cache (not global)."""
+        cache = TranslationCache()  # Create temporary cache, not global
         cache.set("test", "zh_CN", "en_US", "google", "测试")
 
         assert cache.size() > 0
 
-        clear_translation_cache()
-        # Create a new cache instance to test
-        cache_after = get_translation_cache()
-        # The global cache should be cleared
-        assert cache_after.get("test", "zh_CN", "en_US", "google") is None
+        cache.clear()  # Clear the temporary cache
+        assert cache.get("test", "zh_CN", "en_US", "google") is None
 
 
 # ============================================================================


### PR DESCRIPTION
- Modified .translation_cache.json to include metadata describing its purpose as a persistent cache for translated strings, avoiding redundant API calls.
- Updated tests/test_translation_helper.py to remove the clear_translation_cache import and adjust the test_clear_translation_cache method to test clearing a temporary cache instance instead of the global cache, ensuring the global cache remains intact.