### PR TITLE
Fix IndexError in __handle_inactive_mod_key_press when no items selected

### DIFF
--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -435,7 +435,10 @@ class MainContent(QObject):
             iml.setFocus()
             if not iml.selectedIndexes():
                 iml.setCurrentRow(self.___get_relative_middle(iml))
-            item = iml.selectedItems()[0]
+            selected_items = iml.selectedItems()
+            if not selected_items:
+                return
+            item = selected_items[0]
             data = item.data(Qt.ItemDataRole.UserRole)
             uuid = data["uuid"]
             self.__mod_list_slot(uuid, cast(CustomListWidgetItem, item))


### PR DESCRIPTION
Add a check for selected items before accessing the first item to prevent IndexError when the inactive mods list has no selected items.