### PR TITLE
Refactor troubleshooting controller imports and fix test patches

### DIFF
--- a/app/controllers/troubleshooting_controller.py
+++ b/app/controllers/troubleshooting_controller.py
@@ -9,6 +9,8 @@ from loguru import logger
 from PySide6.QtCore import QCoreApplication
 
 from app.models.settings import Settings
+from app.utils.event_bus import EventBus
+from app.utils.generic import platform_specific_open
 from app.utils.gui_info import (
     show_dialogue_conditional,
     show_dialogue_file,
@@ -128,8 +130,6 @@ class TroubleshootingController:
 
         # Try to trigger Steam installation
         try:
-            from app.utils.generic import platform_specific_open
-
             platform_specific_open("steam://install/294100")  # RimWorld's Steam
             logger.info("Triggered Steam installation for game ID 294100.")
             show_information(
@@ -186,8 +186,6 @@ class TroubleshootingController:
 
         # try to trigger redownload for each mod
         try:
-            from app.utils.generic import platform_specific_open
-
             # first verify/repair game files
             platform_specific_open("steam://validate/294100")
 
@@ -397,9 +395,7 @@ class TroubleshootingController:
                 )
                 return
 
-        # refresh mod list
-        from app.utils.event_bus import EventBus
-
+        # refresh mod list so user dont need to click refresh button in main window
         EventBus().do_refresh_mods_lists.emit()
 
     def _on_mod_export_list_button_clicked(self) -> None:
@@ -570,8 +566,6 @@ class TroubleshootingController:
             tree.write(mods_config, encoding="utf-8", xml_declaration=True)
 
             # refresh mod list so user dont need to click refresh button in main window
-            from app.utils.event_bus import EventBus
-
             EventBus().do_refresh_mods_lists.emit()
 
         except (json.JSONDecodeError, ValueError, KeyError) as e:
@@ -678,9 +672,7 @@ class TroubleshootingController:
     def _on_steam_verify_game_clicked(self) -> None:
         """Verify game files through Steam."""
         try:
-            from app.utils.generic import platform_specific_open
-
-            platform_specific_open("steam://validate/294100")  # rim steam app id
+            platform_specific_open("steam://validate/294100")  # RimWorld steam app id
         except Exception as e:
             logger.error(f"Failed to verify game files: {e}")
             show_dialogue_conditional(
@@ -736,8 +728,6 @@ class TroubleshootingController:
                 return
 
             # validate each game
-            from app.utils.generic import platform_specific_open
-
             for app_id in app_ids:
                 platform_specific_open(f"steam://validate/{app_id}")
 

--- a/tests/controllers/test_troubleshooting.py
+++ b/tests/controllers/test_troubleshooting.py
@@ -172,7 +172,9 @@ class TestUIInteractions:
                 "app.controllers.troubleshooting_controller.show_dialogue_conditional",
                 return_value=True,
             ),
-            patch("app.utils.event_bus.EventBus") as mock_event_bus,
+            patch(
+                "app.controllers.troubleshooting_controller.EventBus"
+            ) as mock_event_bus,
         ):
             mock_event_bus_instance = mock_event_bus.return_value
             mock_event_bus_instance.do_refresh_mods_lists = mock_event_bus_instance
@@ -253,7 +255,9 @@ class TestSteamUtilities:
 
         steam_path = Path("C:/Program Files (x86)/Steam")
         with (
-            patch("app.utils.generic.platform_specific_open") as mock_open,
+            patch(
+                "app.controllers.troubleshooting_controller.platform_specific_open"
+            ) as mock_open,
             patch(
                 "app.controllers.troubleshooting_controller.show_dialogue_conditional",
                 return_value=True,
@@ -269,7 +273,9 @@ class TestSteamUtilities:
 
         mock_open.reset_mock()
         with (
-            patch("app.utils.generic.platform_specific_open") as mock_open,
+            patch(
+                "app.controllers.troubleshooting_controller.platform_specific_open"
+            ) as mock_open,
             patch(
                 "app.controllers.troubleshooting_controller.show_dialogue_conditional",
                 return_value=True,
@@ -315,7 +321,9 @@ class TestSteamUtilities:
                 "app.controllers.troubleshooting_controller.show_dialogue_conditional",
                 return_value=True,
             ),
-            patch("app.utils.generic.platform_specific_open") as mock_open,
+            patch(
+                "app.controllers.troubleshooting_controller.platform_specific_open"
+            ) as mock_open,
         ):
             controller._on_steam_repair_library_clicked()
             assert mock_open.call_count == 2
@@ -414,7 +422,9 @@ class TestModListImportExport:
             ),
             patch("builtins.open", create=True) as mock_open,
             patch("json.load", return_value=import_data),
-            patch("app.utils.event_bus.EventBus") as mock_event_bus,
+            patch(
+                "app.controllers.troubleshooting_controller.EventBus"
+            ) as mock_event_bus,
         ):
             controller._on_mod_import_list_button_clicked()
             mock_open.assert_called()


### PR DESCRIPTION
- Moved EventBus and platform_specific_open imports to the top of troubleshooting_controller.py
- Removed redundant import statements within functions
- Fixed comment typo in steam app id
- Updated test patches in test_troubleshooting.py to use full module paths for proper mocking