### PR TITLE
Specify Wix extension version in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,8 +203,8 @@ jobs:
         if: matrix.platform == 'Windows'
         run: |
           dotnet tool install --global wix --version 6.0.0
-          wix extension add WixToolset.UI.wixext
-          wix extension add WixToolset.Util.wixext
+          wix extension add WixToolset.UI.wixext/6.0.0
+          wix extension add WixToolset.Util.wixext/6.0.0
 
           # Absolute paths for license and build output
           $AbsoluteLicensePath = Resolve-Path "data\EULA.rtf" -ErrorAction Stop


### PR DESCRIPTION
Updated Wix extensions to version 6.0.0 in the build workflow.

- Temporarily specify the version
- Fix MSI build error