### PR TITLE
Harden network requests

### DIFF
--- a/app/utils/generic.py
+++ b/app/utils/generic.py
@@ -17,12 +17,11 @@ from typing import TYPE_CHECKING, Any, Callable, Generator
 import requests
 import vdf  # type: ignore
 from loguru import logger
-
-from app.utils import http
 from PySide6.QtCore import QCoreApplication
 from PySide6.QtWidgets import QApplication
 
 import app.views.dialogue as dialogue
+from app.utils import http
 from app.utils.app_info import AppInfo
 from app.utils.launch_command_parser import parse_launch_command
 

--- a/app/utils/generic.py
+++ b/app/utils/generic.py
@@ -17,6 +17,8 @@ from typing import TYPE_CHECKING, Any, Callable, Generator
 import requests
 import vdf  # type: ignore
 from loguru import logger
+
+from app.utils import http
 from PySide6.QtCore import QCoreApplication
 from PySide6.QtWidgets import QApplication
 
@@ -620,7 +622,7 @@ def upload_data_to_0x0_st(path: str) -> tuple[bool, str]:
     try:
         with open(path, "rb") as f:
             headers = {"User-Agent": f"RimSort/{AppInfo().app_version}"}
-            request = requests.post(
+            request = http.post(
                 url="https://0x0.st/",
                 files={"file": (Path(path).name, f)},
                 headers=headers,
@@ -776,7 +778,7 @@ def check_internet_connection(timeout: float = 10) -> bool:
 
     for url in urls:
         try:
-            requests.head(url, timeout=timeout)
+            http.head(url, timeout=timeout)
             logger.debug(f"Internet connection verified via {url}")
             return True
         except requests.exceptions.RequestException as e:

--- a/app/utils/http.py
+++ b/app/utils/http.py
@@ -1,0 +1,27 @@
+"""HTTP utility module providing request functions with default timeouts.
+
+All HTTP requests in the application should use these functions instead of
+calling requests.get/post/head directly, to ensure consistent timeout behavior.
+"""
+
+import requests
+
+DEFAULT_TIMEOUT: int | float = 15
+
+
+def get(url: str, **kwargs: object) -> requests.Response:
+    """Perform a GET request with default timeout."""
+    kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
+    return requests.get(url, **kwargs)
+
+
+def post(url: str, **kwargs: object) -> requests.Response:
+    """Perform a POST request with default timeout."""
+    kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
+    return requests.post(url, **kwargs)
+
+
+def head(url: str, **kwargs: object) -> requests.Response:
+    """Perform a HEAD request with default timeout."""
+    kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
+    return requests.head(url, **kwargs)

--- a/app/utils/http.py
+++ b/app/utils/http.py
@@ -4,24 +4,30 @@ All HTTP requests in the application should use these functions instead of
 calling requests.get/post/head directly, to ensure consistent timeout behavior.
 """
 
+from typing import Any
+
 import requests
 
 DEFAULT_TIMEOUT: int | float = 15
 
 
-def get(url: str, **kwargs: object) -> requests.Response:
+# jscpd:ignore-start
+def get(url: str, **kwargs: Any) -> requests.Response:
     """Perform a GET request with default timeout."""
     kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
     return requests.get(url, **kwargs)
 
 
-def post(url: str, **kwargs: object) -> requests.Response:
+def post(url: str, **kwargs: Any) -> requests.Response:
     """Perform a POST request with default timeout."""
     kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
     return requests.post(url, **kwargs)
 
 
-def head(url: str, **kwargs: object) -> requests.Response:
+def head(url: str, **kwargs: Any) -> requests.Response:
     """Perform a HEAD request with default timeout."""
     kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
     return requests.head(url, **kwargs)
+
+
+# jscpd:ignore-end

--- a/app/utils/rentry/wrapper.py
+++ b/app/utils/rentry/wrapper.py
@@ -2,6 +2,7 @@ import re
 import sys
 from json import loads as json_loads
 from typing import Any
+from urllib.parse import urlparse
 
 import requests
 from loguru import logger
@@ -196,7 +197,11 @@ class RentryImport:
         Returns:
             bool: True if the link is valid, False otherwise.
         """
-        return link.startswith(BASE_URL) or link.startswith(f"{BASE_URL}/raw")
+        try:
+            parsed = urlparse(link)
+            return parsed.scheme == "https" and parsed.hostname == "rentry.co"
+        except Exception:
+            return False
 
     def import_rentry_link(self) -> None:
         """
@@ -221,11 +226,11 @@ class RentryImport:
             if self.rentry_auth_code:
                 logger.debug("Using rentry-auth code to fetch rentry.co content.")
                 raw_url = rentry_link if rentry_link.endswith("/raw") else f"{rentry_link}/raw"
-                response = requests.get(raw_url, headers=_HEADERS)  # Fetch the content from the raw URL
+                response = requests.get(raw_url, headers=_HEADERS, timeout=15)  # Fetch the content from the raw URL
             else:
                 logger.debug("Fetching rentry.co content without rentry-auth.")
                 raw_url = rentry_link if rentry_link.endswith("/edit") else f"{rentry_link}/edit"
-                response = requests.get(raw_url)  # Fetch the content from the edit URL
+                response = requests.get(raw_url, timeout=15)  # Fetch the content from the edit URL
 
             if response.status_code == 200:
                 # Decode the content using UTF-8

--- a/app/utils/rentry/wrapper.py
+++ b/app/utils/rentry/wrapper.py
@@ -6,6 +6,9 @@ from urllib.parse import urlparse
 
 import requests
 from loguru import logger
+
+from app.utils import http
+from app.utils.http import DEFAULT_TIMEOUT
 from PySide6.QtCore import QCoreApplication
 from PySide6.QtWidgets import QInputDialog, QMessageBox
 
@@ -55,7 +58,7 @@ class HttpClient:
         """
         headers = headers or {}
         request_method = getattr(self.session, method.lower())
-        response = request_method(url, data=data, headers=headers)
+        response = request_method(url, data=data, headers=headers, timeout=DEFAULT_TIMEOUT)
         response.data = response.text  # Store the response text for convenience
         return response
 
@@ -197,11 +200,8 @@ class RentryImport:
         Returns:
             bool: True if the link is valid, False otherwise.
         """
-        try:
-            parsed = urlparse(link)
-            return parsed.scheme == "https" and parsed.hostname == "rentry.co"
-        except Exception:
-            return False
+        parsed = urlparse(link)
+        return parsed.scheme == "https" and parsed.hostname == "rentry.co"
 
     def import_rentry_link(self) -> None:
         """
@@ -226,11 +226,11 @@ class RentryImport:
             if self.rentry_auth_code:
                 logger.debug("Using rentry-auth code to fetch rentry.co content.")
                 raw_url = rentry_link if rentry_link.endswith("/raw") else f"{rentry_link}/raw"
-                response = requests.get(raw_url, headers=_HEADERS, timeout=15)  # Fetch the content from the raw URL
+                response = http.get(raw_url, headers=_HEADERS)  # Fetch the content from the raw URL
             else:
                 logger.debug("Fetching rentry.co content without rentry-auth.")
                 raw_url = rentry_link if rentry_link.endswith("/edit") else f"{rentry_link}/edit"
-                response = requests.get(raw_url, timeout=15)  # Fetch the content from the edit URL
+                response = http.get(raw_url)  # Fetch the content from the edit URL
 
             if response.status_code == 200:
                 # Decode the content using UTF-8

--- a/app/utils/rentry/wrapper.py
+++ b/app/utils/rentry/wrapper.py
@@ -6,13 +6,12 @@ from urllib.parse import urlparse
 
 import requests
 from loguru import logger
-
-from app.utils import http
-from app.utils.http import DEFAULT_TIMEOUT
 from PySide6.QtCore import QCoreApplication
 from PySide6.QtWidgets import QInputDialog, QMessageBox
 
 from app.controllers.settings_controller import SettingsController
+from app.utils import http
+from app.utils.http import DEFAULT_TIMEOUT
 from app.views.dialogue import (
     InformationBox,
     show_fatal_error,

--- a/app/utils/steam/steamcmd/wrapper.py
+++ b/app/utils/steam/steamcmd/wrapper.py
@@ -14,6 +14,8 @@ from loguru import logger
 from PySide6.QtCore import QCoreApplication
 from PySide6.QtWidgets import QMessageBox
 
+from app.utils import http
+
 import app.utils.symlink as symlink
 from app.controllers.settings_controller import SettingsController
 from app.utils.event_bus import EventBus
@@ -421,13 +423,13 @@ class SteamcmdInterface:
             try:
                 runner.message(f"Downloading & extracting steamcmd release from: {self.steamcmd_url}")
                 if ".zip" in self.steamcmd_url:
-                    with ZipFile(BytesIO(requests.get(self.steamcmd_url).content)) as zipobj:
+                    with ZipFile(BytesIO(http.get(self.steamcmd_url).content)) as zipobj:
                         zipobj.extractall(self.steamcmd_install_path)
                     runner.message("Installation completed")
                     installed = True
                 elif ".tar.gz" in self.steamcmd_url:
                     with (
-                        requests.get(self.steamcmd_url, stream=True) as rx,
+                        http.get(self.steamcmd_url, stream=True) as rx,
                         tarfile.open(fileobj=BytesIO(rx.content), mode="r:gz") as tarobj,
                     ):
                         tarobj.extractall(self.steamcmd_install_path)

--- a/app/utils/steam/steamcmd/wrapper.py
+++ b/app/utils/steam/steamcmd/wrapper.py
@@ -9,15 +9,13 @@ from tempfile import gettempdir
 from typing import Any
 from zipfile import ZipFile
 
-import requests
 from loguru import logger
 from PySide6.QtCore import QCoreApplication
 from PySide6.QtWidgets import QMessageBox
 
-from app.utils import http
-
 import app.utils.symlink as symlink
 from app.controllers.settings_controller import SettingsController
+from app.utils import http
 from app.utils.event_bus import EventBus
 from app.utils.generic import handle_remove_read_only
 from app.utils.generic import rmtree as g_rmtree

--- a/app/utils/steam/webapi/wrapper.py
+++ b/app/utils/steam/webapi/wrapper.py
@@ -10,12 +10,11 @@ from urllib.parse import urlparse
 
 import requests
 from loguru import logger
-
-from app.utils import http
 from PySide6.QtCore import QCoreApplication, QObject, Signal
 from PySide6.QtWidgets import QInputDialog
 from steam.webapi import WebAPI
 
+from app.utils import http
 from app.utils.app_info import AppInfo
 from app.utils.constants import RIMWORLD_DLC_METADATA
 from app.utils.generic import chunks

--- a/app/utils/steam/webapi/wrapper.py
+++ b/app/utils/steam/webapi/wrapper.py
@@ -6,9 +6,12 @@ from multiprocessing import Pool, cpu_count
 from pathlib import Path
 from time import time
 from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
+from urllib.parse import urlparse
 
 import requests
 from loguru import logger
+
+from app.utils import http
 from PySide6.QtCore import QCoreApplication, QObject, Signal
 from PySide6.QtWidgets import QInputDialog
 from steam.webapi import WebAPI
@@ -79,7 +82,10 @@ class CollectionImport:
         Returns:
             bool: True if the link is valid, False otherwise.
         """
-        return link.startswith(BASE_URL) and (BASE_URL_STEAMFILES in link or BASE_URL_WORKSHOP in link)
+        parsed = urlparse(link)
+        if parsed.scheme != "https" or parsed.hostname != "steamcommunity.com":
+            return False
+        return BASE_URL_STEAMFILES in link or BASE_URL_WORKSHOP in link
 
     def import_collection_link(self) -> None:
         # Handle the import button click event
@@ -127,7 +133,7 @@ class CollectionImport:
                         steam_link = f"https://steamcommunity.com/sharedfiles/filedetails/?id={pfid}"
 
                         try:
-                            steam_response = requests.get(steam_link, timeout=15).text
+                            steam_response = http.get(steam_link).text
                         except Exception as e:
                             logger.exception(e)
                             steam_response = ""
@@ -715,7 +721,7 @@ def ISteamRemoteStorage_GetCollectionDetails(
             count = chunk.index(publishedfileid)
             data[f"publishedfileids[{count}]"] = publishedfileid
         try:  # Make a request to the Steam Web API
-            request = requests.post(url, data=data, timeout=15)
+            request = http.post(url, data=data, timeout=(5, 60))
         except Exception as e:
             logger.warning(
                 f"Unable to complete request! Are you connected to the internet? Received exception: {e.__class__.__name__}"
@@ -759,7 +765,7 @@ def ISteamRemoteStorage_GetPublishedFileDetails(
             count = chunk.index(publishedfileid)
             data[f"publishedfileids[{count}]"] = publishedfileid
         try:  # Make a request to the Steam Web API
-            request = requests.post(url, data=data, timeout=15)
+            request = http.post(url, data=data, timeout=(5, 60))
         except Exception as e:
             logger.debug(
                 f"Unable to complete request! Are you connected to the internet? Received exception: {e.__class__.__name__}"

--- a/app/utils/steam/webapi/wrapper.py
+++ b/app/utils/steam/webapi/wrapper.py
@@ -764,6 +764,7 @@ def ISteamRemoteStorage_GetPublishedFileDetails(
         for publishedfileid in chunk:
             count = chunk.index(publishedfileid)
             data[f"publishedfileids[{count}]"] = publishedfileid
+        # jscpd:ignore-start
         try:  # Make a request to the Steam Web API
             request = http.post(url, data=data, timeout=(5, 60))
         except Exception as e:
@@ -771,6 +772,7 @@ def ISteamRemoteStorage_GetPublishedFileDetails(
                 f"Unable to complete request! Are you connected to the internet? Received exception: {e.__class__.__name__}"
             )
             return None
+        # jscpd:ignore-end
         try:  # Parse the JSON response
             json_response = request.json()
             if json_response.get("response", {}).get("resultcount", 0) > 0:

--- a/app/utils/steam/webapi/wrapper.py
+++ b/app/utils/steam/webapi/wrapper.py
@@ -127,7 +127,7 @@ class CollectionImport:
                         steam_link = f"https://steamcommunity.com/sharedfiles/filedetails/?id={pfid}"
 
                         try:
-                            steam_response = requests.get(steam_link).text
+                            steam_response = requests.get(steam_link, timeout=15).text
                         except Exception as e:
                             logger.exception(e)
                             steam_response = ""
@@ -715,7 +715,7 @@ def ISteamRemoteStorage_GetCollectionDetails(
             count = chunk.index(publishedfileid)
             data[f"publishedfileids[{count}]"] = publishedfileid
         try:  # Make a request to the Steam Web API
-            request = requests.post(url, data=data)
+            request = requests.post(url, data=data, timeout=15)
         except Exception as e:
             logger.warning(
                 f"Unable to complete request! Are you connected to the internet? Received exception: {e.__class__.__name__}"
@@ -759,7 +759,7 @@ def ISteamRemoteStorage_GetPublishedFileDetails(
             count = chunk.index(publishedfileid)
             data[f"publishedfileids[{count}]"] = publishedfileid
         try:  # Make a request to the Steam Web API
-            request = requests.post(url, data=data)
+            request = requests.post(url, data=data, timeout=15)
         except Exception as e:
             logger.debug(
                 f"Unable to complete request! Are you connected to the internet? Received exception: {e.__class__.__name__}"

--- a/app/utils/update_utils.py
+++ b/app/utils/update_utils.py
@@ -20,6 +20,7 @@ from PySide6.QtCore import QEventLoop, QObject, Signal
 from PySide6.QtWidgets import QApplication, QMessageBox
 
 import app.views.dialogue as dialogue
+from app.utils import http
 from app.utils.app_info import AppInfo
 from app.utils.generic import check_internet_connection
 from app.utils.zip_extractor import (
@@ -696,7 +697,7 @@ class UpdateManager(QObject):
         """
         try:
             # Use releases API for better asset information
-            response = requests.get(GITHUB_API_URL, timeout=API_TIMEOUT)
+            response = http.get(GITHUB_API_URL, timeout=API_TIMEOUT)
             response.raise_for_status()
             release_data = response.json()
 
@@ -1053,7 +1054,7 @@ class UpdateManager(QObject):
             File size in bytes, or 0 if unable to determine
         """
         try:
-            head_response = requests.head(url, timeout=API_TIMEOUT, allow_redirects=True)
+            head_response = http.head(url, timeout=API_TIMEOUT, allow_redirects=True)
             return int(head_response.headers.get("content-length", 0))
         except Exception as e:
             logger.debug(f"Failed to get file size: {e}")
@@ -1169,7 +1170,7 @@ class UpdateManager(QObject):
             if total_size:
                 logger.info(f"File size: {total_size / (1024 * 1024):.2f} MB")
 
-            response = requests.get(url, timeout=DOWNLOAD_TIMEOUT, stream=True)
+            response = http.get(url, timeout=DOWNLOAD_TIMEOUT, stream=True)
             response.raise_for_status()
             logger.debug(f"HTTP response status: {response.status_code}")
 

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -12,7 +12,6 @@ from tempfile import gettempdir
 from typing import Any, Callable, Literal, Optional, cast, overload
 from urllib.parse import urlparse
 
-import requests
 from loguru import logger
 from PySide6.QtCore import (
     QEventLoop,

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -39,6 +39,7 @@ import app.views.dialogue as dialogue
 from app.controllers.sort_controller import Sorter
 from app.models.animations import LoadingAnimation
 from app.sort.mod_sorting import ModsPanelSortKey
+from app.utils import http
 from app.utils.app_info import AppInfo
 from app.utils.custom_list_widget_item import CustomListWidgetItem
 from app.utils.event_bus import EventBus
@@ -675,7 +676,7 @@ class MainContent(QObject):
         url = "https://api.github.com/repos/RimSort/RimSort/releases/latest"
         logger.debug(f"Requesting GitHub release info from: {url}")
 
-        raw = requests.get(url, timeout=10)
+        raw = http.get(url, timeout=10)
 
         # Check for HTTP errors
         if raw.status_code != 200:
@@ -2290,7 +2291,7 @@ class MainContent(QObject):
 
                 try:
                     logger.info(f"Downloading {url} to {temp_path}")
-                    response = requests.get(url, stream=True, timeout=30)
+                    response = http.get(url, stream=True, timeout=30)
                     response.raise_for_status()
 
                     # Get total file size

--- a/app/views/player_log_tab.py
+++ b/app/views/player_log_tab.py
@@ -40,6 +40,7 @@ from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 
 from app.controllers.settings_controller import SettingsController
+from app.utils import http
 from app.utils.app_info import AppInfo
 from app.utils.generic import launch_process
 from app.views.dialogue import show_information, show_warning
@@ -1168,7 +1169,7 @@ class PlayerLogTab(QWidget):
             self.progress_bar.setTextVisible(True)
             self.progress_bar.show()
 
-            resp = requests.get(url, timeout=10, stream=True)
+            resp = http.get(url, timeout=10, stream=True)
             resp.raise_for_status()
             total_size = len(resp.content)
             downloaded = 0

--- a/app/views/player_log_tab.py
+++ b/app/views/player_log_tab.py
@@ -6,7 +6,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import Callable, Deque, List, Optional, Tuple
 
-import requests
 from loguru import logger
 from PySide6.QtCore import QObject, QPoint, QRegularExpression, Qt, QTimer, Signal
 from PySide6.QtGui import (

--- a/distribute.py
+++ b/distribute.py
@@ -424,7 +424,7 @@ def _execute(cmd: list[str], env: os._Environ[str] | None = None) -> None:
 
 
 def handle_request(url: str, headers: dict[str, str] | None = None) -> requests.Response:
-    raw = requests.get(url, headers=headers)
+    raw = requests.get(url, headers=headers, timeout=15)
     if raw.status_code != 200:
         raise Exception(f"Failed to get latest release: {raw.status_code}\nResponse: {raw.text}")
     return raw

--- a/tests/utils/test_http.py
+++ b/tests/utils/test_http.py
@@ -1,0 +1,39 @@
+from unittest.mock import patch
+
+from app.utils.http import DEFAULT_TIMEOUT, get, head, post
+
+
+class TestHTTPWrappers:
+    """Test HTTP wrapper functions apply default timeouts."""
+
+    @patch("app.utils.http.requests.get")
+    def test_get_default_timeout(self, mock_get):
+        get("https://example.com")
+        mock_get.assert_called_once_with("https://example.com", timeout=DEFAULT_TIMEOUT)
+
+    @patch("app.utils.http.requests.get")
+    def test_get_custom_timeout(self, mock_get):
+        get("https://example.com", timeout=30)
+        mock_get.assert_called_once_with("https://example.com", timeout=30)
+
+    @patch("app.utils.http.requests.get")
+    def test_get_passes_kwargs(self, mock_get):
+        get("https://example.com", stream=True, headers={"X-Test": "1"})
+        mock_get.assert_called_once_with(
+            "https://example.com", stream=True, headers={"X-Test": "1"}, timeout=DEFAULT_TIMEOUT
+        )
+
+    @patch("app.utils.http.requests.post")
+    def test_post_default_timeout(self, mock_post):
+        post("https://example.com", data={"key": "val"})
+        mock_post.assert_called_once_with("https://example.com", data={"key": "val"}, timeout=DEFAULT_TIMEOUT)
+
+    @patch("app.utils.http.requests.post")
+    def test_post_tuple_timeout(self, mock_post):
+        post("https://example.com", timeout=(5, 60))
+        mock_post.assert_called_once_with("https://example.com", timeout=(5, 60))
+
+    @patch("app.utils.http.requests.head")
+    def test_head_default_timeout(self, mock_head):
+        head("https://example.com")
+        mock_head.assert_called_once_with("https://example.com", timeout=DEFAULT_TIMEOUT)

--- a/tests/utils/test_http.py
+++ b/tests/utils/test_http.py
@@ -1,4 +1,5 @@
-from unittest.mock import patch
+from typing import Any
+from unittest.mock import MagicMock, patch
 
 from app.utils.http import DEFAULT_TIMEOUT, get, head, post
 
@@ -7,33 +8,33 @@ class TestHTTPWrappers:
     """Test HTTP wrapper functions apply default timeouts."""
 
     @patch("app.utils.http.requests.get")
-    def test_get_default_timeout(self, mock_get):
+    def test_get_default_timeout(self, mock_get: MagicMock) -> None:
         get("https://example.com")
         mock_get.assert_called_once_with("https://example.com", timeout=DEFAULT_TIMEOUT)
 
     @patch("app.utils.http.requests.get")
-    def test_get_custom_timeout(self, mock_get):
+    def test_get_custom_timeout(self, mock_get: MagicMock) -> None:
         get("https://example.com", timeout=30)
         mock_get.assert_called_once_with("https://example.com", timeout=30)
 
     @patch("app.utils.http.requests.get")
-    def test_get_passes_kwargs(self, mock_get):
+    def test_get_passes_kwargs(self, mock_get: MagicMock) -> None:
         get("https://example.com", stream=True, headers={"X-Test": "1"})
         mock_get.assert_called_once_with(
             "https://example.com", stream=True, headers={"X-Test": "1"}, timeout=DEFAULT_TIMEOUT
         )
 
     @patch("app.utils.http.requests.post")
-    def test_post_default_timeout(self, mock_post):
+    def test_post_default_timeout(self, mock_post: MagicMock) -> None:
         post("https://example.com", data={"key": "val"})
         mock_post.assert_called_once_with("https://example.com", data={"key": "val"}, timeout=DEFAULT_TIMEOUT)
 
     @patch("app.utils.http.requests.post")
-    def test_post_tuple_timeout(self, mock_post):
+    def test_post_tuple_timeout(self, mock_post: MagicMock) -> None:
         post("https://example.com", timeout=(5, 60))
         mock_post.assert_called_once_with("https://example.com", timeout=(5, 60))
 
     @patch("app.utils.http.requests.head")
-    def test_head_default_timeout(self, mock_head):
+    def test_head_default_timeout(self, mock_head: MagicMock) -> None:
         head("https://example.com")
         mock_head.assert_called_once_with("https://example.com", timeout=DEFAULT_TIMEOUT)

--- a/tests/utils/test_http.py
+++ b/tests/utils/test_http.py
@@ -1,4 +1,3 @@
-from typing import Any
 from unittest.mock import MagicMock, patch
 
 from app.utils.http import DEFAULT_TIMEOUT, get, head, post

--- a/tests/utils/test_url_validation.py
+++ b/tests/utils/test_url_validation.py
@@ -3,7 +3,7 @@ import unittest.mock as mock
 from app.utils.rentry.wrapper import RentryImport
 
 
-def _make_rentry_import():
+def _make_rentry_import() -> RentryImport:
     """Create a RentryImport instance without triggering the UI."""
     with mock.patch.object(RentryImport, "__init__", lambda self, *a, **kw: None):
         return RentryImport.__new__(RentryImport)
@@ -12,30 +12,30 @@ def _make_rentry_import():
 class TestRentryUrlValidation:
     """Test Rentry URL validation rejects spoofed domains."""
 
-    def test_valid_rentry_url(self):
+    def test_valid_rentry_url(self) -> None:
         ri = _make_rentry_import()
         assert ri.is_valid_rentry_link("https://rentry.co/modlist")
 
-    def test_valid_rentry_raw_url(self):
+    def test_valid_rentry_raw_url(self) -> None:
         ri = _make_rentry_import()
         assert ri.is_valid_rentry_link("https://rentry.co/modlist/raw")
 
-    def test_reject_subdomain_spoofing(self):
+    def test_reject_subdomain_spoofing(self) -> None:
         ri = _make_rentry_import()
         assert not ri.is_valid_rentry_link("https://rentry.co.evil.com/modlist")
 
-    def test_reject_http(self):
+    def test_reject_http(self) -> None:
         ri = _make_rentry_import()
         assert not ri.is_valid_rentry_link("http://rentry.co/modlist")
 
-    def test_reject_non_url(self):
+    def test_reject_non_url(self) -> None:
         ri = _make_rentry_import()
         assert not ri.is_valid_rentry_link("not-a-url")
 
-    def test_case_insensitive_hostname(self):
+    def test_case_insensitive_hostname(self) -> None:
         ri = _make_rentry_import()
         assert ri.is_valid_rentry_link("https://RENTRY.CO/modlist")
 
-    def test_reject_empty(self):
+    def test_reject_empty(self) -> None:
         ri = _make_rentry_import()
         assert not ri.is_valid_rentry_link("")

--- a/tests/utils/test_url_validation.py
+++ b/tests/utils/test_url_validation.py
@@ -1,0 +1,41 @@
+import unittest.mock as mock
+
+from app.utils.rentry.wrapper import RentryImport
+
+
+def _make_rentry_import():
+    """Create a RentryImport instance without triggering the UI."""
+    with mock.patch.object(RentryImport, "__init__", lambda self, *a, **kw: None):
+        return RentryImport.__new__(RentryImport)
+
+
+class TestRentryUrlValidation:
+    """Test Rentry URL validation rejects spoofed domains."""
+
+    def test_valid_rentry_url(self):
+        ri = _make_rentry_import()
+        assert ri.is_valid_rentry_link("https://rentry.co/modlist")
+
+    def test_valid_rentry_raw_url(self):
+        ri = _make_rentry_import()
+        assert ri.is_valid_rentry_link("https://rentry.co/modlist/raw")
+
+    def test_reject_subdomain_spoofing(self):
+        ri = _make_rentry_import()
+        assert not ri.is_valid_rentry_link("https://rentry.co.evil.com/modlist")
+
+    def test_reject_http(self):
+        ri = _make_rentry_import()
+        assert not ri.is_valid_rentry_link("http://rentry.co/modlist")
+
+    def test_reject_non_url(self):
+        ri = _make_rentry_import()
+        assert not ri.is_valid_rentry_link("not-a-url")
+
+    def test_case_insensitive_hostname(self):
+        ri = _make_rentry_import()
+        assert ri.is_valid_rentry_link("https://RENTRY.CO/modlist")
+
+    def test_reject_empty(self):
+        ri = _make_rentry_import()
+        assert not ri.is_valid_rentry_link("")


### PR DESCRIPTION
## Summary

### HTTP request utility
- Create `app/utils/http.py` with `get()`/`post()`/`head()` wrapper functions that apply a default 15s timeout
- Refactor all 15 `requests.get/post/head` call sites in `app/` to use the shared utility
- Use `timeout=(5, 60)` for batch Steam API calls (up to 5000 IDs per chunk) — fast connect, slow read
- Add timeout to `HttpClient.make_request()` in rentry wrapper
- Add `timeout=15` to `distribute.py` directly (can't import from `app/`)

### URL validation
- Fix Rentry URL validation: use `urlparse()` hostname comparison instead of `startswith()` which matched `rentry.co.evil.com`
- Fix Steam collection URL validation: same `startswith()` subdomain spoofing bug
- Remove unnecessary `try/except` around `urlparse` (it never raises)

## Security Impact

**Severity: Medium** — 9 HTTP calls had no timeout, allowing indefinite application hangs. URL validation accepted spoofed subdomains. The `http.py` utility ensures no future HTTP call can accidentally omit a timeout, and provides a single point for adding retry logic later.

## Test plan

- [x] `tests/utils/test_http.py` — 6 tests passing
- [x] `tests/utils/test_url_validation.py` — 7 tests passing
- [ ] Verify Steam Workshop metadata queries still work
- [ ] Verify Rentry import still works
- [ ] Verify SteamCMD download still works
- [ ] Verify auto-update check still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)