### PR TITLE
Fix: Add hasattr check to prevent AttributeError when calling DownloadItem in Steamworks API

### DIFF
--- a/app/utils/steam/steamworks/wrapper.py
+++ b/app/utils/steam/steamworks/wrapper.py
@@ -465,12 +465,15 @@ class SteamworksSubscriptionHandler(Process):
                 # Call DownloadItem to force Steam to queue the mod for download
                 # high_priority=True makes Steam skip other queued downloads
                 # Note: callback may not fire, but the download is still queued
-                steamworks_interface.steamworks.Workshop.DownloadItem(
-                    pfid,
-                    high_priority=True,
-                    callback=self._create_download_callback(steamworks_interface),
-                    override_callback=True,
-                )
+                if hasattr(steamworks_interface.steamworks.Workshop, "DownloadItem"):
+                    steamworks_interface.steamworks.Workshop.DownloadItem(
+                        pfid,
+                        high_priority=True,
+                        callback=self._create_download_callback(steamworks_interface),
+                        override_callback=True,
+                    )
+                else:
+                    logger.warning(f"DownloadItem skipped: not supported by SteamworksPy library.")
             except Exception as e:
                 logger.error(f"Failed to trigger download for {pfid}: {e}")
 

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -2176,7 +2176,8 @@ class MainContent(QObject):
                         pfid_or_pfids=instruction[1],
                         _libs=libs_path,
                     )
-                    handler.run()
+                    handler.start()
+                    handler.join()
                     # Clean up after processing
                     self.steamworks_in_use = False
                 else:


### PR DESCRIPTION
Fixes #1800

### Description
This PR resolves two connected issues that were causing Steam Workshop mod updates to crash and get stuck in the download queue.

**1. Fixed the `AttributeError` crash during downloads**
The updater was trying to call a Steam command (`DownloadItem`) that is missing from the current version of the Steam library, which caused the thread to crash. I added a `hasattr()` check to verify the command exists before running it. If it's missing, it now safely skips the forced download, allowing the rest of the unsubscribe/resubscribe queue to finish without throwing Python errors.

**2. Fixed the "hanging" Steam downloads**
Previously, Steam wouldn't actually download the queued mods until RimSort was fully closed. This happened because the Steam update handler was executing inside the main application process (using `.run()`). Because the Steam API was bound to the main app, it tricked Steam into thinking RimWorld was actively running the entire time RimSort was open. Steam intentionally pauses Workshop downloads while a game is running. 

I updated the execution to use `.start()` and `.join()` so the Steam handler runs in a true, isolated background process. Now, once the mod queue is updated, the background process properly terminates, Steam realizes the "game" has closed, and the downloads start immediately!