### PR TITLE
Fix help text for --build-steamworkspy to use raw string

### DIFF
--- a/distribute.py
+++ b/distribute.py
@@ -542,7 +542,7 @@ def make_args() -> argparse.ArgumentParser:
     parser.add_argument(
         "--build-steamworkspy",
         action="store_true",
-        help="build SteamworksPy instead of copying it, optionally using --sdk-url or --sdk-zip for SDK source or extract the sdk from the provided zip file to submodules\SteamworksPy\library",
+        help=r"build SteamworksPy instead of copying it, optionally using --sdk-url or --sdk-zip for SDK source or extract the sdk from the provided zip file to submodules\SteamworksPy\library",
     )
 
     # Force download Steamworks SDK from URL


### PR DESCRIPTION
Added 'r' prefix to the help string for the --build-steamworkspy argument to treat it as a raw string, ensuring backslashes in the path 'submodules\SteamworksPy\library' are not escaped.