### PR TITLE
[fix] Memory leak and hanging process with built-in browser

### DIFF
--- a/app/utils/steam/steambrowser/browser.py
+++ b/app/utils/steam/steambrowser/browser.py
@@ -696,3 +696,69 @@ class SteamBrowser(QWidget):
         }}
         """
         self.web_view.page().runJavaScript(script, 0, lambda result: None)
+
+    def closeEvent(self, event) -> None:
+        """Properly clean up web engine resources to prevent memory leaks and hanging processes"""
+        logger.debug("Cleaning up SteamBrowser resources...")
+        
+        # Delete on close flag
+        self.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose)
+        
+        # Stop any loading
+        if self.web_view:
+            self.web_view.stop()
+            
+            # Disconnect all web view signals
+            try:
+                self.web_view.loadStarted.disconnect()
+                self.web_view.loadProgress.disconnect()
+                self.web_view.loadFinished.disconnect()
+            except Exception:
+                pass
+            
+            # Clean up page
+            if self.web_view.page():
+                # Delete web channel
+                if hasattr(self, 'channel'):
+                    self.channel.deregisterObject(self.js_bridge)
+                    self.channel.deleteLater()
+                
+                # Clear scripts
+                self.web_view.page().profile().scripts().clear()
+                
+                # Delete page
+                self.web_view.page().deleteLater()
+            
+            # Delete web view
+            self.web_view.deleteLater()
+            self.web_view = None
+        
+        # Clean up web profile
+        if hasattr(self, 'web_profile'):
+            self.web_profile.deleteLater()
+            self.web_profile = None
+        
+        # Clear all references
+        self.metadata_manager = None
+        self.settings_controller = None
+        self.js_bridge = None
+        self.downloader_list_mods_tracking.clear()
+        self.downloader_list_dupe_tracking.clear()
+        
+        # Clear layouts
+        self.clear_layout(self.window_layout)
+        
+        logger.debug("SteamBrowser cleanup completed")
+        
+        event.accept()
+
+    def clear_layout(self, layout) -> None:
+        """Recursively clear layout and delete all widgets"""
+        if layout is not None:
+            while layout.count():
+                item = layout.takeAt(0)
+                widget = item.widget()
+                if widget is not None:
+                    widget.deleteLater()
+                else:
+                    self.clear_layout(item.layout())

--- a/app/utils/steam/steambrowser/browser.py
+++ b/app/utils/steam/steambrowser/browser.py
@@ -10,7 +10,7 @@ from typing import Any
 
 from loguru import logger
 from PySide6.QtCore import QPoint, Qt, QUrl
-from PySide6.QtGui import QAction, QPixmap
+from PySide6.QtGui import QAction, QCloseEvent, QPixmap
 from PySide6.QtWebChannel import QWebChannel
 from PySide6.QtWebEngineCore import (
     QWebEnginePage,
@@ -21,6 +21,7 @@ from PySide6.QtWebEngineWidgets import QWebEngineView
 from PySide6.QtWidgets import (
     QHBoxLayout,
     QLabel,
+    QLayout,
     QLineEdit,
     QListWidget,
     QListWidgetItem,
@@ -58,6 +59,13 @@ class SteamBrowser(QWidget):
     """
     A generic panel used to browse Workshop content - downloader included
     """
+
+    # Cleared in closeEvent when the window is closed.
+    web_view: QWebEngineView | None
+    web_profile: QWebEngineProfile | None
+    metadata_manager: MetadataManager | None
+    settings_controller: SettingsController | None
+    js_bridge: JavaScriptBridge | None
 
     def __init__(
         self,
@@ -222,6 +230,7 @@ class SteamBrowser(QWidget):
         """Apply browser window launch state from settings"""
         from app.utils.window_launch_state import apply_window_launch_state
 
+        assert self.settings_controller is not None
         browser_window_launch_state = self.settings_controller.settings.browser_window_launch_state
         custom_width = self.settings_controller.settings.browser_window_custom_width
         custom_height = self.settings_controller.settings.browser_window_custom_height
@@ -230,6 +239,7 @@ class SteamBrowser(QWidget):
         logger.info(f"Browser window started with launch state: {browser_window_launch_state}")
 
     def __browse_to_location(self) -> None:
+        assert self.web_view is not None
         url = QUrl(self.location.text())
         logger.debug(f"Browsing to: {url.url()}")
         self.web_view.load(url)
@@ -454,11 +464,13 @@ class SteamBrowser(QWidget):
         self.progress_bar.setValue(progress)
         # Placeholder done after page begins to load
         if progress > 25:
+            assert self.web_view is not None
             self.web_view_loading_placeholder.hide()
             self.web_view.show()
 
     # TODO: Probably a good idea to break this huge function down into a bunch of smaller helpers
     def _web_view_load_finished(self) -> None:
+        assert self.web_view is not None
         # Progress bar done
         self.progress_bar.setValue(0)
         self.progress_bar.setTextVisible(False)
@@ -663,6 +675,7 @@ class SteamBrowser(QWidget):
 
     def _is_mod_installed(self, publishedfileid: str) -> bool:
         """Check if a mod is installed by looking through local and workshop folders"""
+        assert self.metadata_manager is not None
         # check all mods in internal metadata
         for metadata in self.metadata_manager.internal_local_metadata.values():
             if metadata.get("publishedfileid") == publishedfileid:
@@ -671,6 +684,7 @@ class SteamBrowser(QWidget):
 
     def _get_installed_mods_list(self) -> list[str]:
         """Get list of installed mod IDs"""
+        assert self.metadata_manager is not None
         installed_mods = []
         for metadata in self.metadata_manager.internal_local_metadata.values():
             if metadata.get("publishedfileid"):
@@ -688,6 +702,7 @@ class SteamBrowser(QWidget):
 
     def _update_badge_js(self, mod_id: str, status: BadgeState) -> None:
         """Calls a JavaScript function in the web view to update a specific mod's badge"""
+        assert self.web_view is not None
         script = f"""
         if (typeof window.updateModBadge === 'function') {{
             window.updateModBadge('{mod_id}', '{status.value}');
@@ -697,7 +712,7 @@ class SteamBrowser(QWidget):
         """
         self.web_view.page().runJavaScript(script, 0, lambda result: None)
 
-    def closeEvent(self, event) -> None:
+    def closeEvent(self, event: QCloseEvent) -> None:
         """Properly clean up web engine resources to prevent memory leaks and hanging processes"""
         logger.debug("Cleaning up SteamBrowser resources...")
         
@@ -705,7 +720,7 @@ class SteamBrowser(QWidget):
         self.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose)
         
         # Stop any loading
-        if self.web_view:
+        if self.web_view is not None:
             self.web_view.stop()
             
             # Disconnect all web view signals
@@ -719,7 +734,7 @@ class SteamBrowser(QWidget):
             # Clean up page
             if self.web_view.page():
                 # Delete web channel
-                if hasattr(self, 'channel'):
+                if self.js_bridge is not None and hasattr(self, "channel"):
                     self.channel.deregisterObject(self.js_bridge)
                     self.channel.deleteLater()
                 
@@ -734,7 +749,7 @@ class SteamBrowser(QWidget):
             self.web_view = None
         
         # Clean up web profile
-        if hasattr(self, 'web_profile'):
+        if self.web_profile is not None:
             self.web_profile.deleteLater()
             self.web_profile = None
         
@@ -752,11 +767,13 @@ class SteamBrowser(QWidget):
         
         event.accept()
 
-    def clear_layout(self, layout) -> None:
+    def clear_layout(self, layout: QLayout | None) -> None:
         """Recursively clear layout and delete all widgets"""
         if layout is not None:
             while layout.count():
                 item = layout.takeAt(0)
+                if item is None:
+                    break
                 widget = item.widget()
                 if widget is not None:
                     widget.deleteLater()

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -1951,11 +1951,19 @@ class MainContent(QObject):
             return
 
     def _do_browse_workshop(self) -> None:
+        # Clean up previous instance if it still exists
+        if self.steam_browser:
+            self.steam_browser.close()
+            self.steam_browser.deleteLater()
+        
         self.steam_browser = SteamBrowser(
             "https://steamcommunity.com/app/294100/workshop/",
             self.metadata_manager,
             self.settings_controller,
         )
+        
+        # Automatically null the reference when browser is destroyed
+        self.steam_browser.destroyed.connect(lambda: setattr(self, 'steam_browser', None))
         self.steam_browser.show()
 
     def _do_check_for_workshop_updates(self) -> None:


### PR DESCRIPTION
Fixes #1881, #1871

### Root Cause

SteamBrowser class had no `closeEvent()` override. QWebEngineView / QWebEnginePage require explicit cleanup otherwise they leave zombie processes and circular references that prevent garbage collection. Main window also kept a strong reference that was never nulled.

### Fix Applied:
1. Added proper `closeEvent()` handler to SteamBrowser:
   - Sets `WA_DeleteOnClose` attribute
   - Stops any active page loading
   - Disconnects all web view signals
   - Properly destroys QWebEnginePage, QWebEngineProfile, QWebChannel
   - Recursively cleans up all layouts and widgets
   - Clears all internal references

2. Fixed main_content_panel browser handling:
   - Added cleanup of existing browser instance before creating new one
   - Added `destroyed` signal handler that automatically nulls the reference
   - Added safety checks to prevent multiple instances

Feel free to edit or cherry pick the fix for yourself, I just got tired of restarting app just to get rid of that bug.