### PR TITLE
Improve handling of corrupted settings

### DIFF
--- a/app/utils/app_info.py
+++ b/app/utils/app_info.py
@@ -56,7 +56,6 @@ class AppInfo:
         )
 
         # Application metadata
-
         self._app_name = "RimSort"
         self._app_copyright = ""
 
@@ -75,13 +74,11 @@ class AppInfo:
                     self._app_version += f"+{commit[:7]}"
 
         # Define important directories using platformdirs
-
         platform_dirs = PlatformDirs(appname=self._app_name, appauthor=False)
         self._app_storage_folder: Path = Path(platform_dirs.user_data_dir)
         self._user_log_folder: Path = Path(platform_dirs.user_log_dir)
 
         # Derive some secondary directory paths
-
         self._databases_folder: Path = self._app_storage_folder / "dbs"
         self._saved_modlists_folder: Path = self._app_storage_folder / "modlists"
         self._theme_storage_folder: Path = self._app_storage_folder / "themes"
@@ -91,20 +88,29 @@ class AppInfo:
         self._ignore_mods_file: Path = self.databases_folder / "ignore.json"
         self._language_data_folder: Path = self._application_folder / "locales"
         self._browser_profile_folder: Path = self._app_storage_folder / "browser"
-        self._backup_folder: Path = self._app_storage_folder / "backup"
         self._setup_web_channel_script_file: Path = (
             self._application_folder / "setup_web_channel_script.js"
         )
 
-        # Make sure important directories exist
+        # Backup directories
+        self._backups_folder: Path = self._app_storage_folder / "backups"
+        self._game_saves_backups_folder: Path = self._backups_folder / "saves"
+        self._settings_backups_folder: Path = self._backups_folder / "settings"
+        self._application_backups_folder: Path = self._backups_folder / "rimsort_installation"
 
+        # Make sure important directories exist
         self._app_storage_folder.mkdir(parents=True, exist_ok=True)
         self._user_log_folder.mkdir(parents=True, exist_ok=True)
         self._saved_modlists_folder.mkdir(parents=True, exist_ok=True)
 
         self._databases_folder.mkdir(parents=True, exist_ok=True)
         self._theme_storage_folder.mkdir(parents=True, exist_ok=True)
-        self._backup_folder.mkdir(parents=True, exist_ok=True)
+
+        # Create backup directories
+        self._backups_folder.mkdir(parents=True, exist_ok=True)
+        self._game_saves_backups_folder.mkdir(parents=True, exist_ok=True)
+        self._settings_backups_folder.mkdir(parents=True, exist_ok=True)
+        self._application_backups_folder.mkdir(parents=True, exist_ok=True)
 
         # Initialize user rules file if it does not exist
         if not self._user_rules_file.exists():
@@ -249,15 +255,38 @@ class AppInfo:
         return self._language_data_folder
 
     @property
-    def backup_folder(self) -> Path:
-        """
-        Get the path to the folder where application backups are stored.
-        """
-        return self._backup_folder
-
-    @property
     def setup_web_channel_script_file(self) -> Path:
         """
         Get the path to the file where _setup_web_channel_script_file exists
         """
         return self._setup_web_channel_script_file
+
+    @property
+    def backups_folder(self) -> Path:
+        """
+        Get the path to the folder where various backups are stored.
+
+        This is the main backups folder, which contains subfolders for different types of backups (e.g., saves, settings, installation).
+        """
+        return self._backups_folder
+
+    @property
+    def settings_backups_folder(self) -> Path:
+        """
+        Get the path to the folder where settings backups are stored.
+        """
+        return self._settings_backups_folder
+    
+    @property
+    def game_saves_backups_folder(self) -> Path:
+        """
+        Get the path to the folder where game save backups are stored.
+        """
+        return self._game_saves_backups_folder
+    
+    @property
+    def application_backups_folder(self) -> Path:
+        """
+        Get the path to the folder where application backups are stored.
+        """
+        return self._application_backups_folder

--- a/app/utils/files.py
+++ b/app/utils/files.py
@@ -175,7 +175,7 @@ def create_backup_in_thread(settings: Settings) -> None:
 
     config_path = Path(current_instance.config_folder)
     saves_path = config_path.parent / "Saves"
-    backup_dir = Path(AppInfo().app_storage_folder) / "backups"
+    backup_dir = AppInfo().game_saves_backups_folder
 
     def backup_task() -> None:
         backup_path = create_saves_backup(saves_path, backup_dir, settings)

--- a/app/utils/update_utils.py
+++ b/app/utils/update_utils.py
@@ -2183,12 +2183,12 @@ class UpdateManager(QObject):
         Updates progress widget during backup.
         """
         app_folder = AppInfo().application_folder
-        backup_folder = AppInfo().backup_folder
+        app_backup_folder = AppInfo().application_backups_folder
 
         # Generate backup ZIP filename with timestamp
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         backup_filename = f"RimSort_Backup_{timestamp}.zip"
-        backup_path = backup_folder / backup_filename
+        backup_path = app_backup_folder / backup_filename
 
         logger.info("Creating backup of RimSort installation")
 
@@ -2236,12 +2236,12 @@ class UpdateManager(QObject):
         """
         Clean up old backups, keeping only the most recent ones based on max_backups setting.
         """
-        backup_folder = AppInfo().backup_folder
+        app_backup_folder = AppInfo().application_backups_folder
         max_backups = self.settings_controller.settings.max_backups
 
         try:
             # Get all backup files
-            backup_files = list(backup_folder.glob("RimSort_Backup_*.zip"))
+            backup_files = list(app_backup_folder.glob("RimSort_Backup_*.zip"))
             if len(backup_files) <= max_backups:
                 logger.debug(
                     f"Backup count ({len(backup_files)}) is within limit ({max_backups})"


### PR DESCRIPTION
Organized the backups directory a bit.
<img width="677" height="244" alt="image" src="https://github.com/user-attachments/assets/8619d7ff-786d-4624-a094-b054d7aea008" />


Make simple settings.json backups.
<img width="199" height="117" alt="image" src="https://github.com/user-attachments/assets/8abac9de-2604-4185-91b2-f343bb43353e" />


Notify user their settings file is corrupted and give a few options.

<img width="507" height="208" alt="image" src="https://github.com/user-attachments/assets/03ecf1ae-8e95-42f4-8a28-8d9e04cb8d47" />

<img width="531" height="210" alt="image" src="https://github.com/user-attachments/assets/24e1c143-a6e2-4626-9ad7-25ff2a91b2ec" />

<img width="505" height="174" alt="image" src="https://github.com/user-attachments/assets/890ead34-58b0-489d-9e1b-ff68cc0d7807" />
