### PR TITLE
Refactor user rules file path and clean up browser layout

### DIFF
--- a/app/utils/metadata.py
+++ b/app/utils/metadata.py
@@ -781,7 +781,7 @@ class MetadataManager(QObject):
             self.settings_controller.settings.external_steam_metadata_source
         )
         self.steamcmd_acf_path = self.steamcmd_wrapper.steamcmd_appworkshop_acf_path
-        self.user_rules_file_path = str(AppInfo().databases_folder / "userRules.json")
+        self.user_rules_file_path = str(AppInfo().user_rules_file)
 
     def supplement_dlc_metadata(self, uuid: str) -> None:
         """

--- a/app/utils/steam/steambrowser/browser.py
+++ b/app/utils/steam/steambrowser/browser.py
@@ -223,7 +223,7 @@ class SteamBrowser(QWidget):
         self.downloader_layout.addWidget(self.download_steamcmd_button)
         self.downloader_layout.addWidget(self.download_steamworks_button)
         self.downloader_layout.addWidget(self.clear_list_button)
-        
+
         # Build the browser layout
         self.browser_layout.addWidget(self.location)
         self.browser_layout.addWidget(self.nav_bar)


### PR DESCRIPTION
- Updated MetadataManager to use AppInfo().user_rules_file for user_rules_file_path instead of manually constructing the path with databases_folder / 'userRules.json'
- Removed trailing blank line in SteamBrowser downloader layout for code consistency