### PR TITLE
Delete mods using del key

### DIFF
--- a/app/views/deletion_menu.py
+++ b/app/views/deletion_menu.py
@@ -1,5 +1,4 @@
 import errno
-import os
 from pathlib import Path
 from shutil import rmtree
 from typing import Callable
@@ -168,14 +167,12 @@ class ModDeletionMenu(QMenu):
         selected_mods = self.get_selected_mod_metadata()
         for mod in selected_mods:
             mod_path = mod.get("path")
+            # Only look in Textures dir (I think that's the only relevant location for .dds files)
+            mod_path = Path(mod_path) / "Textures" if mod_path else None
             if mod_path:
                 try:
-                    for root, dirs, files in os.walk(mod_path):
-                        if any(file.endswith(self.DDS_EXTENSION) for file in files):
-                            return True
-                        # Limit depth to avoid performance issues
-                        if root != mod_path:
-                            break
+                    if any(Path(mod_path).rglob(f"*{self.DDS_EXTENSION}")):
+                        return True
                 except (OSError, PermissionError):
                     continue
         return False

--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -885,7 +885,7 @@ class ModListWidget(QListWidget):
             self._get_selected_metadata,
             self.uuids,
         )  # TODO: should we enable items conditionally? For now use all
-        logger.debug("Finished ModListW`idget initialization")
+        logger.debug("Finished ModListWidget initialization")
 
     def on_selection_changed(
         self, selected: QItemSelection, deselected: QItemSelection
@@ -2130,7 +2130,15 @@ class ModListWidget(QListWidget):
         This event occurs when the user presses a key while the mod
         list is in focus.
         """
-        if (
+        if event.key() == Qt.Key.Key_Delete:
+            if len(self.selectedItems()) > 0:
+                # Let deletion menu handle options and actual removal of mods
+                menu = QMenu(self)
+                for action in self.deletion_sub_menu.actions():
+                    menu.addAction(action)
+                self.deletion_sub_menu._refresh_actions()
+                menu.exec_(QCursor.pos())
+        elif (
             event.modifiers() & Qt.KeyboardModifier.ControlModifier
             and event.key() == Qt.Key.Key_Return
         ):


### PR DESCRIPTION
Fixed checking for .dds textures when enabling/disabling relevant action in deletion sub menu. (I think mods will always have `Textures` dir if adding/overwriting textures...)

Allows user to use del key to bring up the deletion menu.

This assumes the deletion menu correctly handles a list that contains a mix of mods that qualify for some options but not others etc.