### PR TITLE
Add Steam game file verification feature

### DIFF
--- a/app/controllers/menu_bar_controller.py
+++ b/app/controllers/menu_bar_controller.py
@@ -138,6 +138,9 @@ class MenuBarController(QObject):
         self.menu_bar.update_workshop_mods_action.triggered.connect(
             EventBus().do_check_for_workshop_updates
         )
+        self.menu_bar.steam_verify_game_files_action.triggered.connect(
+            EventBus().do_steam_verify_game_files
+        )
 
         # Instances menu
         self.menu_bar.backup_instance_action.triggered.connect(

--- a/app/utils/event_bus.py
+++ b/app/utils/event_bus.py
@@ -54,6 +54,7 @@ class EventBus(QObject):
     do_add_zip_mod = Signal()
     do_browse_workshop = Signal()
     do_check_for_workshop_updates = Signal()
+    do_steam_verify_game_files = Signal()
 
     # Instances Menu bar signals
     do_activate_current_instance = Signal(str)

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -224,6 +224,9 @@ class MainContent(QObject):
             EventBus().do_check_for_workshop_updates.connect(
                 self._do_check_for_workshop_updates
             )
+            EventBus().do_steam_verify_game_files.connect(
+                self.do_steam_verify_game_files
+            )
 
             # Textures Menu bar Eventbus
             EventBus().do_optimize_textures.connect(self._do_optimize_textures)
@@ -2263,6 +2266,38 @@ class MainContent(QObject):
             self.status_signal.emit(
                 self.tr("All Workshop mods appear to be up to date!")
             )
+
+    def do_steam_verify_game_files(self) -> None:
+        """Verify RimWorld game files through Steam."""
+        # Retrieve settings for the current RimWorld instance
+        steam_client_integration_enabled = self.settings_controller.settings.instances[
+            self.settings_controller.settings.current_instance
+        ].steam_client_integration
+
+        # Check if Steam Client Integration is enabled
+        if not steam_client_integration_enabled:
+            # Inform user that feature requires Steam Client Integration
+            logger.warning(
+                "Steam Client Integration is disabled. Cannot verify game files."
+            )
+            dialogue.show_warning(
+                title=self.tr("Steam Client Integration is disabled"),
+                text=self.tr(
+                    "This feature requires Steam Client Integration to be enabled in Settings. "
+                    "Please enable Steam Client Integration if you own the game on Steam."
+                ),
+            )
+            return
+
+        # Validate internet connectivity before proceeding
+        if not check_internet_connection():
+            return
+
+        logger.info("Verifying game files through Steam.")
+        logger.info("Steam Client Integration enabled. Opening Steam URI protocol.")
+        # Open Steam's game file verification dialog using URI protocol
+        # RimWorld's Steam app ID is 294100
+        platform_specific_open("steam://validate/294100")
 
     def _do_setup_steamcmd(self) -> None:
         if (

--- a/app/views/menu_bar.py
+++ b/app/views/menu_bar.py
@@ -62,6 +62,7 @@ class MenuBar(QObject):
         self.add_zip_mod_action: QAction
         self.browse_workshop_action: QAction
         self.update_workshop_mods_action: QAction
+        self.steam_verify_game_files_action: QAction
         self.backup_instance_action: QAction
         self.restore_instance_action: QAction
         self.clone_instance_action: QAction
@@ -287,6 +288,10 @@ class MenuBar(QObject):
         )
         self.update_workshop_mods_action = self._add_action(
             download_menu, self.tr("Update Workshop Mods")
+        )
+        download_menu.addSeparator()
+        self.steam_verify_game_files_action = self._add_action(
+            download_menu, self.tr("Verify Game Files")
         )
         return download_menu
 


### PR DESCRIPTION
- Added do_steam_verify_game_files signal to EventBus for triggering game file verification
- Implemented steam_verify_game_files_action in MenuBar under Download menu
- Connected the menu action to the event bus signal in MenuBarController
- Added do_steam_verify_game_files method in MainContentPanel that:
  - Checks if Steam Client Integration is enabled for the current instance
  - Validates internet connectivity
  - Opens Steam's game file verification dialog using URI protocol (steam://validate/294100 for RimWorld)
  - Provides user feedback if integration is disabled or no internet