### PR TITLE
Refactor WorkshopModUpdaterPanel for better initialization & mod handling

### DIFF
--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -2163,7 +2163,6 @@ class MainContent(QObject):
             )
             return
         workshop_mod_updater = WorkshopModUpdaterPanel()
-        workshop_mod_updater._populate_from_metadata()
         if workshop_mod_updater._row_count() > 0:
             logger.debug("Displaying potential Workshop mod updates")
             workshop_mod_updater.show()


### PR DESCRIPTION
- Remove unnecessary _populate_from_metadata() call in MainContent panel
- Add eligible_metadata attribute to WorkshopModUpdaterPanel for storing update-eligible mods
- Improve initialization docstring and add comments for clarity
- Fix typo in title text: 'There updates' -> 'There are updates'
- Update button texts for better clarity: 'Update with SteamCMD' -> 'Update Mods with SteamCMD', 'Update with Steam client' -> 'Update Mods with Steam'
- Conditionally add Steam client button only if integration is enabled
- Refactor _filter_eligible_mods to return (uuid, metadata) tuples instead of just metadata
- Simplify _populate_from_metadata by using the new tuple structure and _add_mod_row directly
- Remove redundant _add_update_mod_row method as it's no longer needed