### PR TITLE
Improve wording for mod resubscribe operation

### DIFF
--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -1572,15 +1572,15 @@ class ModListWidget(QListWidget):
                     answer = show_dialogue_conditional(
                         title=self.tr("Are you sure?"),
                         text=self.tr(
-                            "You have selected {len} mods for unsubscribe + re-subscribe."
+                            "You have selected {len} mods for resubscribe:(unsubscribe + subscribe)."
                         ).format(len=len(publishedfileids)),
                         information=self.tr(
                             "\nThis operation will potentially delete .dds textures leftover. Steam is unreliable for this. Do you want to proceed?"
                         ),
                     )
                     if answer == QMessageBox.StandardButton.Yes:
-                        logger.debug(
-                            f"Unsubscribing + re-subscribing to {len(publishedfileids)} mod(s)"
+                        logger.warning(
+                            f"re-subscribing: (Unsubscribing + subscribing) to {len(publishedfileids)} mod(s)"
                         )
                         for path in steam_mod_paths:
                             delete_files_except_extension(


### PR DESCRIPTION
- Updated the dialogue text in ModListWidget to clarify the resubscribe process as 'resubscribe:(unsubscribe + subscribe)' instead of 'unsubscribe + re-subscribe'.
- Also changed the logger level from debug to warning for the resubscribe operation to improve visibility of this action.