### PR TITLE
Refactor _on_steam_verify_game_clicked to emit EventBus event

### DIFF
--- a/app/controllers/troubleshooting_controller.py
+++ b/app/controllers/troubleshooting_controller.py
@@ -629,6 +629,10 @@ class TroubleshootingController:
 
         return steam_path
 
+    def _on_steam_verify_game_clicked(self) -> None:
+        """Verify RimWorld game files through Steam."""
+        EventBus().do_steam_verify_game_files.emit()
+
     def _on_steam_clear_cache_clicked(self) -> None:
         """Clear Steam download cache."""
         try:
@@ -664,24 +668,6 @@ class TroubleshootingController:
                 text=self.translate(
                     "TroubleshootingController",
                     "Could not delete Steam's downloading folder.\nPlease delete it manually: Steam/steamapps/downloading\nDetails: {e}",
-                ).format(e=str(e)),
-                icon="warning",
-                buttons=["Ok"],
-            )
-
-    def _on_steam_verify_game_clicked(self) -> None:
-        """Verify game files through Steam."""
-        try:
-            platform_specific_open("steam://validate/294100")  # RimWorld steam app id
-        except Exception as e:
-            logger.error(f"Failed to verify game files: {e}")
-            show_dialogue_conditional(
-                title=self.translate(
-                    "TroubleshootingController", "Steam Action Failed"
-                ),
-                text=self.translate(
-                    "TroubleshootingController",
-                    "Could not open Steam to verify game files.\nPlease verify game files manually through Steam's game properties.\nDetails: {e}",
                 ).format(e=str(e)),
                 icon="warning",
                 buttons=["Ok"],

--- a/tests/controllers/test_troubleshooting.py
+++ b/tests/controllers/test_troubleshooting.py
@@ -272,17 +272,11 @@ class TestSteamUtilities:
             controller._on_steam_clear_cache_clicked()
 
         mock_open.reset_mock()
-        with (
-            patch(
-                "app.controllers.troubleshooting_controller.platform_specific_open"
-            ) as mock_open,
-            patch(
-                "app.controllers.troubleshooting_controller.show_dialogue_conditional",
-                return_value=True,
-            ),
-        ):
+        with patch(
+            "app.controllers.troubleshooting_controller.EventBus"
+        ) as mock_eventbus:
             controller._on_steam_verify_game_clicked()
-            mock_open.assert_called_with("steam://validate/294100")
+            mock_eventbus.return_value.do_steam_verify_game_files.emit.assert_called_once()
 
         with (
             patch(


### PR DESCRIPTION
- Moved the Steam game verification logic from direct platform_specific_open call to emitting an event via EventBus for better decoupling and separation of concerns.
- Updated the corresponding unit test in test_troubleshooting.py to mock EventBus instead of platform_specific_open and show_dialogue_conditional.
- Removed exception handling in the controller method, as error handling is now delegated to the event system.