### PR TITLE
Add directory existence check in delete_files_with_condition

### DIFF
--- a/app/utils/generic.py
+++ b/app/utils/generic.py
@@ -168,6 +168,11 @@ def rmtree(path: str | Path, **kwargs: Any) -> bool:
 def delete_files_with_condition(
     directory: Path | str, condition: Callable[[str], bool]
 ) -> bool:
+    # Check if directory exists
+    if not os.path.exists(directory):
+        logger.warning(f"Directory does not exist: {directory}")
+        return False
+
     for root, dirs, files in os.walk(directory):
         for file in files:
             if condition(file):


### PR DESCRIPTION
- This change adds a safety check to verify if the directory exists before attempting to walk through it and delete files based on a condition.
- If the directory does not exist, it logs a warning message and returns False, preventing potential errors or exceptions.