### PR TITLE
fix: prevent double UUID insertion and duplicate item in append_new_item

### DIFF
--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -1976,10 +1976,12 @@ class ModListWidget(QListWidget):
                 aux_metadata_session=aux_metadata_session,
                 settings_controller=self.settings_controller,
             )
-        item = CustomListWidgetItem(self)
-        item.setData(Qt.ItemDataRole.UserRole, data)
+        # Create item without a parent first so we can set data before adding to the list.
+        # This ensures handle_rows_inserted (connected via QueuedConnection) sees the data
+        # when it fires after addItem, and can correctly track the UUID in self.uuids.
+        item = CustomListWidgetItem()
+        item.setData(Qt.ItemDataRole.UserRole, data, avoid_emit=True)
         self.addItem(item)
-        self.uuids.append(uuid)
 
     def get_all_mod_list_items(self) -> list[CustomListWidgetItem]:
         """


### PR DESCRIPTION
Fixes #1810

### Description
This PR addresses two underlying UI bugs in `append_new_item` that caused duplicate visual entries and internal tracking errors when downloading mods via Rentry imports. *(Note: The primary KeyError crash reported in v1.0.74 was resolved by a metadata safety guard added in a commit subsequent to that release).*

**1. Fixed Double UI Item Insertion**
Previously, when a new mod finished downloading, it was being added to the visual list twice. This occurred because passing `self` as a parent when creating `CustomListWidgetItem()` prompted the Qt framework to automatically insert the item into the list. Calling `addItem()` immediately afterward then caused a duplicate insertion. This is resolved by creating the item independently without a parent first, ensuring it only gets inserted when explicitly called.

**2. Fixed Double UUID Tracking**
The application was also inadvertently recording each newly downloaded mod's ID twice in the background. Because the `handle_rows_inserted` signal already automatically tracks UUIDs whenever a new row is added to the UI, the manual `self.uuids.append(uuid)` call was redundant. This manual tracking step has been removed so the internal mod count stays perfectly synchronized with what is actually drawn on the screen.