### PR TITLE
Harden subprocess execution

### DIFF
--- a/app/utils/generic.py
+++ b/app/utils/generic.py
@@ -493,7 +493,6 @@ def launch_process(
             p = subprocess.Popen(
                 popen_args,
                 creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,
-                shell=True,
                 cwd=cwd,
                 env=env,
             )

--- a/app/utils/update_utils.py
+++ b/app/utils/update_utils.py
@@ -1789,9 +1789,10 @@ class UpdateManager(QObject):
 
         # For systems requiring elevation, copy script to temp location to avoid permission issues
         if needs_elevation:
-            temp_script_path = os.path.join(tempfile.gettempdir(), os.path.basename(script_path))
+            fd, temp_script_path = tempfile.mkstemp(suffix=".sh", prefix="rimsort_update_")
+            os.close(fd)
             shutil.copy2(str(script_path), temp_script_path)
-            os.chmod(temp_script_path, 0o755)
+            os.chmod(temp_script_path, 0o700)
             logger.debug(f"Copied script to temp location: {temp_script_path}")
             script_path = Path(temp_script_path)
             # Rebuild args_repr with the new script path
@@ -1879,11 +1880,11 @@ class UpdateManager(QObject):
             logger.warning(f"Could not create log directory: {e}")
 
         # Build msiexec command
-        cmd = f'msiexec /i "{msi_path}" /passive /norestart /log "{log_path}"'
+        cmd = ["msiexec", "/i", str(msi_path), "/passive", "/norestart", "/log", str(log_path)]
 
         try:
             logger.info(f"Launching MSI installer: {msi_path}")
-            subprocess.Popen(cmd, shell=True)
+            subprocess.Popen(cmd)
             self.update_progress.emit(100, "Update launched!")
             logger.info("MSI launched, exiting RimSort to allow file replacement")
 


### PR DESCRIPTION
## Summary

- Remove unnecessary `shell=True` from Windows game launch — list-based arguments don't need shell interpretation
- Replace f-string + `shell=True` with list args for MSI installer launch — `msiexec` is an external binary, not a shell builtin
- Use `tempfile.mkstemp()` instead of predictable `/tmp/update.sh` path for elevated update scripts, tighten permissions to `0o700`

## Security Impact

**Severity: High** — `shell=True` with list args on Windows passes through `cmd.exe` which can interpret metacharacters. Predictable temp paths enable symlink/TOCTOU attacks on shared systems.

## Known limitation

`.bat`/`.cmd` wrapper commands on Windows will no longer work without `shell=True`. This is an unlikely edge case (wrappers are Linux-centric) noted for future enhancement with a `cmd /c` guard.

## Test plan

- [ ] Verify game launch works on Windows without `shell=True`
- [ ] Verify MSI update works on Windows with list args
- [ ] Verify elevated update script launch works on Linux with randomized temp path

🤖 Generated with [Claude Code](https://claude.com/claude-code)