### PR TITLE
Add Steam protocol launch option for enabling Steam overlay

### DIFF
--- a/app/models/instance.py
+++ b/app/models/instance.py
@@ -28,6 +28,8 @@ class Instance(msgspec.Struct):
     )
     steamcmd_ignore: bool = False
     steam_client_integration: bool = False
+    # Launch game via Steam protocol to enable Steam overlay
+    launch_via_steam_protocol: bool = False
     instance_folder_override: str = (
         ""  # Custom instance folder path, empty = use default
     )

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -456,6 +456,7 @@ class Settings(QObject):
         - If steam_client_integration is enabled but workshop_folder is not set, disable it.
         - If workshop_folder is set but the appworkshop_294100.acf file is missing,
           disable steam_client_integration and clear workshop_folder.
+        - If launch_via_steam_protocol is enabled but steam_client_integration is disabled, disable it.
 
         Invalid configurations are silently fixed without user interaction.
 
@@ -464,10 +465,23 @@ class Settings(QObject):
         active_instance = self.instances[self.current_instance]
         steam_client_integration = active_instance.steam_client_integration
         workshop_folder = active_instance.workshop_folder
+        launch_via_steam_protocol = active_instance.launch_via_steam_protocol
 
         # If neither is enabled, no validation needed
-        if not steam_client_integration and not workshop_folder:
+        if (
+            not steam_client_integration
+            and not workshop_folder
+            and not launch_via_steam_protocol
+        ):
             return False
+
+        # If launch_via_steam_protocol is enabled but steam_client_integration is not, disable it
+        if launch_via_steam_protocol and not steam_client_integration:
+            logger.warning(
+                "Steam protocol launch is enabled but Steam client integration is disabled. Disabling..."
+            )
+            active_instance.launch_via_steam_protocol = False
+            return True
 
         # If steam_client_integration is enabled but workshop_folder is not set, disable it
         if steam_client_integration and not workshop_folder:

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -319,6 +319,25 @@ class SettingsDialog(QDialog):
         tab_layout = QVBoxLayout(tab)
         tab_layout.setAlignment(Qt.AlignmentFlag.AlignTop)
 
+        # Steam protocol launch option
+        steam_protocol_group = QGroupBox()
+        tab_layout.addWidget(steam_protocol_group)
+
+        steam_protocol_layout = QVBoxLayout(steam_protocol_group)
+
+        self.launch_via_steam_protocol_checkbox = QCheckBox(
+            self.tr("Launch game via Steam protocol (enables Steam overlay)")
+        )
+        self.launch_via_steam_protocol_checkbox.setToolTip(
+            self.tr(
+                "If enabled, RimSort will launch the game using the Steam protocol (steam://rungameid/294100) "
+                "instead of directly running the executable. This enables the Steam overlay. "
+                "Note: This requires Steam to be running and will ignore custom launch arguments."
+            )
+        )
+        steam_protocol_layout.addWidget(self.launch_via_steam_protocol_checkbox)
+
+        # Game arguments group
         run_args_group = QGroupBox()
         tab_layout.addWidget(run_args_group)
 
@@ -337,10 +356,11 @@ class SettingsDialog(QDialog):
                 "\n   PROTON_LOG=1 %command%\n"
                 "\n   gamemoderun %command% -logfile /tmp/log\n"
                 "\n   DXVK_HUD=1 mangohud %command% -popupwindow\n"
-                "\n NOTE: wrapper commands will be ignored on macOS"
+                "\n NOTE: wrapper commands will be ignored on macOS\n"
+                "\n NOTE: These arguments are ignored if 'Launch game via Steam protocol' is enabled"
             )
         )
-        self.run_args_info_label.setFixedHeight(GUIInfo().default_font_line_height * 17)
+        self.run_args_info_label.setFixedHeight(GUIInfo().default_font_line_height * 18)
         run_args_info_layout.addWidget(self.run_args_info_label, 0)
         self.run_args_info_label.setAlignment(Qt.AlignmentFlag.AlignLeft)
 

--- a/tests/views/test_main_content_run.py
+++ b/tests/views/test_main_content_run.py
@@ -36,6 +36,7 @@ class DummySettings:
                 config_folder="/fake/config",
                 run_args=["--test"],
                 steam_client_integration=False,
+                launch_via_steam_protocol=False,
             )
         }
 
@@ -66,6 +67,8 @@ def patch_launch(monkeypatch: pytest.MonkeyPatch) -> List[Tuple[Path, List[str]]
     monkeypatch.setattr(
         main_content_panel, "launch_game_process", fake_launch_game_process
     )
+    # Also patch platform_specific_open to avoid trying to open Steam protocol
+    monkeypatch.setattr(main_content_panel, "platform_specific_open", Mock())
     return calls
 
 


### PR DESCRIPTION
- Add launch_via_steam_protocol field to Instance model
- Implement loading/saving of Steam protocol launch setting in settings controller
- Add validation to disable Steam protocol launch when Steam integration is disabled
- Add UI checkbox in settings dialog for enabling Steam protocol launch
- Modify game launch logic to use steam://rungameid/294100 URI when enabled
- Ensure Steam protocol launch requires Steam client integration to be enabled
- Update Steam integration validation to handle protocol launch dependency
- updated pytest for tests\views\test_main_content_run.py accordingly

<img width="902" height="673" alt="image" src="https://github.com/user-attachments/assets/6c8b1859-d1d6-4974-9945-e86dd22133a0" />
