### PR TITLE
Add subscribe parameter to mod update function

### DIFF
--- a/app/windows/base_mods_panel.py
+++ b/app/windows/base_mods_panel.py
@@ -644,6 +644,7 @@ class BaseModsPanel(QWidget):
                         self._update_mods_from_table,
                         pfid_column,
                         "Steam",
+                        "subscribe",
                         completed=completion_callback,
                     ),
                 )


### PR DESCRIPTION
Modified the function call in BaseModsPanel to include 'subscribe' as an additional argument, enabling subscription functionality for Steam mods.