### PR TITLE
fix: batch SteamCMD downloads to prevent vprof thread overflow

### DIFF
--- a/app/utils/steam/steamcmd/wrapper.py
+++ b/app/utils/steam/steamcmd/wrapper.py
@@ -9,13 +9,6 @@ from tempfile import gettempdir
 from typing import Any
 from zipfile import ZipFile
 
-# Maximum number of workshop items to download in a single SteamCMD invocation.
-# SteamCMD's internal vprof profiler has a fixed-size thread table
-# (MAX_THREADS_TO_VPROF_AT_ONCE). Exceeding it produces:
-#   src/tier0/vprof.cpp: No room for new profile in vprof thread profile list
-# and causes downloads to time-out.  Keeping batches small avoids the limit.
-STEAMCMD_BATCH_SIZE = 25
-
 import requests
 from loguru import logger
 from PySide6.QtCore import QCoreApplication
@@ -34,6 +27,13 @@ from app.views.dialogue import (
     show_warning,
 )
 from app.windows.runner_panel import RunnerPanel
+
+# Maximum number of workshop items to download in a single SteamCMD invocation.
+# SteamCMD's internal vprof profiler has a fixed-size thread table
+# (MAX_THREADS_TO_VPROF_AT_ONCE). Exceeding it produces:
+#   src/tier0/vprof.cpp: No room for new profile in vprof thread profile list
+# and causes downloads to time-out.  Keeping batches small avoids the limit.
+STEAMCMD_BATCH_SIZE = 25
 
 
 class SteamcmdInterface:
@@ -57,26 +57,36 @@ class SteamcmdInterface:
             logger.debug("Initializing SteamcmdInterface")
             self.initialize_prefix(steamcmd_prefix, validate)
 
-            EventBus().do_clear_steamcmd_depot_cache.connect(lambda: self.clear_depot_cache())
+            EventBus().do_clear_steamcmd_depot_cache.connect(
+                lambda: self.clear_depot_cache()
+            )
             self.translate = QCoreApplication.translate
             logger.debug("Finished SteamcmdInterface initialization")
 
     def initialize_prefix(self, steamcmd_prefix: str, validate: bool) -> None:
         self.steamcmd_prefix = steamcmd_prefix
         self.steamcmd_install_path = str(Path(self.steamcmd_prefix) / "steamcmd")
-        self.steamcmd_depotcache_path = str(Path(self.steamcmd_install_path) / "depotcache")
+        self.steamcmd_depotcache_path = str(
+            Path(self.steamcmd_install_path) / "depotcache"
+        )
         self.steamcmd_steam_path = str(Path(self.steamcmd_prefix) / "steam")
         self.system = platform.system()
         self.validate_downloads = validate
 
         if self.system == "Darwin":
-            self.steamcmd_url = "https://steamcdn-a.akamaihd.net/client/installer/steamcmd_osx.tar.gz"
+            self.steamcmd_url = (
+                "https://steamcdn-a.akamaihd.net/client/installer/steamcmd_osx.tar.gz"
+            )
             self.steamcmd = str((Path(self.steamcmd_install_path) / "steamcmd.sh"))
         elif self.system == "Linux":
-            self.steamcmd_url = "https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz"
+            self.steamcmd_url = (
+                "https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz"
+            )
             self.steamcmd = str((Path(self.steamcmd_install_path) / "steamcmd.sh"))
         elif self.system == "Windows":
-            self.steamcmd_url = "https://steamcdn-a.akamaihd.net/client/installer/steamcmd.zip"
+            self.steamcmd_url = (
+                "https://steamcdn-a.akamaihd.net/client/installer/steamcmd.zip"
+            )
             self.steamcmd = str((Path(self.steamcmd_install_path) / "steamcmd.exe"))
         else:
             show_fatal_error(
@@ -87,14 +97,23 @@ class SteamcmdInterface:
 
         if not os.path.exists(self.steamcmd_install_path):
             os.makedirs(self.steamcmd_install_path)
-            logger.debug(f"SteamCMD does not exist. Creating path for installation: {self.steamcmd_install_path}")
+            logger.debug(
+                f"SteamCMD does not exist. Creating path for installation: {self.steamcmd_install_path}"
+            )
 
         if not os.path.exists(self.steamcmd_steam_path):
             os.makedirs(self.steamcmd_steam_path)
         self.steamcmd_appworkshop_acf_path = str(
-            (Path(self.steamcmd_steam_path) / "steamapps" / "workshop" / "appworkshop_294100.acf")
+            (
+                Path(self.steamcmd_steam_path)
+                / "steamapps"
+                / "workshop"
+                / "appworkshop_294100.acf"
+            )
         )
-        self.steamcmd_content_path = str((Path(self.steamcmd_steam_path) / "steamapps" / "workshop" / "content"))
+        self.steamcmd_content_path = str(
+            (Path(self.steamcmd_steam_path) / "steamapps" / "workshop" / "content")
+        )
 
     @classmethod
     def instance(cls, *args: Any, **kwargs: Any) -> "SteamcmdInterface":
@@ -185,7 +204,9 @@ class SteamcmdInterface:
 
         except Exception as e:
             if runner is not None:
-                runner.message(f"Failed to create symlink. Error: {type(e).__name__}: {str(e)}")
+                runner.message(
+                    f"Failed to create symlink. Error: {type(e).__name__}: {str(e)}"
+                )
             show_warning(
                 "Failed to Create Symlink",
                 f"Failed to create symlink for {sys.platform}",
@@ -339,9 +360,9 @@ class SteamcmdInterface:
         ]
 
         # Stash the queue on the runner instance so finished() can pop it.
-        runner._pending_steamcmd_batches = batches[1:]  # type: ignore[attr-defined]
-        runner._steamcmd_executable = self.steamcmd  # type: ignore[attr-defined]
-        runner._steamcmd_wrapper = self  # type: ignore[attr-defined]
+        runner._pending_steamcmd_batches = batches[1:]
+        runner._steamcmd_executable = self.steamcmd
+        runner._steamcmd_wrapper = self
 
         # Kick off the first batch immediately.
         batch_num = 1
@@ -388,7 +409,9 @@ class SteamcmdInterface:
             btn_text = ["&Yes", "&No"]
 
         # Translate button texts explicitly before passing to show_dialogue_conditional
-        translated_btn_text = [self.translate("SteamcmdInterface", btn) for btn in btn_text]
+        translated_btn_text = [
+            self.translate("SteamcmdInterface", btn) for btn in btn_text
+        ]
         answer = show_dialogue_conditional(
             title=self.translate("SteamcmdInterface", "RimSort - SteamCMD setup"),
             text=self.translate(
@@ -427,20 +450,28 @@ class SteamcmdInterface:
         logger.info("Attempting steamCMD depot cache clear")
         if not self.setup:
             if runner is not None:
-                runner.message("Tried clearing depot cache but SteamCMD was not found. Please setup SteamCMD first!")
+                runner.message(
+                    "Tried clearing depot cache but SteamCMD was not found. Please setup SteamCMD first!"
+                )
 
             self.on_steamcmd_not_found(runner=runner)
             return False
 
         depot_cache = Path(self.steamcmd_install_path + "/depotcache")
         if not os.path.exists(depot_cache):
-            logger.info(f"Skipping depot cache clear. Could not find cache: {depot_cache}")
+            logger.info(
+                f"Skipping depot cache clear. Could not find cache: {depot_cache}"
+            )
             if runner is not None:
-                runner.message(f"Skipping depot cache clear. Could not find cache: {depot_cache}")
+                runner.message(
+                    f"Skipping depot cache clear. Could not find cache: {depot_cache}"
+                )
             else:
                 InformationBox(
                     title=self.translate("SteamcmdInterface", "Depot Cache Cleared"),
-                    text=self.translate("SteamcmdInterface", "SteamCMD depot cache was already cleared."),
+                    text=self.translate(
+                        "SteamcmdInterface", "SteamCMD depot cache was already cleared."
+                    ),
                 ).exec()
             return False
 
@@ -451,7 +482,9 @@ class SteamcmdInterface:
             else:
                 InformationBox(
                     title=self.translate("SteamcmdInterface", "Depot Cache Cleared"),
-                    text=self.translate("SteamcmdInterface", "SteamCMD depot cache has been cleared."),
+                    text=self.translate(
+                        "SteamcmdInterface", "SteamCMD depot cache has been cleared."
+                    ),
                 ).exec()
             return True
 
@@ -461,11 +494,15 @@ class SteamcmdInterface:
 
         return False
 
-    def setup_steamcmd(self, symlink_source_path: str, reinstall: bool, runner: RunnerPanel) -> None:
+    def setup_steamcmd(
+        self, symlink_source_path: str, reinstall: bool, runner: RunnerPanel
+    ) -> None:
         installed = None
         if reinstall:
             runner.message("Existing steamcmd installation found!")
-            runner.message(f"Deleting existing installation from: {self.steamcmd_install_path}")
+            runner.message(
+                f"Deleting existing installation from: {self.steamcmd_install_path}"
+            )
             shutil.rmtree(
                 self.steamcmd_install_path,
                 ignore_errors=False,
@@ -474,16 +511,22 @@ class SteamcmdInterface:
             os.makedirs(self.steamcmd_install_path)
         if not self.check_for_steamcmd(prefix=self.steamcmd_prefix):
             try:
-                runner.message(f"Downloading & extracting steamcmd release from: {self.steamcmd_url}")
+                runner.message(
+                    f"Downloading & extracting steamcmd release from: {self.steamcmd_url}"
+                )
                 if ".zip" in self.steamcmd_url:
-                    with ZipFile(BytesIO(requests.get(self.steamcmd_url).content)) as zipobj:
+                    with ZipFile(
+                        BytesIO(requests.get(self.steamcmd_url).content)
+                    ) as zipobj:
                         zipobj.extractall(self.steamcmd_install_path)
                     runner.message("Installation completed")
                     installed = True
                 elif ".tar.gz" in self.steamcmd_url:
                     with (
                         requests.get(self.steamcmd_url, stream=True) as rx,
-                        tarfile.open(fileobj=BytesIO(rx.content), mode="r:gz") as tarobj,
+                        tarfile.open(
+                            fileobj=BytesIO(rx.content), mode="r:gz"
+                        ) as tarobj,
                     ):
                         tarobj.extractall(self.steamcmd_install_path)
                     runner.message("Installation completed")
@@ -516,10 +559,14 @@ class SteamcmdInterface:
                 runner.message(
                     f"Workshop content path does not exist. Creating for symlinking:\n\n{self.steamcmd_content_path}\n"
                 )
-            symlink_destination_path = str((Path(self.steamcmd_content_path) / "294100"))
+            symlink_destination_path = str(
+                (Path(self.steamcmd_content_path) / "294100")
+            )
             runner.message(f"Symlink source : {symlink_source_path}")
             runner.message(f"Symlink destination: {symlink_destination_path}")
-            if symlink.is_junction_or_link(symlink_destination_path):  # Symlink/junction exists
+            if symlink.is_junction_or_link(
+                symlink_destination_path
+            ):  # Symlink/junction exists
                 runner.message(
                     f"Symlink destination already exists! Please remove existing destination:\n\n{symlink_destination_path}\n"
                 )
@@ -544,8 +591,12 @@ class SteamcmdInterface:
                     + symlink_destination_path,
                 )
                 if answer == QMessageBox.StandardButton.Yes:  # Re-create symlink
-                    self.setup = self.create_symlink(symlink_source_path, symlink_destination_path, runner=runner)
-            elif os.path.exists(symlink_destination_path):  # A dir exists (not a symlink/junction)
+                    self.setup = self.create_symlink(
+                        symlink_source_path, symlink_destination_path, runner=runner
+                    )
+            elif os.path.exists(
+                symlink_destination_path
+            ):  # A dir exists (not a symlink/junction)
                 runner.message(
                     f"Symlink destination already exists! Please remove existing destination:\n\n{symlink_destination_path}\n"
                 )
@@ -570,24 +621,34 @@ class SteamcmdInterface:
                     )
                     + symlink_destination_path,
                 )
-                if answer == QMessageBox.StandardButton.Yes:  # Re-create symlink/junction
-                    self.setup = self.create_symlink(symlink_source_path, symlink_destination_path, runner=runner)
+                if (
+                    answer == QMessageBox.StandardButton.Yes
+                ):  # Re-create symlink/junction
+                    self.setup = self.create_symlink(
+                        symlink_source_path, symlink_destination_path, runner=runner
+                    )
             else:  # Symlink/junction does not exist
                 answer = show_dialogue_conditional(
                     self.translate("SteamcmdInterface", "Create Symlink?"),
-                    self.translate("SteamcmdInterface", "Do you want to create a symlink?"),
+                    self.translate(
+                        "SteamcmdInterface", "Do you want to create a symlink?"
+                    ),
                     self.translate(
                         "SteamcmdInterface",
                         "The symlink makes SteamCMD download mods to the local mods folder"
                         + " and is required for SteamCMD mod downloads to work correctly.",
                     ),
-                    self.translate("SteamcmdInterface", "New symlink:\n[{symlink_source_path}] -> ").format(
+                    self.translate(
+                        "SteamcmdInterface", "New symlink:\n[{symlink_source_path}] -> "
+                    ).format(
                         symlink_source_path=symlink_source_path,
                     )
                     + symlink_destination_path,
                 )
                 if answer == QMessageBox.StandardButton.Yes:
-                    self.setup = self.create_symlink(symlink_source_path, symlink_destination_path, runner=runner)
+                    self.setup = self.create_symlink(
+                        symlink_source_path, symlink_destination_path, runner=runner
+                    )
 
 
 if __name__ == "__main__":

--- a/app/utils/steam/steamcmd/wrapper.py
+++ b/app/utils/steam/steamcmd/wrapper.py
@@ -9,6 +9,13 @@ from tempfile import gettempdir
 from typing import Any
 from zipfile import ZipFile
 
+# Maximum number of workshop items to download in a single SteamCMD invocation.
+# SteamCMD's internal vprof profiler has a fixed-size thread table
+# (MAX_THREADS_TO_VPROF_AT_ONCE). Exceeding it produces:
+#   src/tier0/vprof.cpp: No room for new profile in vprof thread profile list
+# and causes downloads to time-out.  Keeping batches small avoids the limit.
+STEAMCMD_BATCH_SIZE = 25
+
 import requests
 from loguru import logger
 from PySide6.QtCore import QCoreApplication
@@ -254,6 +261,37 @@ class SteamcmdInterface:
 
         return False
 
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _build_download_script(self, publishedfileids: list[str]) -> str:
+        """Write a SteamCMD script for *publishedfileids* and return its path.
+
+        :param publishedfileids: Workshop IDs to include in this script.
+        :return: Absolute path to the written script file.
+        """
+        download_cmd = "workshop_download_item 294100"
+        script_lines = [
+            f'force_install_dir "{self.steamcmd_steam_path}"',
+            "login anonymous",
+        ]
+        for pfid in publishedfileids:
+            if self.validate_downloads:
+                script_lines.append(f"{download_cmd} {pfid} validate")
+            else:
+                script_lines.append(f"{download_cmd} {pfid}")
+        script_lines.append("quit\n")
+
+        script_path = str(Path(gettempdir()) / "steamcmd_script.txt")
+        with open(script_path, "w", encoding="utf-8") as fh:
+            fh.write("\n".join(script_lines))
+        return script_path
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
     def download_mods(
         self,
         publishedfileids: list[str],
@@ -261,48 +299,65 @@ class SteamcmdInterface:
         clear_cache: bool = False,
     ) -> None:
         """
-        This function downloads a list of mods from a list publishedfileids
+        Download a list of Workshop mods via SteamCMD.
+
+        To avoid the Steam vprof thread-profiler overflow
+        (``src/tier0/vprof.cpp: No room for new profile in vprof thread
+        profile list, grow MAX_THREADS_TO_VPROF_AT_ONCE``) the IDs are
+        split into batches of at most :data:`STEAMCMD_BATCH_SIZE` items.
+        SteamCMD is invoked once per batch; the runner chains batches
+        automatically via its ``_pending_steamcmd_batches`` queue.
 
         https://developer.valvesoftware.com/wiki/SteamCMD
 
-        :param appid: a Steam AppID to pass to steamcmd
-        :param publishedfileids: list of publishedfileids
-        :param runner: a RimSort RunnerPanel to interact with
-        :param clear_cache: whether to clear the steamcmd depot cache before downloading
+        :param publishedfileids: Workshop IDs to download.
+        :param runner: RunnerPanel used to display output and run the process.
+        :param clear_cache: Clear the SteamCMD depot cache before downloading.
         """
         runner.message("Checking for steamcmd...")
-        if self.setup:
-            runner.message(
-                f"Got it: {self.steamcmd}\n"
-                + f"Downloading list of {str(len(publishedfileids))} "
-                + f"publishedfileids to: {self.steamcmd_steam_path}"
-            )
-            if clear_cache:
-                self.clear_depot_cache(runner=runner)
-
-            script = [
-                f'force_install_dir "{self.steamcmd_steam_path}"',
-                "login anonymous",
-            ]
-            download_cmd = "workshop_download_item 294100"
-            for publishedfileid in publishedfileids:
-                if self.validate_downloads:
-                    script.append(f"{download_cmd} {publishedfileid} validate")
-                else:
-                    script.append(f"{download_cmd} {publishedfileid}")
-            script.extend(["quit\n"])
-            script_path = str((Path(gettempdir()) / "steamcmd_script.txt"))
-            with open(script_path, "w", encoding="utf-8") as script_output:
-                script_output.write("\n".join(script))
-            runner.message(f"Compiled & using script: {script_path}")
-            runner.execute(
-                self.steamcmd,
-                [f'+runscript "{script_path}"'],
-                len(publishedfileids),
-            )
-        else:
+        if not self.setup:
             runner.message("SteamCMD was not found. Please setup SteamCMD first!")
             self.on_steamcmd_not_found(runner=runner)
+            return
+
+        total = len(publishedfileids)
+        runner.message(
+            f"Got it: {self.steamcmd}\n"
+            f"Downloading list of {total} publishedfileid(s) to: {self.steamcmd_steam_path}\n"
+            f"(splitting into batches of up to {STEAMCMD_BATCH_SIZE} to avoid SteamCMD vprof overflow)"
+        )
+
+        if clear_cache:
+            self.clear_depot_cache(runner=runner)
+
+        # Build all batch lists up-front; stored on the runner so the
+        # finished() callback can chain them without needing a reference
+        # back to this wrapper.
+        batches: list[list[str]] = [
+            publishedfileids[i : i + STEAMCMD_BATCH_SIZE]
+            for i in range(0, total, STEAMCMD_BATCH_SIZE)
+        ]
+
+        # Stash the queue on the runner instance so finished() can pop it.
+        runner._pending_steamcmd_batches = batches[1:]  # type: ignore[attr-defined]
+        runner._steamcmd_executable = self.steamcmd  # type: ignore[attr-defined]
+        runner._steamcmd_wrapper = self  # type: ignore[attr-defined]
+
+        # Kick off the first batch immediately.
+        batch_num = 1
+        num_batches = len(batches)
+        first_batch = batches[0]
+        runner.message(
+            f"\nBatch {batch_num}/{num_batches}: "
+            f"downloading {len(first_batch)} mod(s)..."
+        )
+        script_path = self._build_download_script(first_batch)
+        runner.message(f"Compiled & using script: {script_path}")
+        runner.execute(
+            self.steamcmd,
+            [f'+runscript "{script_path}"'],
+            total,
+        )
 
     def check_for_steamcmd(self, prefix: str) -> bool:
         executable_name = os.path.split(self.steamcmd)[1] if self.steamcmd else None

--- a/app/windows/runner_panel.py
+++ b/app/windows/runner_panel.py
@@ -1,7 +1,10 @@
 import os
 from platform import system
 from re import compile, search
-from typing import Any, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Optional, Sequence
+
+if TYPE_CHECKING:
+    from app.utils.steam.steamcmd.wrapper import SteamcmdInterface
 
 import psutil
 from loguru import logger
@@ -80,7 +83,7 @@ class RunnerPanel(QWidget):
         # Batch-download state (populated by SteamcmdInterface.download_mods)
         self._pending_steamcmd_batches: list[list[str]] = []
         self._steamcmd_executable: str = ""
-        self._steamcmd_wrapper: Optional[object] = None  # SteamcmdInterface
+        self._steamcmd_wrapper: Optional["SteamcmdInterface"] = None
         self._steamcmd_batch_index: int = 1  # 1-based; first batch already sent
 
         # Set up UI components
@@ -118,34 +121,50 @@ class RunnerPanel(QWidget):
         self.setObjectName("RunnerPanel")
 
         # Clear button
-        self.clear_runner_icon = QIcon(str(AppInfo().theme_data_folder / "default-icons" / "clear.png"))
+        self.clear_runner_icon = QIcon(
+            str(AppInfo().theme_data_folder / "default-icons" / "clear.png")
+        )
         self.clear_runner_button = QToolButton()
         self.clear_runner_button.setIcon(self.clear_runner_icon)
         self.clear_runner_button.clicked.connect(self._do_clear_runner)
-        self.clear_runner_button.setToolTip(self.tr("Clear the text currently displayed by the runner"))
+        self.clear_runner_button.setToolTip(
+            self.tr("Clear the text currently displayed by the runner")
+        )
 
         # Restart button
-        self.restart_process_icon = QIcon(str(AppInfo().theme_data_folder / "default-icons" / "restart_process.png"))
+        self.restart_process_icon = QIcon(
+            str(AppInfo().theme_data_folder / "default-icons" / "restart_process.png")
+        )
         self.restart_process_button = QToolButton()
         self.restart_process_button.setIcon(self.restart_process_icon)
         self.restart_process_button.clicked.connect(self._do_restart_process)
-        self.restart_process_button.setToolTip(self.tr("Re-run the process last used by the runner"))
+        self.restart_process_button.setToolTip(
+            self.tr("Re-run the process last used by the runner")
+        )
         self.restart_process_button.hide()  # Hidden until execute() is called
 
         # Kill button
-        self.kill_process_icon = QIcon(str(AppInfo().theme_data_folder / "default-icons" / "kill_process.png"))
+        self.kill_process_icon = QIcon(
+            str(AppInfo().theme_data_folder / "default-icons" / "kill_process.png")
+        )
         self.kill_process_button = QToolButton()
         self.kill_process_button.setIcon(self.kill_process_icon)
         self.kill_process_button.clicked.connect(self._do_kill_process)
-        self.kill_process_button.setToolTip(self.tr("Kill a process currently being executed by the runner"))
+        self.kill_process_button.setToolTip(
+            self.tr("Kill a process currently being executed by the runner")
+        )
         self.kill_process_button.hide()  # Hidden until execute() is called
 
         # Save output button
-        self.save_runner_icon = QIcon(str(AppInfo().theme_data_folder / "default-icons" / "save_output.png"))
+        self.save_runner_icon = QIcon(
+            str(AppInfo().theme_data_folder / "default-icons" / "save_output.png")
+        )
         self.save_runner_output_button = QToolButton()
         self.save_runner_output_button.setIcon(self.save_runner_icon)
         self.save_runner_output_button.clicked.connect(self._do_save_runner_output)
-        self.save_runner_output_button.setToolTip(self.tr("Save the current output to a file"))
+        self.save_runner_output_button.setToolTip(
+            self.tr("Save the current output to a file")
+        )
 
     def _setup_progress_bar(self) -> None:
         """Set up the progress bar."""
@@ -492,7 +511,9 @@ class RunnerPanel(QWidget):
         # Skip detailed output in dry run mode
         if not self.todds_dry_run_support:
             # Show completion status
-            status_message = "Subprocess killed!" if self.process_killed else "Subprocess completed."
+            status_message = (
+                "Subprocess killed!" if self.process_killed else "Subprocess completed."
+            )
             self.message(status_message)
             self.process_killed = False  # Reset the kill flag
 
@@ -527,10 +548,12 @@ class RunnerPanel(QWidget):
         # _steamcmd_wrapper is the SteamcmdInterface instance set by download_mods()
         wrapper = self._steamcmd_wrapper
         if wrapper is None:
-            logger.error("_start_next_steamcmd_batch: no wrapper reference stored on runner")
+            logger.error(
+                "_start_next_steamcmd_batch: no wrapper reference stored on runner"
+            )
             return
 
-        script_path = wrapper._build_download_script(next_batch)  # type: ignore[union-attr]
+        script_path = wrapper._build_download_script(next_batch)
         self.message(f"Compiled & using script: {script_path}")
 
         # Re-wire the finished signal before starting the new process.
@@ -568,7 +591,8 @@ class RunnerPanel(QWidget):
 
         # Compile details of failed mods for the report
         details = "\n".join(
-            f"{pfids_to_name.get(pfid, f'Mod name not found (ID: {pfid})')}" for pfid in self.steamcmd_download_tracking
+            f"{pfids_to_name.get(pfid, f'Mod name not found (ID: {pfid})')}"
+            for pfid in self.steamcmd_download_tracking
         )
         # Prompt user for action on failed mods
         answer = show_dialogue_conditional(
@@ -614,7 +638,9 @@ class RunnerPanel(QWidget):
         # For mods not found in local DB, try Steam API
         if failed_mods_no_names:
             try:
-                mod_details_lookup = ISteamRemoteStorage_GetPublishedFileDetails(failed_mods_no_names)
+                mod_details_lookup = ISteamRemoteStorage_GetPublishedFileDetails(
+                    failed_mods_no_names
+                )
                 if mod_details_lookup:
                     for mod_metadata in mod_details_lookup:
                         mod_title = mod_metadata.get("title")

--- a/app/windows/runner_panel.py
+++ b/app/windows/runner_panel.py
@@ -77,6 +77,12 @@ class RunnerPanel(QWidget):
         self.login_error = False
         self.redownloading = False
 
+        # Batch-download state (populated by SteamcmdInterface.download_mods)
+        self._pending_steamcmd_batches: list[list[str]] = []
+        self._steamcmd_executable: str = ""
+        self._steamcmd_wrapper: Optional[object] = None  # SteamcmdInterface
+        self._steamcmd_batch_index: int = 1  # 1-based; first batch already sent
+
         # Set up UI components
         self._setup_text_display()
         self._setup_buttons()
@@ -478,6 +484,10 @@ class RunnerPanel(QWidget):
     def finished(self) -> None:
         """
         Handle process completion, including success/failure reporting and cleanup.
+
+        If the completed process was a SteamCMD batch download and additional
+        batches are still pending, the next batch is started automatically
+        instead of showing the final completion dialog.
         """
         # Skip detailed output in dry run mode
         if not self.todds_dry_run_support:
@@ -488,6 +498,12 @@ class RunnerPanel(QWidget):
 
             # Handle process-specific completion tasks
             if "SteamCMD" in self.windowTitle():
+                # If more batches remain, start the next one instead of
+                # finalising.  _handle_steamcmd_completion() is only called
+                # once every batch has been processed.
+                if self._pending_steamcmd_batches and not self.redownloading:
+                    self._start_next_steamcmd_batch()
+                    return
                 self._handle_steamcmd_completion()
             elif "todds" in self.windowTitle():
                 self._handle_todds_completion()
@@ -496,6 +512,36 @@ class RunnerPanel(QWidget):
         if not self.redownloading:
             self.process.terminate()
             self.process_complete()
+
+    def _start_next_steamcmd_batch(self) -> None:
+        """Pop the next pending batch and start a new SteamCMD process for it."""
+        next_batch = self._pending_steamcmd_batches.pop(0)
+        self._steamcmd_batch_index += 1
+        total_batches = self._steamcmd_batch_index + len(self._pending_steamcmd_batches)
+
+        self.message(
+            f"\nBatch {self._steamcmd_batch_index}/{total_batches}: "
+            f"downloading {len(next_batch)} mod(s)..."
+        )
+
+        # _steamcmd_wrapper is the SteamcmdInterface instance set by download_mods()
+        wrapper = self._steamcmd_wrapper
+        if wrapper is None:
+            logger.error("_start_next_steamcmd_batch: no wrapper reference stored on runner")
+            return
+
+        script_path = wrapper._build_download_script(next_batch)  # type: ignore[union-attr]
+        self.message(f"Compiled & using script: {script_path}")
+
+        # Re-wire the finished signal before starting the new process.
+        self.process = QProcess(self)
+        self.process.setProgram(self._steamcmd_executable)
+        self.process.setArguments([f'+runscript "{script_path}"'])
+        self.process.setProcessChannelMode(QProcess.ProcessChannelMode.MergedChannels)
+        self.process.readyReadStandardError.connect(self.handle_output)
+        self.process.readyReadStandardOutput.connect(self.handle_output)
+        self.process.finished.connect(self.finished)
+        self.process.start()
 
     def _handle_steamcmd_completion(self) -> None:
         """Handle SteamCMD-specific completion tasks."""


### PR DESCRIPTION
Fixes #1411

### Description
This PR resolves SteamCMD timeouts and stalls caused by the `No room for new profile in vprof thread profile list` error. This error occurs because SteamCMD relies on an internal, fixed-size thread profiler table. When a single script contains too many `workshop_download_item` commands, SteamCMD spawns enough internal threads to overflow this table, resulting in stalled downloads and system timeouts.

**1. Implemented Batch Processing for SteamCMD**
To prevent overflowing Steam's internal limits, a new `STEAMCMD_BATCH_SIZE` constant (set to 25) was introduced in `wrapper.py`. The `download_mods()` function was refactored to split large mod ID lists into smaller, manageable chunks. A new `_build_download_script()` helper method was also extracted to handle script generation safely per batch.

**2. Updated Runner Panel for Sequential Execution**
`RunnerPanel` was updated with new state variables to track and execute pending SteamCMD batches. The `finished()` method now checks for remaining batches before finalizing; if any exist, it triggers `_start_next_steamcmd_batch()` to generate a fresh script and spawn a new `QProcess`. This allows the UI to stay active continuously across multiple SteamCMD invocations (displaying progress like "Batch 1/4", "Batch 2/4"), ensuring a seamless user experience while safely adhering to Steam's hardcoded thread limits.

---
*Disclaimer: Claude Sonnet 4.6 (thinking) was used to help diagnose and code this fix.*