### PR TITLE
Fix: Resolve TypeError when restoring instance backups by using standard setattr

### DIFF
--- a/app/controllers/instance_controller.py
+++ b/app/controllers/instance_controller.py
@@ -277,13 +277,13 @@ class InstanceController(QObject):
             if path_value and not Path(path_value).exists():
                 invalid_paths.append(path_name)
                 if clear:
-                    object.__setattr__(self.instance, path_name, "")
+                    setattr(self.instance, path_name, "")
 
         # Auto-recover steamcmd path if folder exists in instance directory
         if "steamcmd_install_path" in invalid_paths:
             default_path = self.instance_folder_path / STEAMCMD_FOLDER_NAME
             if default_path.exists():
-                object.__setattr__(
+                setattr(
                     self.instance,
                     "steamcmd_install_path",
                     str(self.instance_folder_path),


### PR DESCRIPTION
Fixes #1785

### Description
This PR resolves a crash that occurs when users attempt to restore an instance backup created on a different machine or an older version of RimSort.

**1. Fixed the `TypeError` crash during instance restoration**
The crash was happening because the instance validation code (`validate_paths`) was trying to use a Python bypass (`object.__setattr__`) to clear out invalid file paths from the imported backup. Because the `Instance` object is built using `msgspec.Struct` (which uses strict C-level memory guards for high performance), it explicitly rejects this bypass, causing the application to throw a `TypeError` and crash.

I replaced the `object.__setattr__` calls with the standard built-in `setattr()`. This properly routes the assignment through the struct's own native C-level setters, safely clearing the invalid paths and allowing the backup restoration process to finish successfully.