### PR TITLE
fix(nuitka): remove =yes from --noinclude-qt-translations

### DIFF
--- a/app/__main__.py
+++ b/app/__main__.py
@@ -13,7 +13,7 @@
 
 # The PySide6 plugin covers qt-plugins
 # nuitka-project: --enable-plugin=pyside6
-# nuitka-project: --noinclude-qt-translations=yes
+# nuitka-project: --noinclude-qt-translations
 
 # OS-Specific options
 # nuitka-project-if: {OS} == "Darwin":

--- a/app/__main__.py
+++ b/app/__main__.py
@@ -82,7 +82,9 @@ def handle_exception(
             title="RimSort crashed",
             text="The RimSort application crashed! Sorry for the inconvenience!",
             information="Please contact us on the Discord/Github to report the issue.",
-            details="".join(traceback.format_exception(exc_type, exc_value, exc_traceback)),
+            details="".join(
+                traceback.format_exception(exc_type, exc_value, exc_traceback)
+            ),
         )
 
     sys.exit()
@@ -120,10 +122,15 @@ def main_thread() -> None:
             # If an HTTPError from steam/urllib3 module(s) somehow is uncaught,
             # try to remove the Steam API key from the stacktrace
             pattern = "&key="
-            stacktrace = stacktrace[: len(stacktrace) - (len(stacktrace) - (stacktrace.find(pattern) + len(pattern)))]
+            stacktrace = stacktrace[
+                : len(stacktrace)
+                - (len(stacktrace) - (stacktrace.find(pattern) + len(pattern)))
+            ]
         else:
             stacktrace = traceback.format_exc()
-        logger.error("The main application instantiation has failed with an uncaught exception:")
+        logger.error(
+            "The main application instantiation has failed with an uncaught exception:"
+        )
         logger.error(stacktrace)
         show_fatal_error(details=stacktrace)
     finally:
@@ -134,7 +141,9 @@ def main_thread() -> None:
             except Exception as e:
                 stacktrace = traceback.format_exc()
                 logger.warning(f"Exception: {e}")
-                logger.warning(f"watchdog received the following exception while exiting: {stacktrace}")
+                logger.warning(
+                    f"watchdog received the following exception while exiting: {stacktrace}"
+                )
         logger.info("Exiting application!")
         sys.exit()
 
@@ -186,9 +195,7 @@ if __name__ == "__main__":
 
     def formatter(record: "loguru.Record") -> str:
         """Custom formatter for loguru logger"""
-        format_string = (
-            "[{level}][{time:YYYY-MM-DD HH:mm:ss}][{process.id}][{thread.name}][{module}][{function}][{line}] : "
-        )
+        format_string = "[{level}][{time:YYYY-MM-DD HH:mm:ss}][{process.id}][{thread.name}][{module}][{function}][{line}] : "
 
         record["extra"]["obfuscated_message"] = obfuscate_message(record["message"])
         return format_string + "{extra[obfuscated_message]}\n"
@@ -211,7 +218,9 @@ if __name__ == "__main__":
         logger.debug("Running using Python interpreter")
     else:
         # Configure QtWebEngine locales path
-        os.environ["QTWEBENGINE_LOCALES_PATH"] = str(AppInfo().application_folder / "qtwebengine_locales")
+        os.environ["QTWEBENGINE_LOCALES_PATH"] = str(
+            AppInfo().application_folder / "qtwebengine_locales"
+        )
 
         # MacOS and Windows do not support fork, and can only use spawn
         if SYSTEM != "Linux":

--- a/app/controllers/app_controller.py
+++ b/app/controllers/app_controller.py
@@ -72,7 +72,9 @@ class AppController(QObject):
         self.settings.load()
         self.initialize_translator(self.settings.language)
         self.settings_dialog = SettingsDialog()
-        self.settings_controller = SettingsController(model=self.settings, view=self.settings_dialog)
+        self.settings_controller = SettingsController(
+            model=self.settings, view=self.settings_dialog
+        )
 
     def initialize_theme_controller(self) -> None:
         """Initializes the ThemeController."""
@@ -86,7 +88,9 @@ class AppController(QObject):
         else:
             print(f"Translation file {path} not found.")
 
-        qt_translations_path = QLibraryInfo.path(QLibraryInfo.LibraryPath.TranslationsPath)
+        qt_translations_path = QLibraryInfo.path(
+            QLibraryInfo.LibraryPath.TranslationsPath
+        )
 
         qt_file_path = os.path.join(qt_translations_path, f"qtbase_{language}.qm")
         if qt_translator.load(qt_file_path):
@@ -111,7 +115,9 @@ class AppController(QObject):
 
     def initialize_metadata_manager(self) -> None:
         """Initializes the MetadataManager."""
-        self.metadata_manager = MetadataManager.instance(settings_controller=self.settings_controller)
+        self.metadata_manager = MetadataManager.instance(
+            settings_controller=self.settings_controller
+        )
 
     def initialize_main_window(self) -> None:
         """Initializes the main window and its controller."""

--- a/app/controllers/file_search_controller.py
+++ b/app/controllers/file_search_controller.py
@@ -109,7 +109,9 @@ class SearchWorker(QThread):
             # For all other file types, use standard search
             self.options["algorithm"] = "standard search"
 
-        logger.info(f"Auto-selected search algorithm: {self.options['algorithm']} for {file_type}")
+        logger.info(
+            f"Auto-selected search algorithm: {self.options['algorithm']} for {file_type}"
+        )
 
     def _check_memory_usage(self) -> bool:
         """
@@ -121,10 +123,17 @@ class SearchWorker(QThread):
             memory_info = process.memory_info()
             memory_percent = process.memory_percent()
 
-            logger.debug(f"Memory usage: {memory_info.rss / (1024 * 1024):.1f} MB ({memory_percent:.1f}%)")
+            logger.debug(
+                f"Memory usage: {memory_info.rss / (1024 * 1024):.1f} MB ({memory_percent:.1f}%)"
+            )
 
-            if memory_percent > self.memory_warning_threshold and not self.memory_warning_shown:
-                logger.warning(f"High memory usage detected: {memory_percent:.1f}%. Consider optimizing the search.")
+            if (
+                memory_percent > self.memory_warning_threshold
+                and not self.memory_warning_shown
+            ):
+                logger.warning(
+                    f"High memory usage detected: {memory_percent:.1f}%. Consider optimizing the search."
+                )
                 self.memory_warning_shown = True
 
             return memory_percent <= self.memory_warning_threshold
@@ -157,12 +166,17 @@ class SearchWorker(QThread):
             # Skip very large files to prevent memory issues
             max_size = 20 * 1024 * 1024  # 20MB
             if file_size > max_size:
-                logger.warning(f"File too large to read fully: {file_path} ({format_file_size(file_size)})")
+                logger.warning(
+                    f"File too large to read fully: {file_path} ({format_file_size(file_size)})"
+                )
                 # For large files, read only the first part
                 try:
                     with open(file_path, "rb") as f:
                         binary_content = f.read(1024 * 1024)  # Read first 1MB
-                        return binary_content.decode("utf-8", errors="replace") + "\n\n[File truncated due to size...]"
+                        return (
+                            binary_content.decode("utf-8", errors="replace")
+                            + "\n\n[File truncated due to size...]"
+                        )
                 except Exception as e:
                     logger.warning(f"Failed to read large file {file_path}: {e}")
                     return ""
@@ -181,7 +195,9 @@ class SearchWorker(QThread):
                         detected_encoding = results.encoding
                         # Use explicit text mode with detected encoding
                         content = ""
-                        with open(file_path, "r", encoding=detected_encoding) as text_file:
+                        with open(
+                            file_path, "r", encoding=detected_encoding
+                        ) as text_file:
                             content = text_file.read()
                             return content
                     except UnicodeDecodeError:
@@ -240,8 +256,14 @@ class SearchWorker(QThread):
                     return xml_preview
 
             # Find the position of the search term
-            search_term = self.pattern.lower() if not self.options.get("case_sensitive") else self.pattern
-            content_to_search = content.lower() if not self.options.get("case_sensitive") else content
+            search_term = (
+                self.pattern.lower()
+                if not self.options.get("case_sensitive")
+                else self.pattern
+            )
+            content_to_search = (
+                content.lower() if not self.options.get("case_sensitive") else content
+            )
 
             # For regex patterns, we need to find all matches
             if self.options.get("use_regex", False):
@@ -301,14 +323,24 @@ class SearchWorker(QThread):
                     if self.options.get("use_regex", False):
                         # For regex search, we need to find the match in this specific line
                         try:
-                            flags = 0 if self.options.get("case_sensitive") else re.IGNORECASE
+                            flags = (
+                                0
+                                if self.options.get("case_sensitive")
+                                else re.IGNORECASE
+                            )
                             regex = re.compile(self.pattern, flags)
                             line_match = regex.search(line)
                             if line_match:
                                 match_pos = line_match.start()
                                 match_end = line_match.end()
                                 # Highlight with ** around the match
-                                line = line[:match_pos] + "**" + line[match_pos:match_end] + "**" + line[match_end:]
+                                line = (
+                                    line[:match_pos]
+                                    + "**"
+                                    + line[match_pos:match_end]
+                                    + "**"
+                                    + line[match_end:]
+                                )
                         except re.error:
                             # If regex fails, just show the line without highlighting
                             pass
@@ -365,7 +397,11 @@ class SearchWorker(QThread):
     def _get_xml_preview(self, file_path: str, content: str) -> str:
         """Generate a more structured preview for XML files with better formatting"""
         try:  # Find the position of the search term
-            search_term = self.pattern.lower() if not self.options.get("case_sensitive") else self.pattern
+            search_term = (
+                self.pattern.lower()
+                if not self.options.get("case_sensitive")
+                else self.pattern
+            )
 
             # Try to parse the XML
             try:
@@ -393,21 +429,27 @@ class SearchWorker(QThread):
 
                     # Check children
                     for child in element:
-                        result = find_element_with_text(child, search_text, case_sensitive)
+                        result = find_element_with_text(
+                            child, search_text, case_sensitive
+                        )
                         if result is not None:
                             return result
 
                     return None
 
                 # Find the element containing the search term
-                element = find_element_with_text(root, search_term, self.options.get("case_sensitive", False))
+                element = find_element_with_text(
+                    root, search_term, self.options.get("case_sensitive", False)
+                )
 
                 if element is not None:
                     # Convert element to string with nice formatting
                     element_str = ET.tostring(element, encoding="unicode")
 
                     # Pretty print the XML
-                    pretty_xml = minidom.parseString(element_str).toprettyxml(indent="  ")
+                    pretty_xml = minidom.parseString(element_str).toprettyxml(
+                        indent="  "
+                    )
 
                     # Remove XML declaration
                     if pretty_xml.startswith("<?xml"):
@@ -418,7 +460,9 @@ class SearchWorker(QThread):
                         pattern = re.compile(re.escape(search_term), re.IGNORECASE)
                         pretty_xml = pattern.sub("**\\g<0>**", pretty_xml)
                     else:
-                        pretty_xml = pretty_xml.replace(search_term, f"**{search_term}**")
+                        pretty_xml = pretty_xml.replace(
+                            search_term, f"**{search_term}**"
+                        )
 
                     # Create the preview
                     file_name = os.path.basename(file_path)
@@ -468,7 +512,9 @@ class SearchWorker(QThread):
             return False
         is_active = mod_id in self.active_mod_ids
 
-        return (scope == "active mods" and is_active) or (scope == "inactive mods" and not is_active)
+        return (scope == "active mods" and is_active) or (
+            scope == "inactive mods" and not is_active
+        )
 
     def _should_exclude(self, file_path: str) -> bool:
         """Check if a file or directory should be excluded based on exclude_options."""
@@ -526,7 +572,9 @@ class SearchWorker(QThread):
 
             # Check if the method exists
             if not hasattr(self.searcher, method_name):
-                logger.warning(f"Search method {method_name} not found, falling back to simple_search")
+                logger.warning(
+                    f"Search method {method_name} not found, falling back to simple_search"
+                )
                 method_name = "simple_search"
 
             search_method = getattr(self.searcher, method_name)
@@ -534,7 +582,9 @@ class SearchWorker(QThread):
 
             # Perform the search
             for root_path in self.root_paths:
-                self.stats.emit(self.tr("Searching in: {root_path}").format(root_path=root_path))
+                self.stats.emit(
+                    self.tr("Searching in: {root_path}").format(root_path=root_path)
+                )
                 for result in search_method(self.pattern, [root_path], self.options):
                     mod_name, file_name, path = result
                     preview = self._get_file_preview(path)
@@ -585,7 +635,9 @@ class FileSearchController(QObject):
         self.mods_panel = ModsPanel(
             settings_controller=self.settings_controller,
         )
-        self.active_mod_ids = active_mod_ids or set()  # This is used for the controller, not the worker
+        self.active_mod_ids = (
+            active_mod_ids or set()
+        )  # This is used for the controller, not the worker
         self.search_results: list[SearchResult] = []
         self.search_worker: Optional[SearchWorker] = None
         self.searcher = FileSearch()
@@ -703,9 +755,13 @@ class FileSearchController(QObject):
         """
         self._on_search_start()
         self.dialog.search_button.setEnabled(False)
-        self.dialog.search_button.setStyleSheet("font-weight: bold; background-color: nornal;")
+        self.dialog.search_button.setStyleSheet(
+            "font-weight: bold; background-color: nornal;"
+        )
         self.dialog.stop_button.setEnabled(True)
-        self.dialog.stop_button.setStyleSheet("font-weight: bold; background-color: red;")
+        self.dialog.stop_button.setStyleSheet(
+            "font-weight: bold; background-color: red;"
+        )
 
         options = self.dialog.get_search_options()
         search_text = self.dialog.search_input.text()
@@ -738,7 +794,9 @@ class FileSearchController(QObject):
 
         if scope == "all mods":
             # Get all mod IDs by combining active and inactive mods
-            all_uuids = set(self.mods_panel.active_mods_list.uuids) | set(self.mods_panel.inactive_mods_list.uuids)
+            all_uuids = set(self.mods_panel.active_mods_list.uuids) | set(
+                self.mods_panel.inactive_mods_list.uuids
+            )
             # Use our helper method to get paths and extract IDs
             all_paths = self._get_mod_paths_from_uuids(list(all_uuids))
             for path in all_paths:
@@ -782,7 +840,9 @@ class FileSearchController(QObject):
             return
         # For active/inactive mods, we're already searching in specific mod folders
         # so we don't need to filter by mod ID
-        root_paths_list = list(root_paths) if not isinstance(root_paths, list) else root_paths
+        root_paths_list = (
+            list(root_paths) if not isinstance(root_paths, list) else root_paths
+        )
 
         # Log the search paths
         logger.info(f"Searching in {len(root_paths_list)} paths: {root_paths_list}")
@@ -790,9 +850,13 @@ class FileSearchController(QObject):
         # Start the search worker
         # Pass mod_ids_for_search for active/inactive mods to enable filtering
         if scope in ("active mods", "inactive mods"):
-            self._start_search_worker(root_paths_list, search_text, options, mod_ids_for_search, scope)
+            self._start_search_worker(
+                root_paths_list, search_text, options, mod_ids_for_search, scope
+            )
         else:
-            self._start_search_worker(root_paths_list, search_text, options, None, scope)
+            self._start_search_worker(
+                root_paths_list, search_text, options, None, scope
+            )
 
     def _start_search_worker(
         self,
@@ -818,7 +882,9 @@ class FileSearchController(QObject):
         self.dialog.set_search_paths(root_paths)
         self.dialog.clear_results()
 
-        worker = self._setup_search_worker(root_paths, search_text, options, mod_ids, scope)
+        worker = self._setup_search_worker(
+            root_paths, search_text, options, mod_ids, scope
+        )
         worker.start()
         self.search_worker = worker
 
@@ -836,7 +902,9 @@ class FileSearchController(QObject):
         root_paths = active_mods + inactive_mods
 
         # Log the combined paths for debugging
-        logger.info(f"All mods paths: {len(root_paths)} paths found (active + inactive)")
+        logger.info(
+            f"All mods paths: {len(root_paths)} paths found (active + inactive)"
+        )
 
         return root_paths
 
@@ -923,7 +991,9 @@ class FileSearchController(QObject):
         instance = self.settings.instances[self.settings.current_instance]
         mod_list_path = os.path.join(instance.config_folder, "ModsConfig.xml")
         _, inactive_uuids, _, _ = metadata.get_mods_from_list(mod_list_path)
-        logger.info(f"Getting paths for {len(inactive_uuids)} inactive mods from mod list")
+        logger.info(
+            f"Getting paths for {len(inactive_uuids)} inactive mods from mod list"
+        )
         return get_mod_paths_from_uuids(inactive_uuids)
 
     def _on_stop_clicked(self) -> None:
@@ -960,9 +1030,13 @@ class FileSearchController(QObject):
         """
         # Reset buttons
         self.dialog.search_button.setEnabled(True)
-        self.dialog.search_button.setStyleSheet("font-weight: bold; background-color: green;")
+        self.dialog.search_button.setStyleSheet(
+            "font-weight: bold; background-color: green;"
+        )
         self.dialog.stop_button.setEnabled(False)
-        self.dialog.stop_button.setStyleSheet("font-weight: bold; background-color: normal;")
+        self.dialog.stop_button.setStyleSheet(
+            "font-weight: bold; background-color: normal;"
+        )
 
     def _on_search_error(self, error_msg: str) -> None:
         """
@@ -978,10 +1052,12 @@ class FileSearchController(QObject):
         if "regex" in error_msg.lower():
             show_warning(
                 title=self.tr("Regular Expression Error"),
-                text=self.tr("There was an error with your regular expression pattern."),
-                information=self.tr("{error_msg}\n\nTry simplifying your pattern or check for syntax errors.").format(
-                    error_msg=error_msg
+                text=self.tr(
+                    "There was an error with your regular expression pattern."
                 ),
+                information=self.tr(
+                    "{error_msg}\n\nTry simplifying your pattern or check for syntax errors."
+                ).format(error_msg=error_msg),
             )
         elif "permission" in error_msg.lower() or "access" in error_msg.lower():
             show_warning(
@@ -1003,13 +1079,15 @@ class FileSearchController(QObject):
             show_warning(
                 title=self.tr("Search Error"),
                 text=self.tr("An error occurred during the search."),
-                information=self.tr("{error_msg}\n\nPlease check your settings and try again.").format(
-                    error_msg=error_msg
-                ),
+                information=self.tr(
+                    "{error_msg}\n\nPlease check your settings and try again."
+                ).format(error_msg=error_msg),
             )
 
         # Update the stats label to show the error
-        self.dialog.update_stats(self.tr("Search failed: {error_msg[:100]}...").format(error_msg=error_msg))
+        self.dialog.update_stats(
+            self.tr("Search failed: {error_msg[:100]}...").format(error_msg=error_msg)
+        )
 
         # Reset the UI
         self._on_search_finished()
@@ -1027,7 +1105,9 @@ class FileSearchController(QObject):
             self._filter_timer.timeout.connect(self._apply_filter)
 
         self._filter_text = text.lower()
-        self._filter_timer.start(200)  # Reduced debounce to 200 ms for more responsiveness
+        self._filter_timer.start(
+            200
+        )  # Reduced debounce to 200 ms for more responsiveness
 
     def _apply_filter(self) -> None:
         """
@@ -1061,7 +1141,9 @@ class FileSearchController(QObject):
             )
         )
 
-        logger.debug(f"Filter complete - Visible rows: {visible_rows}/{self.dialog.results_table.rowCount()}")
+        logger.debug(
+            f"Filter complete - Visible rows: {visible_rows}/{self.dialog.results_table.rowCount()}"
+        )
 
     def location_not_set(self) -> None:
         """

--- a/app/controllers/instance_controller.py
+++ b/app/controllers/instance_controller.py
@@ -43,9 +43,15 @@ class InstanceController(QObject):
         if not cls._validate_archive_path(archive_path):
             logger.error(f"Invalid archive path: {archive_path}")
             show_warning(
-                title=QCoreApplication.translate("InstanceController", "Invalid archive path"),
-                text=QCoreApplication.translate("InstanceController", "The provided archive path is invalid."),
-                information=QCoreApplication.translate("InstanceController", "Please provide a valid archive path."),
+                title=QCoreApplication.translate(
+                    "InstanceController", "Invalid archive path"
+                ),
+                text=QCoreApplication.translate(
+                    "InstanceController", "The provided archive path is invalid."
+                ),
+                information=QCoreApplication.translate(
+                    "InstanceController", "Please provide a valid archive path."
+                ),
             )
             raise InvalidArchivePathError(archive_path)
 
@@ -57,7 +63,9 @@ class InstanceController(QObject):
         except Exception as e:
             logger.error(f"An error occurred while reading instance archive: {e}")
             show_fatal_error(
-                title=QCoreApplication.translate("InstanceController", "Error restoring instance"),
+                title=QCoreApplication.translate(
+                    "InstanceController", "Error restoring instance"
+                ),
                 text=QCoreApplication.translate(
                     "InstanceController",
                     "An error occurred while reading instance archive: {e}",
@@ -75,7 +83,10 @@ class InstanceController(QObject):
     def instance_folder_path(self) -> Path:
         """Get instance folder path, using override if configured."""
         # Default instance never uses override
-        if self.instance.instance_folder_override and self.instance.name != DEFAULT_INSTANCE_NAME:
+        if (
+            self.instance.instance_folder_override
+            and self.instance.name != DEFAULT_INSTANCE_NAME
+        ):
             return Path(self.instance.instance_folder_override) / self.instance.name
         return AppInfo().app_storage_folder / INSTANCE_FOLDER_NAME / self.instance.name
 
@@ -173,7 +184,9 @@ class InstanceController(QObject):
 
     def _add_instance_folder_to_archive(self, archive: ZipFile) -> None:
         """Add instance folder contents to archive, skipping symlinks and junctions."""
-        for root, dirs, files in os.walk(self.instance_folder_path, topdown=True, followlinks=False):
+        for root, dirs, files in os.walk(
+            self.instance_folder_path, topdown=True, followlinks=False
+        ):
             # Detect and skip symlinks by comparing resolved vs absolute paths
             if Path(root).absolute() != Path(root).resolve():
                 logger.debug(f"Skipping symlinked directory: {root}")
@@ -220,7 +233,9 @@ class InstanceController(QObject):
         """Safely delete instance folder, handling read-only files on Windows."""
         logger.info(f"Deleting existing instance folder: {self.instance_folder_path}")
 
-        def ignore_extended_attributes(func: Callable[[Any], Any], filename: str, exc_info: Any) -> None:
+        def ignore_extended_attributes(
+            func: Callable[[Any], Any], filename: str, exc_info: Any
+        ) -> None:
             """Ignore macOS extended attribute files (._*) that may be read-only."""
             is_meta_file = os.path.basename(filename).startswith("._")
             if not (func is os.unlink and is_meta_file):

--- a/app/controllers/language_controller.py
+++ b/app/controllers/language_controller.py
@@ -27,7 +27,9 @@ class LanguageController:
         logger.info(f"Supported languages: {self.languages}")
 
     def _get_supported_languages(self) -> set[str]:
-        language_names = self._get_language_names_from_folder(self._language_data_folder)
+        language_names = self._get_language_names_from_folder(
+            self._language_data_folder
+        )
         logger.info(f"Supported languages retrieved: {language_names}")
         logger.debug(f"Checking language folders: {[self._language_data_folder]}")
 
@@ -71,7 +73,9 @@ class LanguageController:
             display_name = language_map.get(lang_code, lang_code)
             combox.addItem(display_name, lang_code)
 
-    def setup_language_dialog(self, settings_dialog: "SettingsDialog", settings: "Settings") -> None:
+    def setup_language_dialog(
+        self, settings_dialog: "SettingsDialog", settings: "Settings"
+    ) -> None:
         """
         Set up the settings dialog with current settings and connect language change signal.
         """
@@ -88,7 +92,9 @@ class LanguageController:
             lambda: self._on_language_changed(settings_dialog, settings)
         )
 
-    def _on_language_changed(self, settings_dialog: "SettingsDialog", settings: "Settings") -> None:
+    def _on_language_changed(
+        self, settings_dialog: "SettingsDialog", settings: "Settings"
+    ) -> None:
         """Handle language change and prompt user to restart."""
         new_language = settings_dialog.language_combobox.currentData()
         if new_language != settings.language:
@@ -98,7 +104,9 @@ class LanguageController:
             answer = dialogue.show_dialogue_conditional(
                 title=self.tr("Language Changed"),
                 text=self.tr("The language has been updated."),
-                information=self.tr("Restart the application to apply the change. Restart now?"),
+                information=self.tr(
+                    "Restart the application to apply the change. Restart now?"
+                ),
                 button_text_override=[
                     self.tr("Restart"),
                 ],

--- a/app/controllers/main_content_controller.py
+++ b/app/controllers/main_content_controller.py
@@ -42,7 +42,9 @@ from app.views.main_content_panel import MainContent
 class MainContentController(QObject):
     """Controller with concurrent checking/updating and improved structure."""
 
-    def __init__(self, view: MainContent, settings_controller: SettingsController) -> None:
+    def __init__(
+        self, view: MainContent, settings_controller: SettingsController
+    ) -> None:
         super().__init__()
         self.view = view
         self.settings_controller = settings_controller
@@ -65,11 +67,15 @@ class MainContentController(QObject):
             ),
             EventBus().do_download_use_this_instead_db_from_github: (
                 AppInfo().databases_folder,
-                lambda: self.settings_controller.settings.external_use_this_instead_repo_path,
+                lambda: (
+                    self.settings_controller.settings.external_use_this_instead_repo_path
+                ),
             ),
             EventBus().do_download_no_version_warning_db_from_github: (
                 AppInfo().databases_folder,
-                lambda: self.settings_controller.settings.external_no_version_warning_repo_path,
+                lambda: (
+                    self.settings_controller.settings.external_no_version_warning_repo_path
+                ),
             ),
         }
 
@@ -90,14 +96,20 @@ class MainContentController(QObject):
         # Bind download signals
         for event_signal, (base_path_obj, url_getter) in self.download_signals.items():
             event_signal.connect(
-                lambda url_getter=url_getter, base_path_obj=base_path_obj: self._do_git_clone(
-                    base_path=str(base_path_obj),
-                    repo_url=url_getter(),
+                lambda url_getter=url_getter, base_path_obj=base_path_obj: (
+                    self._do_git_clone(
+                        base_path=str(base_path_obj),
+                        repo_url=url_getter(),
+                    )
                 )
             )
 
-        EventBus().do_upload_steam_workshop_db_to_github.connect(self._on_do_upload_steam_workshop_db_to_github)
-        EventBus().do_upload_community_rules_db_to_github.connect(self._on_do_upload_community_db_to_github)
+        EventBus().do_upload_steam_workshop_db_to_github.connect(
+            self._on_do_upload_steam_workshop_db_to_github
+        )
+        EventBus().do_upload_community_rules_db_to_github.connect(
+            self._on_do_upload_community_db_to_github
+        )
 
     @Slot(list)
     def _on_check_updates_requested(self, repos_paths: List[Path]) -> None:
@@ -109,7 +121,9 @@ class MainContentController(QObject):
                 information=self.tr("Please select at least one repository to check."),
             ).exec()
             return
-        logger.debug(f"Scheduling concurrent check for {len(repos_paths)} repositories.")
+        logger.debug(
+            f"Scheduling concurrent check for {len(repos_paths)} repositories."
+        )
         config = GitOperationConfig(notify_errors=True)
         worker = GitCheckUpdatesWorker(repos_paths, config=config)
         worker.signals.finished.connect(self._handle_check_updates_results)
@@ -134,7 +148,9 @@ class MainContentController(QObject):
             InformationBox(
                 title=self.tr("Errors during update check"),
                 text=self.tr("Some repositories encountered errors."),
-                information=self.tr("Errors occurred while checking for updates:\n{errors}").format(errors=msg),
+                information=self.tr(
+                    "Errors occurred while checking for updates:\n{errors}"
+                ).format(errors=msg),
             ).exec()
             return
 
@@ -155,7 +171,9 @@ class MainContentController(QObject):
 
         binary_diag = BinaryChoiceDialog(
             title=self.tr("Git Updates Found"),
-            text=self.tr("{len} repositories have updates available.").format(len=len(updates)),
+            text=self.tr("{len} repositories have updates available.").format(
+                len=len(updates)
+            ),
             information=self.tr("Would you like to update them now?"),
             details=details_msg,
             positive_text=self.tr("Update All"),
@@ -168,7 +186,9 @@ class MainContentController(QObject):
 
     def _on_update_repos(self, repos_paths: List[Path]) -> None:
         """Schedule concurrent batch pull for multiple repositories."""
-        logger.debug(f"Scheduling concurrent update for {len(repos_paths)} repositories.")
+        logger.debug(
+            f"Scheduling concurrent update for {len(repos_paths)} repositories."
+        )
         config = GitOperationConfig(notify_errors=True)
         worker = GitBatchUpdateWorker(repos_paths, config=config)
         worker.signals.finished.connect(self._handle_batch_update_results)
@@ -185,15 +205,17 @@ class MainContentController(QObject):
             details_msg = ""
             for repo_path in successful:
                 repo_name = Path(repo_path).name
-                commit_info = getattr(results, "commit_info", {}).get(str(repo_path), "No commit info")
+                commit_info = getattr(results, "commit_info", {}).get(
+                    str(repo_path), "No commit info"
+                )
                 details_msg += f"✓ {repo_name}\n  └─ {commit_info}\n\n"
 
             InformationBox(
                 title=self.tr("Updates Completed"),
                 text=self.tr("All repositories updated successfully!"),
-                information=self.tr("{count} repositories were updated with their latest commits:").format(
-                    count=len(successful)
-                ),
+                information=self.tr(
+                    "{count} repositories were updated with their latest commits:"
+                ).format(count=len(successful)),
                 details=details_msg.strip(),
             ).exec()
         elif not successful:
@@ -204,14 +226,18 @@ class MainContentController(QObject):
             InformationBox(
                 title=self.tr("Failed to update repo!"),
                 text=self.tr("All pull operations failed."),
-                information=self.tr("{count} repositories could not be updated.").format(count=len(failed)),
+                information=self.tr(
+                    "{count} repositories could not be updated."
+                ).format(count=len(failed)),
                 details=details_msg,
             ).exec()
         else:
             details_msg = self.tr("Successful updates:\n")
             for repo_path in successful:
                 repo_name = Path(repo_path).name
-                commit_info = getattr(results, "commit_info", {}).get(str(repo_path), "No commit info")
+                commit_info = getattr(results, "commit_info", {}).get(
+                    str(repo_path), "No commit info"
+                )
                 details_msg += f"  ✓ {repo_name}\n    └─ {commit_info}\n"
 
             details_msg += f"\n{self.tr('Failed updates:')}\n"
@@ -221,9 +247,9 @@ class MainContentController(QObject):
             InformationBox(
                 title=self.tr("Partial Updates Completed"),
                 text=self.tr("Some repositories updated successfully."),
-                information=self.tr("{success} succeeded, {failed} failed out of {total}.").format(
-                    success=len(successful), failed=len(failed), total=total
-                ),
+                information=self.tr(
+                    "{success} succeeded, {failed} failed out of {total}."
+                ).format(success=len(successful), failed=len(failed), total=total),
                 details=details_msg,
             ).exec()
 
@@ -243,7 +269,9 @@ class MainContentController(QObject):
         binary_diag = BinaryChoiceDialog(
             title=self.tr("Push Options"),
             text=self.tr("Push changes to remote repositories?"),
-            information=self.tr("This will push local commits to the remote repositories."),
+            information=self.tr(
+                "This will push local commits to the remote repositories."
+            ),
             details="\n".join([str(p) for p in repos_paths]),
             positive_text=self.tr("Push"),
             negative_text=self.tr("Cancel"),
@@ -257,7 +285,9 @@ class MainContentController(QObject):
         force_diag = BinaryChoiceDialog(
             title=self.tr("Force Push"),
             text=self.tr("Use force push?"),
-            information=self.tr("Force push will overwrite remote history. Use with caution!"),
+            information=self.tr(
+                "Force push will overwrite remote history. Use with caution!"
+            ),
             positive_text=self.tr("Force Push"),
             negative_text=self.tr("Normal Push"),
         )
@@ -267,7 +297,9 @@ class MainContentController(QObject):
 
     def _on_push_repos(self, repos_paths: List[Path], force: bool = False) -> None:
         """Schedule concurrent batch push for multiple repositories."""
-        logger.debug(f"Scheduling concurrent push for {len(repos_paths)} repositories (force={force}).")
+        logger.debug(
+            f"Scheduling concurrent push for {len(repos_paths)} repositories (force={force})."
+        )
         config = GitOperationConfig(notify_errors=True)
 
         # Get GitHub authentication from settings
@@ -295,7 +327,9 @@ class MainContentController(QObject):
             InformationBox(
                 title=self.tr("Push Completed"),
                 text=self.tr("All repositories pushed successfully!"),
-                information=self.tr("{count} repositories were pushed.").format(count=len(successful)),
+                information=self.tr("{count} repositories were pushed.").format(
+                    count=len(successful)
+                ),
                 details="\n".join([Path(p).name for p in successful]),
             ).exec()
         elif not successful:
@@ -306,7 +340,9 @@ class MainContentController(QObject):
             InformationBox(
                 title=self.tr("Push Failed"),
                 text=self.tr("All push operations failed."),
-                information=self.tr("{count} repositories could not be pushed.").format(count=len(failed)),
+                information=self.tr("{count} repositories could not be pushed.").format(
+                    count=len(failed)
+                ),
                 details=details_msg,
             ).exec()
         else:
@@ -320,9 +356,9 @@ class MainContentController(QObject):
             InformationBox(
                 title=self.tr("Partial Push Completed"),
                 text=self.tr("Some repositories pushed successfully."),
-                information=self.tr("{success} succeeded, {failed} failed out of {total}.").format(
-                    success=len(successful), failed=len(failed), total=total
-                ),
+                information=self.tr(
+                    "{success} succeeded, {failed} failed out of {total}."
+                ).format(success=len(successful), failed=len(failed), total=total),
                 details=details_msg,
             ).exec()
 
@@ -352,7 +388,9 @@ class MainContentController(QObject):
         if full_repo_path.exists():
             answer = show_dialogue_conditional(
                 title=self.tr("Existing repository found"),
-                text=self.tr("An existing local repo that matches this repository was found:"),
+                text=self.tr(
+                    "An existing local repo that matches this repository was found:"
+                ),
                 information=self.tr(
                     "{repo_folder}<br/>"
                     + "How would you like to handle? Choose option:<br/>"
@@ -385,7 +423,8 @@ class MainContentController(QObject):
 
         # Community Rules database
         if (
-            self.settings_controller.settings.external_community_rules_metadata_source == "Configured git repository"
+            self.settings_controller.settings.external_community_rules_metadata_source
+            == "Configured git repository"
             and self.settings_controller.settings.external_community_rules_repo
         ):
             logger.info("Auto-updating Community Rules database from GitHub.")
@@ -396,7 +435,8 @@ class MainContentController(QObject):
 
         # Steam Workshop database
         if (
-            self.settings_controller.settings.external_steam_metadata_source == "Configured git repository"
+            self.settings_controller.settings.external_steam_metadata_source
+            == "Configured git repository"
             and self.settings_controller.settings.external_steam_metadata_repo
         ):
             logger.info("Auto-updating Steam Workshop database from GitHub.")
@@ -407,7 +447,8 @@ class MainContentController(QObject):
 
         # No Version Warning database
         if (
-            self.settings_controller.settings.external_no_version_warning_metadata_source == "Configured git repository"
+            self.settings_controller.settings.external_no_version_warning_metadata_source
+            == "Configured git repository"
             and self.settings_controller.settings.external_no_version_warning_repo_path
         ):
             logger.info('Auto-updating "No Version Warning" database from GitHub.')
@@ -418,7 +459,8 @@ class MainContentController(QObject):
 
         # Use This Instead database (Cross Version Databases)
         if (
-            self.settings_controller.settings.external_use_this_instead_metadata_source == "Configured git repository"
+            self.settings_controller.settings.external_use_this_instead_metadata_source
+            == "Configured git repository"
             and self.settings_controller.settings.external_use_this_instead_repo_path
         ):
             logger.info('Auto-updating "Use This Instead" database from GitHub.')
@@ -444,13 +486,17 @@ class MainContentController(QObject):
 
     def _on_update_repos_silent(self, repos_paths: List[Path]) -> None:
         """Schedule concurrent batch pull for multiple repositories silently."""
-        logger.debug(f"Scheduling silent concurrent update for {len(repos_paths)} repositories.")
+        logger.debug(
+            f"Scheduling silent concurrent update for {len(repos_paths)} repositories."
+        )
         config = GitOperationConfig(notify_errors=False)
         worker = GitBatchUpdateWorker(repos_paths, config=config)
         worker.signals.finished.connect(self._handle_batch_update_results_silent)
         self.thread_pool.start(worker)
 
-    def _start_git_clone_worker(self, repo_url: str, base_path: str, force: bool) -> None:
+    def _start_git_clone_worker(
+        self, repo_url: str, base_path: str, force: bool
+    ) -> None:
         """Initialize and start GitCloneWorker."""
         if self._git_clone_worker is not None:
             try:
@@ -482,7 +528,9 @@ class MainContentController(QObject):
 
     @Slot(bool, str, str)
     def _on_git_clone_finished(self, success: bool, message: str, path: str) -> None:
-        logger.info(f"Git clone finished: success={success}, message={message}, path={path}")
+        logger.info(
+            f"Git clone finished: success={success}, message={message}, path={path}"
+        )
         if success:
             InformationBox(
                 title=self.tr("Repo retrieved"),
@@ -549,7 +597,9 @@ class MainContentController(QObject):
             InformationBox(
                 title=self.tr("Invalid repository"),
                 text=self.tr("Repository URL is empty or invalid."),
-                information=self.tr("Please configure a valid repository URL in settings."),
+                information=self.tr(
+                    "Please configure a valid repository URL in settings."
+                ),
             ).exec()
             return
 
@@ -573,7 +623,9 @@ class MainContentController(QObject):
             InformationBox(
                 title=self.tr("Invalid repository URL"),
                 text=self.tr("Failed to parse repository information from URL."),
-                information=self.tr("URL: {repo_url}\nError: {error}").format(repo_url=repo_url, error=str(e)),
+                information=self.tr("URL: {repo_url}\nError: {error}").format(
+                    repo_url=repo_url, error=str(e)
+                ),
             ).exec()
             return
 
@@ -584,8 +636,12 @@ class MainContentController(QObject):
         if not github_username or not github_token:
             InformationBox(
                 title=self.tr("GitHub credentials missing"),
-                text=self.tr("GitHub username and token are required for database upload."),
-                information=self.tr("Please configure your GitHub credentials in settings."),
+                text=self.tr(
+                    "GitHub username and token are required for database upload."
+                ),
+                information=self.tr(
+                    "Please configure your GitHub credentials in settings."
+                ),
             ).exec()
             return
 
@@ -611,10 +667,12 @@ class MainContentController(QObject):
         if not file_full_path.exists():
             InformationBox(
                 title=self.tr("File does not exist"),
-                text=self.tr("Please ensure the file exists and then try to upload again!"),
-                information=self.tr("File not found:\n{file_full_path}\nRepository:\n{repo_url}").format(
-                    file_full_path=file_full_path, repo_url=repo_url
+                text=self.tr(
+                    "Please ensure the file exists and then try to upload again!"
                 ),
+                information=self.tr(
+                    "File not found:\n{file_full_path}\nRepository:\n{repo_url}"
+                ).format(file_full_path=file_full_path, repo_url=repo_url),
             ).exec()
             return
 
@@ -624,14 +682,21 @@ class MainContentController(QObject):
                 database = json.loads(f.read())
 
             if database.get("version"):
-                database_version = database["version"] - self.settings_controller.settings.database_expiry
+                database_version = (
+                    database["version"]
+                    - self.settings_controller.settings.database_expiry
+                )
             elif database.get("timestamp"):
                 database_version = database["timestamp"]
             else:
                 InformationBox(
                     title=self.tr("Invalid database"),
-                    text=self.tr("Database file does not contain version or timestamp."),
-                    information=self.tr("File: {file_path}").format(file_path=str(file_full_path)),
+                    text=self.tr(
+                        "Database file does not contain version or timestamp."
+                    ),
+                    information=self.tr("File: {file_path}").format(
+                        file_path=str(file_full_path)
+                    ),
                 ).exec()
                 return
         except (json.JSONDecodeError, IOError) as e:
@@ -644,9 +709,12 @@ class MainContentController(QObject):
             return
 
         # Create human-readable version
-        timezone_abbreviation = datetime.datetime.now(datetime.timezone.utc).astimezone().tzinfo
+        timezone_abbreviation = (
+            datetime.datetime.now(datetime.timezone.utc).astimezone().tzinfo
+        )
         database_version_human_readable = (
-            time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(database_version)) + f" {timezone_abbreviation}"
+            time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(database_version))
+            + f" {timezone_abbreviation}"
         )
         # Initialize GitHub API
         try:
@@ -774,20 +842,27 @@ class MainContentController(QObject):
 
                 # Step 1: Check if there are uncommitted changes and stash them
                 if git_utils.git_has_uncommitted_changes(repo, config):
-                    logger.info("Uncommitted changes detected, stashing them before pull")
+                    logger.info(
+                        "Uncommitted changes detected, stashing them before pull"
+                    )
                     stash_result = git_utils.git_stash(
                         repo,
                         message="Auto-stash before database upload pull",
                         config=config,
                     )
-                    if stash_result.is_successful() and stash_result == git_utils.GitStashResult.STASHED:
+                    if (
+                        stash_result.is_successful()
+                        and stash_result == git_utils.GitStashResult.STASHED
+                    ):
                         stash_created = True
                         logger.info("Successfully stashed uncommitted changes")
                     elif not stash_result.is_successful():
                         logger.error(f"Failed to stash changes: {stash_result}")
                         InformationBox(
                             title=self.tr("Stash failed"),
-                            text=self.tr("Failed to stash uncommitted changes before pull."),
+                            text=self.tr(
+                                "Failed to stash uncommitted changes before pull."
+                            ),
                             information=str(stash_result),
                         ).exec()
                         return
@@ -808,8 +883,12 @@ class MainContentController(QObject):
                         logger.error("Merge conflicts detected during pull")
                         InformationBox(
                             title=self.tr("Pull conflict"),
-                            text=self.tr("Merge conflicts encountered during pull operation."),
-                            information=self.tr("Please manually resolve conflicts and try again."),
+                            text=self.tr(
+                                "Merge conflicts encountered during pull operation."
+                            ),
+                            information=self.tr(
+                                "Please manually resolve conflicts and try again."
+                            ),
                         ).exec()
                         return
                     else:
@@ -825,7 +904,9 @@ class MainContentController(QObject):
                 commit_message = f"DB Update: {database_version_human_readable}"
                 # Step 4: Restore stashed changes with automatic conflict resolution
                 if stash_created:
-                    logger.info("Restoring stashed changes on main branch after successful pull")
+                    logger.info(
+                        "Restoring stashed changes on main branch after successful pull"
+                    )
 
                     # Store current HEAD before attempting stash pop for potential rollback
                     current_head_after_pull = repo.head.target
@@ -837,7 +918,9 @@ class MainContentController(QObject):
                     )
 
                     if not unstash_result.is_successful():
-                        logger.warning(f"Failed to restore stashed changes: {unstash_result}")
+                        logger.warning(
+                            f"Failed to restore stashed changes: {unstash_result}"
+                        )
 
                         # Check if there are merge conflicts in the working directory
                         conflict_detected = False
@@ -850,23 +933,31 @@ class MainContentController(QObject):
 
                             if conflict_files:
                                 conflict_detected = True
-                                logger.error(f"Merge conflicts detected in files: {conflict_files}")
+                                logger.error(
+                                    f"Merge conflicts detected in files: {conflict_files}"
+                                )
 
                                 # Automatic conflict resolution: Reset to clean state
                                 logger.info(
                                     "Automatically resolving conflicts by resetting to clean state"
                                 )  # Reset the working directory and index to clean state
-                                repo.reset(current_head_after_pull, pygit2.enums.ResetMode.HARD)
+                                repo.reset(
+                                    current_head_after_pull, pygit2.enums.ResetMode.HARD
+                                )
 
                                 # Clear any remaining conflicted state
                                 repo.state_cleanup()
 
-                                logger.info("Repository reset to clean state after conflicts")
+                                logger.info(
+                                    "Repository reset to clean state after conflicts"
+                                )
 
                                 # Inform user about the automatic resolution
                                 InformationBox(
                                     title=self.tr("Conflicts Auto-Resolved"),
-                                    text=self.tr("Merge conflicts were detected and automatically resolved."),
+                                    text=self.tr(
+                                        "Merge conflicts were detected and automatically resolved."
+                                    ),
                                     information=self.tr(
                                         "Your local changes conflicted with remote changes. "
                                         "The repository has been reset to a clean state with the latest remote changes. "
@@ -879,10 +970,14 @@ class MainContentController(QObject):
                         # If conflicts were detected and resolved, continue with clean state
                         # If no conflicts but still failed, show warning and continue
                         if not conflict_detected:
-                            logger.warning("Stash pop failed but no conflicts detected, continuing...")
+                            logger.warning(
+                                "Stash pop failed but no conflicts detected, continuing..."
+                            )
                             InformationBox(
                                 title=self.tr("Stash restore warning"),
-                                text=self.tr("Failed to restore stashed changes, but no conflicts detected."),
+                                text=self.tr(
+                                    "Failed to restore stashed changes, but no conflicts detected."
+                                ),
                                 information=self.tr(
                                     "Continuing with current state. Your database changes should still be present."
                                 ),
@@ -909,7 +1004,9 @@ class MainContentController(QObject):
 
                     # IMPORTANT: Don't switch branches yet! Keep the changes in the working directory
                     # We'll switch after committing the changes
-                    logger.info(f"Created branch: {branch_name} (will switch after commit)")
+                    logger.info(
+                        f"Created branch: {branch_name} (will switch after commit)"
+                    )
                 except Exception as e:
                     logger.error(f"Failed to create branch {branch_name}: {e}")
                     InformationBox(
@@ -920,13 +1017,17 @@ class MainContentController(QObject):
                     return
 
                 # Step 6: Verify changes are still present in working directory
-                logger.info("Verifying changes are present in working directory before staging")
+                logger.info(
+                    "Verifying changes are present in working directory before staging"
+                )
 
                 # Quick verification that we have uncommitted changes as expected
                 if git_utils.git_has_uncommitted_changes(repo, config):
                     logger.info("Uncommitted changes confirmed in working directory")
                 else:
-                    logger.warning("No uncommitted changes detected in working directory")
+                    logger.warning(
+                        "No uncommitted changes detected in working directory"
+                    )
                     # Don't return here - let git_stage_commit make the final determination
 
                 # Log the current working tree status before staging
@@ -950,7 +1051,9 @@ class MainContentController(QObject):
                 logger.info(f"Stage and commit result: {stage_commit_result}")
 
                 if stage_commit_result == git_utils.GitStageCommitResult.COMMITTED:
-                    logger.info("Successfully staged and committed changes on main branch")
+                    logger.info(
+                        "Successfully staged and committed changes on main branch"
+                    )
 
                     # Now move the commit to the new branch
                     try:
@@ -967,12 +1070,16 @@ class MainContentController(QObject):
                         main_branch = repo.branches.local["main"]
                         main_branch.set_target(current_commit_oid)
 
-                        logger.info(f"Moved commit to branch: {branch_name} and reset main branch")
+                        logger.info(
+                            f"Moved commit to branch: {branch_name} and reset main branch"
+                        )
                     except Exception as e:
                         logger.error(f"Failed to move commit to new branch: {e}")
                         # If this fails, the commit is still on main, but we can continue
                         # Just switch to the new branch and the commit will be duplicated
-                        repo.head.set_target(branch_ref.target)  # Push to user's fork with the new branch
+                        repo.head.set_target(
+                            branch_ref.target
+                        )  # Push to user's fork with the new branch
                     push_result = git_utils.git_push(
                         repo=repo,
                         branch=branch_name,
@@ -993,8 +1100,12 @@ class MainContentController(QObject):
                             database_version_human_readable=database_version_human_readable,
                             commit_message=commit_message,
                         )
-                    elif push_result == git_utils.GitPushResult.REJECTED_NON_FAST_FORWARD:
-                        logger.warning("Push rejected due to non-fast-forward. Attempting force push.")
+                    elif (
+                        push_result == git_utils.GitPushResult.REJECTED_NON_FAST_FORWARD
+                    ):
+                        logger.warning(
+                            "Push rejected due to non-fast-forward. Attempting force push."
+                        )
 
                         # For a feature branch in a fork, force push is generally safe
                         # since it's a new branch that only we are working on
@@ -1023,7 +1134,9 @@ class MainContentController(QObject):
                             else:
                                 InformationBox(
                                     title=self.tr("Force push failed"),
-                                    text=self.tr("Failed to force push changes to fork."),
+                                    text=self.tr(
+                                        "Failed to force push changes to fork."
+                                    ),
                                     information=str(push_result_force),
                                 ).exec()
 
@@ -1031,7 +1144,9 @@ class MainContentController(QObject):
                             logger.error(f"Error during force push: {e}")
                             InformationBox(
                                 title=self.tr("Force push error"),
-                                text=self.tr("Error occurred while force pushing to remote."),
+                                text=self.tr(
+                                    "Error occurred while force pushing to remote."
+                                ),
                                 information=str(e),
                             ).exec()
                     else:
@@ -1045,7 +1160,9 @@ class MainContentController(QObject):
                     InformationBox(
                         title=self.tr("No changes"),
                         text=self.tr("No changes detected in database file."),
-                        information=self.tr("The database appears to be up to date with the remote repository."),
+                        information=self.tr(
+                            "The database appears to be up to date with the remote repository."
+                        ),
                     ).exec()
                     return
                 # Stop execution here since there's nothing to push or create PR for
@@ -1075,7 +1192,9 @@ class MainContentController(QObject):
                                 repo.checkout(main_branch)
                                 logger.info("Switched back to main branch")
                             else:
-                                logger.warning("Main branch not found, staying on current branch")
+                                logger.warning(
+                                    "Main branch not found, staying on current branch"
+                                )
                         except Exception as e:
                             logger.warning(f"Failed to switch to main branch: {e}")
             except Exception as e:
@@ -1152,8 +1271,12 @@ class MainContentController(QObject):
         """Ask user for confirmation before uploading Steam Workshop database."""
         binary_diag = BinaryChoiceDialog(
             title=self.tr("Upload Steam Workshop Database"),
-            text=self.tr("Are you sure you want to upload the Steam Workshop database to GitHub?"),
-            information=self.tr("This will create a pull request with your local database changes."),
+            text=self.tr(
+                "Are you sure you want to upload the Steam Workshop database to GitHub?"
+            ),
+            information=self.tr(
+                "This will create a pull request with your local database changes."
+            ),
             positive_text=self.tr("Upload"),
             negative_text=self.tr("Cancel"),
         )
@@ -1171,8 +1294,12 @@ class MainContentController(QObject):
         """Ask user for confirmation before uploading Community Rules database."""
         binary_diag = BinaryChoiceDialog(
             title=self.tr("Upload Community Rules Database"),
-            text=self.tr("Are you sure you want to upload the Community Rules database to GitHub?"),
-            information=self.tr("This will create a pull request with your local database changes."),
+            text=self.tr(
+                "Are you sure you want to upload the Community Rules database to GitHub?"
+            ),
+            information=self.tr(
+                "This will create a pull request with your local database changes."
+            ),
             positive_text=self.tr("Upload"),
             negative_text=self.tr("Cancel"),
         )
@@ -1186,13 +1313,19 @@ class MainContentController(QObject):
             logger.debug("User cancelled Community Rules database upload.")
 
     @Slot(object)
-    def _handle_batch_update_results_silent(self, results: GitBatchUpdateResults) -> None:
+    def _handle_batch_update_results_silent(
+        self, results: GitBatchUpdateResults
+    ) -> None:
         """Process results from GitBatchUpdateWorker silently."""
         successful = results.successful
         failed = results.failed
 
         if successful:
-            logger.info(f"Silently updated {len(successful)} database repositories successfully")
+            logger.info(
+                f"Silently updated {len(successful)} database repositories successfully"
+            )
 
         if failed:
-            logger.warning(f"Failed to update {len(failed)} database repositories: {[str(p) for p, e in failed]}")
+            logger.warning(
+                f"Failed to update {len(failed)} database repositories: {[str(p) for p, e in failed]}"
+            )

--- a/app/controllers/main_window_controller.py
+++ b/app/controllers/main_window_controller.py
@@ -47,12 +47,18 @@ class MainWindowController(QObject):
             button.clicked.connect(signal.emit)
 
         # Connect check dependencies signal from mods panel
-        self.main_window.main_content_panel.mods_panel.check_dependencies_signal.connect(self.check_dependencies)
+        self.main_window.main_content_panel.mods_panel.check_dependencies_signal.connect(
+            self.check_dependencies
+        )
 
         # Connect EventBus signals to slots
         EventBus().do_button_animation.connect(self.on_button_animation)
-        EventBus().do_save_button_animation_stop.connect(self.on_save_button_animation_stop)
-        EventBus().list_updated_signal.connect(self.on_save_button_animation_start)  # Save btn animation
+        EventBus().do_save_button_animation_stop.connect(
+            self.on_save_button_animation_stop
+        )
+        EventBus().list_updated_signal.connect(
+            self.on_save_button_animation_start
+        )  # Save btn animation
         EventBus().refresh_started.connect(self.on_refresh_started)
         EventBus().refresh_finished.connect(self.on_refresh_finished)
 
@@ -72,12 +78,18 @@ class MainWindowController(QObject):
             workshop_id = workshop_id.split("/")[0]
         return workshop_id
 
-    def _find_workshop_id_in_deps(self, deps_node: Element, target_pkg_id: str) -> str | None:
+    def _find_workshop_id_in_deps(
+        self, deps_node: Element, target_pkg_id: str
+    ) -> str | None:
         """Search a <modDependencies> or versioned child node for a matching packageId and return its Workshop ID."""
         target = target_pkg_id.lower()
         for dep in deps_node.findall("li"):
             package_id = dep.find("packageId")
-            if package_id is not None and package_id.text is not None and package_id.text.lower() == target:
+            if (
+                package_id is not None
+                and package_id.text is not None
+                and package_id.text.lower() == target
+            ):
                 workshop_url = dep.find("steamWorkshopUrl")
                 if workshop_url is not None and workshop_url.text is not None:
                     return self._parse_workshop_id(workshop_url.text)
@@ -85,13 +97,18 @@ class MainWindowController(QObject):
 
     def check_dependencies(self) -> None:
         # Get the active mods list
-        active_mods = set(self.main_window.main_content_panel.mods_panel.active_mods_list.uuids)
+        active_mods = set(
+            self.main_window.main_content_panel.mods_panel.active_mods_list.uuids
+        )
 
         # Create a dictionary to store missing dependencies
         missing_deps: dict[str, set[str]] = {}
 
         # Precompute active package IDs for quick lookup
-        active_ids = {self.metadata_manager.internal_local_metadata[u].get("packageid") for u in active_mods}
+        active_ids = {
+            self.metadata_manager.internal_local_metadata[u].get("packageid")
+            for u in active_mods
+        }
 
         # Check each active mod's dependencies
         for uuid in active_mods:
@@ -113,7 +130,11 @@ class MainWindowController(QObject):
                 if isinstance(dep, tuple):
                     dep_id = dep[0]
                     alt_ids = set()
-                    if len(dep) > 1 and isinstance(dep[1], dict) and isinstance(dep[1].get("alternatives"), set):
+                    if (
+                        len(dep) > 1
+                        and isinstance(dep[1], dict)
+                        and isinstance(dep[1].get("alternatives"), set)
+                    ):
                         alt_ids = dep[1]["alternatives"]
                 else:
                     dep_id = dep
@@ -143,7 +164,9 @@ class MainWindowController(QObject):
                 for dep_id in selected_deps:
                     # First check if it exists locally
                     found_locally = False
-                    for mod_data in self.metadata_manager.internal_local_metadata.values():
+                    for (
+                        mod_data
+                    ) in self.metadata_manager.internal_local_metadata.values():
                         if mod_data.get("packageid") == dep_id:
                             local_mods.append(dep_id)
                             found_locally = True
@@ -158,7 +181,10 @@ class MainWindowController(QObject):
                                 pfid,
                                 metadata,
                             ) in self.metadata_manager.external_steam_metadata.items():
-                                if metadata.get("packageId", "").lower() == dep_id.lower():
+                                if (
+                                    metadata.get("packageId", "").lower()
+                                    == dep_id.lower()
+                                ):
                                     workshop_id = pfid
                                     break
 
@@ -168,12 +194,18 @@ class MainWindowController(QObject):
                             # If not in Steam metadata, try to find it in the mod's About.xml
                             # search through all active mods' About.xml files
                             for active_uuid in active_mods:
-                                active_mod_data = self.metadata_manager.internal_local_metadata[active_uuid]
+                                active_mod_data = (
+                                    self.metadata_manager.internal_local_metadata[
+                                        active_uuid
+                                    ]
+                                )
                                 mod_path = active_mod_data.get("path")
                                 if not mod_path:
                                     continue
 
-                                about_path = os.path.join(mod_path, "About", "About.xml")
+                                about_path = os.path.join(
+                                    mod_path, "About", "About.xml"
+                                )
                                 if os.path.exists(about_path):
                                     try:
                                         import xml.etree.ElementTree as ET
@@ -197,7 +229,11 @@ class MainWindowController(QObject):
                                         used_versioned = False
                                         if prefer_versioned:
                                             try:
-                                                major, minor = self.metadata_manager.game_version.split(".")[:2]
+                                                major, minor = (
+                                                    self.metadata_manager.game_version.split(
+                                                        "."
+                                                    )[:2]
+                                                )
                                                 target_keys = [
                                                     f"v{major}.{minor}",
                                                     f"{major}.{minor}",
@@ -205,8 +241,13 @@ class MainWindowController(QObject):
                                             except Exception:
                                                 target_keys = []
 
-                                            deps_by_version = root.find("modDependenciesByVersion")
-                                            if deps_by_version is not None and target_keys:
+                                            deps_by_version = root.find(
+                                                "modDependenciesByVersion"
+                                            )
+                                            if (
+                                                deps_by_version is not None
+                                                and target_keys
+                                            ):
                                                 # Try exact matches, then prefix matches
                                                 candidate = None
                                                 for child in list(deps_by_version):
@@ -215,7 +256,11 @@ class MainWindowController(QObject):
                                                         break
                                                 if candidate is None:
                                                     for child in list(deps_by_version):
-                                                        if any(child.tag.startswith(k) for k in target_keys if k):
+                                                        if any(
+                                                            child.tag.startswith(k)
+                                                            for k in target_keys
+                                                            if k
+                                                        ):
                                                             candidate = child
                                                             break
 
@@ -230,9 +275,13 @@ class MainWindowController(QObject):
                                                         logger.debug(
                                                             f"Prefer versioned tags: using dependencies from {candidate.tag} in {about_path}"
                                                         )
-                                                        workshop_id = self._find_workshop_id_in_deps(candidate, dep_id)
+                                                        workshop_id = self._find_workshop_id_in_deps(
+                                                            candidate, dep_id
+                                                        )
                                                         if workshop_id:
-                                                            mods_to_download.append(workshop_id)
+                                                            mods_to_download.append(
+                                                                workshop_id
+                                                            )
                                                             break
 
                                         if used_versioned:
@@ -244,7 +293,11 @@ class MainWindowController(QObject):
                                             if deps is None:
                                                 continue
 
-                                            workshop_id = self._find_workshop_id_in_deps(deps, dep_id)
+                                            workshop_id = (
+                                                self._find_workshop_id_in_deps(
+                                                    deps, dep_id
+                                                )
+                                            )
                                             if workshop_id:
                                                 mods_to_download.append(workshop_id)
                                                 break
@@ -266,29 +319,39 @@ class MainWindowController(QObject):
                                 break
 
                     # Update the active mods list with local mods
-                    self.main_window.main_content_panel.mods_panel.active_mods_list.uuids = list(active_mods)
+                    self.main_window.main_content_panel.mods_panel.active_mods_list.uuids = list(
+                        active_mods
+                    )
                     # Trigger list updated signal to refresh UI
                     self.main_window.main_content_panel.mods_panel.list_updated_signal.emit()
 
                 # If there are mods to download, check SteamCMD setup first
                 if mods_to_download:
                     # Check if SteamCMD is set up
-                    steamcmd_wrapper = self.main_window.main_content_panel.steamcmd_wrapper
+                    steamcmd_wrapper = (
+                        self.main_window.main_content_panel.steamcmd_wrapper
+                    )
 
                     if not steamcmd_wrapper.setup:
                         # Set up SteamCMD first
                         self.main_window.main_content_panel._do_setup_steamcmd()
                         # After setup, try downloading again if setup was successful
                         if steamcmd_wrapper.setup:
-                            self.main_window.main_content_panel._do_download_mods_with_steamcmd(mods_to_download)
+                            self.main_window.main_content_panel._do_download_mods_with_steamcmd(
+                                mods_to_download
+                            )
                             # Don't sort yet - let the download completion handler do it
                             return
                         else:
                             # Sort what we have so far
-                            self.main_window.main_content_panel._do_sort(check_deps=False)
+                            self.main_window.main_content_panel._do_sort(
+                                check_deps=False
+                            )
                     else:
                         # SteamCMD is already set up, proceed with download
-                        self.main_window.main_content_panel._do_download_mods_with_steamcmd(mods_to_download)
+                        self.main_window.main_content_panel._do_download_mods_with_steamcmd(
+                            mods_to_download
+                        )
                         # Don't sort yet - let the download completion handler do it
                         return
                 else:
@@ -303,7 +366,9 @@ class MainWindowController(QObject):
 
     # @Slot() # TODO: fix @slot() related MYPY errors once bug is fixed in https://bugreports.qt.io/browse/PYSIDE-2942
     def on_button_animation(self, button: QPushButton) -> None:
-        button.setObjectName("%s" % ("" if button.objectName() == "indicator" else "indicator"))
+        button.setObjectName(
+            "%s" % ("" if button.objectName() == "indicator" else "indicator")
+        )
         button.style().unpolish(button)
         button.style().polish(button)
 
@@ -314,11 +379,15 @@ class MainWindowController(QObject):
     @Slot()
     def on_refresh_finished(self) -> None:
         self.set_buttons_enabled(True)
-        self.main_window.game_version_label.setText("RimWorld version " + MetadataManager.instance().game_version)
+        self.main_window.game_version_label.setText(
+            "RimWorld version " + MetadataManager.instance().game_version
+        )
 
     @Slot()
     def on_save_button_animation_start(self) -> None:
-        logger.debug("Active mods list has been updated. Managing save button animation state.")
+        logger.debug(
+            "Active mods list has been updated. Managing save button animation state."
+        )
         if (
             # Compare current active list with last save to see if the list has changed
             self.main_window.main_content_panel.mods_panel.active_mods_list.uuids
@@ -326,7 +395,9 @@ class MainWindowController(QObject):
         ):
             if not self.main_window.save_button_flashing_animation.isActive():
                 logger.debug("Starting save button animation")
-                self.main_window.save_button_flashing_animation.start(500)  # Blink every 500 milliseconds
+                self.main_window.save_button_flashing_animation.start(
+                    500
+                )  # Blink every 500 milliseconds
         else:
             self.on_save_button_animation_stop()
 

--- a/app/controllers/menu_bar_controller.py
+++ b/app/controllers/menu_bar_controller.py
@@ -29,7 +29,9 @@ class MenuBarController(QObject):
 
         # Update menu (only if updater is not disabled)
         if self.menu_bar.check_for_updates_action is not None:
-            self.menu_bar.check_for_updates_action.triggered.connect(EventBus().do_check_for_application_update.emit)
+            self.menu_bar.check_for_updates_action.triggered.connect(
+                EventBus().do_check_for_application_update.emit
+            )
         if self.menu_bar.check_for_updates_on_startup_action is not None:
             self.menu_bar.check_for_updates_on_startup_action.toggled.connect(
                 self._on_menu_bar_check_for_updates_on_startup_triggered
@@ -39,18 +41,32 @@ class MenuBarController(QObject):
             )
 
         # Settings menu
-        self.menu_bar.settings_action.triggered.connect(self.settings_controller.show_settings_dialog)
+        self.menu_bar.settings_action.triggered.connect(
+            self.settings_controller.show_settings_dialog
+        )
 
         # File menu
-        self.menu_bar.open_mod_list_action.triggered.connect(EventBus().do_open_mod_list.emit)
-        self.menu_bar.save_mod_list_action.triggered.connect(EventBus().do_save_mod_list_as.emit)
-        self.menu_bar.import_from_rentry_action.triggered.connect(EventBus().do_import_mod_list_from_rentry)
+        self.menu_bar.open_mod_list_action.triggered.connect(
+            EventBus().do_open_mod_list.emit
+        )
+        self.menu_bar.save_mod_list_action.triggered.connect(
+            EventBus().do_save_mod_list_as.emit
+        )
+        self.menu_bar.import_from_rentry_action.triggered.connect(
+            EventBus().do_import_mod_list_from_rentry
+        )
         self.menu_bar.import_from_workshop_collection_action.triggered.connect(
             EventBus().do_import_mod_list_from_workshop_collection
         )
-        self.menu_bar.import_from_save_file_action.triggered.connect(EventBus().do_import_mod_list_from_save_file)
-        self.menu_bar.export_to_clipboard_action.triggered.connect(EventBus().do_export_mod_list_to_clipboard)
-        self.menu_bar.export_to_rentry_action.triggered.connect(EventBus().do_export_mod_list_to_rentry)
+        self.menu_bar.import_from_save_file_action.triggered.connect(
+            EventBus().do_import_mod_list_from_save_file
+        )
+        self.menu_bar.export_to_clipboard_action.triggered.connect(
+            EventBus().do_export_mod_list_to_clipboard
+        )
+        self.menu_bar.export_to_rentry_action.triggered.connect(
+            EventBus().do_export_mod_list_to_rentry
+        )
 
         for action in self.menu_bar.upload_log_actions:
             action.triggered.connect(
@@ -69,60 +85,114 @@ class MenuBarController(QObject):
             )
 
         # Shortcuts SubMenu
-        self.menu_bar.open_app_directory_action.triggered.connect(EventBus().do_open_app_directory)
-        self.menu_bar.open_settings_directory_action.triggered.connect(EventBus().do_open_settings_directory)
-        self.menu_bar.open_rimsort_logs_directory_action.triggered.connect(EventBus().do_open_rimsort_logs_directory)
-        self.menu_bar.open_rimworld_directory_action.triggered.connect(EventBus().do_open_rimworld_directory)
+        self.menu_bar.open_app_directory_action.triggered.connect(
+            EventBus().do_open_app_directory
+        )
+        self.menu_bar.open_settings_directory_action.triggered.connect(
+            EventBus().do_open_settings_directory
+        )
+        self.menu_bar.open_rimsort_logs_directory_action.triggered.connect(
+            EventBus().do_open_rimsort_logs_directory
+        )
+        self.menu_bar.open_rimworld_directory_action.triggered.connect(
+            EventBus().do_open_rimworld_directory
+        )
         self.menu_bar.open_rimworld_config_directory_action.triggered.connect(
             EventBus().do_open_rimworld_config_directory
         )
-        self.menu_bar.open_rimworld_logs_directory_action.triggered.connect(EventBus().do_open_rimworld_logs_directory)
-        self.menu_bar.open_local_mods_directory_action.triggered.connect(EventBus().do_open_local_mods_directory)
-        self.menu_bar.open_steam_mods_directory_action.triggered.connect(EventBus().do_open_steam_mods_directory)
+        self.menu_bar.open_rimworld_logs_directory_action.triggered.connect(
+            EventBus().do_open_rimworld_logs_directory
+        )
+        self.menu_bar.open_local_mods_directory_action.triggered.connect(
+            EventBus().do_open_local_mods_directory
+        )
+        self.menu_bar.open_steam_mods_directory_action.triggered.connect(
+            EventBus().do_open_steam_mods_directory
+        )
 
         # Edit menu
         self.menu_bar.cut_action.triggered.connect(self._on_menu_bar_cut_triggered)
         self.menu_bar.copy_action.triggered.connect(self._on_menu_bar_copy_triggered)
         self.menu_bar.paste_action.triggered.connect(self._on_menu_bar_paste_triggered)
         self.menu_bar.rule_editor_action.triggered.connect(EventBus().do_rule_editor)
-        self.menu_bar.ignore_json_editor_action.triggered.connect(EventBus().do_ignore_json_editor)
-        self.menu_bar.reset_all_warnings_action.triggered.connect(self._on_menu_bar_reset_warnings_triggered)
-        self.menu_bar.reset_all_mod_colors_action.triggered.connect(self._on_menu_bar_reset_all_mod_colors_triggered)
+        self.menu_bar.ignore_json_editor_action.triggered.connect(
+            EventBus().do_ignore_json_editor
+        )
+        self.menu_bar.reset_all_warnings_action.triggered.connect(
+            self._on_menu_bar_reset_warnings_triggered
+        )
+        self.menu_bar.reset_all_mod_colors_action.triggered.connect(
+            self._on_menu_bar_reset_all_mod_colors_triggered
+        )
 
         # Download menu
-        self.menu_bar.add_git_mod_action.triggered.connect(EventBus().do_add_git_mod.emit)
-        self.menu_bar.add_zip_mod_action.triggered.connect(EventBus().do_add_zip_mod.emit)
-        self.menu_bar.browse_workshop_action.triggered.connect(EventBus().do_browse_workshop)
-        self.menu_bar.update_workshop_mods_action.triggered.connect(EventBus().do_check_for_workshop_updates)
-        self.menu_bar.steam_verify_game_files_action.triggered.connect(EventBus().do_steam_verify_game_files)
+        self.menu_bar.add_git_mod_action.triggered.connect(
+            EventBus().do_add_git_mod.emit
+        )
+        self.menu_bar.add_zip_mod_action.triggered.connect(
+            EventBus().do_add_zip_mod.emit
+        )
+        self.menu_bar.browse_workshop_action.triggered.connect(
+            EventBus().do_browse_workshop
+        )
+        self.menu_bar.update_workshop_mods_action.triggered.connect(
+            EventBus().do_check_for_workshop_updates
+        )
+        self.menu_bar.steam_verify_game_files_action.triggered.connect(
+            EventBus().do_steam_verify_game_files
+        )
 
         # View menu
-        self.menu_bar.show_translation_status_action.toggled.connect(EventBus().do_toggle_translation_status.emit)
-        self.menu_bar.auto_add_translations_action.triggered.connect(EventBus().do_auto_add_translations.emit)
+        self.menu_bar.show_translation_status_action.toggled.connect(
+            EventBus().do_toggle_translation_status.emit
+        )
+        self.menu_bar.auto_add_translations_action.triggered.connect(
+            EventBus().do_auto_add_translations.emit
+        )
 
         # Instances menu
-        self.menu_bar.backup_instance_action.triggered.connect(self._on_do_backup_current_instance)
-        self.menu_bar.restore_instance_action.triggered.connect(EventBus().do_restore_instance_from_archive.emit)
-        self.menu_bar.clone_instance_action.triggered.connect(self._on_do_clone_current_instance)
-        self.menu_bar.create_instance_action.triggered.connect(EventBus().do_create_new_instance.emit)
-        self.menu_bar.delete_instance_action.triggered.connect(EventBus().do_delete_current_instance.emit)
+        self.menu_bar.backup_instance_action.triggered.connect(
+            self._on_do_backup_current_instance
+        )
+        self.menu_bar.restore_instance_action.triggered.connect(
+            EventBus().do_restore_instance_from_archive.emit
+        )
+        self.menu_bar.clone_instance_action.triggered.connect(
+            self._on_do_clone_current_instance
+        )
+        self.menu_bar.create_instance_action.triggered.connect(
+            EventBus().do_create_new_instance.emit
+        )
+        self.menu_bar.delete_instance_action.triggered.connect(
+            EventBus().do_delete_current_instance.emit
+        )
 
         # Textures menu
-        self.menu_bar.optimize_textures_action.triggered.connect(EventBus().do_optimize_textures)
-        self.menu_bar.delete_dds_textures_action.triggered.connect(EventBus().do_delete_dds_textures)
+        self.menu_bar.optimize_textures_action.triggered.connect(
+            EventBus().do_optimize_textures
+        )
+        self.menu_bar.delete_dds_textures_action.triggered.connect(
+            EventBus().do_delete_dds_textures
+        )
         # Help menu
         self.menu_bar.wiki_action.triggered.connect(self._on_menu_bar_wiki_triggered)
-        self.menu_bar.github_action.triggered.connect(self._on_menu_bar_github_triggered)
+        self.menu_bar.github_action.triggered.connect(
+            self._on_menu_bar_github_triggered
+        )
 
         # External signals
         EventBus().refresh_started.connect(self._on_refresh_started)
         EventBus().refresh_finished.connect(self._on_refresh_finished)
 
     def _on_do_backup_current_instance(self) -> None:
-        EventBus().do_backup_existing_instance.emit(self.settings_controller.settings.current_instance)
+        EventBus().do_backup_existing_instance.emit(
+            self.settings_controller.settings.current_instance
+        )
 
     def _on_do_clone_current_instance(self) -> None:
-        EventBus().do_clone_existing_instance.emit(self.settings_controller.settings.current_instance)
+        EventBus().do_clone_existing_instance.emit(
+            self.settings_controller.settings.current_instance
+        )
 
     def _on_instances_submenu_population(self, instance_names: list[str]) -> None:
         self.menu_bar.instances_submenu.clear()
@@ -137,12 +207,22 @@ class MenuBarController(QObject):
             )
         self.menu_bar.instances_submenu.addActions(actions)
 
-    def _on_set_current_instance(self, current_instance: str, initialize: bool = False) -> None:
+    def _on_set_current_instance(
+        self, current_instance: str, initialize: bool = False
+    ) -> None:
         self.menu_bar.instances_submenu.setTitle(
-            self.tr("Current: {current_instance}").format(current_instance=current_instance)
+            self.tr("Current: {current_instance}").format(
+                current_instance=current_instance
+            )
         )
         self.menu_bar.instances_submenu.setActiveAction(
-            next((action for action in self.menu_bar.instances_submenu.actions() if action.text() == current_instance))
+            next(
+                (
+                    action
+                    for action in self.menu_bar.instances_submenu.actions()
+                    if action.text() == current_instance
+                )
+            )
         )
         if initialize:
             EventBus().do_activate_current_instance.emit(current_instance)

--- a/app/controllers/metadata_controller.py
+++ b/app/controllers/metadata_controller.py
@@ -52,7 +52,8 @@ class MetadataController(QObject):
             if self.metadata_mediator.workshop_mods_path is not None:
                 self.metadata_db_controller.update_from_acf(
                     session,
-                    self.metadata_mediator.workshop_mods_path.parent.parent / "appworkshop_294100.acf",
+                    self.metadata_mediator.workshop_mods_path.parent.parent
+                    / "appworkshop_294100.acf",
                     ModType.STEAM_WORKSHOP,
                 )
 
@@ -93,7 +94,9 @@ class MetadataController(QObject):
         self.metadata_mediator.local_mods_path = local_mods_path
         self.metadata_mediator.game_path = game_path
 
-    def get_metadata_with_path(self, path: str | Path) -> tuple[ListedMod, AuxMetadataEntry] | tuple[None, None]:
+    def get_metadata_with_path(
+        self, path: str | Path
+    ) -> tuple[ListedMod, AuxMetadataEntry] | tuple[None, None]:
         mod_data = self.metadata_mediator.mods_metadata.get(str(path), None)
         if mod_data is None:
             return None, None

--- a/app/controllers/metadata_db_controller.py
+++ b/app/controllers/metadata_db_controller.py
@@ -19,14 +19,18 @@ class MetadataDbController:
             if db_path.parent:
                 db_path.parent.mkdir(parents=True, exist_ok=True)
         except Exception as e:
-            logger.exception(f"Failed to ensure database directory exists for {db_path}: {e}")
+            logger.exception(
+                f"Failed to ensure database directory exists for {db_path}: {e}"
+            )
 
         self.engine = create_engine(f"sqlite+pysqlite:///{db_path}")
         self.Session = sessionmaker(bind=self.engine, expire_on_commit=False)
 
 
 class AuxMetadataController(MetadataDbController):
-    _instances: dict[Path, "AuxMetadataController"] = {}  # db_path : AuxMetadataController
+    _instances: dict[
+        Path, "AuxMetadataController"
+    ] = {}  # db_path : AuxMetadataController
 
     def __init__(self, db_path: Path) -> None:
         super().__init__(db_path)
@@ -43,7 +47,9 @@ class AuxMetadataController(MetadataDbController):
         return cls._instances[db_path]
 
     @staticmethod
-    def update(session: Session, item_path: Path | str, **kwargs: Any) -> AuxMetadataEntry | None:
+    def update(
+        session: Session, item_path: Path | str, **kwargs: Any
+    ) -> AuxMetadataEntry | None:
         """
         Update an aux metadata entry by the mod path.
 
@@ -88,7 +94,11 @@ class AuxMetadataController(MetadataDbController):
         if isinstance(item_path, Path):
             item_path = str(item_path)
 
-        return session.query(AuxMetadataEntry).filter(AuxMetadataEntry.path == item_path).first()
+        return (
+            session.query(AuxMetadataEntry)
+            .filter(AuxMetadataEntry.path == item_path)
+            .first()
+        )
 
     @staticmethod
     def get_or_create(session: Session, item_path: Path | str) -> AuxMetadataEntry:
@@ -118,8 +128,12 @@ class AuxMetadataController(MetadataDbController):
                 # Query again to get the existing entry
                 entry = AuxMetadataController.get(session, item_path)
                 if entry is None:
-                    logger.error(f"Failed to create or retrieve aux metadata entry for path: {item_path}")
-                    raise RuntimeError(f"Failed to create or retrieve aux metadata entry for path: {item_path}")
+                    logger.error(
+                        f"Failed to create or retrieve aux metadata entry for path: {item_path}"
+                    )
+                    raise RuntimeError(
+                        f"Failed to create or retrieve aux metadata entry for path: {item_path}"
+                    )
             except Exception as e:
                 session.rollback()
                 logger.exception(f"Failed to create new aux metadata entry: {e}")
@@ -128,7 +142,9 @@ class AuxMetadataController(MetadataDbController):
         return entry
 
     @staticmethod
-    def get_value_equals(session: Session, key: str, value: str) -> list[AuxMetadataEntry]:
+    def get_value_equals(
+        session: Session, key: str, value: str
+    ) -> list[AuxMetadataEntry]:
         """Get aux metadata entries where the key equals the value.
 
         :param session: The database session.
@@ -140,7 +156,11 @@ class AuxMetadataController(MetadataDbController):
         :return: A list of aux metadata entries.
         :rtype: list[AuxMetadataEntry
         """
-        return session.query(AuxMetadataEntry).filter(getattr(AuxMetadataEntry, key) == value).all()
+        return (
+            session.query(AuxMetadataEntry)
+            .filter(getattr(AuxMetadataEntry, key) == value)
+            .all()
+        )
 
     @staticmethod
     def query(session: Session, query: str) -> list[AuxMetadataEntry]:
@@ -157,7 +177,9 @@ class AuxMetadataController(MetadataDbController):
         return [AuxMetadataEntry(**row._mapping) for row in result]
 
     @staticmethod
-    def add(session: Session, item: AuxMetadataEntry | Iterable[AuxMetadataEntry]) -> None:
+    def add(
+        session: Session, item: AuxMetadataEntry | Iterable[AuxMetadataEntry]
+    ) -> None:
         """Add an aux metadata entry or entries to the database.
 
         :param session: The database session.
@@ -177,7 +199,9 @@ class AuxMetadataController(MetadataDbController):
         """Delete mod(s) from database."""
 
         for path in paths:
-            session.query(AuxMetadataEntry).filter(AuxMetadataEntry.path == str(path)).delete()
+            session.query(AuxMetadataEntry).filter(
+                AuxMetadataEntry.path == str(path)
+            ).delete()
 
         session.commit()
 
@@ -209,7 +233,9 @@ class AuxMetadataController(MetadataDbController):
 
         workshop_items = {
             published_file_id: data
-            for published_file_id, data in acf_data.get("AppWorkshop", {}).get("WorkshopItemDetails", {}).items()
+            for published_file_id, data in acf_data.get("AppWorkshop", {})
+            .get("WorkshopItemDetails", {})
+            .items()
         }
 
         entries = (

--- a/app/controllers/mods_panel_controller.py
+++ b/app/controllers/mods_panel_controller.py
@@ -14,7 +14,9 @@ from app.views.mods_panel import ModListWidget, ModsPanel
 
 
 class ModsPanelController(QObject):
-    def __init__(self, view: ModsPanel, settings_controller: SettingsController) -> None:
+    def __init__(
+        self, view: ModsPanel, settings_controller: SettingsController
+    ) -> None:
         super().__init__()
 
         self.mods_panel = view
@@ -33,18 +35,41 @@ class ModsPanelController(QObject):
             partial(self._change_visibility_of_mods_with_warnings_errors, "errors")
         )
         # New mods filter label (only when save-comparison feature enabled)
-        if hasattr(self.mods_panel, "new_text") and self.settings_controller.settings.show_save_comparison_indicators:
-            self.mods_panel.new_text.clicked.connect(self._change_visibility_of_new_mods)
-        EventBus().reset_warnings_signal.connect(self._on_menu_bar_reset_warnings_triggered)
-        EventBus().reset_mod_colors_signal.connect(self._on_menu_bar_reset_mod_colors_triggered)
-        EventBus().do_change_mod_coloring_mode.connect(self._on_change_mod_coloring_mode)
-        EventBus().filters_changed_in_active_modlist.connect(self._on_filters_changed_in_active_modlist)
-        EventBus().filters_changed_in_inactive_modlist.connect(self._on_filters_changed_in_inactive_modlist)
-        EventBus().do_delete_outdated_entries_in_aux_db.connect(self.delete_outdated_aux_db_entries)
-        EventBus().do_set_all_entries_in_aux_db_as_outdated.connect(self.do_all_entries_in_aux_db_as_outdated)
+        if (
+            hasattr(self.mods_panel, "new_text")
+            and self.settings_controller.settings.show_save_comparison_indicators
+        ):
+            self.mods_panel.new_text.clicked.connect(
+                self._change_visibility_of_new_mods
+            )
+        EventBus().reset_warnings_signal.connect(
+            self._on_menu_bar_reset_warnings_triggered
+        )
+        EventBus().reset_mod_colors_signal.connect(
+            self._on_menu_bar_reset_mod_colors_triggered
+        )
+        EventBus().do_change_mod_coloring_mode.connect(
+            self._on_change_mod_coloring_mode
+        )
+        EventBus().filters_changed_in_active_modlist.connect(
+            self._on_filters_changed_in_active_modlist
+        )
+        EventBus().filters_changed_in_inactive_modlist.connect(
+            self._on_filters_changed_in_inactive_modlist
+        )
+        EventBus().do_delete_outdated_entries_in_aux_db.connect(
+            self.delete_outdated_aux_db_entries
+        )
+        EventBus().do_set_all_entries_in_aux_db_as_outdated.connect(
+            self.do_all_entries_in_aux_db_as_outdated
+        )
         # Translation signals
-        EventBus().do_toggle_translation_status.connect(self.mods_panel._on_toggle_translation_status)
-        EventBus().do_auto_add_translations.connect(self.mods_panel._on_auto_add_translations)
+        EventBus().do_toggle_translation_status.connect(
+            self.mods_panel._on_toggle_translation_status
+        )
+        EventBus().do_auto_add_translations.connect(
+            self.mods_panel._on_auto_add_translations
+        )
 
     def _reemit_active_filter_signal(self) -> None:
         """Re-emit the active filter label's click signal to reapply filtering."""
@@ -84,16 +109,22 @@ class ModsPanelController(QObject):
         if not binary_diag.exec_is_positive():
             return
         # Do visible mods first to resize the visible widgets
-        loaded_active_mods = self.mods_panel.active_mods_list.get_all_loaded_and_toggled_mod_list_items()
+        loaded_active_mods = (
+            self.mods_panel.active_mods_list.get_all_loaded_and_toggled_mod_list_items()
+        )
         loaded_inactive_mods = self.mods_panel.inactive_mods_list.get_all_loaded_and_toggled_mod_list_items()
         mods_done = set()
         for loaded_mod in loaded_active_mods + loaded_inactive_mods:
-            package_id = loaded_mod.metadata_manager.internal_local_metadata.get(loaded_mod.uuid, {}).get("packageid")
+            package_id = loaded_mod.metadata_manager.internal_local_metadata.get(
+                loaded_mod.uuid, {}
+            ).get("packageid")
             loaded_mod.toggle_warning_signal.emit(package_id, loaded_mod.uuid)
             mods_done.add(loaded_mod.uuid)
 
         active_mods = self.mods_panel.active_mods_list.get_all_toggled_mod_list_items()
-        inactive_mods = self.mods_panel.inactive_mods_list.get_all_toggled_mod_list_items()
+        inactive_mods = (
+            self.mods_panel.inactive_mods_list.get_all_toggled_mod_list_items()
+        )
         for mod in active_mods + inactive_mods:
             mod_data = mod.data(Qt.ItemDataRole.UserRole)
             uuid = mod_data["uuid"]
@@ -106,11 +137,15 @@ class ModsPanelController(QObject):
                 widget = mod.listWidget()
                 # Widget should always be of type ModListWidget
                 if isinstance(widget, ModListWidget):
-                    package_id = widget.metadata_manager.internal_local_metadata[mod_data["uuid"]]["packageid"]
+                    package_id = widget.metadata_manager.internal_local_metadata[
+                        mod_data["uuid"]
+                    ]["packageid"]
                     self._remove_from_all_ignore_lists(package_id)
                     # Update Aux DB
-                    aux_metadata_controller = AuxMetadataController.get_or_create_cached_instance(
-                        self.settings_controller.settings.aux_db_path
+                    aux_metadata_controller = (
+                        AuxMetadataController.get_or_create_cached_instance(
+                            self.settings_controller.settings.aux_db_path
+                        )
                     )
                     if not uuid:
                         logger.error(
@@ -118,7 +153,9 @@ class ModsPanelController(QObject):
                         )
                         return
                     with aux_metadata_controller.Session() as aux_metadata_session:
-                        mod_path = widget.metadata_manager.internal_local_metadata[uuid]["path"]
+                        mod_path = widget.metadata_manager.internal_local_metadata[
+                            uuid
+                        ]["path"]
                         aux_metadata_controller.update(
                             aux_metadata_session,
                             mod_path,
@@ -150,8 +187,12 @@ class ModsPanelController(QObject):
             return
         active_mods = self.mods_panel.active_mods_list.get_all_mod_list_items()
         inactive_mods = self.mods_panel.inactive_mods_list.get_all_mod_list_items()
-        active_uuids = [mod.data(Qt.ItemDataRole.UserRole)["uuid"] for mod in active_mods]
-        inactive_uuids = [mod.data(Qt.ItemDataRole.UserRole)["uuid"] for mod in inactive_mods]
+        active_uuids = [
+            mod.data(Qt.ItemDataRole.UserRole)["uuid"] for mod in active_mods
+        ]
+        inactive_uuids = [
+            mod.data(Qt.ItemDataRole.UserRole)["uuid"] for mod in inactive_mods
+        ]
         self.mods_panel.active_mods_list.reset_all_mod_colors(active_uuids)
         self.mods_panel.inactive_mods_list.reset_all_mod_colors(inactive_uuids)
 
@@ -244,14 +285,20 @@ class ModsPanelController(QObject):
         # This is more performant, but we dont update db_time_touched. But that should be ok
         time_limit = self.settings_controller.settings.aux_db_time_limit
         if time_limit < 0:
-            logger.debug("Skipping the setting entries as outdated because time limit is negative.")
+            logger.debug(
+                "Skipping the setting entries as outdated because time limit is negative."
+            )
             return
 
         aux_metadata_controller = AuxMetadataController.get_or_create_cached_instance(
             self.settings_controller.settings.aux_db_path
         )
         with aux_metadata_controller.Session() as aux_metadata_session:
-            stmt = update(AuxMetadataEntry).where(AuxMetadataEntry.outdated.is_(False)).values(outdated=True)
+            stmt = (
+                update(AuxMetadataEntry)
+                .where(AuxMetadataEntry.outdated.is_(False))
+                .values(outdated=True)
+            )
             aux_metadata_session.execute(stmt)
             aux_metadata_session.commit()
 
@@ -267,14 +314,18 @@ class ModsPanelController(QObject):
         """
         time_limit = self.settings_controller.settings.aux_db_time_limit
         if time_limit < 0:
-            logger.debug("Skipping the deletion of outdated entries because time limit is negative.")
+            logger.debug(
+                "Skipping the deletion of outdated entries because time limit is negative."
+            )
             return
 
         aux_metadata_controller = AuxMetadataController.get_or_create_cached_instance(
             self.settings_controller.settings.aux_db_path
         )
         with aux_metadata_controller.Session() as aux_metadata_session:
-            limit = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(seconds=time_limit)
+            limit = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(
+                seconds=time_limit
+            )
             stmt = (
                 delete(AuxMetadataEntry)
                 .where(AuxMetadataEntry.outdated)

--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -84,9 +84,13 @@ class SettingsController(QObject):
             self._on_global_reset_to_defaults_button_clicked
         )
 
-        self.settings_dialog.global_cancel_button.clicked.connect(self._on_global_cancel_button_clicked)
+        self.settings_dialog.global_cancel_button.clicked.connect(
+            self._on_global_cancel_button_clicked
+        )
 
-        self.settings_dialog.global_ok_button.clicked.connect(self._on_global_ok_button_clicked)
+        self.settings_dialog.global_ok_button.clicked.connect(
+            self._on_global_ok_button_clicked
+        )
 
         # Connect launch state radio buttons to update spinbox enabled/disabled state
         # Main Window
@@ -128,12 +132,22 @@ class SettingsController(QObject):
         )
 
         # Locations tab
-        self.settings_dialog.game_location.textChanged.connect(self._on_game_location_text_changed)
-        self.settings_dialog.game_location_open_button.clicked.connect(self._on_game_location_open_button_clicked)
-        self.settings_dialog.game_location_choose_button.clicked.connect(self._on_game_location_choose_button_clicked)
-        self.settings_dialog.game_location_clear_button.clicked.connect(self._on_game_location_clear_button_clicked)
+        self.settings_dialog.game_location.textChanged.connect(
+            self._on_game_location_text_changed
+        )
+        self.settings_dialog.game_location_open_button.clicked.connect(
+            self._on_game_location_open_button_clicked
+        )
+        self.settings_dialog.game_location_choose_button.clicked.connect(
+            self._on_game_location_choose_button_clicked
+        )
+        self.settings_dialog.game_location_clear_button.clicked.connect(
+            self._on_game_location_clear_button_clicked
+        )
 
-        self.settings_dialog.config_folder_location.textChanged.connect(self._on_config_folder_location_text_changed)
+        self.settings_dialog.config_folder_location.textChanged.connect(
+            self._on_config_folder_location_text_changed
+        )
         self.settings_dialog.config_folder_location_open_button.clicked.connect(
             self._on_config_folder_location_open_button_clicked
         )
@@ -182,17 +196,27 @@ class SettingsController(QObject):
             # Buttons may not exist if UI hasn't been updated yet
             pass
 
-        self.settings_dialog.locations_clear_button.clicked.connect(self._on_locations_clear_button_clicked)
+        self.settings_dialog.locations_clear_button.clicked.connect(
+            self._on_locations_clear_button_clicked
+        )
 
-        self.settings_dialog.locations_autodetect_button.clicked.connect(self._on_locations_autodetect_button_clicked)
+        self.settings_dialog.locations_autodetect_button.clicked.connect(
+            self._on_locations_autodetect_button_clicked
+        )
 
         # Game Launch tab
-        self.settings_dialog.run_args.textChanged.connect(self._on_run_args_text_changed)
+        self.settings_dialog.run_args.textChanged.connect(
+            self._on_run_args_text_changed
+        )
 
         # Wire up the Databases tab buttons
 
-        self.settings_dialog.community_rules_db_none_radio.clicked.connect(self._on_community_rules_db_radio_clicked)
-        self.settings_dialog.community_rules_db_github_radio.clicked.connect(self._on_community_rules_db_radio_clicked)
+        self.settings_dialog.community_rules_db_none_radio.clicked.connect(
+            self._on_community_rules_db_radio_clicked
+        )
+        self.settings_dialog.community_rules_db_github_radio.clicked.connect(
+            self._on_community_rules_db_radio_clicked
+        )
         self.settings_dialog.community_rules_db_local_file_radio.clicked.connect(
             self._on_community_rules_db_radio_clicked
         )
@@ -207,8 +231,12 @@ class SettingsController(QObject):
             EventBus().do_download_community_rules_db_from_github
         )
 
-        self.settings_dialog.steam_workshop_db_none_radio.clicked.connect(self._on_steam_workshop_db_radio_clicked)
-        self.settings_dialog.steam_workshop_db_github_radio.clicked.connect(self._on_steam_workshop_db_radio_clicked)
+        self.settings_dialog.steam_workshop_db_none_radio.clicked.connect(
+            self._on_steam_workshop_db_radio_clicked
+        )
+        self.settings_dialog.steam_workshop_db_github_radio.clicked.connect(
+            self._on_steam_workshop_db_radio_clicked
+        )
         self.settings_dialog.steam_workshop_db_local_file_radio.clicked.connect(
             self._on_steam_workshop_db_radio_clicked
         )
@@ -244,7 +272,9 @@ class SettingsController(QObject):
             EventBus().do_download_no_version_warning_db_from_github
         )
 
-        self.settings_dialog.use_this_instead_db_none_radio.clicked.connect(self._on_use_this_instead_db_radio_clicked)
+        self.settings_dialog.use_this_instead_db_none_radio.clicked.connect(
+            self._on_use_this_instead_db_radio_clicked
+        )
         self.settings_dialog.use_this_instead_db_github_radio.clicked.connect(
             self._on_use_this_instead_db_radio_clicked
         )
@@ -286,9 +316,15 @@ class SettingsController(QObject):
         self.settings_dialog.steamcmd_clear_depot_cache_button.clicked.connect(
             self._on_steamcmd_clear_depot_cache_button_clicked
         )
-        self.settings_dialog.steamcmd_import_acf_button.clicked.connect(self._on_steamcmd_import_acf_button_clicked)
-        self.settings_dialog.steamcmd_delete_acf_button.clicked.connect(self._on_steamcmd_delete_acf_button_clicked)
-        self.settings_dialog.steamcmd_install_button.clicked.connect(self._on_steamcmd_install_button_clicked)
+        self.settings_dialog.steamcmd_import_acf_button.clicked.connect(
+            self._on_steamcmd_import_acf_button_clicked
+        )
+        self.settings_dialog.steamcmd_delete_acf_button.clicked.connect(
+            self._on_steamcmd_delete_acf_button_clicked
+        )
+        self.settings_dialog.steamcmd_install_button.clicked.connect(
+            self._on_steamcmd_install_button_clicked
+        )
 
         # Other External Tools Tab
         self.settings_dialog.text_editor_location_choose_button.clicked.connect(
@@ -296,7 +332,9 @@ class SettingsController(QObject):
         )
 
         # Theme tab
-        self.settings_dialog.theme_location_open_button.clicked.connect(self._on_theme_location_open_button_clicked)
+        self.settings_dialog.theme_location_open_button.clicked.connect(
+            self._on_theme_location_open_button_clicked
+        )
 
         # Advanced tab
         self.settings_dialog.color_background_instead_of_text_checkbox.stateChanged.connect(
@@ -330,9 +368,24 @@ class SettingsController(QObject):
         Get the mod paths for the current instance. Return the Default instance if the current instance is not found.
         """
         return [
-            str(Path(self.settings.instances[self.settings.current_instance].game_folder) / "Data"),
-            str(Path(self.settings.instances[self.settings.current_instance].local_folder)),
-            str(Path(self.settings.instances[self.settings.current_instance].workshop_folder)),
+            str(
+                Path(
+                    self.settings.instances[self.settings.current_instance].game_folder
+                )
+                / "Data"
+            ),
+            str(
+                Path(
+                    self.settings.instances[self.settings.current_instance].local_folder
+                )
+            ),
+            str(
+                Path(
+                    self.settings.instances[
+                        self.settings.current_instance
+                    ].workshop_folder
+                )
+            ),
         ]
 
     def resolve_data_source(self, path: str) -> str | None:
@@ -342,9 +395,16 @@ class SettingsController(QObject):
         # Pathlib the provided path string
         sanitized_path = Path(path)
         # Grab paths from Settings
-        expansions_path = Path(self.settings.instances[self.settings.current_instance].game_folder) / "Data"
-        local_path = Path(self.settings.instances[self.settings.current_instance].local_folder)
-        workshop_path = Path(self.settings.instances[self.settings.current_instance].workshop_folder)
+        expansions_path = (
+            Path(self.settings.instances[self.settings.current_instance].game_folder)
+            / "Data"
+        )
+        local_path = Path(
+            self.settings.instances[self.settings.current_instance].local_folder
+        )
+        workshop_path = Path(
+            self.settings.instances[self.settings.current_instance].workshop_folder
+        )
         # Validate data source, then emit if path is valid and not mapped
         if sanitized_path.parent == expansions_path:
             return "expansion"
@@ -433,7 +493,9 @@ class SettingsController(QObject):
             str(self.settings.instances[self.settings.current_instance].game_folder)
         )
         self.settings_dialog.game_location.setCursorPosition(0)
-        self.settings_dialog.game_location_open_button.setEnabled(self.settings_dialog.game_location.text() != "")
+        self.settings_dialog.game_location_open_button.setEnabled(
+            self.settings_dialog.game_location.text() != ""
+        )
         self.settings_dialog.config_folder_location.setText(
             str(self.settings.instances[self.settings.current_instance].config_folder)
         )
@@ -456,102 +518,178 @@ class SettingsController(QObject):
             self.settings_dialog.local_mods_folder_location.text() != ""
         )
         self.settings_dialog.steam_client_integration_checkbox.setChecked(
-            self.settings.instances[self.settings.current_instance].steam_client_integration
+            self.settings.instances[
+                self.settings.current_instance
+            ].steam_client_integration
         )
         # Enable/disable Steam mods location fields based on checkbox state
         checked = self.settings_dialog.steam_client_integration_checkbox.isChecked()
         self.settings_dialog.steam_mods_folder_location.setEnabled(checked)
         self.settings_dialog.steam_mods_folder_location_open_button.setEnabled(checked)
-        self.settings_dialog.steam_mods_folder_location_choose_button.setEnabled(checked)
+        self.settings_dialog.steam_mods_folder_location_choose_button.setEnabled(
+            checked
+        )
         self.settings_dialog.steam_mods_folder_location_clear_button.setEnabled(checked)
 
         # Load Steam protocol launch option
         self.settings_dialog.launch_via_steam_protocol_checkbox.setChecked(
-            self.settings.instances[self.settings.current_instance].launch_via_steam_protocol
+            self.settings.instances[
+                self.settings.current_instance
+            ].launch_via_steam_protocol
         )
         # Update run_args group enabled state based on Steam protocol setting
-        launch_via_steam_protocol = self.settings.instances[self.settings.current_instance].launch_via_steam_protocol
+        launch_via_steam_protocol = self.settings.instances[
+            self.settings.current_instance
+        ].launch_via_steam_protocol
         self.settings_dialog.run_args_group.setEnabled(not launch_via_steam_protocol)
 
         # Instance folder location (custom override)
         # Only enable for Default instance
         is_default_instance = self.settings.current_instance == DEFAULT_INSTANCE_NAME
         self.settings_dialog.instance_folder_location.setText(
-            self.settings.instances[self.settings.current_instance].instance_folder_override
+            self.settings.instances[
+                self.settings.current_instance
+            ].instance_folder_override
         )
         self.settings_dialog.instance_folder_location.setCursorPosition(0)
         self.settings_dialog.instance_folder_location.setEnabled(is_default_instance)
-        self.settings_dialog.instance_folder_location_choose_button.setEnabled(is_default_instance)
-        self.settings_dialog.instance_folder_location_clear_button.setEnabled(is_default_instance)
+        self.settings_dialog.instance_folder_location_choose_button.setEnabled(
+            is_default_instance
+        )
+        self.settings_dialog.instance_folder_location_clear_button.setEnabled(
+            is_default_instance
+        )
 
         # Databases tab
         if self.settings.external_community_rules_metadata_source == "None":
             self.settings_dialog.community_rules_db_none_radio.setChecked(True)
             self.settings_dialog.community_rules_db_github_url.setEnabled(False)
-            self.settings_dialog.community_rules_db_github_download_button.setEnabled(False)
+            self.settings_dialog.community_rules_db_github_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.community_rules_db_local_file.setEnabled(False)
-            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(False)
-        elif self.settings.external_community_rules_metadata_source == "Configured git repository":
+            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(
+                False
+            )
+        elif (
+            self.settings.external_community_rules_metadata_source
+            == "Configured git repository"
+        ):
             self.settings_dialog.community_rules_db_github_radio.setChecked(True)
             self.settings_dialog.community_rules_db_github_url.setEnabled(True)
-            self.settings_dialog.community_rules_db_github_download_button.setEnabled(True)
+            self.settings_dialog.community_rules_db_github_download_button.setEnabled(
+                True
+            )
             self.settings_dialog.community_rules_db_local_file.setEnabled(False)
-            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(False)
-        elif self.settings.external_community_rules_metadata_source == "Configured file path":
+            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(
+                False
+            )
+        elif (
+            self.settings.external_community_rules_metadata_source
+            == "Configured file path"
+        ):
             self.settings_dialog.community_rules_db_local_file_radio.setChecked(True)
             self.settings_dialog.community_rules_db_github_url.setEnabled(False)
-            self.settings_dialog.community_rules_db_github_download_button.setEnabled(False)
+            self.settings_dialog.community_rules_db_github_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.community_rules_db_local_file.setEnabled(True)
-            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(True)
-        self.settings_dialog.community_rules_db_local_file.setText(self.settings.external_community_rules_file_path)
+            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(
+                True
+            )
+        self.settings_dialog.community_rules_db_local_file.setText(
+            self.settings.external_community_rules_file_path
+        )
         self.settings_dialog.community_rules_db_local_file.setCursorPosition(0)
-        self.settings_dialog.community_rules_db_github_url.setText(self.settings.external_community_rules_repo)
+        self.settings_dialog.community_rules_db_github_url.setText(
+            self.settings.external_community_rules_repo
+        )
 
         if self.settings.external_steam_metadata_source == "None":
             self.settings_dialog.steam_workshop_db_none_radio.setChecked(True)
             self.settings_dialog.steam_workshop_db_github_url.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(False)
+            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.steam_workshop_db_local_file.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(False)
-        elif self.settings.external_steam_metadata_source == "Configured git repository":
+            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(
+                False
+            )
+        elif (
+            self.settings.external_steam_metadata_source == "Configured git repository"
+        ):
             self.settings_dialog.steam_workshop_db_github_radio.setChecked(True)
             self.settings_dialog.steam_workshop_db_github_url.setEnabled(True)
-            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(True)
+            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(
+                True
+            )
             self.settings_dialog.steam_workshop_db_local_file.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(False)
+            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(
+                False
+            )
         elif self.settings.external_steam_metadata_source == "Configured file path":
             self.settings_dialog.steam_workshop_db_local_file_radio.setChecked(True)
             self.settings_dialog.steam_workshop_db_github_url.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(False)
+            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.steam_workshop_db_local_file.setEnabled(True)
-            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(True)
-        self.settings_dialog.steam_workshop_db_local_file.setText(self.settings.external_steam_metadata_file_path)
+            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(
+                True
+            )
+        self.settings_dialog.steam_workshop_db_local_file.setText(
+            self.settings.external_steam_metadata_file_path
+        )
         self.settings_dialog.steam_workshop_db_local_file.setCursorPosition(0)
-        self.settings_dialog.steam_workshop_db_github_url.setText(self.settings.external_steam_metadata_repo)
+        self.settings_dialog.steam_workshop_db_github_url.setText(
+            self.settings.external_steam_metadata_repo
+        )
         self.settings_dialog.steam_workshop_db_github_url.setCursorPosition(0)
         self.settings_dialog.database_expiry.setText(str(self.settings.database_expiry))
-        self.settings_dialog.aux_db_time_limit.setText(str(self.settings.aux_db_time_limit))
-        self.settings_dialog.aux_db_time_limit.setEnabled(self.settings.enable_aux_db_behavior_editing)
+        self.settings_dialog.aux_db_time_limit.setText(
+            str(self.settings.aux_db_time_limit)
+        )
+        self.settings_dialog.aux_db_time_limit.setEnabled(
+            self.settings.enable_aux_db_behavior_editing
+        )
 
         # Cross Version DB Tab
         if self.settings.external_no_version_warning_metadata_source == "None":
             self.settings_dialog.no_version_warning_db_none_radio.setChecked(True)
             self.settings_dialog.no_version_warning_db_github_url.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(False)
+            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.no_version_warning_db_local_file.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(False)
-        elif self.settings.external_no_version_warning_metadata_source == "Configured git repository":
+            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(
+                False
+            )
+        elif (
+            self.settings.external_no_version_warning_metadata_source
+            == "Configured git repository"
+        ):
             self.settings_dialog.no_version_warning_db_github_radio.setChecked(True)
             self.settings_dialog.no_version_warning_db_github_url.setEnabled(True)
-            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(True)
+            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(
+                True
+            )
             self.settings_dialog.no_version_warning_db_local_file.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(False)
-        elif self.settings.external_no_version_warning_metadata_source == "Configured file path":
+            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(
+                False
+            )
+        elif (
+            self.settings.external_no_version_warning_metadata_source
+            == "Configured file path"
+        ):
             self.settings_dialog.no_version_warning_db_local_file_radio.setChecked(True)
             self.settings_dialog.no_version_warning_db_github_url.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(False)
+            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.no_version_warning_db_local_file.setEnabled(True)
-            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(True)
+            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(
+                True
+            )
         self.settings_dialog.no_version_warning_db_local_file.setText(
             self.settings.external_no_version_warning_file_path
         )
@@ -564,24 +702,46 @@ class SettingsController(QObject):
         if self.settings.external_use_this_instead_metadata_source == "None":
             self.settings_dialog.use_this_instead_db_none_radio.setChecked(True)
             self.settings_dialog.use_this_instead_db_github_url.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(False)
+            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.use_this_instead_db_local_file.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(False)
-        elif self.settings.external_use_this_instead_metadata_source == "Configured git repository":
+            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(
+                False
+            )
+        elif (
+            self.settings.external_use_this_instead_metadata_source
+            == "Configured git repository"
+        ):
             self.settings_dialog.use_this_instead_db_github_radio.setChecked(True)
             self.settings_dialog.use_this_instead_db_github_url.setEnabled(True)
-            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(True)
+            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(
+                True
+            )
             self.settings_dialog.use_this_instead_db_local_file.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(False)
-        elif self.settings.external_use_this_instead_metadata_source == "Configured file path":
+            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(
+                False
+            )
+        elif (
+            self.settings.external_use_this_instead_metadata_source
+            == "Configured file path"
+        ):
             self.settings_dialog.use_this_instead_db_local_file_radio.setChecked(True)
             self.settings_dialog.use_this_instead_db_github_url.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(False)
+            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.use_this_instead_db_local_file.setEnabled(True)
-            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(True)
-        self.settings_dialog.use_this_instead_db_local_file.setText(self.settings.external_use_this_instead_file_path)
+            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(
+                True
+            )
+        self.settings_dialog.use_this_instead_db_local_file.setText(
+            self.settings.external_use_this_instead_file_path
+        )
         self.settings_dialog.use_this_instead_db_local_file.setCursorPosition(0)
-        self.settings_dialog.use_this_instead_db_github_url.setText(self.settings.external_use_this_instead_repo_path)
+        self.settings_dialog.use_this_instead_db_github_url.setText(
+            self.settings.external_use_this_instead_repo_path
+        )
         self.settings_dialog.use_this_instead_db_github_url.setCursorPosition(0)
 
         # Sorting tab
@@ -591,29 +751,47 @@ class SettingsController(QObject):
             self.settings_dialog.sorting_topological_radio.setChecked(True)
         # Use dependencies for sorting checkbox
         if self.settings.use_moddependencies_as_loadTheseBefore:
-            (self.settings_dialog.use_moddependencies_as_loadTheseBefore.setChecked(True))
+            (
+                self.settings_dialog.use_moddependencies_as_loadTheseBefore.setChecked(
+                    True
+                )
+            )
         # Use alternativePackageIds as satisfying dependencies
         if self.settings.use_alternative_package_ids_as_satisfying_dependencies:
-            self.settings_dialog.use_alternative_package_ids_as_satisfying_dependencies_checkbox.setChecked(True)
+            self.settings_dialog.use_alternative_package_ids_as_satisfying_dependencies_checkbox.setChecked(
+                True
+            )
         # Set dependencies checkbox
-        self.settings_dialog.check_deps_checkbox.setChecked(self.settings.check_dependencies_on_sort)
+        self.settings_dialog.check_deps_checkbox.setChecked(
+            self.settings.check_dependencies_on_sort
+        )
         # Prefer versioned About.xml tags over base tags
         if self.settings.prefer_versioned_about_tags:
             self.settings_dialog.prefer_versioned_about_tags_checkbox.setChecked(True)
         # Download missing mods checkbox
-        self.settings_dialog.download_missing_mods_checkbox.setChecked(self.settings.try_download_missing_mods)
+        self.settings_dialog.download_missing_mods_checkbox.setChecked(
+            self.settings.try_download_missing_mods
+        )
         # Duplicate mod notification checkbox
-        self.settings_dialog.show_duplicate_mods_warning_checkbox.setChecked(self.settings.duplicate_mods_warning)
+        self.settings_dialog.show_duplicate_mods_warning_checkbox.setChecked(
+            self.settings.duplicate_mods_warning
+        )
         # Mod type filter checkbox
-        self.settings_dialog.mod_type_filter_checkbox.setChecked(self.settings.mod_type_filter)
+        self.settings_dialog.mod_type_filter_checkbox.setChecked(
+            self.settings.mod_type_filter
+        )
         # Hide invalid mod filtering checkbox
         self.settings_dialog.hide_invalid_mods_when_filtering_checkbox.setChecked(
             self.settings.hide_invalid_mods_when_filtering
         )
         # Inactive mods sorting options checkbox
-        self.settings_dialog.enable_inactive_mods_sorting_checkbox.setChecked(self.settings.inactive_mods_sorting)
+        self.settings_dialog.enable_inactive_mods_sorting_checkbox.setChecked(
+            self.settings.inactive_mods_sorting
+        )
         # Enable/disable the inactive mods sorting group box based on the checkbox state
-        self.settings_dialog.inactive_mods_sorting_group_box.setEnabled(self.settings.inactive_mods_sorting)
+        self.settings_dialog.inactive_mods_sorting_group_box.setEnabled(
+            self.settings.inactive_mods_sorting
+        )
         # Save inactive mods sort state
         self.settings_dialog.save_inactive_mods_sort_state_checkbox.setChecked(
             self.settings.save_inactive_mods_sort_state
@@ -624,22 +802,34 @@ class SettingsController(QObject):
             self.settings_dialog.db_builder_include_all_radio.setChecked(True)
         elif self.settings.db_builder_include == "no_local":
             self.settings_dialog.db_builder_include_no_local_radio.setChecked(True)
-        self.settings_dialog.db_builder_query_dlc_checkbox.setChecked(self.settings.build_steam_database_dlc_data)
+        self.settings_dialog.db_builder_query_dlc_checkbox.setChecked(
+            self.settings.build_steam_database_dlc_data
+        )
         self.settings_dialog.db_builder_update_instead_of_overwriting_checkbox.setChecked(
             self.settings.build_steam_database_update_toggle
         )
-        self.settings_dialog.db_builder_steam_api_key.setText(self.settings.steam_apikey)
+        self.settings_dialog.db_builder_steam_api_key.setText(
+            self.settings.steam_apikey
+        )
 
         # SteamCMD tab
-        self.settings_dialog.steamcmd_validate_downloads_checkbox.setChecked(self.settings.steamcmd_validate_downloads)
+        self.settings_dialog.steamcmd_validate_downloads_checkbox.setChecked(
+            self.settings.steamcmd_validate_downloads
+        )
         self.settings_dialog.steamcmd_auto_clear_depot_cache_checkbox.setChecked(
-            self.settings.instances[self.settings.current_instance].steamcmd_auto_clear_depot_cache
+            self.settings.instances[
+                self.settings.current_instance
+            ].steamcmd_auto_clear_depot_cache
         )
         self.settings_dialog.steamcmd_delete_before_update_checkbox.setChecked(
             self.settings.steamcmd_delete_before_update
         )
         self.settings_dialog.steamcmd_install_location.setText(
-            str(self.settings.instances[self.settings.current_instance].steamcmd_install_path)
+            str(
+                self.settings.instances[
+                    self.settings.current_instance
+                ].steamcmd_install_path
+            )
         )
 
         # todds tab
@@ -656,26 +846,48 @@ class SettingsController(QObject):
             self.settings_dialog.todds_active_mods_only_radio.setChecked(True)
         else:
             self.settings_dialog.todds_all_mods_radio.setChecked(True)
-        self.settings_dialog.todds_dry_run_checkbox.setChecked(self.settings.todds_dry_run)
-        self.settings_dialog.todds_overwrite_checkbox.setChecked(self.settings.todds_overwrite)
-        self.settings_dialog.todds_custom_command_lineedit.setText(self.settings.todds_custom_command)
-        self.settings_dialog.auto_delete_orphaned_dds_checkbox.setChecked(self.settings.auto_delete_orphaned_dds)
+        self.settings_dialog.todds_dry_run_checkbox.setChecked(
+            self.settings.todds_dry_run
+        )
+        self.settings_dialog.todds_overwrite_checkbox.setChecked(
+            self.settings.todds_overwrite
+        )
+        self.settings_dialog.todds_custom_command_lineedit.setText(
+            self.settings.todds_custom_command
+        )
+        self.settings_dialog.auto_delete_orphaned_dds_checkbox.setChecked(
+            self.settings.auto_delete_orphaned_dds
+        )
         self.settings_dialog.auto_run_todds_before_launch_checkbox.setChecked(
             self.settings.auto_run_todds_before_launch
         )
 
         # External Tools Tab
-        self.settings_dialog.text_editor_location.setText(self.settings.text_editor_location)
-        self.settings_dialog.text_editor_folder_arg.setText(self.settings.text_editor_folder_arg)
-        self.settings_dialog.text_editor_file_arg.setText(self.settings.text_editor_file_arg)
+        self.settings_dialog.text_editor_location.setText(
+            self.settings.text_editor_location
+        )
+        self.settings_dialog.text_editor_folder_arg.setText(
+            self.settings.text_editor_folder_arg
+        )
+        self.settings_dialog.text_editor_file_arg.setText(
+            self.settings.text_editor_file_arg
+        )
 
         # Themes tab
-        self.settings_dialog.enable_themes_checkbox.setChecked(self.settings.enable_themes)
-        self.theme_controller.populate_themes_combobox(self.settings_dialog.themes_combobox)
+        self.settings_dialog.enable_themes_checkbox.setChecked(
+            self.settings.enable_themes
+        )
+        self.theme_controller.populate_themes_combobox(
+            self.settings_dialog.themes_combobox
+        )
         self.theme_controller.setup_theme_dialog(self.settings_dialog, self.settings)
 
-        self.language_controller.populate_languages_combobox(self.settings_dialog.language_combobox)
-        self.language_controller.setup_language_dialog(self.settings_dialog, self.settings)
+        self.language_controller.populate_languages_combobox(
+            self.settings_dialog.language_combobox
+        )
+        self.language_controller.setup_language_dialog(
+            self.settings_dialog, self.settings
+        )
 
         # Advanced tab values
         try:
@@ -740,30 +952,54 @@ class SettingsController(QObject):
             self.settings_dialog.browser_launch_maximized_radio.setChecked(True)
 
         # Settings Window (only custom option)
-        self.settings_dialog.settings_custom_width_spinbox.setValue(self.settings.settings_window_custom_width)
-        self.settings_dialog.settings_custom_height_spinbox.setValue(self.settings.settings_window_custom_height)
+        self.settings_dialog.settings_custom_width_spinbox.setValue(
+            self.settings.settings_window_custom_width
+        )
+        self.settings_dialog.settings_custom_height_spinbox.setValue(
+            self.settings.settings_window_custom_height
+        )
 
         # Advanced tab
-        self.settings_dialog.debug_logging_checkbox.setChecked(self.settings.debug_logging_enabled)
+        self.settings_dialog.debug_logging_checkbox.setChecked(
+            self.settings.debug_logging_enabled
+        )
         self.settings_dialog.watchdog_checkbox.setChecked(self.settings.watchdog_toggle)
-        self.settings_dialog.backup_saves_on_launch_checkbox.setChecked(self.settings.backup_saves_on_launch)
-        self.settings_dialog.auto_backup_retention_count_spinbox.setValue(self.settings.auto_backup_retention_count)
-        self.settings_dialog.auto_backup_compression_count_spinbox.setValue(self.settings.auto_backup_compression_count)
+        self.settings_dialog.backup_saves_on_launch_checkbox.setChecked(
+            self.settings.backup_saves_on_launch
+        )
+        self.settings_dialog.auto_backup_retention_count_spinbox.setValue(
+            self.settings.auto_backup_retention_count
+        )
+        self.settings_dialog.auto_backup_compression_count_spinbox.setValue(
+            self.settings.auto_backup_compression_count
+        )
         self.settings_dialog.color_background_instead_of_text_checkbox.setChecked(
             self.settings.color_background_instead_of_text_toggle
         )
         # Clear button behavior
-        self.settings_dialog.clear_moves_dlc_checkbox.setChecked(self.settings.clear_moves_dlc)
-        self.settings_dialog.show_mod_updates_checkbox.setChecked(self.settings.steam_mods_update_check)
-        self.settings_dialog.render_unity_rich_text_checkbox.setChecked(self.settings.render_unity_rich_text)
-        self.settings_dialog.update_databases_on_startup_checkbox.setChecked(self.settings.update_databases_on_startup)
+        self.settings_dialog.clear_moves_dlc_checkbox.setChecked(
+            self.settings.clear_moves_dlc
+        )
+        self.settings_dialog.show_mod_updates_checkbox.setChecked(
+            self.settings.steam_mods_update_check
+        )
+        self.settings_dialog.render_unity_rich_text_checkbox.setChecked(
+            self.settings.render_unity_rich_text
+        )
+        self.settings_dialog.update_databases_on_startup_checkbox.setChecked(
+            self.settings.update_databases_on_startup
+        )
         self.settings_dialog.include_mod_notes_in_mod_name_filter_checkbox.setChecked(
             self.settings.include_mod_notes_in_mod_name_filter
         )
 
-        self.settings_dialog.enable_backup_before_update_checkbox.setChecked(self.settings.enable_backup_before_update)
+        self.settings_dialog.enable_backup_before_update_checkbox.setChecked(
+            self.settings.enable_backup_before_update
+        )
         self.settings_dialog.max_backups_spinbox.setValue(self.settings.max_backups)
-        self.settings_dialog.enable_aux_db_behavior_editing.setChecked(self.settings.enable_aux_db_behavior_editing)
+        self.settings_dialog.enable_aux_db_behavior_editing.setChecked(
+            self.settings.enable_aux_db_behavior_editing
+        )
         self.settings_dialog.rentry_auth_code.setText(self.settings.rentry_auth_code)
         self.settings_dialog.rentry_auth_code.setCursorPosition(0)
         self.settings_dialog.github_username.setText(self.settings.github_username)
@@ -772,10 +1008,17 @@ class SettingsController(QObject):
         self.settings_dialog.github_token.setCursorPosition(0)
 
         # Migrate old comma-separated format to new space-separated format if needed
-        run_args_list = self._migrate_run_args(self.settings.instances[self.settings.current_instance].run_args)
+        run_args_list = self._migrate_run_args(
+            self.settings.instances[self.settings.current_instance].run_args
+        )
         # Save migrated format back to settings
-        if run_args_list != self.settings.instances[self.settings.current_instance].run_args:
-            self.settings.instances[self.settings.current_instance].run_args = run_args_list
+        if (
+            run_args_list
+            != self.settings.instances[self.settings.current_instance].run_args
+        ):
+            self.settings.instances[
+                self.settings.current_instance
+            ].run_args = run_args_list
             self.settings.save()
             logger.info(f"Saved migrated run_args: {run_args_list}")
 
@@ -790,7 +1033,9 @@ class SettingsController(QObject):
         """
 
         # Locations tab
-        self.settings.instances[self.settings.current_instance].game_folder = self.settings_dialog.game_location.text()
+        self.settings.instances[
+            self.settings.current_instance
+        ].game_folder = self.settings_dialog.game_location.text()
         self.settings.instances[
             self.settings.current_instance
         ].config_folder = self.settings_dialog.config_folder_location.text()
@@ -802,39 +1047,59 @@ class SettingsController(QObject):
         ].local_folder = self.settings_dialog.local_mods_folder_location.text()
         self.settings.instances[
             self.settings.current_instance
-        ].steam_client_integration = self.settings_dialog.steam_client_integration_checkbox.isChecked()
+        ].steam_client_integration = (
+            self.settings_dialog.steam_client_integration_checkbox.isChecked()
+        )
 
         # Save Steam protocol launch option
         self.settings.instances[
             self.settings.current_instance
-        ].launch_via_steam_protocol = self.settings_dialog.launch_via_steam_protocol_checkbox.isChecked()
+        ].launch_via_steam_protocol = (
+            self.settings_dialog.launch_via_steam_protocol_checkbox.isChecked()
+        )
 
         # Databases tab
         if self.settings_dialog.community_rules_db_none_radio.isChecked():
             self.settings.external_community_rules_metadata_source = "None"
         elif self.settings_dialog.community_rules_db_local_file_radio.isChecked():
-            self.settings.external_community_rules_metadata_source = "Configured file path"
+            self.settings.external_community_rules_metadata_source = (
+                "Configured file path"
+            )
         elif self.settings_dialog.community_rules_db_github_radio.isChecked():
-            self.settings.external_community_rules_metadata_source = "Configured git repository"
-        self.settings.external_community_rules_file_path = self.settings_dialog.community_rules_db_local_file.text()
-        self.settings.external_community_rules_repo = self.settings_dialog.community_rules_db_github_url.text()
+            self.settings.external_community_rules_metadata_source = (
+                "Configured git repository"
+            )
+        self.settings.external_community_rules_file_path = (
+            self.settings_dialog.community_rules_db_local_file.text()
+        )
+        self.settings.external_community_rules_repo = (
+            self.settings_dialog.community_rules_db_github_url.text()
+        )
         if self.settings_dialog.steam_workshop_db_none_radio.isChecked():
             self.settings.external_steam_metadata_source = "None"
         elif self.settings_dialog.steam_workshop_db_local_file_radio.isChecked():
             self.settings.external_steam_metadata_source = "Configured file path"
         elif self.settings_dialog.steam_workshop_db_github_radio.isChecked():
             self.settings.external_steam_metadata_source = "Configured git repository"
-        self.settings.external_steam_metadata_repo = self.settings_dialog.steam_workshop_db_github_url.text()
-        self.settings.external_steam_metadata_file_path = self.settings_dialog.steam_workshop_db_local_file.text()
+        self.settings.external_steam_metadata_repo = (
+            self.settings_dialog.steam_workshop_db_github_url.text()
+        )
+        self.settings.external_steam_metadata_file_path = (
+            self.settings_dialog.steam_workshop_db_local_file.text()
+        )
         self.settings.database_expiry = int(self.settings_dialog.database_expiry.text())
 
         # Cross Version Databases Tab
         if self.settings_dialog.no_version_warning_db_none_radio.isChecked():
             self.settings.external_no_version_warning_metadata_source = "None"
         elif self.settings_dialog.no_version_warning_db_local_file_radio.isChecked():
-            self.settings.external_no_version_warning_metadata_source = "Configured file path"
+            self.settings.external_no_version_warning_metadata_source = (
+                "Configured file path"
+            )
         elif self.settings_dialog.no_version_warning_db_github_radio.isChecked():
-            self.settings.external_no_version_warning_metadata_source = "Configured git repository"
+            self.settings.external_no_version_warning_metadata_source = (
+                "Configured git repository"
+            )
         self.settings.external_no_version_warning_file_path = (
             self.settings_dialog.no_version_warning_db_local_file.text()
         )
@@ -845,13 +1110,23 @@ class SettingsController(QObject):
         if self.settings_dialog.use_this_instead_db_none_radio.isChecked():
             self.settings.external_use_this_instead_metadata_source = "None"
         elif self.settings_dialog.use_this_instead_db_local_file_radio.isChecked():
-            self.settings.external_use_this_instead_metadata_source = "Configured file path"
+            self.settings.external_use_this_instead_metadata_source = (
+                "Configured file path"
+            )
         elif self.settings_dialog.use_this_instead_db_github_radio.isChecked():
-            self.settings.external_use_this_instead_metadata_source = "Configured git repository"
-        self.settings.external_use_this_instead_file_path = self.settings_dialog.use_this_instead_db_local_file.text()
-        self.settings.external_use_this_instead_repo_path = self.settings_dialog.use_this_instead_db_github_url.text()
+            self.settings.external_use_this_instead_metadata_source = (
+                "Configured git repository"
+            )
+        self.settings.external_use_this_instead_file_path = (
+            self.settings_dialog.use_this_instead_db_local_file.text()
+        )
+        self.settings.external_use_this_instead_repo_path = (
+            self.settings_dialog.use_this_instead_db_github_url.text()
+        )
         try:
-            self.settings.aux_db_time_limit = int(self.settings_dialog.aux_db_time_limit.text())
+            self.settings.aux_db_time_limit = int(
+                self.settings_dialog.aux_db_time_limit.text()
+            )
         except Exception:
             logger.warning("Failed setting Aux DB time limit, falling back to -1")
             self.settings.aux_db_time_limit = -1
@@ -867,27 +1142,35 @@ class SettingsController(QObject):
             self.settings_dialog.use_moddependencies_as_loadTheseBefore.isChecked()
         )
         # Use alternativePackageIds as satisfying dependencies
-        self.settings.use_alternative_package_ids_as_satisfying_dependencies = (
-            self.settings_dialog.use_alternative_package_ids_as_satisfying_dependencies_checkbox.isChecked()
-        )
+        self.settings.use_alternative_package_ids_as_satisfying_dependencies = self.settings_dialog.use_alternative_package_ids_as_satisfying_dependencies_checkbox.isChecked()
         # Set dependencies checkbox
-        self.settings.check_dependencies_on_sort = self.settings_dialog.check_deps_checkbox.isChecked()
+        self.settings.check_dependencies_on_sort = (
+            self.settings_dialog.check_deps_checkbox.isChecked()
+        )
         # Prefer versioned About.xml tags over base tags
         self.settings.prefer_versioned_about_tags = (
             self.settings_dialog.prefer_versioned_about_tags_checkbox.isChecked()
         )
         # Download missing mods checkbox
-        self.settings.try_download_missing_mods = self.settings_dialog.download_missing_mods_checkbox.isChecked()
+        self.settings.try_download_missing_mods = (
+            self.settings_dialog.download_missing_mods_checkbox.isChecked()
+        )
         # Duplicate mod notification checkbox
-        self.settings.duplicate_mods_warning = self.settings_dialog.show_duplicate_mods_warning_checkbox.isChecked()
+        self.settings.duplicate_mods_warning = (
+            self.settings_dialog.show_duplicate_mods_warning_checkbox.isChecked()
+        )
         # Mod type filter checkbox
-        self.settings.mod_type_filter = self.settings_dialog.mod_type_filter_checkbox.isChecked()
+        self.settings.mod_type_filter = (
+            self.settings_dialog.mod_type_filter_checkbox.isChecked()
+        )
         # Hide invalid mod filtering checkbox
         self.settings.hide_invalid_mods_when_filtering = (
             self.settings_dialog.hide_invalid_mods_when_filtering_checkbox.isChecked()
         )
         # Inactive mods sorting options checkbox
-        self.settings.inactive_mods_sorting = self.settings_dialog.enable_inactive_mods_sorting_checkbox.isChecked()
+        self.settings.inactive_mods_sorting = (
+            self.settings_dialog.enable_inactive_mods_sorting_checkbox.isChecked()
+        )
         # Save inactive mods sort state
         self.settings.save_inactive_mods_sort_state = (
             self.settings_dialog.save_inactive_mods_sort_state_checkbox.isChecked()
@@ -898,11 +1181,13 @@ class SettingsController(QObject):
             self.settings.db_builder_include = "all_mods"
         elif self.settings_dialog.db_builder_include_no_local_radio.isChecked():
             self.settings.db_builder_include = "no_local"
-        self.settings.build_steam_database_dlc_data = self.settings_dialog.db_builder_query_dlc_checkbox.isChecked()
-        self.settings.build_steam_database_update_toggle = (
-            self.settings_dialog.db_builder_update_instead_of_overwriting_checkbox.isChecked()
+        self.settings.build_steam_database_dlc_data = (
+            self.settings_dialog.db_builder_query_dlc_checkbox.isChecked()
         )
-        self.settings.steam_apikey = self.settings_dialog.db_builder_steam_api_key.text()
+        self.settings.build_steam_database_update_toggle = self.settings_dialog.db_builder_update_instead_of_overwriting_checkbox.isChecked()
+        self.settings.steam_apikey = (
+            self.settings_dialog.db_builder_steam_api_key.text()
+        )
 
         # SteamCMD tab
         self.settings.steamcmd_validate_downloads = (
@@ -913,7 +1198,9 @@ class SettingsController(QObject):
         )
         self.settings.instances[
             self.settings.current_instance
-        ].steamcmd_auto_clear_depot_cache = self.settings_dialog.steamcmd_auto_clear_depot_cache_checkbox.isChecked()
+        ].steamcmd_auto_clear_depot_cache = (
+            self.settings_dialog.steamcmd_auto_clear_depot_cache_checkbox.isChecked()
+        )
         self.settings.instances[
             self.settings.current_instance
         ].steamcmd_install_path = self.settings_dialog.steamcmd_install_location.text()
@@ -923,38 +1210,54 @@ class SettingsController(QObject):
             self.settings.todds_preset = "optimized"
         if self.settings_dialog.todds_preset_custom_radio.isChecked():
             self.settings.todds_preset = "custom"
-            self.settings.todds_custom_command = self.settings_dialog.todds_custom_command_lineedit.text()
+            self.settings.todds_custom_command = (
+                self.settings_dialog.todds_custom_command_lineedit.text()
+            )
         else:
             self.settings.todds_preset = "optimized"
         if self.settings_dialog.todds_active_mods_only_radio.isChecked():
             self.settings.todds_active_mods_target = True
         elif self.settings_dialog.todds_all_mods_radio.isChecked():
             self.settings.todds_active_mods_target = False
-        self.settings.todds_dry_run = self.settings_dialog.todds_dry_run_checkbox.isChecked()
-        self.settings.todds_overwrite = self.settings_dialog.todds_overwrite_checkbox.isChecked()
-        self.settings.auto_delete_orphaned_dds = self.settings_dialog.auto_delete_orphaned_dds_checkbox.isChecked()
+        self.settings.todds_dry_run = (
+            self.settings_dialog.todds_dry_run_checkbox.isChecked()
+        )
+        self.settings.todds_overwrite = (
+            self.settings_dialog.todds_overwrite_checkbox.isChecked()
+        )
+        self.settings.auto_delete_orphaned_dds = (
+            self.settings_dialog.auto_delete_orphaned_dds_checkbox.isChecked()
+        )
         self.settings.auto_run_todds_before_launch = (
             self.settings_dialog.auto_run_todds_before_launch_checkbox.isChecked()
         )
 
         # Other External Tools Tab
-        self.settings.text_editor_location = self.settings_dialog.text_editor_location.text()
-        self.settings.text_editor_folder_arg = self.settings_dialog.text_editor_folder_arg.text()
-        self.settings.text_editor_file_arg = self.settings_dialog.text_editor_file_arg.text()
+        self.settings.text_editor_location = (
+            self.settings_dialog.text_editor_location.text()
+        )
+        self.settings.text_editor_folder_arg = (
+            self.settings_dialog.text_editor_folder_arg.text()
+        )
+        self.settings.text_editor_file_arg = (
+            self.settings_dialog.text_editor_file_arg.text()
+        )
 
         # Themes tab
-        self.settings.enable_themes = self.settings_dialog.enable_themes_checkbox.isChecked()
+        self.settings.enable_themes = (
+            self.settings_dialog.enable_themes_checkbox.isChecked()
+        )
         self.settings.theme_name = self.settings_dialog.themes_combobox.currentText()
 
-        self.settings.font_family = self.settings_dialog.font_family_combobox.currentText()
+        self.settings.font_family = (
+            self.settings_dialog.font_family_combobox.currentText()
+        )
         self.settings.font_size = self.settings_dialog.font_size_spinbox.value()
         self.settings.language = self.settings_dialog.language_combobox.currentData()
 
         # Launch State tab
         # Dialogue positioning
-        self.settings.constrain_dialogues_to_main_window_monitor = (
-            self.settings_dialog.constrain_dialogues_to_main_window_monitor_checkbox.isChecked()
-        )
+        self.settings.constrain_dialogues_to_main_window_monitor = self.settings_dialog.constrain_dialogues_to_main_window_monitor_checkbox.isChecked()
 
         # Windows launch state
         # Main Window
@@ -964,8 +1267,12 @@ class SettingsController(QObject):
             self.settings.main_window_launch_state = "normal"
         elif self.settings_dialog.main_launch_custom_radio.isChecked():
             self.settings.main_window_launch_state = "custom"
-            self.settings.main_window_custom_width = self.settings_dialog.main_custom_width_spinbox.value()
-            self.settings.main_window_custom_height = self.settings_dialog.main_custom_height_spinbox.value()
+            self.settings.main_window_custom_width = (
+                self.settings_dialog.main_custom_width_spinbox.value()
+            )
+            self.settings.main_window_custom_height = (
+                self.settings_dialog.main_custom_height_spinbox.value()
+            )
         else:
             self.settings.main_window_launch_state = "maximized"
         # Browser Window
@@ -975,45 +1282,71 @@ class SettingsController(QObject):
             self.settings.browser_window_launch_state = "normal"
         elif self.settings_dialog.browser_launch_custom_radio.isChecked():
             self.settings.browser_window_launch_state = "custom"
-            self.settings.browser_window_custom_width = self.settings_dialog.browser_custom_width_spinbox.value()
-            self.settings.browser_window_custom_height = self.settings_dialog.browser_custom_height_spinbox.value()
+            self.settings.browser_window_custom_width = (
+                self.settings_dialog.browser_custom_width_spinbox.value()
+            )
+            self.settings.browser_window_custom_height = (
+                self.settings_dialog.browser_custom_height_spinbox.value()
+            )
         else:
             self.settings.browser_window_launch_state = "maximized"
 
         # Settings Window (only custom option)
-        self.settings.settings_window_custom_width = self.settings_dialog.settings_custom_width_spinbox.value()
-        self.settings.settings_window_custom_height = self.settings_dialog.settings_custom_height_spinbox.value()
+        self.settings.settings_window_custom_width = (
+            self.settings_dialog.settings_custom_width_spinbox.value()
+        )
+        self.settings.settings_window_custom_height = (
+            self.settings_dialog.settings_custom_height_spinbox.value()
+        )
 
         # Advanced tab
-        self.settings.debug_logging_enabled = self.settings_dialog.debug_logging_checkbox.isChecked()
-        self.settings.watchdog_toggle = self.settings_dialog.watchdog_checkbox.isChecked()
-        self.settings.backup_saves_on_launch = self.settings_dialog.backup_saves_on_launch_checkbox.isChecked()
-        self.settings.auto_backup_retention_count = self.settings_dialog.auto_backup_retention_count_spinbox.value()
-        self.settings.auto_backup_compression_count = self.settings_dialog.auto_backup_compression_count_spinbox.value()
+        self.settings.debug_logging_enabled = (
+            self.settings_dialog.debug_logging_checkbox.isChecked()
+        )
+        self.settings.watchdog_toggle = (
+            self.settings_dialog.watchdog_checkbox.isChecked()
+        )
+        self.settings.backup_saves_on_launch = (
+            self.settings_dialog.backup_saves_on_launch_checkbox.isChecked()
+        )
+        self.settings.auto_backup_retention_count = (
+            self.settings_dialog.auto_backup_retention_count_spinbox.value()
+        )
+        self.settings.auto_backup_compression_count = (
+            self.settings_dialog.auto_backup_compression_count_spinbox.value()
+        )
         self.settings.color_background_instead_of_text_toggle = (
             self.settings_dialog.color_background_instead_of_text_checkbox.isChecked()
         )
         # Clear button behavior
-        self.settings.clear_moves_dlc = self.settings_dialog.clear_moves_dlc_checkbox.isChecked()
-        self.settings.steam_mods_update_check = self.settings_dialog.show_mod_updates_checkbox.isChecked()
-        self.settings.render_unity_rich_text = self.settings_dialog.render_unity_rich_text_checkbox.isChecked()
+        self.settings.clear_moves_dlc = (
+            self.settings_dialog.clear_moves_dlc_checkbox.isChecked()
+        )
+        self.settings.steam_mods_update_check = (
+            self.settings_dialog.show_mod_updates_checkbox.isChecked()
+        )
+        self.settings.render_unity_rich_text = (
+            self.settings_dialog.render_unity_rich_text_checkbox.isChecked()
+        )
         self.settings.update_databases_on_startup = (
             self.settings_dialog.update_databases_on_startup_checkbox.isChecked()
         )
-        self.settings.include_mod_notes_in_mod_name_filter = (
-            self.settings_dialog.include_mod_notes_in_mod_name_filter_checkbox.isChecked()
-        )
+        self.settings.include_mod_notes_in_mod_name_filter = self.settings_dialog.include_mod_notes_in_mod_name_filter_checkbox.isChecked()
 
         self.settings.enable_backup_before_update = (
             self.settings_dialog.enable_backup_before_update_checkbox.isChecked()
         )
         self.settings.max_backups = self.settings_dialog.max_backups_spinbox.value()
-        self.settings.enable_aux_db_behavior_editing = self.settings_dialog.enable_aux_db_behavior_editing.isChecked()
+        self.settings.enable_aux_db_behavior_editing = (
+            self.settings_dialog.enable_aux_db_behavior_editing.isChecked()
+        )
         self.settings.rentry_auth_code = self.settings_dialog.rentry_auth_code.text()
         self.settings.github_username = self.settings_dialog.github_username.text()
         self.settings.github_token = self.settings_dialog.github_token.text()
         # Migrate and extract command string from single-element list
-        run_args_list = self._migrate_run_args(self.settings.instances[self.settings.current_instance].run_args)
+        run_args_list = self._migrate_run_args(
+            self.settings.instances[self.settings.current_instance].run_args
+        )
         run_args_str = run_args_list[0] if run_args_list else ""
         self.settings_dialog.run_args.setText(run_args_str)
 
@@ -1024,7 +1357,9 @@ class SettingsController(QObject):
         """
         answer = BinaryChoiceDialog(
             title=self.tr("Reset to defaults"),
-            text=self.tr("Are you sure you want to reset all settings to their default values?"),
+            text=self.tr(
+                "Are you sure you want to reset all settings to their default values?"
+            ),
         )
         if not answer.exec_is_positive():
             return
@@ -1076,7 +1411,9 @@ class SettingsController(QObject):
             return False
         return True
 
-    def _check_steam_integration_validity(self, steam_client_integration: bool, steam_mods_location: str) -> bool:
+    def _check_steam_integration_validity(
+        self, steam_client_integration: bool, steam_mods_location: str
+    ) -> bool:
         """
         Check if Steam client integration and Steam mods location are valid.
 
@@ -1122,8 +1459,12 @@ class SettingsController(QObject):
 
         :return: True if valid configuration, False if invalid.
         """
-        steam_client_integration = self.settings_dialog.steam_client_integration_checkbox.isChecked()
-        steam_mods_location = self.settings_dialog.steam_mods_folder_location.text().strip()
+        steam_client_integration = (
+            self.settings_dialog.steam_client_integration_checkbox.isChecked()
+        )
+        steam_mods_location = (
+            self.settings_dialog.steam_mods_folder_location.text().strip()
+        )
 
         # Handle user explicitly disabling Steam integration
         if not steam_client_integration:
@@ -1139,7 +1480,9 @@ class SettingsController(QObject):
             self.settings_dialog.launch_via_steam_protocol_checkbox.setChecked(False)
 
         # Validate Steam integration configuration
-        is_valid = self._check_steam_integration_validity(steam_client_integration, steam_mods_location)
+        is_valid = self._check_steam_integration_validity(
+            steam_client_integration, steam_mods_location
+        )
 
         if not is_valid:
             # Disable all Steam integration settings if validation fails
@@ -1155,7 +1498,9 @@ class SettingsController(QObject):
                         "Steam client integration, Steam mods location, and Steam protocol launch have been disabled."
                     ),
                 )
-            elif steam_mods_location and not validate_acf_file_exists(steam_mods_location):
+            elif steam_mods_location and not validate_acf_file_exists(
+                steam_mods_location
+            ):
                 QMessageBox.warning(
                     self.settings_dialog,
                     self.tr("Steam Workshop File Not Found"),
@@ -1180,7 +1525,9 @@ class SettingsController(QObject):
 
         # Validate config folder if set
         config_folder_text = self.settings_dialog.config_folder_location.text().strip()
-        if config_folder_text and not self._validate_config_folder_location(config_folder_text):
+        if config_folder_text and not self._validate_config_folder_location(
+            config_folder_text
+        ):
             return
 
         # Validate Steam integration if enabled
@@ -1204,7 +1551,9 @@ class SettingsController(QObject):
 
     @Slot()
     def _on_game_location_text_changed(self) -> None:
-        self.settings_dialog.game_location_open_button.setEnabled(self.settings_dialog.game_location.text() != "")
+        self.settings_dialog.game_location_open_button.setEnabled(
+            self.settings_dialog.game_location.text() != ""
+        )
 
     @Slot()
     def _on_game_location_open_button_clicked(self) -> None:
@@ -1225,7 +1574,9 @@ class SettingsController(QObject):
         if not self._validate_game_location(str(game_location)):
             return
         self.settings_dialog.game_location.setText(str(game_location))
-        self.settings_dialog.local_mods_folder_location.setText(str(game_location / "Mods"))
+        self.settings_dialog.local_mods_folder_location.setText(
+            str(game_location / "Mods")
+        )
         self._last_file_dialog_path = str(game_location)
 
     def _on_game_location_choose_button_clicked_macos(self) -> Path | None:
@@ -1317,7 +1668,9 @@ class SettingsController(QObject):
         if not steam_mods_folder_location:
             return
 
-        self.settings_dialog.steam_mods_folder_location.setText(steam_mods_folder_location)
+        self.settings_dialog.steam_mods_folder_location.setText(
+            steam_mods_folder_location
+        )
         self._last_file_dialog_path = str(Path(steam_mods_folder_location).parent)
 
     @Slot()
@@ -1337,7 +1690,9 @@ class SettingsController(QObject):
         if not local_mods_folder_location:
             return
 
-        self.settings_dialog.local_mods_folder_location.setText(local_mods_folder_location)
+        self.settings_dialog.local_mods_folder_location.setText(
+            local_mods_folder_location
+        )
         self._last_file_dialog_path = str(Path(local_mods_folder_location).parent)
 
     @Slot()
@@ -1355,7 +1710,9 @@ class SettingsController(QObject):
         self.settings_dialog.local_mods_folder_location.setText("")
 
     @Slot()
-    def _on_locations_clear_button_clicked(self, skip_confirmation: bool = False) -> None:
+    def _on_locations_clear_button_clicked(
+        self, skip_confirmation: bool = False
+    ) -> None:
         """
         Clear the settings dialog's location fields.
         """
@@ -1402,7 +1759,9 @@ class SettingsController(QObject):
 
         path_groups = [
             _PathGroup(os_paths[0], self.settings_dialog.game_location, "game"),
-            _PathGroup(os_paths[1], self.settings_dialog.config_folder_location, "config"),
+            _PathGroup(
+                os_paths[1], self.settings_dialog.config_folder_location, "config"
+            ),
             _PathGroup(
                 os_paths[2],
                 self.settings_dialog.steam_mods_folder_location,
@@ -1417,14 +1776,20 @@ class SettingsController(QObject):
 
         for group in path_groups:
             if group.folder.exists():
-                logger.info(f"Auto-detected {group.name} folder path exists: {group.folder}")
+                logger.info(
+                    f"Auto-detected {group.name} folder path exists: {group.folder}"
+                )
                 if not group.settings_line.text():
-                    logger.info(f"No value set currently for {group.name} folder. Overwriting with auto-detected path")
+                    logger.info(
+                        f"No value set currently for {group.name} folder. Overwriting with auto-detected path"
+                    )
                     group.settings_line.setText(str(group.folder))
                 else:
                     logger.info(f"Value already set for {group.name} folder. Passing")
             else:
-                logger.warning(f"Auto-detected {group.name} folder path does not exist: {group.folder}")
+                logger.warning(
+                    f"Auto-detected {group.name} folder path does not exist: {group.folder}"
+                )
 
     def __get_darwin_paths(self) -> tuple[Path, Path, Path]:
         """
@@ -1434,9 +1799,15 @@ class SettingsController(QObject):
             tuple[Path, Path, Path]: game_folder, config_folder, steam_mods_folder
         """
         user_home = Path.home()
-        game_folder = Path(f"/{user_home}/Library/Application Support/Steam/steamapps/common/Rimworld/RimworldMac.app")
-        config_folder = Path(f"/{user_home}/Library/Application Support/Rimworld/Config")
-        steam_mods_folder = Path(f"/{user_home}/Library/Application Support/Steam/steamapps/workshop/content/294100")
+        game_folder = Path(
+            f"/{user_home}/Library/Application Support/Steam/steamapps/common/Rimworld/RimworldMac.app"
+        )
+        config_folder = Path(
+            f"/{user_home}/Library/Application Support/Rimworld/Config"
+        )
+        steam_mods_folder = Path(
+            f"/{user_home}/Library/Application Support/Steam/steamapps/workshop/content/294100"
+        )
 
         return game_folder, config_folder, steam_mods_folder
 
@@ -1453,7 +1824,10 @@ class SettingsController(QObject):
             steam_path = user_home / ".steam/steam"
             debian_path = steam_path / "steamapps/common/RimWorld"
         game_folder = debian_path / "steamapps/common/RimWorld"
-        config_folder = user_home / ".config/unity3d/Ludeon Studios/RimWorld by Ludeon Studios/Config"
+        config_folder = (
+            user_home
+            / ".config/unity3d/Ludeon Studios/RimWorld by Ludeon Studios/Config"
+        )
         steam_mods_folder = debian_path / "steamapps/workshop/content/294100"
 
         return game_folder, config_folder, steam_mods_folder
@@ -1472,7 +1846,9 @@ class SettingsController(QObject):
             steam_folder, found = find_steam_folder()
 
             if not found:
-                logger.error("[win32] Could not find Steam folder. Using fallback assumptions")
+                logger.error(
+                    "[win32] Could not find Steam folder. Using fallback assumptions"
+                )
                 steam_folder = "C:/Program Files (x86)/Steam"
 
             game_folder: str | Path = find_steam_rimworld(steam_folder)
@@ -1482,12 +1858,18 @@ class SettingsController(QObject):
                 game_folder = f"{steam_folder}/steamapps/common/RimWorld"
             game_folder = Path(game_folder)
 
-            config_folder = Path(f"{user_home}/AppData/LocalLow/Ludeon Studios/RimWorld by Ludeon Studios/Config")
+            config_folder = Path(
+                f"{user_home}/AppData/LocalLow/Ludeon Studios/RimWorld by Ludeon Studios/Config"
+            )
 
-            steam_mods_folder = get_path_up_to_string(game_folder, "common", exclude=True)
+            steam_mods_folder = get_path_up_to_string(
+                game_folder, "common", exclude=True
+            )
             if steam_mods_folder == "":
                 # Fallback steam mods path
-                steam_mods_folder = Path(f"{steam_folder}/steamapps/workshop/content/294100")
+                steam_mods_folder = Path(
+                    f"{steam_folder}/steamapps/workshop/content/294100"
+                )
             else:
                 steam_mods_folder = Path(steam_mods_folder) / "workshop/content/294100"
 
@@ -1501,30 +1883,51 @@ class SettingsController(QObject):
         This function handles the community rules db radio buttons. Clicking one button
         enables the associated widgets and disables the other widgets.
         """
-        if self.sender() == self.settings_dialog.community_rules_db_none_radio and checked:
+        if (
+            self.sender() == self.settings_dialog.community_rules_db_none_radio
+            and checked
+        ):
             self.settings_dialog.community_rules_db_github_url.setEnabled(False)
-            self.settings_dialog.community_rules_db_github_download_button.setEnabled(False)
+            self.settings_dialog.community_rules_db_github_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.community_rules_db_local_file.setEnabled(False)
-            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(False)
+            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(
+                False
+            )
             if isinstance(self.app_instance, QApplication):
                 focused_widget = self.app_instance.focusWidget()
                 if focused_widget is not None:
                     focused_widget.clearFocus()
             return
 
-        if self.sender() == self.settings_dialog.community_rules_db_github_radio and checked:
+        if (
+            self.sender() == self.settings_dialog.community_rules_db_github_radio
+            and checked
+        ):
             self.settings_dialog.community_rules_db_github_url.setEnabled(True)
-            self.settings_dialog.community_rules_db_github_download_button.setEnabled(True)
+            self.settings_dialog.community_rules_db_github_download_button.setEnabled(
+                True
+            )
             self.settings_dialog.community_rules_db_local_file.setEnabled(False)
-            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(False)
+            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(
+                False
+            )
             self.settings_dialog.community_rules_db_github_url.setFocus()
             return
 
-        if self.sender() == self.settings_dialog.community_rules_db_local_file_radio and checked:
+        if (
+            self.sender() == self.settings_dialog.community_rules_db_local_file_radio
+            and checked
+        ):
             self.settings_dialog.community_rules_db_github_url.setEnabled(False)
-            self.settings_dialog.community_rules_db_github_download_button.setEnabled(False)
+            self.settings_dialog.community_rules_db_github_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.community_rules_db_local_file.setEnabled(True)
-            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(True)
+            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(
+                True
+            )
             self.settings_dialog.community_rules_db_local_file.setFocus()
             return
 
@@ -1541,7 +1944,9 @@ class SettingsController(QObject):
         if not community_rules_db_location:
             return
 
-        self.settings_dialog.community_rules_db_local_file.setText(community_rules_db_location)
+        self.settings_dialog.community_rules_db_local_file.setText(
+            community_rules_db_location
+        )
         self._last_file_dialog_path = str(Path(community_rules_db_location).parent)
 
     @Slot(bool)
@@ -1550,30 +1955,51 @@ class SettingsController(QObject):
         This function handles the Steam workshop db radio buttons. Clicking one button
         enables the associated widgets and disables the other widgets.
         """
-        if self.sender() == self.settings_dialog.steam_workshop_db_none_radio and checked:
+        if (
+            self.sender() == self.settings_dialog.steam_workshop_db_none_radio
+            and checked
+        ):
             self.settings_dialog.steam_workshop_db_github_url.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(False)
+            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.steam_workshop_db_local_file.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(False)
+            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(
+                False
+            )
             if isinstance(self.app_instance, QApplication):
                 focused_widget = self.app_instance.focusWidget()
                 if focused_widget is not None:
                     focused_widget.clearFocus()
             return
 
-        if self.sender() == self.settings_dialog.steam_workshop_db_github_radio and checked:
+        if (
+            self.sender() == self.settings_dialog.steam_workshop_db_github_radio
+            and checked
+        ):
             self.settings_dialog.steam_workshop_db_github_url.setEnabled(True)
-            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(True)
+            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(
+                True
+            )
             self.settings_dialog.steam_workshop_db_local_file.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(False)
+            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(
+                False
+            )
             self.settings_dialog.steam_workshop_db_github_url.setFocus()
             return
 
-        if self.sender() == self.settings_dialog.steam_workshop_db_local_file_radio and checked:
+        if (
+            self.sender() == self.settings_dialog.steam_workshop_db_local_file_radio
+            and checked
+        ):
             self.settings_dialog.steam_workshop_db_github_url.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(False)
+            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.steam_workshop_db_local_file.setEnabled(True)
-            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(True)
+            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(
+                True
+            )
             self.settings_dialog.steam_workshop_db_local_file.setFocus()
             return
 
@@ -1590,7 +2016,9 @@ class SettingsController(QObject):
         if not steam_workshop_db_location:
             return
 
-        self.settings_dialog.steam_workshop_db_local_file.setText(steam_workshop_db_location)
+        self.settings_dialog.steam_workshop_db_local_file.setText(
+            steam_workshop_db_location
+        )
         self._last_file_dialog_path = str(Path(steam_workshop_db_location).parent)
 
     @Slot(bool)
@@ -1599,11 +2027,18 @@ class SettingsController(QObject):
         This function handles the "No Version Warning" db radio buttons. Clicking one button
         enables the associated widgets and disables the other widgets.
         """
-        if self.sender() == self.settings_dialog.no_version_warning_db_none_radio and checked:
+        if (
+            self.sender() == self.settings_dialog.no_version_warning_db_none_radio
+            and checked
+        ):
             self.settings_dialog.no_version_warning_db_github_url.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(False)
+            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.no_version_warning_db_local_file.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(False)
+            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(
+                False
+            )
             app_instance = QApplication.instance()
             if isinstance(app_instance, QApplication):
                 focused_widget = app_instance.focusWidget()
@@ -1611,19 +2046,33 @@ class SettingsController(QObject):
                     focused_widget.clearFocus()
             return
 
-        if self.sender() == self.settings_dialog.no_version_warning_db_github_radio and checked:
+        if (
+            self.sender() == self.settings_dialog.no_version_warning_db_github_radio
+            and checked
+        ):
             self.settings_dialog.no_version_warning_db_github_url.setEnabled(True)
-            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(True)
+            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(
+                True
+            )
             self.settings_dialog.no_version_warning_db_local_file.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(False)
+            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(
+                False
+            )
             self.settings_dialog.no_version_warning_db_github_url.setFocus()
             return
 
-        if self.sender() == self.settings_dialog.no_version_warning_db_local_file_radio and checked:
+        if (
+            self.sender() == self.settings_dialog.no_version_warning_db_local_file_radio
+            and checked
+        ):
             self.settings_dialog.no_version_warning_db_github_url.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(False)
+            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.no_version_warning_db_local_file.setEnabled(True)
-            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(True)
+            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(
+                True
+            )
             self.settings_dialog.no_version_warning_db_local_file.setFocus()
             return
 
@@ -1640,7 +2089,9 @@ class SettingsController(QObject):
         if not no_version_warning_db_location:
             return
 
-        self.settings_dialog.no_version_warning_db_local_file.setText(no_version_warning_db_location)
+        self.settings_dialog.no_version_warning_db_local_file.setText(
+            no_version_warning_db_location
+        )
         self._last_file_dialog_path = str(Path(no_version_warning_db_location).parent)
 
     @Slot(bool)
@@ -1649,11 +2100,18 @@ class SettingsController(QObject):
         This function handles the "Use This Instead" db radio buttons. Clicking one button
         enables the associated widgets and disables the other widgets.
         """
-        if self.sender() == self.settings_dialog.use_this_instead_db_none_radio and checked:
+        if (
+            self.sender() == self.settings_dialog.use_this_instead_db_none_radio
+            and checked
+        ):
             self.settings_dialog.use_this_instead_db_github_url.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(False)
+            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.use_this_instead_db_local_file.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(False)
+            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(
+                False
+            )
             app_instance = QApplication.instance()
             if isinstance(app_instance, QApplication):
                 focused_widget = app_instance.focusWidget()
@@ -1661,19 +2119,33 @@ class SettingsController(QObject):
                     focused_widget.clearFocus()
             return
 
-        if self.sender() == self.settings_dialog.use_this_instead_db_github_radio and checked:
+        if (
+            self.sender() == self.settings_dialog.use_this_instead_db_github_radio
+            and checked
+        ):
             self.settings_dialog.use_this_instead_db_github_url.setEnabled(True)
-            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(True)
+            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(
+                True
+            )
             self.settings_dialog.use_this_instead_db_local_file.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(False)
+            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(
+                False
+            )
             self.settings_dialog.use_this_instead_db_github_url.setFocus()
             return
 
-        if self.sender() == self.settings_dialog.use_this_instead_db_local_file_radio and checked:
+        if (
+            self.sender() == self.settings_dialog.use_this_instead_db_local_file_radio
+            and checked
+        ):
             self.settings_dialog.use_this_instead_db_github_url.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(False)
+            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.use_this_instead_db_local_file.setEnabled(True)
-            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(True)
+            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(
+                True
+            )
             self.settings_dialog.use_this_instead_db_local_file.setFocus()
             return
 
@@ -1691,7 +2163,9 @@ class SettingsController(QObject):
         if not use_this_instead_db_location:
             return
 
-        self.settings_dialog.use_this_instead_db_local_file.setText(use_this_instead_db_location)
+        self.settings_dialog.use_this_instead_db_local_file.setText(
+            use_this_instead_db_location
+        )
         self._last_file_dialog_path = str(Path(use_this_instead_db_location).parent)
 
     @Slot()
@@ -1707,7 +2181,9 @@ class SettingsController(QObject):
         if not steamcmd_install_location:
             return
 
-        self.settings_dialog.steamcmd_install_location.setText(steamcmd_install_location)
+        self.settings_dialog.steamcmd_install_location.setText(
+            steamcmd_install_location
+        )
         self._last_file_dialog_path = str(Path(steamcmd_install_location).parent)
 
     @Slot()
@@ -1905,7 +2381,9 @@ class SettingsController(QObject):
 
         # Validate the path before setting it
 
-        test_controller = InstanceController(self.settings.instances[self.settings.current_instance])
+        test_controller = InstanceController(
+            self.settings.instances[self.settings.current_instance]
+        )
         test_controller.instance.instance_folder_override = instance_folder_location
         is_valid, error_msg = test_controller.validate_instance_folder_override()
 
@@ -1918,7 +2396,9 @@ class SettingsController(QObject):
             return
 
         # Update the instance and UI
-        self.settings.instances[self.settings.current_instance].instance_folder_override = instance_folder_location
+        self.settings.instances[
+            self.settings.current_instance
+        ].instance_folder_override = instance_folder_location
         self.settings_dialog.instance_folder_location.setText(instance_folder_location)
         self._last_file_dialog_path = str(Path(instance_folder_location).parent)
         self.settings.save()
@@ -1935,7 +2415,9 @@ class SettingsController(QObject):
             )
             return
 
-        self.settings.instances[self.settings.current_instance].instance_folder_override = ""
+        self.settings.instances[
+            self.settings.current_instance
+        ].instance_folder_override = ""
         self.settings_dialog.instance_folder_location.setText("")
         self.settings.save()
 
@@ -1952,12 +2434,16 @@ class SettingsController(QObject):
         """
         selected_theme_name = self.settings_dialog.themes_combobox.currentText()
         logger.info(f"Opening theme location: {selected_theme_name}")
-        stylesheet_path = self.theme_controller.get_theme_stylesheet_path(selected_theme_name)
+        stylesheet_path = self.theme_controller.get_theme_stylesheet_path(
+            selected_theme_name
+        )
 
         if stylesheet_path and stylesheet_path.exists():
             platform_specific_open(stylesheet_path.parent)
         else:
-            logger.warning(f"Failed to open theme location: {stylesheet_path} not found or does not exist")
+            logger.warning(
+                f"Failed to open theme location: {stylesheet_path} not found or does not exist"
+            )
 
     @Slot()
     def _on_use_background_coloring_checkbox_changed(self) -> None:
@@ -1965,9 +2451,7 @@ class SettingsController(QObject):
 
     @Slot()
     def _on_include_mod_notes_in_mod_name_filter_changed(self) -> None:
-        self.settings.include_mod_notes_in_mod_name_filter = (
-            self.settings_dialog.include_mod_notes_in_mod_name_filter_checkbox.isChecked()
-        )
+        self.settings.include_mod_notes_in_mod_name_filter = self.settings_dialog.include_mod_notes_in_mod_name_filter_checkbox.isChecked()
 
     @Slot()
     def _handle_mod_coloring_mode_changed(self) -> None:

--- a/app/controllers/sort_controller.py
+++ b/app/controllers/sort_controller.py
@@ -20,7 +20,9 @@ class Sorter:
     ):
         self.active_package_ids = active_package_ids.copy()
         self.active_uuids = active_uuids.copy()
-        self.use_moddependencies_as_loadTheseBefore = use_moddependencies_as_loadTheseBefore
+        self.use_moddependencies_as_loadTheseBefore = (
+            use_moddependencies_as_loadTheseBefore
+        )
 
         if isinstance(sort_method, SortMethod) or isinstance(sort_method, str):
             logger.info(f"Created sorter instance with {sort_method} sort method")
@@ -34,18 +36,28 @@ class Sorter:
         elif callable(sort_method):
             self.sort_method = sort_method
         else:
-            raise ValueError(f"Invalid sort method {sort_method}, type: {type(sort_method)}")
+            raise ValueError(
+                f"Invalid sort method {sort_method}, type: {type(sort_method)}"
+            )
 
     def generate_dependency_graphs(
         self,
     ) -> list[dict[str, set[str]]]:
         logger.info("Generating dependency graphs")
-        dependencies_graph = sort_deps.gen_deps_graph(self.active_uuids, list(self.active_package_ids))
-        reverse_dependencies_graph = sort_deps.gen_rev_deps_graph(self.active_uuids, list(self.active_package_ids))
+        dependencies_graph = sort_deps.gen_deps_graph(
+            self.active_uuids, list(self.active_package_ids)
+        )
+        reverse_dependencies_graph = sort_deps.gen_rev_deps_graph(
+            self.active_uuids, list(self.active_package_ids)
+        )
 
-        tier_zero_graph, tier_zero_mods = sort_deps.gen_tier_zero_deps_graph(dependencies_graph)
+        tier_zero_graph, tier_zero_mods = sort_deps.gen_tier_zero_deps_graph(
+            dependencies_graph
+        )
 
-        tier_one_graph, tier_one_mods = sort_deps.gen_tier_one_deps_graph(dependencies_graph)
+        tier_one_graph, tier_one_mods = sort_deps.gen_tier_one_deps_graph(
+            dependencies_graph
+        )
 
         tier_three_graph, tier_three_mods = sort_deps.gen_tier_three_deps_graph(
             dependencies_graph,
@@ -63,7 +75,9 @@ class Sorter:
 
         return [tier_zero_graph, tier_one_graph, tier_two_graph, tier_three_graph]
 
-    def sort(self, dependency_graphs: list[dict[str, set[str]]] | None = None) -> tuple[bool, list[str]]:
+    def sort(
+        self, dependency_graphs: list[dict[str, set[str]]] | None = None
+    ) -> tuple[bool, list[str]]:
         """Sorts the given dependency graph using the controller's sort method.
 
         :param dependency_graphs: The dependency graph to be sorted, defaults to None

--- a/app/controllers/theme_controller.py
+++ b/app/controllers/theme_controller.py
@@ -33,11 +33,17 @@ class ThemeController:
 
     def _get_supported_themes(self) -> set[str]:
         """Retrieves a set of supported themes from the theme data and storage folders."""
-        theme_data_folders = self._get_theme_names_from_folder(self.app_info.theme_data_folder)
-        theme_storage_folders = self._get_theme_names_from_folder(self.app_info.theme_storage_folder)
+        theme_data_folders = self._get_theme_names_from_folder(
+            self.app_info.theme_data_folder
+        )
+        theme_storage_folders = self._get_theme_names_from_folder(
+            self.app_info.theme_storage_folder
+        )
         supported_themes = theme_data_folders | theme_storage_folders
         logger.info(f"Supported themes retrieved: {supported_themes}")
-        logger.debug(f"Checking theme folders: {[self.app_info.theme_data_folder, self.app_info.theme_storage_folder]}")
+        logger.debug(
+            f"Checking theme folders: {[self.app_info.theme_data_folder, self.app_info.theme_storage_folder]}"
+        )
         return supported_themes
 
     def _get_theme_names_from_folder(self, folder: Path) -> set[str]:
@@ -54,7 +60,9 @@ class ThemeController:
             for subfolder in folder.iterdir():
                 if subfolder.is_dir() and (subfolder / "style.qss").exists():
                     supported_themes.add(subfolder.name)
-                    logger.info(f"Found theme with stylesheet in {folder}: {subfolder.name}")
+                    logger.info(
+                        f"Found theme with stylesheet in {folder}: {subfolder.name}"
+                    )
         else:
             logger.warning(f"Folder does not exist: {folder}")
         return supported_themes
@@ -116,7 +124,9 @@ class ThemeController:
             potential_path = folder / theme_name / "style.qss"
             logger.debug(f"Checking for stylesheet at: {potential_path}")
             if potential_path.exists():
-                logger.info(f"Found stylesheet for theme '{theme_name}' at: {potential_path}")
+                logger.info(
+                    f"Found stylesheet for theme '{theme_name}' at: {potential_path}"
+                )
                 return potential_path
         logger.error(f"Stylesheet path does not exist for theme '{theme_name}'")
         show_warning(
@@ -131,7 +141,9 @@ class ThemeController:
         )
         return None
 
-    def apply_selected_theme(self, enable_themes: bool, selected_theme_name: str) -> None:
+    def apply_selected_theme(
+        self, enable_themes: bool, selected_theme_name: str
+    ) -> None:
         """Apply the selected theme without restarting the application.
 
         Args:
@@ -189,7 +201,9 @@ class ThemeController:
         available_themes = list(self._get_supported_themes())
         combobox.addItems(available_themes)
 
-    def setup_theme_dialog(self, settings_dialog: "SettingsDialog", settings: "Settings") -> None:
+    def setup_theme_dialog(
+        self, settings_dialog: "SettingsDialog", settings: "Settings"
+    ) -> None:
         """
         Set up the settings dialog with current settings.
         Reloading settings is required since ThemeController will reset to RimPy if the theme is invalid.
@@ -201,10 +215,14 @@ class ThemeController:
             current_index = settings_dialog.themes_combobox.findText(current_theme_name)
             current_font_family = settings.font_family
             current_font_size = settings.font_size
-            current_font_family_index = settings_dialog.font_family_combobox.findText(current_font_family)
+            current_font_family_index = settings_dialog.font_family_combobox.findText(
+                current_font_family
+            )
             settings_dialog.font_size_spinbox.setValue(current_font_size)
             if current_font_family_index != -1:
-                settings_dialog.font_family_combobox.setCurrentIndex(current_font_family_index)
+                settings_dialog.font_family_combobox.setCurrentIndex(
+                    current_font_family_index
+                )
             else:
                 settings_dialog.font_family_combobox.setCurrentIndex(-1)
             if current_index != -1:
@@ -221,4 +239,6 @@ class ThemeController:
                 self.apply_selected_theme(settings.enable_themes, default_theme)
         else:
             self.set_fusion_theme()
-            logger.info("Themes disabled, setting Fusion theme. Please enable themes to apply a theme.")
+            logger.info(
+                "Themes disabled, setting Fusion theme. Please enable themes to apply a theme."
+            )

--- a/app/controllers/troubleshooting_controller.py
+++ b/app/controllers/troubleshooting_controller.py
@@ -27,18 +27,34 @@ class TroubleshootingController:
         self.translate = QCoreApplication.translate
 
         # Connect button signals
-        self.dialog.integrity_apply_button.clicked.connect(self._on_integrity_apply_button_clicked)
-        self.dialog.integrity_cancel_button.clicked.connect(self._on_integrity_cancel_button_clicked)
+        self.dialog.integrity_apply_button.clicked.connect(
+            self._on_integrity_apply_button_clicked
+        )
+        self.dialog.integrity_cancel_button.clicked.connect(
+            self._on_integrity_cancel_button_clicked
+        )
 
         # Connect mod configuration buttons
-        self.dialog.clear_mods_button.clicked.connect(self._on_clear_mods_button_clicked)
-        self.dialog.mod_export_list_button.clicked.connect(self._on_mod_export_list_button_clicked)
-        self.dialog.mod_import_list_button.clicked.connect(self._on_mod_import_list_button_clicked)
+        self.dialog.clear_mods_button.clicked.connect(
+            self._on_clear_mods_button_clicked
+        )
+        self.dialog.mod_export_list_button.clicked.connect(
+            self._on_mod_export_list_button_clicked
+        )
+        self.dialog.mod_import_list_button.clicked.connect(
+            self._on_mod_import_list_button_clicked
+        )
 
         # Connect Steam utility buttons
-        self.dialog.steam_clear_cache_button.clicked.connect(self._on_steam_clear_cache_clicked)
-        self.dialog.steam_verify_game_button.clicked.connect(self._on_steam_verify_game_clicked)
-        self.dialog.steam_repair_library_button.clicked.connect(self._on_steam_repair_library_clicked)
+        self.dialog.steam_clear_cache_button.clicked.connect(
+            self._on_steam_clear_cache_clicked
+        )
+        self.dialog.steam_verify_game_button.clicked.connect(
+            self._on_steam_verify_game_clicked
+        )
+        self.dialog.steam_repair_library_button.clicked.connect(
+            self._on_steam_repair_library_clicked
+        )
 
     @property
     def game_location(self) -> Optional[str]:
@@ -52,7 +68,9 @@ class TroubleshootingController:
     def steam_mods_location(self) -> Optional[str]:
         return self.settings.instances[self.settings.current_instance].workshop_folder
 
-    def _delete_files_in_directory(self, directory: Path, exclude: Optional[List[str]] = None) -> None:
+    def _delete_files_in_directory(
+        self, directory: Path, exclude: Optional[List[str]] = None
+    ) -> None:
         """Helper method to delete files and folders in a directory, excluding specified names."""
         if exclude is None:
             exclude = []
@@ -124,7 +142,9 @@ class TroubleshootingController:
         except Exception as e:
             logger.error(f"Failed to launch Steam installation: {e}")
             show_dialogue_conditional(
-                title=self.translate("TroubleshootingController", "Steam Launch Failed"),
+                title=self.translate(
+                    "TroubleshootingController", "Steam Launch Failed"
+                ),
                 text=self.translate(
                     "TroubleshootingController",
                     "Could not automatically start game installation through Steam.\n\nPlease manually verify/install the game through Steam.",
@@ -148,7 +168,9 @@ class TroubleshootingController:
         # get list of mod IDs before deleting
         mod_ids = []
         for item in steam_mods_dir.iterdir():
-            if item.is_dir() and item.name.isdigit():  # workshop folders are numeric IDs
+            if (
+                item.is_dir() and item.name.isdigit()
+            ):  # workshop folders are numeric IDs
                 mod_ids.append(item.name)
 
         # delete all files and folders
@@ -169,12 +191,16 @@ class TroubleshootingController:
 
             # then trigger download for each mod
             for mod_id in mod_ids:
-                platform_specific_open(f"steam://workshop_download_item/294100/{mod_id}")
+                platform_specific_open(
+                    f"steam://workshop_download_item/294100/{mod_id}"
+                )
                 logger.info(f"opening: steam://workshop_download_item/294100/{mod_id}")
         except Exception as e:
             logger.error(f"Failed to trigger Steam workshop redownload: {e}")
             show_dialogue_conditional(
-                title=self.translate("TroubleshootingController", "Steam Workshop Redownload"),
+                title=self.translate(
+                    "TroubleshootingController", "Steam Workshop Redownload"
+                ),
                 text=self.translate(
                     "TroubleshootingController",
                     "Mods have been deleted. Please restart Steam to trigger automatic redownload of subscribed mods.\n\nIf mods don't download automatically, try:\n1. Restart Steam\n2. Verify game files in Steam\n3. Visit the Workshop page of each mod",
@@ -248,10 +274,12 @@ class TroubleshootingController:
                     item.unlink()
                     logger.info(f"Deleted {item} successfully.")
                     show_information(
-                        title=self.translate("TroubleshootingController", "Process complete"),
-                        text=self.translate("TroubleshootingController", "Deleted {item} successfully.").format(
-                            item=item
+                        title=self.translate(
+                            "TroubleshootingController", "Process complete"
                         ),
+                        text=self.translate(
+                            "TroubleshootingController", "Deleted {item} successfully."
+                        ).format(item=item),
                     )
                 except Exception as e:
                     logger.error(f"Failed to delete game config file {item}: {e}")
@@ -344,9 +372,13 @@ class TroubleshootingController:
   </knownExpansions>
 </ModsConfigData>"""
                 mods_config.write_text(vanilla_content)
-                logger.info("Successfully deleted all mods and resetting ModsConfig.xml to vanilla state.")
+                logger.info(
+                    "Successfully deleted all mods and resetting ModsConfig.xml to vanilla state."
+                )
                 show_information(
-                    title=self.translate("TroubleshootingController", "Process complete"),
+                    title=self.translate(
+                        "TroubleshootingController", "Process complete"
+                    ),
                     text=self.translate(
                         "TroubleshootingController",
                         "Successfully deleted all mods and resetting ModsConfig.xml to vanilla state.",
@@ -356,7 +388,9 @@ class TroubleshootingController:
                 logger.error(f"Failed to reset ModsConfig.xml: {e}")
                 show_dialogue_conditional(
                     title=self.translate("TroubleshootingController", "Error"),
-                    text=self.translate("TroubleshootingController", "Failed to reset ModsConfig.xml."),
+                    text=self.translate(
+                        "TroubleshootingController", "Failed to reset ModsConfig.xml."
+                    ),
                     icon="warning",
                 )
                 return
@@ -403,7 +437,9 @@ class TroubleshootingController:
 
         if not show_dialogue_conditional(
             self.translate("TroubleshootingController", "Confirm Export"),
-            self.translate("TroubleshootingController", "Export current mod list to file?"),
+            self.translate(
+                "TroubleshootingController", "Export current mod list to file?"
+            ),
         ):
             return
 
@@ -412,7 +448,9 @@ class TroubleshootingController:
             content = mods_config.read_text()
             tree = ElementTree.fromstring(content)
             active_mod_list = [mod.text for mod in tree.findall(".//activeMods/li")]
-            known_expansions_list = [exp.text for exp in tree.findall(".//knownExpansions/li")]
+            known_expansions_list = [
+                exp.text for exp in tree.findall(".//knownExpansions/li")
+            ]
 
             # create new ModsConfig.xml content
             root = ElementTree.Element("ModsConfigData")
@@ -452,7 +490,9 @@ class TroubleshootingController:
             logger.error(f"Failed to export mod list: {e}")
             show_warning(
                 title=self.translate("TroubleshootingController", "Error"),
-                text=self.translate("TroubleshootingController", "Failed to export mod list."),
+                text=self.translate(
+                    "TroubleshootingController", "Failed to export mod list."
+                ),
                 information=self.translate(
                     "TroubleshootingController",
                     "Error: {e}",
@@ -532,7 +572,9 @@ class TroubleshootingController:
             logger.error(f"Failed to import mod list: {e}")
             show_dialogue_conditional(
                 self.translate("TroubleshootingController", "Error"),
-                self.translate("TroubleshootingController", "Failed to import mod list"),
+                self.translate(
+                    "TroubleshootingController", "Failed to import mod list"
+                ),
                 self.translate(
                     "TroubleshootingController",
                     "The selected file is not a valid mod list file.\nDetails: {e}",
@@ -552,7 +594,10 @@ class TroubleshootingController:
         try:
             if "steamapps" in str(workshop_path):
                 steam_root = workshop_path
-                while steam_root.name.lower() != "steam" and steam_root.parent != steam_root:
+                while (
+                    steam_root.name.lower() != "steam"
+                    and steam_root.parent != steam_root
+                ):
                     steam_root = steam_root.parent
                 if steam_root.name.lower() == "steam":
                     return steam_root
@@ -658,7 +703,9 @@ class TroubleshootingController:
 
             # ask for confirmation since this will validate all games
             if not show_dialogue_conditional(
-                title=self.translate("TroubleshootingController", "Confirm Library Repair"),
+                title=self.translate(
+                    "TroubleshootingController", "Confirm Library Repair"
+                ),
                 text=self.translate(
                     "TroubleshootingController",
                     "This will verify all {len} games in your Steam library.\nThis may take a while. Continue?",
@@ -671,7 +718,9 @@ class TroubleshootingController:
                 platform_specific_open(f"steam://validate/{app_id}")
 
             show_dialogue_conditional(
-                title=self.translate("TroubleshootingController", "Library Repair Started"),
+                title=self.translate(
+                    "TroubleshootingController", "Library Repair Started"
+                ),
                 text=self.translate(
                     "TroubleshootingController",
                     "Steam will now verify {len} games.\nYou can monitor progress in the Steam client.",
@@ -682,7 +731,9 @@ class TroubleshootingController:
         except Exception as e:
             logger.error(f"Failed to repair Steam library: {e}")
             show_dialogue_conditional(
-                title=self.translate("TroubleshootingController", "Steam Action Failed"),
+                title=self.translate(
+                    "TroubleshootingController", "Steam Action Failed"
+                ),
                 text=self.translate(
                     "TroubleshootingController",
                     "Could not repair Steam library.\nPlease verify your games manually through Steam.\nDetails: {e}",
@@ -702,7 +753,9 @@ class TroubleshootingController:
     def show_failed_warning(self, item: Path | str, e: Exception) -> None:
         show_warning(
             title=self.translate("TroubleshootingController", "Process failed"),
-            text=self.translate("TroubleshootingController", "Could not process: {item}").format(item=item),
+            text=self.translate(
+                "TroubleshootingController", "Could not process: {item}"
+            ).format(item=item),
             information=self.translate(
                 "TroubleshootingController",
                 "Failed to process item: {item} due to the following error: {e}",
@@ -711,7 +764,9 @@ class TroubleshootingController:
 
     def show_steam_user_warning(self) -> None:
         show_warning(
-            title=self.translate("TroubleshootingController", "Steam user Check failed"),
+            title=self.translate(
+                "TroubleshootingController", "Steam user Check failed"
+            ),
             text=self.translate(
                 "TroubleshootingController",
                 "You are not a Steam user, or Path not set, Please check settings and try again.",

--- a/app/models/instance.py
+++ b/app/models/instance.py
@@ -21,10 +21,16 @@ class Instance(msgspec.Struct):
     workshop_folder: str = ""
     run_args: list[str] = msgspec.field(default_factory=list)
     steamcmd_auto_clear_depot_cache: bool = True
-    steamcmd_install_path: str = str(Path(AppInfo().app_storage_folder / INSTANCE_FOLDER_NAME / DEFAULT_INSTANCE_NAME))
+    steamcmd_install_path: str = str(
+        Path(
+            AppInfo().app_storage_folder / INSTANCE_FOLDER_NAME / DEFAULT_INSTANCE_NAME
+        )
+    )
     steamcmd_ignore: bool = False
     steam_client_integration: bool = False
     # Launch game via Steam protocol to enable Steam overlay
     launch_via_steam_protocol: bool = False
-    instance_folder_override: str = ""  # Custom instance folder path, empty = use default
+    instance_folder_override: str = (
+        ""  # Custom instance folder path, empty = use default
+    )
     initial_setup: bool = True

--- a/app/models/metadata/metadata_db.py
+++ b/app/models/metadata/metadata_db.py
@@ -34,13 +34,17 @@ class AuxMetadataEntry(Base):
     acf_time_updated: Mapped[int] = mapped_column(Integer, default=-1)
 
     user_notes: Mapped[str] = mapped_column(String, default="")
-    color_hex: Mapped[str] = mapped_column(String, default=None, nullable=True)  # None/NULL means use theme default
+    color_hex: Mapped[str] = mapped_column(
+        String, default=None, nullable=True
+    )  # None/NULL means use theme default
     ignore_warnings: Mapped[bool] = mapped_column(Boolean, default=False)
 
     outdated: Mapped[bool] = mapped_column(Boolean, default=False)
     db_time_touched = Column(DateTime, default=func.now(), onupdate=func.now())
 
-    tags: Mapped[list["TagsEntry"]] = relationship(secondary=tags_table, back_populates="mods")
+    tags: Mapped[list["TagsEntry"]] = relationship(
+        secondary=tags_table, back_populates="mods"
+    )
 
     def __repr__(self) -> str:
         return f"Path: {self.path}, Time Touched: {self.acf_time_touched}, Time Updated: {self.acf_time_updated}"
@@ -52,7 +56,9 @@ class TagsEntry(Base):
     id: Mapped[int] = mapped_column(primary_key=True)
     tag: Mapped[str] = mapped_column(String, unique=True)
 
-    mods: Mapped[list[AuxMetadataEntry]] = relationship(secondary=tags_table, back_populates="tags")
+    mods: Mapped[list[AuxMetadataEntry]] = relationship(
+        secondary=tags_table, back_populates="tags"
+    )
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, TagsEntry) and self.tag == other.tag:

--- a/app/models/metadata/metadata_factory.py
+++ b/app/models/metadata/metadata_factory.py
@@ -96,11 +96,19 @@ def read_mods_config(path: Path) -> ModsConfig | None:
             logger.error("Error reading mods config: Required fields not found.")
             return None
 
-        if not isinstance(version, str) or not isinstance(activeMods, list) or not isinstance(knownExpansions, list):
-            logger.error("Error reading mods config: Required fields have invalid types.")
+        if (
+            not isinstance(version, str)
+            or not isinstance(activeMods, list)
+            or not isinstance(knownExpansions, list)
+        ):
+            logger.error(
+                "Error reading mods config: Required fields have invalid types."
+            )
             return None
 
-        return ModsConfig(version=version, activeMods=activeMods, knownExpansions=knownExpansions)
+        return ModsConfig(
+            version=version, activeMods=activeMods, knownExpansions=knownExpansions
+        )
     except Exception as e:
         logger.error(f"Failed to read mods config: {e}")
         return None
@@ -114,7 +122,9 @@ def write_mods_config(path: Path, mods_config: ModsConfig) -> bool:
     :param mods_config: The ModsConfig object.
     """
     try:
-        json_to_xml_write({"ModsConfigData": mods_config.to_dict()}, str(path), raise_errs=True)
+        json_to_xml_write(
+            {"ModsConfigData": mods_config.to_dict()}, str(path), raise_errs=True
+        )
         return True
     except Exception as e:
         logger.error(f"Failed to write mods config: {e}")
@@ -173,7 +183,9 @@ def create_scenario_mod(scenario_data: dict[str, Any]) -> tuple[bool, ScenarioMo
         elif isinstance(game_version, list):
             mod.supported_versions = set(game_version)
     else:
-        _set_mod_invalid(mod, "No metadata found for scenario. This scenario may be invalid.")
+        _set_mod_invalid(
+            mod, "No metadata found for scenario. This scenario may be invalid."
+        )
         return False, mod
 
     if "scenario" in scenario_data:
@@ -186,17 +198,23 @@ def create_scenario_mod(scenario_data: dict[str, Any]) -> tuple[bool, ScenarioMo
         if isinstance(name, str):
             mod.name = name
         else:
-            _set_mod_invalid(mod, "Couldn't parse a valid name. This scenario may be invalid.")
+            _set_mod_invalid(
+                mod, "Couldn't parse a valid name. This scenario may be invalid."
+            )
 
         if isinstance(summary, str):
             mod.summary = summary
         else:
-            _set_mod_invalid(mod, "Summary parsed seems invalid. This scenario may be invalid.")
+            _set_mod_invalid(
+                mod, "Summary parsed seems invalid. This scenario may be invalid."
+            )
 
         if isinstance(description, str):
             mod.description = description
         else:
-            _set_mod_invalid(mod, "Description parsed seems invalid. This scenario may be invalid.")
+            _set_mod_invalid(
+                mod, "Description parsed seems invalid. This scenario may be invalid."
+            )
     else:
         _set_mod_invalid(mod, "No scenario data found. This scenario may be invalid.")
         return False, mod
@@ -204,7 +222,9 @@ def create_scenario_mod(scenario_data: dict[str, Any]) -> tuple[bool, ScenarioMo
     return mod.valid, mod
 
 
-def create_about_mod(mod_data: dict[str, Any], target_version: str) -> tuple[bool, AboutXmlMod]:
+def create_about_mod(
+    mod_data: dict[str, Any], target_version: str
+) -> tuple[bool, AboutXmlMod]:
     """Factory method for creating a ListedMod object.
 
     :param mod_data: The dictionary containing the mod data.
@@ -302,7 +322,9 @@ def _parse_basic(mod_data: dict[str, Any], mod: AboutXmlMod) -> AboutXmlMod:
     return mod
 
 
-def _parse_optional(mod_data: dict[str, Any], mod: AboutXmlMod, target_version: str) -> AboutXmlMod:
+def _parse_optional(
+    mod_data: dict[str, Any], mod: AboutXmlMod, target_version: str
+) -> AboutXmlMod:
     """
     Parse the optional fields from the mod_data and set them on the mod object.
     """
@@ -321,7 +343,9 @@ def _parse_optional(mod_data: dict[str, Any], mod: AboutXmlMod, target_version: 
 
     mod.about_rules = create_base_rules(mod_data, target_version)
 
-    descriptions_by_version: bool | dict[str, str] = mod_data.get("descriptionsByVersion", False)
+    descriptions_by_version: bool | dict[str, str] = mod_data.get(
+        "descriptionsByVersion", False
+    )
     if isinstance(descriptions_by_version, dict):
         _, description = match_version(descriptions_by_version, target_version)
         if description and isinstance(description, str):
@@ -330,7 +354,9 @@ def _parse_optional(mod_data: dict[str, Any], mod: AboutXmlMod, target_version: 
     return mod
 
 
-def _set_mod_type(mod: ListedMod, local_path: Path, rimworld_path: Path, workshop_path: Path | None) -> ListedMod:
+def _set_mod_type(
+    mod: ListedMod, local_path: Path, rimworld_path: Path, workshop_path: Path | None
+) -> ListedMod:
     """
     Set the mod type based on the paths given.
 
@@ -354,11 +380,17 @@ def _set_mod_type(mod: ListedMod, local_path: Path, rimworld_path: Path, worksho
         try:
             repo = pygit2.discover_repository(str(mod.mod_path))
 
-            if repo is not None and Path(repo).exists() and Path(repo).parent == mod.mod_path:
+            if (
+                repo is not None
+                and Path(repo).exists()
+                and Path(repo).parent == mod.mod_path
+            ):
                 mod.mod_type = ModType.GIT
                 return mod
         except pygit2.GitError as e:
-            logger.error(f"Encountered git error while trying to discover git repository at: {mod.mod_path}")
+            logger.error(
+                f"Encountered git error while trying to discover git repository at: {mod.mod_path}"
+            )
             logger.error(e)
 
         if (mod.mod_path / Path("About/PublishedFileId.txt")).exists():
@@ -369,13 +401,19 @@ def _set_mod_type(mod: ListedMod, local_path: Path, rimworld_path: Path, worksho
     return mod
 
 
-def create_base_rules(mod_data: dict[str, Any], target_version: str) -> BaseRules | Rules:
+def create_base_rules(
+    mod_data: dict[str, Any], target_version: str
+) -> BaseRules | Rules:
     rules = BaseRules()
 
     # Dependencies
     mod_dependencies = value_extractor(mod_data.get("modDependencies", []))
-    mod_dependencies = mod_dependencies if isinstance(mod_dependencies, list) else [mod_dependencies]
-    versioned_mod_dependencies = value_extractor(mod_data.get("modDependenciesByVersion", {}))
+    mod_dependencies = (
+        mod_dependencies if isinstance(mod_dependencies, list) else [mod_dependencies]
+    )
+    versioned_mod_dependencies = value_extractor(
+        mod_data.get("modDependenciesByVersion", {})
+    )
 
     if isinstance(versioned_mod_dependencies, dict):
         _, dependencies = match_version(versioned_mod_dependencies, target_version)
@@ -396,7 +434,11 @@ def create_base_rules(mod_data: dict[str, Any], target_version: str) -> BaseRule
                         for v in alt_li:
                             if isinstance(v, str):
                                 alt_list.append(v)
-                            elif isinstance(v, dict) and "#text" in v and isinstance(v["#text"], str):
+                            elif (
+                                isinstance(v, dict)
+                                and "#text" in v
+                                and isinstance(v["#text"], str)
+                            ):
                                 alt_list.append(v["#text"])  # MayRequire-like form
                     elif isinstance(alt_li, str):
                         alt_list.append(alt_li)
@@ -404,18 +446,26 @@ def create_base_rules(mod_data: dict[str, Any], target_version: str) -> BaseRule
                     if alt_list:
                         deps["alternativePackageIds"] = alt_list
                 else:
-                    logger.warning(f"Skipping invalid dependency value: {value}. This mod's about.xml may be invalid.")
+                    logger.warning(
+                        f"Skipping invalid dependency value: {value}. This mod's about.xml may be invalid."
+                    )
 
             dep = create_mod_dependency(deps)
 
             if dep.package_id in rules.dependencies:
-                logger.warning(f"Duplicate dependency found: {dep.package_id}. Skipping.")
+                logger.warning(
+                    f"Duplicate dependency found: {dep.package_id}. Skipping."
+                )
             else:
                 rules.dependencies[dep.package_id] = dep
         else:
-            logger.warning(f"Skipping invalid dependency: {dependency}. This mod may be invalid.")
+            logger.warning(
+                f"Skipping invalid dependency: {dependency}. This mod may be invalid."
+            )
 
-    def load_operations(mod_data: dict[str, Any], key: str, force_key: str, target_version: str) -> CaseInsensitiveSet:
+    def load_operations(
+        mod_data: dict[str, Any], key: str, force_key: str, target_version: str
+    ) -> CaseInsensitiveSet:
         load = value_extractor(mod_data.get(key, []))
         load = load if isinstance(load, list) else [load]
 
@@ -434,22 +484,36 @@ def create_base_rules(mod_data: dict[str, Any], target_version: str) -> BaseRule
         return CaseInsensitiveSet(load)
 
     # Load Before
-    rules.load_before = load_operations(mod_data, "loadBefore", "forceLoadBefore", target_version)
+    rules.load_before = load_operations(
+        mod_data, "loadBefore", "forceLoadBefore", target_version
+    )
 
     # Load After
-    rules.load_after = load_operations(mod_data, "loadAfter", "forceLoadAfter", target_version)
+    rules.load_after = load_operations(
+        mod_data, "loadAfter", "forceLoadAfter", target_version
+    )
 
     # incompatibleWith
     incompatible_with = value_extractor(mod_data.get("incompatibleWith", []))
-    incompatible_with = incompatible_with if isinstance(incompatible_with, list) else [incompatible_with]
+    incompatible_with = (
+        incompatible_with
+        if isinstance(incompatible_with, list)
+        else [incompatible_with]
+    )
 
-    incompatible_withByVersion = value_extractor(mod_data.get("incompatibleWithByVersion", {}))
+    incompatible_withByVersion = value_extractor(
+        mod_data.get("incompatibleWithByVersion", {})
+    )
     if isinstance(incompatible_withByVersion, dict):
         _, incompatibles = match_version(incompatible_withByVersion, target_version)
         if incompatibles:
             incompatible_with.extend(incompatibles)
 
-    incompatible_with = [item for item in incompatible_with if isinstance(item, (str, CaseInsensitiveStr))]
+    incompatible_with = [
+        item
+        for item in incompatible_with
+        if isinstance(item, (str, CaseInsensitiveStr))
+    ]
     rules.incompatible_with = CaseInsensitiveSet(incompatible_with)
 
     return rules
@@ -485,11 +549,15 @@ def create_mod_dependency(input_dict: dict[str, str]) -> DependencyMod:
     return mod
 
 
-def _create_about_mod_from_xml(base_path: Path, mod_xml_path: Path, target_version: str) -> tuple[bool, AboutXmlMod]:
+def _create_about_mod_from_xml(
+    base_path: Path, mod_xml_path: Path, target_version: str
+) -> tuple[bool, AboutXmlMod]:
     try:
         mod_data = xml_path_to_json(str(mod_xml_path))
     except Exception:
-        logger.error(f"Unable to parse {mod_xml_path} with the exception: {traceback.format_exc()}")
+        logger.error(
+            f"Unable to parse {mod_xml_path} with the exception: {traceback.format_exc()}"
+        )
         return False, AboutXmlMod(valid=False)
 
     mod_data = {k.lower(): v for k, v in mod_data.items()}
@@ -505,11 +573,15 @@ def _create_about_mod_from_xml(base_path: Path, mod_xml_path: Path, target_versi
     return valid, mod
 
 
-def _create_scenario_mod_from_rsc(base_path: Path, mod_rsc_path: Path) -> tuple[bool, ScenarioMod]:
+def _create_scenario_mod_from_rsc(
+    base_path: Path, mod_rsc_path: Path
+) -> tuple[bool, ScenarioMod]:
     try:
         mod_data = xml_path_to_json(str(mod_rsc_path))
     except Exception:
-        logger.error(f"Unable to parse {mod_rsc_path} with the exception: {traceback.format_exc()}")
+        logger.error(
+            f"Unable to parse {mod_rsc_path} with the exception: {traceback.format_exc()}"
+        )
         return False, ScenarioMod(valid=False)
 
     mod_data = {k.lower(): v for k, v in mod_data.items()}
@@ -561,8 +633,12 @@ def create_listed_mod_from_path(
         # Check if About.xml exists
         about_xml_path = path / Path("About/About.xml")
         if about_xml_path.exists():
-            success, about_mod = _create_about_mod_from_xml(path, about_xml_path, target_version)
-            return success, _set_mod_type(about_mod, local_path, rimworld_path, workshop_path)
+            success, about_mod = _create_about_mod_from_xml(
+                path, about_xml_path, target_version
+            )
+            return success, _set_mod_type(
+                about_mod, local_path, rimworld_path, workshop_path
+            )
 
         # Check for any file with .rsc extension
         generator = path.glob("*.rsc")
@@ -586,7 +662,9 @@ def create_listed_mod_from_path(
             )
         elif gen1 is not None:
             success, scenario_mod = _create_scenario_mod_from_rsc(path, rsc_files[0])
-            return success, _set_mod_type(scenario_mod, local_path, rimworld_path, workshop_path)
+            return success, _set_mod_type(
+                scenario_mod, local_path, rimworld_path, workshop_path
+            )
 
         logger.warning(f"No About.xml or .rsc file found in directory: {path}")
         return False, _set_mod_type(
@@ -662,7 +740,9 @@ def read_steam_db(path: Path) -> SteamDbSchema | None:
             json_string = f.read()
             logger.info("Reading info from SteamDB")
             steam_db = msgspec.json.decode(json_string, type=SteamDbSchema)
-            logger.info(f"Loaded {len(steam_db.database)} mods from SteamDB version: {steam_db.version}")
+            logger.info(
+                f"Loaded {len(steam_db.database)} mods from SteamDB version: {steam_db.version}"
+            )
             return steam_db
     else:  # Assume db_data_missing
         logger.warning("SteamDB not found at specified path.")

--- a/app/models/metadata/metadata_mediator.py
+++ b/app/models/metadata/metadata_mediator.py
@@ -93,34 +93,48 @@ class MetadataMediator:
 
         for path in {self.local_mods_path, self.game_path}:
             if path is None or not path.exists() or not path.is_dir():
-                raise ValueError("Essential paths are missing, invalid, or not directories")
+                raise ValueError(
+                    "Essential paths are missing, invalid, or not directories"
+                )
 
         self._refresh_game_version()
 
         self._user_rules = read_rules_db(self.user_rules_path)
 
         self._community_rules = (
-            read_rules_db(self.community_rules_path) if self.community_rules_path is not None else None
+            read_rules_db(self.community_rules_path)
+            if self.community_rules_path is not None
+            else None
         )
-        self._steam_db = read_steam_db(self.steam_db_path) if self.steam_db_path is not None else None
+        self._steam_db = (
+            read_steam_db(self.steam_db_path)
+            if self.steam_db_path is not None
+            else None
+        )
 
         # Get all folders in the workshop and local mods paths
         mod_paths = list()
         if self.workshop_mods_path is not None:
             if not self.workshop_mods_path.exists():
-                logger.warning(f"Workshop mods path does not exist: {self.workshop_mods_path}")
+                logger.warning(
+                    f"Workshop mods path does not exist: {self.workshop_mods_path}"
+                )
             else:
                 mod_paths += list(self.workshop_mods_path.iterdir())
 
         if self.local_mods_path is not None:
             if not self.local_mods_path.exists():
-                logger.warning(f"Local mods path does not exist: {self.local_mods_path}")
+                logger.warning(
+                    f"Local mods path does not exist: {self.local_mods_path}"
+                )
             else:
                 mod_paths += list(self.local_mods_path.iterdir())
 
         if self.game_modules_path is not None:
             if not self.game_modules_path.exists():
-                logger.warning(f"Game modules path does not exist: {self.game_modules_path}")
+                logger.warning(
+                    f"Game modules path does not exist: {self.game_modules_path}"
+                )
             else:
                 mod_paths += list(self.game_modules_path.iterdir())
 
@@ -128,8 +142,12 @@ class MetadataMediator:
         threads = QThread.idealThreadCount()
         batch_size = max(len(mod_paths) // threads, 1)
 
-        logger.debug(f"Creating {threads} threads for metadata parsing with batch size of {batch_size}")
-        mod_paths_batches = [mod_paths[i : i + batch_size] for i in range(0, len(mod_paths), batch_size)]
+        logger.debug(
+            f"Creating {threads} threads for metadata parsing with batch size of {batch_size}"
+        )
+        mod_paths_batches = [
+            mod_paths[i : i + batch_size] for i in range(0, len(mod_paths), batch_size)
+        ]
 
         assert self.local_mods_path is not None
         assert self.game_path is not None
@@ -171,14 +189,20 @@ class MetadataMediator:
             try:
                 with open(version_file_path, encoding="utf-8") as f:
                     self._game_version = f.read().strip()
-                    logger.info(f"Retrieved game version from Version.txt: {self.game_version}")
+                    logger.info(
+                        f"Retrieved game version from Version.txt: {self.game_version}"
+                    )
                     return True
             except Exception:
-                logger.error(f"Unable to parse Version.txt from game folder: {version_file_path}")
+                logger.error(
+                    f"Unable to parse Version.txt from game folder: {version_file_path}"
+                )
                 self._game_version = "Unknown"
                 return False
         else:
-            logger.error(f"The provided Version.txt path does not exist: {version_file_path}")
+            logger.error(
+                f"The provided Version.txt path does not exist: {version_file_path}"
+            )
             self._game_version = "Unknown"
             return False
 
@@ -234,7 +258,9 @@ class MetadataMediator:
             self.mods_metadata = mods_metadata
 
         def run(self) -> None:
-            paths = self.mod_path if isinstance(self.mod_path, list) else [self.mod_path]
+            paths = (
+                self.mod_path if isinstance(self.mod_path, list) else [self.mod_path]
+            )
 
             results: dict[str, ListedMod] = {}
             for path in paths:
@@ -253,12 +279,18 @@ class MetadataMediator:
                         logger.warning(f"Mod at path {self.mod_path} is not valid")
 
                     if isinstance(mod, AboutXmlMod):
-                        if self.user_rules is not None and mod.package_id in self.user_rules.rules:
+                        if (
+                            self.user_rules is not None
+                            and mod.package_id in self.user_rules.rules
+                        ):
                             mod.user_rules = create_rules_from_external_rules(
                                 external_rule=self.user_rules.rules[mod.package_id]
                             )
 
-                        if self.community_rules is not None and mod.package_id in self.community_rules.rules:
+                        if (
+                            self.community_rules is not None
+                            and mod.package_id in self.community_rules.rules
+                        ):
                             mod.community_rules = create_rules_from_external_rules(
                                 external_rule=self.community_rules.rules[mod.package_id]
                             )

--- a/app/models/metadata/metadata_structure.py
+++ b/app/models/metadata/metadata_structure.py
@@ -319,7 +319,9 @@ class ListedMod(BaseMod):
         return self._uuid
 
     @functools.cached_property
-    def published_file_id(self, expected_sub_path: Path = Path("About/PublishedFileId.txt")) -> int:
+    def published_file_id(
+        self, expected_sub_path: Path = Path("About/PublishedFileId.txt")
+    ) -> int:
         """Cached property to return the published file id from the mod's path. If the file does not exist, returns
         the mod folder if it is a valid published file id (non-zero natural number). Otherwise return -1."""
         if self.mod_path is None:
@@ -440,12 +442,16 @@ class AboutXmlMod(ListedMod, PackageIdMod):
 
         # Load before
         overall_rules.load_before = (
-            self.about_rules.load_before | self.community_rules.load_before | self.user_rules.load_before
+            self.about_rules.load_before
+            | self.community_rules.load_before
+            | self.user_rules.load_before
         )
 
         # Load after
         overall_rules.load_after = (
-            self.about_rules.load_after | self.community_rules.load_after | self.user_rules.load_after
+            self.about_rules.load_after
+            | self.community_rules.load_after
+            | self.user_rules.load_after
         )
 
         # Incompatible with
@@ -463,8 +469,12 @@ class AboutXmlMod(ListedMod, PackageIdMod):
         }
 
         # Load first / last
-        overall_rules.load_first = self.community_rules.load_first or self.user_rules.load_first
-        overall_rules.load_last = self.community_rules.load_last or self.user_rules.load_last
+        overall_rules.load_first = (
+            self.community_rules.load_first or self.user_rules.load_first
+        )
+        overall_rules.load_last = (
+            self.community_rules.load_last or self.user_rules.load_last
+        )
 
         return overall_rules
 
@@ -538,8 +548,12 @@ class SteamDbEntry(msgspec.Struct, omit_defaults=True):
     steamName: str = msgspec.field(default_factory=str)
     name: str = msgspec.field(default_factory=str)
     authors: list[str] | str | None = msgspec.field(default_factory=str)
-    dependencies: dict[str, list[str] | SteamDbEntryDependency] = msgspec.field(default_factory=dict)
-    blacklist: SteamDbEntryBlacklist = msgspec.field(default_factory=SteamDbEntryBlacklist)
+    dependencies: dict[str, list[str] | SteamDbEntryDependency] = msgspec.field(
+        default_factory=dict
+    )
+    blacklist: SteamDbEntryBlacklist = msgspec.field(
+        default_factory=SteamDbEntryBlacklist
+    )
 
 
 class SteamDbSchema(msgspec.Struct):

--- a/app/models/search_result.py
+++ b/app/models/search_result.py
@@ -29,7 +29,9 @@ class SearchResult:
             if not self.file_size:
                 self.file_size = os.path.getsize(self.file_path)
             if not self.last_modified:
-                self.last_modified = datetime.fromtimestamp(os.path.getmtime(self.file_path))
+                self.last_modified = datetime.fromtimestamp(
+                    os.path.getmtime(self.file_path)
+                )
 
         # Set file_type based on extension if not provided
         if not self.file_type:

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -54,12 +54,20 @@ class Settings(QObject):
 
         # Databases
         self.external_steam_metadata_source: str = "None"
-        self.external_steam_metadata_file_path: str = str(AppInfo().app_storage_folder / "steamDB.json")
-        self.external_steam_metadata_repo: str = "https://github.com/RimSort/Steam-Workshop-Database"
+        self.external_steam_metadata_file_path: str = str(
+            AppInfo().app_storage_folder / "steamDB.json"
+        )
+        self.external_steam_metadata_repo: str = (
+            "https://github.com/RimSort/Steam-Workshop-Database"
+        )
 
         self.external_community_rules_metadata_source: str = "None"
-        self.external_community_rules_file_path: str = str(AppInfo().app_storage_folder / "communityRules.json")
-        self.external_community_rules_repo: str = "https://github.com/RimSort/Community-Rules-Database"
+        self.external_community_rules_file_path: str = str(
+            AppInfo().app_storage_folder / "communityRules.json"
+        )
+        self.external_community_rules_repo: str = (
+            "https://github.com/RimSort/Community-Rules-Database"
+        )
 
         # Disable by default previously this was 7 days "604800"
         self.database_expiry: int = 0
@@ -67,14 +75,20 @@ class Settings(QObject):
         self.aux_db_time_limit: int = -1
 
         self.external_no_version_warning_metadata_source: str = "None"
-        self.external_no_version_warning_file_path: str = str(AppInfo().app_storage_folder / "ModIdsToFix.xml")
-        self.external_no_version_warning_repo_path: str = "https://github.com/emipa606/NoVersionWarning"
+        self.external_no_version_warning_file_path: str = str(
+            AppInfo().app_storage_folder / "ModIdsToFix.xml"
+        )
+        self.external_no_version_warning_repo_path: str = (
+            "https://github.com/emipa606/NoVersionWarning"
+        )
 
         self.external_use_this_instead_metadata_source: str = "None"
         self.external_use_this_instead_file_path: str = str(
             AppInfo().app_storage_folder / "UseThisInstead" / "replacements.json.gz"
         )
-        self.external_use_this_instead_repo_path: str = "https://github.com/emipa606/UseThisInstead"
+        self.external_use_this_instead_repo_path: str = (
+            "https://github.com/emipa606/UseThisInstead"
+        )
 
         # Sorting
         self.sorting_algorithm: SortMethod = SortMethod.TOPOLOGICAL
@@ -196,7 +210,9 @@ class Settings(QObject):
         # Instances
         self.current_instance: str = DEFAULT_INSTANCE_NAME
         self.current_instance_path: str = str(
-            Path(AppInfo().app_storage_folder) / INSTANCE_FOLDER_NAME / self.current_instance
+            Path(AppInfo().app_storage_folder)
+            / INSTANCE_FOLDER_NAME
+            / self.current_instance
         )
         self.instances: dict[str, Instance] = {DEFAULT_INSTANCE_NAME: Instance()}
 
@@ -211,8 +227,14 @@ class Settings(QObject):
 
         instance = self.instances[self.current_instance]
         # Default instance never uses override
-        override = "" if self.current_instance == DEFAULT_INSTANCE_NAME else instance.instance_folder_override
-        instance_path = InstanceController.get_instance_folder_path(self.current_instance, override)
+        override = (
+            ""
+            if self.current_instance == DEFAULT_INSTANCE_NAME
+            else instance.instance_folder_override
+        )
+        instance_path = InstanceController.get_instance_folder_path(
+            self.current_instance, override
+        )
         return instance_path / "aux_metadata.db"
 
     def __setattr__(self, key: str, value: Any) -> None:
@@ -239,9 +261,15 @@ class Settings(QObject):
                 mitigations = True
                 # Mitigate issues when "instances" key is not parsed, but the old path attributes are present
                 if not data.get("instances"):
-                    logger.debug("Instances key not found in settings.json. Performing mitigation.")
+                    logger.debug(
+                        "Instances key not found in settings.json. Performing mitigation."
+                    )
                     steamcmd_prefix_default_instance_path = str(
-                        Path(AppInfo().app_storage_folder / INSTANCE_FOLDER_NAME / DEFAULT_INSTANCE_NAME)
+                        Path(
+                            AppInfo().app_storage_folder
+                            / INSTANCE_FOLDER_NAME
+                            / DEFAULT_INSTANCE_NAME
+                        )
                     )
                     # Create Default instance
                     data["instances"] = {
@@ -257,17 +285,25 @@ class Settings(QObject):
                         )
                     }
                     steamcmd_prefix_to_mitigate = data.get("steamcmd_install_path", "")
-                    steamcmd_path_to_mitigate = str(Path(steamcmd_prefix_to_mitigate) / STEAMCMD_FOLDER_NAME)
-                    steam_path_to_mitigate = str(Path(steamcmd_prefix_to_mitigate) / STEAM_FOLDER_NAME)
-                    if steamcmd_prefix_to_mitigate and path.exists(steamcmd_prefix_to_mitigate):
+                    steamcmd_path_to_mitigate = str(
+                        Path(steamcmd_prefix_to_mitigate) / STEAMCMD_FOLDER_NAME
+                    )
+                    steam_path_to_mitigate = str(
+                        Path(steamcmd_prefix_to_mitigate) / STEAM_FOLDER_NAME
+                    )
+                    if steamcmd_prefix_to_mitigate and path.exists(
+                        steamcmd_prefix_to_mitigate
+                    ):
                         logger.debug(
                             "Configured SteamCMD install path found. Attempting to migrate it to the Default instance path..."
                         )
                         steamcmd_prefix_steamcmd_path = str(
-                            Path(steamcmd_prefix_default_instance_path) / STEAMCMD_FOLDER_NAME
+                            Path(steamcmd_prefix_default_instance_path)
+                            / STEAMCMD_FOLDER_NAME
                         )
                         steamcmd_prefix_steam_path = str(
-                            Path(steamcmd_prefix_default_instance_path) / STEAM_FOLDER_NAME
+                            Path(steamcmd_prefix_default_instance_path)
+                            / STEAM_FOLDER_NAME
                         )
                         try:
                             if path.exists(steamcmd_prefix_steamcmd_path):
@@ -290,7 +326,9 @@ class Settings(QObject):
                                 steamcmd_prefix_steamcmd_path,
                                 symlinks=True,
                             )
-                            logger.info(f"Deleting old SteamCMD install path at {steamcmd_path_to_mitigate}...")
+                            logger.info(
+                                f"Deleting old SteamCMD install path at {steamcmd_path_to_mitigate}..."
+                            )
                             rmtree(
                                 steamcmd_path_to_mitigate,
                                 ignore_errors=False,
@@ -304,22 +342,39 @@ class Settings(QObject):
                                 steamcmd_prefix_steam_path,
                                 symlinks=True,
                             )
-                            logger.info(f"Deleting old SteamCMD data path at {steam_path_to_mitigate}...")
+                            logger.info(
+                                f"Deleting old SteamCMD data path at {steam_path_to_mitigate}..."
+                            )
                             rmtree(
                                 steam_path_to_mitigate,
                                 ignore_errors=False,
                                 onerror=handle_remove_read_only,
                             )
                         except Exception as e:
-                            logger.error(f"Failed to migrate SteamCMD install path. Error: {e}")
-                elif not data.get("current_instance") or data["current_instance"] not in data["instances"]:
-                    logger.debug("Current instance not found in settings.json. Performing mitigation.")
+                            logger.error(
+                                f"Failed to migrate SteamCMD install path. Error: {e}"
+                            )
+                elif (
+                    not data.get("current_instance")
+                    or data["current_instance"] not in data["instances"]
+                ):
+                    logger.debug(
+                        "Current instance not found in settings.json. Performing mitigation."
+                    )
                     data["current_instance"] = DEFAULT_INSTANCE_NAME
 
-                    new_path = str(Path(AppInfo().app_storage_folder) / "instances" / data.get("current_instance"))
+                    new_path = str(
+                        Path(AppInfo().app_storage_folder)
+                        / "instances"
+                        / data.get("current_instance")
+                    )
                     data["current_instance_path"] = new_path
                 elif not data.get("current_instance_path"):
-                    new_path = str(Path(AppInfo().app_storage_folder) / "instances" / data.get("current_instance"))
+                    new_path = str(
+                        Path(AppInfo().app_storage_folder)
+                        / "instances"
+                        / data.get("current_instance")
+                    )
                     data["current_instance_path"] = new_path
                 else:
                     # There was nothing to mitigate, so don't save the model to the file
@@ -453,7 +508,9 @@ class Settings(QObject):
                 elif isinstance(instance_data, dict):
                     instances[instance_name] = msgspec.convert(instance_data, Instance)
                 else:
-                    logger.warning(f"Instance data for {instance_name} is not a valid type: {type(instance_data)}")
+                    logger.warning(
+                        f"Instance data for {instance_name} is not a valid type: {type(instance_data)}"
+                    )
             self.instances = instances
 
     def _to_dict(self, skip_private: bool = True) -> Dict[str, Any]:
@@ -474,7 +531,9 @@ class Settings(QObject):
         # Serialize instances using msgspec
         instances_dict = {}
         for name, instance in self.instances.items():
-            instances_dict[name] = msgspec.json.decode(msgspec.json.encode(instance), type=dict)
+            instances_dict[name] = msgspec.json.decode(
+                msgspec.json.encode(instance), type=dict
+            )
         data["instances"] = instances_dict
         return data
 
@@ -498,18 +557,26 @@ class Settings(QObject):
         launch_via_steam_protocol = active_instance.launch_via_steam_protocol
 
         # If neither is enabled, no validation needed
-        if not steam_client_integration and not workshop_folder and not launch_via_steam_protocol:
+        if (
+            not steam_client_integration
+            and not workshop_folder
+            and not launch_via_steam_protocol
+        ):
             return False
 
         # If launch_via_steam_protocol is enabled but steam_client_integration is not, disable it
         if launch_via_steam_protocol and not steam_client_integration:
-            logger.warning("Steam protocol launch is enabled but Steam client integration is disabled. Disabling...")
+            logger.warning(
+                "Steam protocol launch is enabled but Steam client integration is disabled. Disabling..."
+            )
             active_instance.launch_via_steam_protocol = False
             return True
 
         # If steam_client_integration is enabled but workshop_folder is not set, disable it
         if steam_client_integration and not workshop_folder:
-            logger.warning("Steam client integration is enabled but workshop folder is not configured. Disabling...")
+            logger.warning(
+                "Steam client integration is enabled but workshop folder is not configured. Disabling..."
+            )
             active_instance.steam_client_integration = False
             return True
 

--- a/app/sort/alphabetical_sort.py
+++ b/app/sort/alphabetical_sort.py
@@ -3,7 +3,9 @@ from loguru import logger
 from app.utils.metadata import MetadataManager
 
 
-def do_alphabetical_sort(dependency_graph: dict[str, set[str]], active_mods_uuids: set[str]) -> list[str]:
+def do_alphabetical_sort(
+    dependency_graph: dict[str, set[str]], active_mods_uuids: set[str]
+) -> list[str]:
     logger.info(f"Starting Alphabetical sort for {len(dependency_graph)} mods")
     # Cache MetadataManager instance
     metadata_manager = MetadataManager.instance()
@@ -30,11 +32,15 @@ def do_alphabetical_sort(dependency_graph: dict[str, set[str]], active_mods_uuid
         else:
             return "name error in mod about.xml"
 
-    active_mods_alphabetized = sorted(active_mods_id_to_name.items(), key=lambda x: safe_name(x[1]), reverse=False)
+    active_mods_alphabetized = sorted(
+        active_mods_id_to_name.items(), key=lambda x: safe_name(x[1]), reverse=False
+    )
     dependencies_alphabetized = {}
     for tuple_id_name in active_mods_alphabetized:
         if tuple_id_name[0] in dependency_graph:
-            dependencies_alphabetized[tuple_id_name[0]] = dependency_graph[tuple_id_name[0]]
+            dependencies_alphabetized[tuple_id_name[0]] = dependency_graph[
+                tuple_id_name[0]
+            ]
     mods_load_order = []
     for package_id in dependencies_alphabetized:
         # Avoid repeating adding packages that have already been added
@@ -77,8 +83,12 @@ def recursively_force_insert(
         for uuid in active_mods_uuids:
             mod_package_id = metadata_manager.internal_local_metadata[uuid]["packageid"]
             if dependency_id == mod_package_id:
-                deps_id_to_name[dependency_id] = metadata_manager.internal_local_metadata[uuid]["name"]
-    deps_of_package_alphabetized = sorted(deps_id_to_name.items(), key=lambda x: x[1], reverse=False)
+                deps_id_to_name[dependency_id] = (
+                    metadata_manager.internal_local_metadata[uuid]["name"]
+                )
+    deps_of_package_alphabetized = sorted(
+        deps_id_to_name.items(), key=lambda x: x[1], reverse=False
+    )
 
     # Iterate through the list of reverse alphabetized dependencies
     # The idea is to insert at the list index so that e.g.
@@ -98,7 +108,9 @@ def recursively_force_insert(
             # want to shift that dep back. Otherwise, if no dep of dep is found, then we insert
             # at the original index normally.
             index_to_insert_at = index_just_appended
-            for e in reversed(mods_load_order[index_just_appended : mods_load_order.index(package_id)]):
+            for e in reversed(
+                mods_load_order[index_just_appended : mods_load_order.index(package_id)]
+            ):
                 if e in dependency_graph[dep_id]:
                     index_to_insert_at = mods_load_order.index(e) + 1
                     break

--- a/app/sort/dependencies.py
+++ b/app/sort/dependencies.py
@@ -4,7 +4,9 @@ from app.utils.constants import KNOWN_TIER_ONE_MODS, KNOWN_TIER_ZERO_MODS
 from app.utils.metadata import MetadataManager
 
 
-def gen_deps_graph(active_mods_uuids: set[str], active_mod_ids: list[str]) -> dict[str, set[str]]:
+def gen_deps_graph(
+    active_mods_uuids: set[str], active_mod_ids: list[str]
+) -> dict[str, set[str]]:
     """
     Get dependencies
     """
@@ -16,22 +18,32 @@ def gen_deps_graph(active_mods_uuids: set[str], active_mod_ids: list[str]) -> di
     for uuid in active_mods_uuids:
         package_id = metadata_manager.internal_local_metadata[uuid]["packageid"]
         dependencies_graph[package_id] = set()
-        if metadata_manager.internal_local_metadata[uuid].get("loadTheseBefore"):  # Will either be None, or a set
-            for dependency in metadata_manager.internal_local_metadata[uuid]["loadTheseBefore"]:
+        if metadata_manager.internal_local_metadata[uuid].get(
+            "loadTheseBefore"
+        ):  # Will either be None, or a set
+            for dependency in metadata_manager.internal_local_metadata[uuid][
+                "loadTheseBefore"
+            ]:
                 # Only add a dependency if dependency exists in active_mods. Recall
                 # that dependencies exist for all_mods, but not all of these will be
                 # in active mods. Also note that dependencies here refers to load order
                 # rules. Also note that dependency[0] is required as dependency is a tuple
                 # of package_id, explicit_bool
                 if not isinstance(dependency, tuple):
-                    logger.error(f"Expected load order rule to be a tuple: [{dependency}]")
+                    logger.error(
+                        f"Expected load order rule to be a tuple: [{dependency}]"
+                    )
                 if dependency[0] in active_mod_ids:
                     dependencies_graph[package_id].add(dependency[0])
-    logger.info(f"Finished generating dependencies graph of {len(dependencies_graph)} items")
+    logger.info(
+        f"Finished generating dependencies graph of {len(dependencies_graph)} items"
+    )
     return dependencies_graph
 
 
-def gen_rev_deps_graph(active_mods_uuids: set[str], active_mod_ids: list[str]) -> dict[str, set[str]]:
+def gen_rev_deps_graph(
+    active_mods_uuids: set[str], active_mod_ids: list[str]
+) -> dict[str, set[str]]:
     # Cache MetadataManager instance
     metadata_manager = MetadataManager.instance()
     # Schema: {item: {isDependentOn1, isDependentOn2, ...}}
@@ -40,14 +52,22 @@ def gen_rev_deps_graph(active_mods_uuids: set[str], active_mod_ids: list[str]) -
     for uuid in active_mods_uuids:
         package_id = metadata_manager.internal_local_metadata[uuid]["packageid"]
         reverse_dependencies_graph[package_id] = set()
-        if metadata_manager.internal_local_metadata[uuid].get("loadTheseAfter"):  # Will either be None, or a set
-            for dependent in metadata_manager.internal_local_metadata[uuid]["loadTheseAfter"]:
+        if metadata_manager.internal_local_metadata[uuid].get(
+            "loadTheseAfter"
+        ):  # Will either be None, or a set
+            for dependent in metadata_manager.internal_local_metadata[uuid][
+                "loadTheseAfter"
+            ]:
                 # Dependent[0] is required here as as dependency is a tuple of package_id, explicit_bool
                 if not isinstance(dependent, tuple):
-                    logger.error(f"Expected load order rule to be a tuple: [{dependent}]")
+                    logger.error(
+                        f"Expected load order rule to be a tuple: [{dependent}]"
+                    )
                 if dependent[0] in active_mod_ids:
                     reverse_dependencies_graph[package_id].add(dependent[0])
-    logger.debug(f"Finished generating reverse dependencies graph of {len(reverse_dependencies_graph)}")
+    logger.debug(
+        f"Finished generating reverse dependencies graph of {len(reverse_dependencies_graph)}"
+    )
     return reverse_dependencies_graph
 
 
@@ -76,14 +96,20 @@ def gen_tier_zero_deps_graph(
         if known_tier_zero_mod in dependencies_graph:
             # Some known tier zero mods might not actually be active
             tier_zero_mods.add(known_tier_zero_mod)
-            dependencies_set = get_dependencies_recursive(known_tier_zero_mod, dependencies_graph, processed_ids)
+            dependencies_set = get_dependencies_recursive(
+                known_tier_zero_mod, dependencies_graph, processed_ids
+            )
             tier_zero_mods.update(dependencies_set)
-    logger.info(f"Recursively generated the following set of tier one mods: {tier_zero_mods}")
+    logger.info(
+        f"Recursively generated the following set of tier one mods: {tier_zero_mods}"
+    )
     tier_zero_dependency_graph = {}
     for tier_zero_mod in tier_zero_mods:
         # Tier zero mods will only ever reference other tier zero mods in their dependencies graph
         if tier_zero_mod in dependencies_graph:
-            tier_zero_dependency_graph[tier_zero_mod] = dependencies_graph[tier_zero_mod]
+            tier_zero_dependency_graph[tier_zero_mod] = dependencies_graph[
+                tier_zero_mod
+            ]
     logger.info("Attached corresponding dependencies to every tier zero mod, returning")
     return tier_zero_dependency_graph, tier_zero_mods
 
@@ -105,7 +131,9 @@ def gen_tier_one_deps_graph(
     # Add mods with loadTop set to True to known_tier_one_mods
     for uuid in metadata_manager.internal_local_metadata:
         if metadata_manager.internal_local_metadata[uuid].get("loadTop"):
-            known_tier_one_mods.add(metadata_manager.internal_local_metadata[uuid]["packageid"])
+            known_tier_one_mods.add(
+                metadata_manager.internal_local_metadata[uuid]["packageid"]
+            )
     # Bug fix: if there are circular dependencies in tier one mods
     # then an infinite loop happens here unless we keep track of what has
     # already been processed.
@@ -115,9 +143,13 @@ def gen_tier_one_deps_graph(
         if known_tier_one_mod in dependencies_graph:
             # Some known tier one mods might not actually be active
             tier_one_mods.add(known_tier_one_mod)
-            dependencies_set = get_dependencies_recursive(known_tier_one_mod, dependencies_graph, processed_ids)
+            dependencies_set = get_dependencies_recursive(
+                known_tier_one_mod, dependencies_graph, processed_ids
+            )
             tier_one_mods.update(dependencies_set)
-    logger.info(f"Recursively generated the following set of tier one mods: {tier_one_mods}")
+    logger.info(
+        f"Recursively generated the following set of tier one mods: {tier_one_mods}"
+    )
     tier_one_dependency_graph = {}
     for tier_one_mod in tier_one_mods:
         # Tier one mods will only ever reference other tier one mods in their dependencies graph
@@ -137,9 +169,13 @@ def get_dependencies_recursive(
         for dependency_id in active_mods_dependencies[package_id]:
             if dependency_id not in processed_ids:
                 processed_ids.add(dependency_id)
-                dependencies_set.add(dependency_id)  # Safe, as should refer to active id
+                dependencies_set.add(
+                    dependency_id
+                )  # Safe, as should refer to active id
                 dependencies_set.update(  # Safe, as should refer to active ids
-                    get_dependencies_recursive(dependency_id, active_mods_dependencies, processed_ids)
+                    get_dependencies_recursive(
+                        dependency_id, active_mods_dependencies, processed_ids
+                    )
                 )
     return dependencies_set
 
@@ -170,9 +206,13 @@ def gen_tier_three_deps_graph(
         if known_tier_three_mod in dependencies_graph:
             # Some known tier three mods might not actually be active
             tier_three_mods.add(known_tier_three_mod)
-            rev_dependencies_set = get_reverse_dependencies_recursive(known_tier_three_mod, reverse_dependencies_graph)
+            rev_dependencies_set = get_reverse_dependencies_recursive(
+                known_tier_three_mod, reverse_dependencies_graph
+            )
             tier_three_mods.update(rev_dependencies_set)
-    logger.info(f"Recursively generated the following set of tier three mods: {tier_three_mods}")
+    logger.info(
+        f"Recursively generated the following set of tier three mods: {tier_three_mods}"
+    )
     tier_three_dependency_graph: dict[str, set[str]] = {}
     for tier_three_mod in tier_three_mods:
         # Tier three mods may reference non-tier-three mods in their dependencies graph,
@@ -181,18 +221,26 @@ def gen_tier_three_deps_graph(
         for possible_add in dependencies_graph[tier_three_mod]:
             if possible_add in tier_three_mods:
                 tier_three_dependency_graph[tier_three_mod].add(possible_add)
-    logger.info("Attached corresponding dependencies to every tier three mod, returning")
+    logger.info(
+        "Attached corresponding dependencies to every tier three mod, returning"
+    )
     return tier_three_dependency_graph, tier_three_mods
 
 
-def get_reverse_dependencies_recursive(package_id: str, active_mods_rev_dependencies: dict[str, set[str]]) -> set[str]:
+def get_reverse_dependencies_recursive(
+    package_id: str, active_mods_rev_dependencies: dict[str, set[str]]
+) -> set[str]:
     reverse_dependencies_set = set()
     # Should always be true since all active ids get initialized with a set()
     if package_id in active_mods_rev_dependencies:
         for dependent_id in active_mods_rev_dependencies[package_id]:
-            reverse_dependencies_set.add(dependent_id)  # Safe, as should refer to active id
+            reverse_dependencies_set.add(
+                dependent_id
+            )  # Safe, as should refer to active id
             reverse_dependencies_set.update(  # Safe, as should refer to active ids
-                get_reverse_dependencies_recursive(dependent_id, active_mods_rev_dependencies)
+                get_reverse_dependencies_recursive(
+                    dependent_id, active_mods_rev_dependencies
+                )
             )
     return reverse_dependencies_set
 
@@ -221,7 +269,9 @@ def gen_tier_two_deps_graph(
     # Cache MetadataManager instance
     metadata_manager = MetadataManager.instance()
     logger.info("Generating dependencies graph for tier two mods")
-    logger.info("Stripping all references to tier one and tier three mods and their dependencies")
+    logger.info(
+        "Stripping all references to tier one and tier three mods and their dependencies"
+    )
 
     # First pass: collect explicit loadTheseBefore rules (highest priority)
     explicit_rules = {}  # mod_id -> set of dependencies from loadTheseBefore
@@ -234,11 +284,17 @@ def gen_tier_two_deps_graph(
         if package_id not in tier_one_mods and package_id not in tier_three_mods:
             # Always collect explicit loadTheseBefore rules
             explicit_dependencies = set()
-            loadTheseBefore = metadata_manager.internal_local_metadata[uuid].get("loadTheseBefore")
+            loadTheseBefore = metadata_manager.internal_local_metadata[uuid].get(
+                "loadTheseBefore"
+            )
             if loadTheseBefore and isinstance(loadTheseBefore, (set, list)):
                 for dep in loadTheseBefore:
                     if isinstance(dep, tuple):
-                        if dep[0] not in tier_one_mods and dep[0] not in tier_three_mods and dep[0] in active_mod_ids:
+                        if (
+                            dep[0] not in tier_one_mods
+                            and dep[0] not in tier_three_mods
+                            and dep[0] in active_mod_ids
+                        ):
                             explicit_dependencies.add(dep[0])
                     else:
                         logger.error(f"loadTheseBefore entry is not a tuple: [{dep}]")
@@ -248,7 +304,9 @@ def gen_tier_two_deps_graph(
             # Collect inferred rules from dependencies if enabled
             inferred_dependencies = set()
             if use_moddependencies_as_loadTheseBefore:
-                about_dependencies = metadata_manager.internal_local_metadata[uuid].get("dependencies")
+                about_dependencies = metadata_manager.internal_local_metadata[uuid].get(
+                    "dependencies"
+                )
                 if about_dependencies and isinstance(about_dependencies, (set, list)):
                     for dep in about_dependencies:
                         # Accept both str and tuple for about_dependencies
@@ -265,11 +323,17 @@ def gen_tier_two_deps_graph(
                             ):
                                 alt_ids = dep[1]["alternatives"]
                         else:
-                            logger.error(f"About.xml dependency is not a string or tuple: [{dep}]")
+                            logger.error(
+                                f"About.xml dependency is not a string or tuple: [{dep}]"
+                            )
                             continue
 
                         # Prefer primary dep when present; optionally use alternatives
-                        if dep_id in active_mod_ids and dep_id not in tier_one_mods and dep_id not in tier_three_mods:
+                        if (
+                            dep_id in active_mod_ids
+                            and dep_id not in tier_one_mods
+                            and dep_id not in tier_three_mods
+                        ):
                             inferred_dependencies.add(dep_id)
                         else:
                             # Only use alternatives if allowed by settings
@@ -318,7 +382,11 @@ def gen_tier_two_deps_graph(
         tier_two_dependency_graph[package_id] = final_dependencies
 
     if conflicts_ignored > 0:
-        logger.info(f"Resolved {conflicts_ignored} conflicts by prioritizing explicit loadTheseBefore rules")
+        logger.info(
+            f"Resolved {conflicts_ignored} conflicts by prioritizing explicit loadTheseBefore rules"
+        )
 
-    logger.info("Generated tier two dependency graph with conflict resolution, returning")
+    logger.info(
+        "Generated tier two dependency graph with conflict resolution, returning"
+    )
     return tier_two_dependency_graph

--- a/app/sort/mod_sorting.py
+++ b/app/sort/mod_sorting.py
@@ -25,7 +25,9 @@ def uuid_no_key(uuid: str) -> str:
     return uuid
 
 
-def uuid_to_mod_name(uuid: str, cached_metadata: Optional[dict[str, Any]] = None) -> str:
+def uuid_to_mod_name(
+    uuid: str, cached_metadata: Optional[dict[str, Any]] = None
+) -> str:
     """
     Get mod name for inactive mods list sorting.
 
@@ -51,7 +53,9 @@ def uuid_to_mod_name(uuid: str, cached_metadata: Optional[dict[str, Any]] = None
         return "name error in mod about.xml"
 
 
-def uuid_to_filesystem_modified_time(uuid: str, cached_metadata: Optional[dict[str, Any]] = None) -> int:
+def uuid_to_filesystem_modified_time(
+    uuid: str, cached_metadata: Optional[dict[str, Any]] = None
+) -> int:
     """
     Get filesystem modification time for inactive mods list sorting.
 
@@ -115,7 +119,9 @@ def uuid_to_author(uuid: str, cached_metadata: Optional[dict[str, Any]] = None) 
     return author.lower() if isinstance(author, str) else ""
 
 
-def uuid_to_folder_size(uuid: str, cached_metadata: Optional[dict[str, Any]] = None) -> int:
+def uuid_to_folder_size(
+    uuid: str, cached_metadata: Optional[dict[str, Any]] = None
+) -> int:
     """
     Calculate mod folder size for inactive mods list sorting.
 
@@ -152,7 +158,9 @@ def uuid_to_folder_size(uuid: str, cached_metadata: Optional[dict[str, Any]] = N
     return total_size
 
 
-def uuid_to_packageid(uuid: str, cached_metadata: Optional[dict[str, Any]] = None) -> str:
+def uuid_to_packageid(
+    uuid: str, cached_metadata: Optional[dict[str, Any]] = None
+) -> str:
     """
     Get mod package ID for inactive mods list sorting.
 
@@ -204,7 +212,9 @@ def uuid_to_version(uuid: str, cached_metadata: Optional[dict[str, Any]] = None)
         return ""
 
 
-def uuid_to_mod_color(uuid: str, cached_metadata: Optional[dict[str, Any]] = None) -> str:
+def uuid_to_mod_color(
+    uuid: str, cached_metadata: Optional[dict[str, Any]] = None
+) -> str:
     """
     Get mod color hex value for inactive mods list sorting.
 
@@ -435,7 +445,11 @@ def sort_uuids(
     start_time = time.perf_counter()
 
     # Automatically fetch auxiliary metadata if sorting by color
-    if key == ModsPanelSortKey.MOD_COLOR and cached_metadata is None and settings_controller is not None:
+    if (
+        key == ModsPanelSortKey.MOD_COLOR
+        and cached_metadata is None
+        and settings_controller is not None
+    ):
         cached_metadata = get_cached_metadata_for_batch(
             uuids,
             include_aux_metadata=True,
@@ -458,7 +472,9 @@ def sort_uuids(
 
     # Log performance metrics for debugging and monitoring
     elapsed = time.perf_counter() - start_time
-    logger.debug(f"Sorted {len(uuids)} mods by {key.name} ({reverse_flag and 'desc' or 'asc'}) in {elapsed:.3f}s")
+    logger.debug(
+        f"Sorted {len(uuids)} mods by {key.name} ({reverse_flag and 'desc' or 'asc'}) in {elapsed:.3f}s"
+    )
 
     return sorted_result
 
@@ -507,7 +523,9 @@ class FolderSizeWorker(QObject):
 
         # Pre-fetch all metadata once to avoid repeated lookups
         cached_metadata = get_cached_metadata_for_batch(self._uuids)
-        logger.debug(f"Pre-cached metadata for {len(cached_metadata)} mods in FolderSizeWorker")
+        logger.debug(
+            f"Pre-cached metadata for {len(cached_metadata)} mods in FolderSizeWorker"
+        )
 
         # Calculate folder sizes with progress reporting
         for idx, uuid in enumerate(self._uuids, start=1):

--- a/app/sort/topo_sort.py
+++ b/app/sort/topo_sort.py
@@ -7,7 +7,9 @@ from app.utils.metadata import MetadataManager
 from app.views.dialogue import show_warning
 
 
-def do_topo_sort(dependency_graph: dict[str, set[str]], active_mods_uuids: set[str]) -> list[str]:
+def do_topo_sort(
+    dependency_graph: dict[str, set[str]], active_mods_uuids: set[str]
+) -> list[str]:
     """
     Sort mods using the topological sort algorithm. For each
     topological level, sort the mods alphabetically by name for consistency.
@@ -80,7 +82,9 @@ def find_circular_dependencies(dependency_graph: dict[str, set[str]]) -> None:
         logger.info("No circular dependencies found.")
 
     show_warning(
-        title=QCoreApplication.translate("find_circular_dependencies", "Unable to Sort"),
+        title=QCoreApplication.translate(
+            "find_circular_dependencies", "Unable to Sort"
+        ),
         text=QCoreApplication.translate("find_circular_dependencies", "Unable to Sort"),
         information=QCoreApplication.translate(
             "find_circular_dependencies",

--- a/app/utils/acf_utils.py
+++ b/app/utils/acf_utils.py
@@ -66,7 +66,9 @@ def load_acf_from_path(acf_path: str | Path) -> dict[str, Any]:
         return {}
 
 
-def refresh_acf_metadata(metadata_manager: "MetadataManager", steamclient: bool = True, steamcmd: bool = True) -> None:
+def refresh_acf_metadata(
+    metadata_manager: "MetadataManager", steamclient: bool = True, steamcmd: bool = True
+) -> None:
     """
     Load and cache ACF metadata from Steam and SteamCMD sources.
 
@@ -100,7 +102,9 @@ def refresh_acf_metadata(metadata_manager: "MetadataManager", steamclient: bool 
 
     # Load SteamCMD appworkshop_294100.acf if enabled
     if steamcmd:
-        steamcmd_data = load_acf_from_path(metadata_manager.steamcmd_wrapper.steamcmd_appworkshop_acf_path)
+        steamcmd_data = load_acf_from_path(
+            metadata_manager.steamcmd_wrapper.steamcmd_appworkshop_acf_path
+        )
         if steamcmd_data:
             metadata_manager.steamcmd_acf_data = steamcmd_data
             logger.info(
@@ -217,7 +221,9 @@ def _merge_workshop_items_from_sources(
             # Parse timestamp with validation
             timeupdated_int = parse_timeupdated(item.get("timeupdated"))
             if timeupdated_int is None and item.get("timeupdated") is not None:
-                logger.warning(f"Invalid timeupdated for PFID {pfid_str}: {item.get('timeupdated')}")
+                logger.warning(
+                    f"Invalid timeupdated for PFID {pfid_str}: {item.get('timeupdated')}"
+                )
             entries.append((pfid_str, steamcmd_source, timeupdated_int))
             seen_pfids.add(pfid_str)
 
@@ -230,7 +236,9 @@ def _merge_workshop_items_from_sources(
             # Parse timestamp with validation
             timeupdated_int = parse_timeupdated(item.get("timeupdated"))
             if timeupdated_int is None and item.get("timeupdated") is not None:
-                logger.warning(f"Invalid timeupdated for PFID {pfid_str}: {item.get('timeupdated')}")
+                logger.warning(
+                    f"Invalid timeupdated for PFID {pfid_str}: {item.get('timeupdated')}"
+                )
             entries.append((pfid_str, steam_source, timeupdated_int))
             seen_pfids.add(pfid_str)
 
@@ -267,15 +275,21 @@ def get_acf_workshop_items(
     """
     # Extract workshop items from cached SteamCMD ACF data
     steamcmd_items = (
-        get_workshop_items_from_acf(metadata_manager.steamcmd_acf_data) if metadata_manager.steamcmd_acf_data else {}
+        get_workshop_items_from_acf(metadata_manager.steamcmd_acf_data)
+        if metadata_manager.steamcmd_acf_data
+        else {}
     )
     # Extract workshop items from cached Steam ACF data
     workshop_items = (
-        get_workshop_items_from_acf(metadata_manager.workshop_acf_data) if metadata_manager.workshop_acf_data else {}
+        get_workshop_items_from_acf(metadata_manager.workshop_acf_data)
+        if metadata_manager.workshop_acf_data
+        else {}
     )
 
     # Merge items with source attribution and deduplication
-    entries = _merge_workshop_items_from_sources(steamcmd_items, workshop_items, "SteamCMD", "Steam")
+    entries = _merge_workshop_items_from_sources(
+        steamcmd_items, workshop_items, "SteamCMD", "Steam"
+    )
 
     return (
         entries,
@@ -310,7 +324,9 @@ def load_and_merge_acf_data(
         ValueError: If no ACF data could be loaded from either source.
     """
     # Load ACF files from both sources
-    steamcmd_acf_data = load_acf_from_path(steamcmd_acf_path) if steamcmd_acf_path else {}
+    steamcmd_acf_data = (
+        load_acf_from_path(steamcmd_acf_path) if steamcmd_acf_path else {}
+    )
     steam_acf_data = load_acf_from_path(steam_acf_path) if steam_acf_path else {}
 
     if not steamcmd_acf_data and not steam_acf_data:
@@ -324,12 +340,16 @@ def load_and_merge_acf_data(
         raise ValueError("Invalid workshop items data format")
 
     # Merge items with source attribution using shared helper
-    entries = _merge_workshop_items_from_sources(steamcmd_items, steam_items, "SteamCMD", "Steam")
+    entries = _merge_workshop_items_from_sources(
+        steamcmd_items, steam_items, "SteamCMD", "Steam"
+    )
 
     return entries, steamcmd_acf_data, steam_acf_data
 
 
-def _extract_manifest_ids_and_remove_pfid(workshop_section: dict[str, Any] | None, delete_pfid: str) -> set[str]:
+def _extract_manifest_ids_and_remove_pfid(
+    workshop_section: dict[str, Any] | None, delete_pfid: str
+) -> set[str]:
     """
     Extract manifest IDs from a workshop section and remove a PFID entry.
 
@@ -400,15 +420,21 @@ def steamcmd_purge_mods(
     acf_path = metadata_manager.steamcmd_wrapper.steamcmd_appworkshop_acf_path
     acf_metadata = load_acf_from_path(acf_path)
     if not acf_metadata:
-        logger.warning(f"SteamCMD ACF file not found or failed to parse at: {acf_path}. Skipping mod removal.")
+        logger.warning(
+            f"SteamCMD ACF file not found or failed to parse at: {acf_path}. Skipping mod removal."
+        )
         return
 
     # Get depotcache directory path for manifest file cleanup
     depotcache_path = metadata_manager.steamcmd_wrapper.steamcmd_depotcache_path
 
     # Extract workshop sections from ACF metadata
-    workshop_items_installed = acf_metadata.get("AppWorkshop", {}).get("WorkshopItemsInstalled")
-    workshop_item_details = acf_metadata.get("AppWorkshop", {}).get("WorkshopItemDetails")
+    workshop_items_installed = acf_metadata.get("AppWorkshop", {}).get(
+        "WorkshopItemsInstalled"
+    )
+    workshop_item_details = acf_metadata.get("AppWorkshop", {}).get(
+        "WorkshopItemDetails"
+    )
 
     # Collect manifest IDs associated with mods being removed
     mod_manifest_ids = set()
@@ -416,8 +442,12 @@ def steamcmd_purge_mods(
     # Process each PFID to be removed
     for delete_pfid in publishedfileids:
         # Extract manifest IDs from both sections and remove entries
-        manifest_ids_installed = _extract_manifest_ids_and_remove_pfid(workshop_items_installed, delete_pfid)
-        manifest_ids_details = _extract_manifest_ids_and_remove_pfid(workshop_item_details, delete_pfid)
+        manifest_ids_installed = _extract_manifest_ids_and_remove_pfid(
+            workshop_items_installed, delete_pfid
+        )
+        manifest_ids_details = _extract_manifest_ids_and_remove_pfid(
+            workshop_item_details, delete_pfid
+        )
         # Accumulate all manifest IDs found
         mod_manifest_ids.update(manifest_ids_installed)
         mod_manifest_ids.update(manifest_ids_details)
@@ -462,7 +492,9 @@ def validate_acf_file_exists(steam_mods_location: str) -> bool:
         return False
 
     try:
-        acf_file_path = Path(steam_mods_location).parent.parent / "appworkshop_294100.acf"
+        acf_file_path = (
+            Path(steam_mods_location).parent.parent / "appworkshop_294100.acf"
+        )
         exists = acf_file_path.exists() and acf_file_path.is_file()
 
         if exists:

--- a/app/utils/app_info.py
+++ b/app/utils/app_info.py
@@ -88,13 +88,17 @@ class AppInfo:
         self._ignore_mods_file: Path = self.databases_folder / "ignore.json"
         self._language_data_folder: Path = self._application_folder / "locales"
         self._browser_profile_folder: Path = self._app_storage_folder / "browser"
-        self._setup_web_channel_script_file: Path = self._application_folder / "setup_web_channel_script.js"
+        self._setup_web_channel_script_file: Path = (
+            self._application_folder / "setup_web_channel_script.js"
+        )
 
         # Backup directories
         self._backups_folder: Path = self._app_storage_folder / "backups"
         self._game_saves_backups_folder: Path = self._backups_folder / "saves"
         self._settings_backups_folder: Path = self._backups_folder / "settings"
-        self._application_backups_folder: Path = self._backups_folder / "rimsort_installation"
+        self._application_backups_folder: Path = (
+            self._backups_folder / "rimsort_installation"
+        )
 
         # Make sure important directories exist
         self._app_storage_folder.mkdir(parents=True, exist_ok=True)

--- a/app/utils/aux_db_utils.py
+++ b/app/utils/aux_db_utils.py
@@ -23,8 +23,11 @@ def auxdb_get_aux_db_entry(
     :return: AuxMetadataEntry | None, the AuxMetadataEntry for the given UUID, or None if no entry exists
     """
     metadata_manager = MetadataManager.instance()
-    local_controller = aux_db_controller or AuxMetadataController.get_or_create_cached_instance(
-        settings_controller.settings.aux_db_path
+    local_controller = (
+        aux_db_controller
+        or AuxMetadataController.get_or_create_cached_instance(
+            settings_controller.settings.aux_db_path
+        )
     )
     local_session = session or local_controller.Session()
     try:
@@ -53,7 +56,9 @@ def auxdb_get_mod_color(
     :param session: Session | None, optional SQLAlchemy session to use for the query; if None, a new session will be created and closed within this function
     :return: QColor | None, Color of the mod, or None if no color
     """
-    entry = auxdb_get_aux_db_entry(settings_controller, uuid, aux_db_controller, session)
+    entry = auxdb_get_aux_db_entry(
+        settings_controller, uuid, aux_db_controller, session
+    )
     mod_color = None
     if entry:
         color_text = entry.color_hex
@@ -78,7 +83,9 @@ def auxdb_get_mod_user_notes(
     :param session: Session | None, optional SQLAlchemy session to use for the query; if None, a new session will be created and closed within this function
     :return: str, User notes for the mod, or empty string if no notes
     """
-    entry = auxdb_get_aux_db_entry(settings_controller, uuid, aux_db_controller, session)
+    entry = auxdb_get_aux_db_entry(
+        settings_controller, uuid, aux_db_controller, session
+    )
     user_notes = ""
     if entry:
         user_notes = entry.user_notes
@@ -101,7 +108,9 @@ def auxdb_get_mod_warning_toggled(
     :param session: Session | None, optional SQLAlchemy session to use for the query; if None, a new session will be created and closed within this function
     :return: bool, Warning toggled status for the mod
     """
-    entry = auxdb_get_aux_db_entry(settings_controller, uuid, aux_db_controller, session)
+    entry = auxdb_get_aux_db_entry(
+        settings_controller, uuid, aux_db_controller, session
+    )
     warning_toggled = False
     if entry:
         warning_toggled = entry.ignore_warnings
@@ -126,8 +135,11 @@ def auxdb_update_mod_color(
     :param session: Session | None, optional SQLAlchemy session to use for the update; if None, a new session will be created and closed within this function
     """
     metadata_manager = MetadataManager.instance()
-    local_controller = aux_db_controller or AuxMetadataController.get_or_create_cached_instance(
-        settings_controller.settings.aux_db_path
+    local_controller = (
+        aux_db_controller
+        or AuxMetadataController.get_or_create_cached_instance(
+            settings_controller.settings.aux_db_path
+        )
     )
 
     local_session = session or local_controller.Session()
@@ -158,8 +170,11 @@ def auxdb_update_all_mod_colors(
     :param session: Session | None, optional SQLAlchemy session to use for the update; if None, a new session will be created and closed within this function
     """
     metadata_manager = MetadataManager.instance()
-    local_controller = aux_db_controller or AuxMetadataController.get_or_create_cached_instance(
-        settings_controller.settings.aux_db_path
+    local_controller = (
+        aux_db_controller
+        or AuxMetadataController.get_or_create_cached_instance(
+            settings_controller.settings.aux_db_path
+        )
     )
 
     local_session = session or local_controller.Session()

--- a/app/utils/button_factory.py
+++ b/app/utils/button_factory.py
@@ -23,7 +23,9 @@ class ButtonFactory:
     def __init__(self, panel: Any):
         self.panel = panel
 
-    def create_refresh_button(self, callback: Callable[[], None] | None = None) -> QPushButton:
+    def create_refresh_button(
+        self, callback: Callable[[], None] | None = None
+    ) -> QPushButton:
         """Create a refresh button."""
         return self.panel._create_refresh_button(callback)
 
@@ -70,13 +72,17 @@ class ButtonFactory:
             enable_delete_and_resubscribe,
         )
 
-    def create_custom_button(self, text: str, callback: Callable[[], None]) -> QPushButton:
+    def create_custom_button(
+        self, text: str, callback: Callable[[], None]
+    ) -> QPushButton:
         """Create a custom button."""
         button = QPushButton(text)
         button.clicked.connect(callback)
         return button
 
-    def create_select_button(self, text: str, menu_items: list[MenuItem]) -> QToolButton:
+    def create_select_button(
+        self, text: str, menu_items: list[MenuItem]
+    ) -> QToolButton:
         """Create a select button with dropdown menu."""
         button = QToolButton()
         button.setText(text)

--- a/app/utils/csv_export_utils.py
+++ b/app/utils/csv_export_utils.py
@@ -189,7 +189,9 @@ def _write_csv_metadata(panel: BaseModsPanel, writer: Any) -> None:
 
     # Add SteamCMD ACF path if available (AcfLogReader has this)
     acf_path = None
-    if hasattr(panel, "metadata_manager") and hasattr(panel.metadata_manager, "steamcmd_wrapper"):
+    if hasattr(panel, "metadata_manager") and hasattr(
+        panel.metadata_manager, "steamcmd_wrapper"
+    ):
         acf_path = getattr(
             panel.metadata_manager.steamcmd_wrapper,
             "steamcmd_appworkshop_acf_path",
@@ -216,7 +218,12 @@ def _write_csv_headers(panel: BaseModsPanel, writer: Any) -> None:
     headers = []
     descriptions = []
     for col in range(model.columnCount()):
-        header = model.headerData(col, Qt.Orientation.Horizontal, Qt.ItemDataRole.DisplayRole) or ""
+        header = (
+            model.headerData(
+                col, Qt.Orientation.Horizontal, Qt.ItemDataRole.DisplayRole
+            )
+            or ""
+        )
         headers.append(header)
         descriptions.append(_get_column_description(panel, col))
 
@@ -284,7 +291,9 @@ def _get_table_model(panel: BaseModsPanel) -> Any:
         The table model object.
     """
     return (
-        panel.editor_model if hasattr(panel, "editor_model") else panel.table_view.model()  # type: ignore[attr-defined]
+        panel.editor_model
+        if hasattr(panel, "editor_model")
+        else panel.table_view.model()  # type: ignore[attr-defined]
     )
 
 
@@ -303,5 +312,8 @@ def _get_column_description(panel: BaseModsPanel, col: int) -> str:
         The column header/description string.
     """
     model = _get_table_model(panel)
-    header = model.headerData(col, Qt.Orientation.Horizontal, Qt.ItemDataRole.DisplayRole) or ""
+    header = (
+        model.headerData(col, Qt.Orientation.Horizontal, Qt.ItemDataRole.DisplayRole)
+        or ""
+    )
     return header

--- a/app/utils/custom_list_widget_item.py
+++ b/app/utils/custom_list_widget_item.py
@@ -38,4 +38,6 @@ class CustomListWidgetItem(QListWidgetItem):
             list_widget.itemChanged.emit(self)
         else:
             # If the CustomListWidgetItem is not added to a QListWidget the signal will not be emitted
-            logger.warning("Could not emit itemChanged signal from CustomListWidgetItem, listWidget is None.")
+            logger.warning(
+                "Could not emit itemChanged signal from CustomListWidgetItem, listWidget is None."
+            )

--- a/app/utils/custom_list_widget_item_metadata.py
+++ b/app/utils/custom_list_widget_item_metadata.py
@@ -75,19 +75,29 @@ class CustomListWidgetItemMetadata:
             )
         else:
             self.warning_toggled = warning_toggled
-        self.invalid = invalid if invalid is not None else self.get_invalid_by_uuid(uuid)
-        self.mismatch = mismatch if mismatch is not None else self.get_mismatch_by_uuid(uuid)
+        self.invalid = (
+            invalid if invalid is not None else self.get_invalid_by_uuid(uuid)
+        )
+        self.mismatch = (
+            mismatch if mismatch is not None else self.get_mismatch_by_uuid(uuid)
+        )
         if mod_color is None:
             self.mod_color = auxdb_get_mod_color(
                 settings_controller, uuid, aux_metadata_controller, aux_metadata_session
             )
         else:
             self.mod_color = mod_color
-        self.alternative = alternative if alternative is not None else self.get_alternative_by_uuid(uuid)
+        self.alternative = (
+            alternative
+            if alternative is not None
+            else self.get_alternative_by_uuid(uuid)
+        )
         # Persist list type for UI logic that depends on which list the item is in (Active/Inactive)
         self.list_type = list_type
 
-        logger.debug(f"Finished initializing CustomListWidgetItemMetadata for uuid: {uuid}")
+        logger.debug(
+            f"Finished initializing CustomListWidgetItemMetadata for uuid: {uuid}"
+        )
         if user_notes == "":
             self.user_notes = auxdb_get_mod_user_notes(
                 settings_controller, uuid, aux_metadata_controller, aux_metadata_session

--- a/app/utils/db_builder_core.py
+++ b/app/utils/db_builder_core.py
@@ -64,7 +64,9 @@ class DBBuilderCore:
         # We only support "no_local" mode in the CLI
         mode = "no_local"
 
-        self.progress_callback(f"\nInitiating RimSort Steam Database Builder with mode : {mode}\n")
+        self.progress_callback(
+            f"\nInitiating RimSort Steam Database Builder with mode : {mode}\n"
+        )
 
         if len(self.apikey) == 32:  # If supplied WebAPI key is 32 characters
             self.progress_callback("Received valid Steam WebAPI key")
@@ -89,17 +91,25 @@ class DBBuilderCore:
                 )
                 return False  # Exit operation
 
-            database = self._init_empty_db_from_publishedfileids(dynamic_query.publishedfileids)
-            dynamic_query.create_steam_db(database=database, publishedfileids=dynamic_query.publishedfileids)
+            database = self._init_empty_db_from_publishedfileids(
+                dynamic_query.publishedfileids
+            )
+            dynamic_query.create_steam_db(
+                database=database, publishedfileids=dynamic_query.publishedfileids
+            )
             self._output_database(dynamic_query.database)
             self.progress_callback("SteamDatabasebuilder: Completed!")
             return True
         else:  # Otherwise, API key is not valid
-            self.progress_callback("SteamDatabaseBuilder (no_local): Invalid Steam WebAPI key!")
+            self.progress_callback(
+                "SteamDatabaseBuilder (no_local): Invalid Steam WebAPI key!"
+            )
             self.progress_callback("SteamDatabaseBuilder (no_local): Exiting...")
             return False
 
-    def _init_empty_db_from_publishedfileids(self, publishedfileids: list[str]) -> dict[str, Any]:
+    def _init_empty_db_from_publishedfileids(
+        self, publishedfileids: list[str]
+    ) -> dict[str, Any]:
         """
         Initialize an empty database from a list of PublishedFileIds.
 
@@ -129,7 +139,11 @@ class DBBuilderCore:
                 },
             },
         }
-        total = len(database["database"].keys()) if isinstance(database["database"], dict) else 0
+        total = (
+            len(database["database"].keys())
+            if isinstance(database["database"], dict)
+            else 0
+        )
         self.progress_callback(
             f"\nPopulated {total} items queried from Steam Workshop into initial database for AppId {self.appid}"
         )
@@ -159,7 +173,9 @@ class DBBuilderCore:
                     self.progress_callback("\nReading info from file...")
                     db_to_update = json.loads(json_string)
                     self.progress_callback("Retrieved cached database!\n")
-                self.progress_callback("Recursively updating previous database with new metadata...\n")
+                self.progress_callback(
+                    "Recursively updating previous database with new metadata...\n"
+                )
                 recursively_update_dict(
                     db_to_update,
                     database,
@@ -169,14 +185,21 @@ class DBBuilderCore:
                 with open(self.output_database_path, "w", encoding="utf-8") as output:
                     json.dump(db_to_update, output, indent=4)
             else:
-                self.progress_callback("Unable to load database from specified path! Does the file exist...?")
-                appended_path = str(
-                    Path(self.output_database_path).parent / ("NEW_" + Path(self.output_database_path).name)
+                self.progress_callback(
+                    "Unable to load database from specified path! Does the file exist...?"
                 )
-                self.progress_callback(f"\nCaching DynamicQuery result:\n\n{appended_path}")
+                appended_path = str(
+                    Path(self.output_database_path).parent
+                    / ("NEW_" + Path(self.output_database_path).name)
+                )
+                self.progress_callback(
+                    f"\nCaching DynamicQuery result:\n\n{appended_path}"
+                )
                 with open(appended_path, "w", encoding="utf-8") as output:
                     json.dump(database, output, indent=4)
         else:  # Dump new db to specified path, effectively "overwriting" the db with fresh data
-            self.progress_callback(f"\nCaching DynamicQuery result:\n{self.output_database_path}")
+            self.progress_callback(
+                f"\nCaching DynamicQuery result:\n{self.output_database_path}"
+            )
             with open(self.output_database_path, "w", encoding="utf-8") as output:
                 json.dump(database, output, indent=4)

--- a/app/utils/dds_utility.py
+++ b/app/utils/dds_utility.py
@@ -17,7 +17,9 @@ class DDSUtility:
 
     def delete_dds_files_without_png(self) -> None:
         """Deletes all DDS files that do not have a corresponding PNG file."""
-        logger.info("Running checks for deleting DDS files without corresponding PNG files...")
+        logger.info(
+            "Running checks for deleting DDS files without corresponding PNG files..."
+        )
         local_mods_target = self.settings_controller.settings.instances[
             self.settings_controller.settings.current_instance
         ].local_folder
@@ -27,7 +29,9 @@ class DDSUtility:
 
         # Combine both paths to search for DDS files
         combined_paths = [local_mods_target, workshop_mods_target]
-        combined_paths = [path for path in combined_paths if path and os.path.exists(path)]
+        combined_paths = [
+            path for path in combined_paths if path and os.path.exists(path)
+        ]
 
         dds_files = []
         for path in combined_paths:
@@ -45,4 +49,6 @@ class DDSUtility:
                 except OSError as e:
                     logger.error(f"Failed to delete {dds_file}: {e}")
 
-        logger.info(f"Deleted {deleted_count} DDS files without corresponding PNG files")
+        logger.info(
+            f"Deleted {deleted_count} DDS files without corresponding PNG files"
+        )

--- a/app/utils/external_metadata_loaders.py
+++ b/app/utils/external_metadata_loaders.py
@@ -35,7 +35,9 @@ class ExternalMetadataLoader:
             path,
         )
 
-    def _validate_db_path(self, path: str, db_type: str, expect_directory: bool = False) -> bool:
+    def _validate_db_path(
+        self, path: str, db_type: str, expect_directory: bool = False
+    ) -> bool:
         """Validate that a database path exists and matches expected type."""
         if not os.path.exists(path):
             self._emit_db_error(
@@ -140,12 +142,22 @@ class ExternalMetadataLoader:
                 self.manager.external_user_rules = rules
             else:
                 self.manager.external_user_rules = None
-            total_entries = len(self.manager.external_user_rules) if self.manager.external_user_rules else 0
+            total_entries = (
+                len(self.manager.external_user_rules)
+                if self.manager.external_user_rules
+                else 0
+            )
             if self.manager.external_user_rules is None:
-                logger.warning("Unable to load userRules.json. 'rules' is None or not a dict")
-            logger.info(f"Loaded {total_entries} additional sorting rules from User Rules")
+                logger.warning(
+                    "Unable to load userRules.json. 'rules' is None or not a dict"
+                )
+            logger.info(
+                f"Loaded {total_entries} additional sorting rules from User Rules"
+            )
 
-    def _load_steam_db(self, life: int, path: str) -> tuple[dict[str, Any] | None, str | None]:
+    def _load_steam_db(
+        self, life: int, path: str
+    ) -> tuple[dict[str, Any] | None, str | None]:
         """Load and validate Steam database with expiry checking.
 
         NOTE: Steam DB has special handling for expired data - it will still be loaded
@@ -191,7 +203,9 @@ class ExternalMetadataLoader:
 
         db_json_data = db_data.get("database", {})
         total_entries = len(db_json_data)
-        logger.info(f"Loaded metadata for {total_entries} Steam Workshop mods from Steam DB")
+        logger.info(
+            f"Loaded metadata for {total_entries} Steam Workshop mods from Steam DB"
+        )
 
         # Build packageid to name mapping for faster lookups
         self.manager.steamdb_packageid_to_name = {
@@ -220,7 +234,9 @@ class ExternalMetadataLoader:
             else (None, None)
         )
 
-    def _load_community_rules_db(self, path: str) -> tuple[dict[str, Any] | None, str | None]:
+    def _load_community_rules_db(
+        self, path: str
+    ) -> tuple[dict[str, Any] | None, str | None]:
         """Load and validate Community Rules database."""
         logger.info(f"Checking for Community Rules DB at: {path}")
         if not self._validate_db_path(path, "Community Rules"):
@@ -233,7 +249,9 @@ class ExternalMetadataLoader:
 
         community_rules_json_data = rule_data.get("rules", {})
         total_entries = len(community_rules_json_data)
-        logger.info(f"Loaded {total_entries} additional sorting rules from Community Rules")
+        logger.info(
+            f"Loaded {total_entries} additional sorting rules from Community Rules"
+        )
         return community_rules_json_data, path
 
     def _load_community_rules_metadata(self, settings: Any) -> None:
@@ -254,7 +272,9 @@ class ExternalMetadataLoader:
             else (None, None)
         )
 
-    def _load_no_version_warning_db(self, path: str) -> tuple[list[str] | None, str | None]:
+    def _load_no_version_warning_db(
+        self, path: str
+    ) -> tuple[list[str] | None, str | None]:
         """Load and validate No Version Warning database."""
         logger.info(f'Checking for "No Version Warning" DB at: {path}')
         if not self._validate_db_path(path, "No Version Warning"):
@@ -263,7 +283,9 @@ class ExternalMetadataLoader:
         logger.info("No Version Warning DB exists, loading")
         no_version_warning_json_data = xml_path_to_json(path)
         total_entries = len(no_version_warning_json_data)
-        logger.info(f'Loaded {total_entries} compatibility version overrides from "No Version Warning"')
+        logger.info(
+            f'Loaded {total_entries} compatibility version overrides from "No Version Warning"'
+        )
         return list(
             map(
                 str.lower,
@@ -290,7 +312,9 @@ class ExternalMetadataLoader:
             else (None, None)
         )
 
-    def _load_use_this_instead_db(self, path: str) -> tuple[dict[str, Any] | None, str | None]:
+    def _load_use_this_instead_db(
+        self, path: str
+    ) -> tuple[dict[str, Any] | None, str | None]:
         """Load and validate Use This Instead database."""
         logger.info(f"Checking for Use This Instead DB at: {path}")
         if not self._validate_db_path(path, "Use This Instead"):
@@ -302,7 +326,9 @@ class ExternalMetadataLoader:
             return None, None
 
         total_entries = len(db_data)
-        logger.info(f"Loaded metadata for {total_entries} mod replacements from Use This Instead DB")
+        logger.info(
+            f"Loaded metadata for {total_entries} mod replacements from Use This Instead DB"
+        )
         return db_data, path
 
     def _load_use_this_instead_metadata(self, settings: Any) -> None:

--- a/app/utils/file_search.py
+++ b/app/utils/file_search.py
@@ -48,7 +48,9 @@ class FileSearch:
         search_options["preview"] = True
         search_options["return_dict"] = True
 
-        for result in self._generic_search(search_text, root_paths, search_options, result_callback):
+        for result in self._generic_search(
+            search_text, root_paths, search_options, result_callback
+        ):
             if isinstance(result, dict):
                 yield result
 
@@ -96,17 +98,24 @@ class FileSearch:
                         continue
 
                     # Only process files with specified extensions if provided
-                    if file_extensions and not any(filename.lower().endswith(ext.lower()) for ext in file_extensions):
+                    if file_extensions and not any(
+                        filename.lower().endswith(ext.lower())
+                        for ext in file_extensions
+                    ):
                         continue
 
                     file_path = os.path.join(dirpath, filename)
                     try:
                         for content_chunk in self._read_file_in_chunks(file_path):
-                            if self._matches(content_chunk, search_text, case_sensitive, use_regex):
+                            if self._matches(
+                                content_chunk, search_text, case_sensitive, use_regex
+                            ):
                                 if return_dict:
                                     result: dict[str, str] | Tuple[str, str, str] = {
                                         "file_path": file_path,
-                                        "preview": self._get_preview(content_chunk, search_text, case_sensitive)
+                                        "preview": self._get_preview(
+                                            content_chunk, search_text, case_sensitive
+                                        )
                                         if preview
                                         else "",
                                     }
@@ -131,7 +140,9 @@ class FileSearch:
                     except Exception as e:
                         logger.error(f"Error reading file {file_path}: {e}")
 
-    def _read_file_in_chunks(self, file_path: str, chunk_size: int = 1024 * 1024) -> Generator[str, None, None]:
+    def _read_file_in_chunks(
+        self, file_path: str, chunk_size: int = 1024 * 1024
+    ) -> Generator[str, None, None]:
         """
         Read a file in chunks to handle large files efficiently.
 
@@ -185,7 +196,9 @@ class FileSearch:
                 search_options["use_regex"] = True
 
             # Use a generator expression to ensure we only yield tuples
-            for result in self._generic_search(search_text, root_paths, search_options, result_callback):
+            for result in self._generic_search(
+                search_text, root_paths, search_options, result_callback
+            ):
                 if isinstance(result, tuple):
                     yield result
 
@@ -196,7 +209,9 @@ class FileSearch:
     standard_search = property(lambda self: self._create_search_method("standard"))
     pattern_search = property(lambda self: self._create_search_method("pattern"))
 
-    def _matches(self, content: str, search_text: str, case_sensitive: bool, use_regex: bool) -> bool:
+    def _matches(
+        self, content: str, search_text: str, case_sensitive: bool, use_regex: bool
+    ) -> bool:
         """Check if the content matches the search criteria."""
         if use_regex:
             flags = 0 if case_sensitive else re.IGNORECASE
@@ -260,7 +275,9 @@ class FileSearch:
                     if encoding:
                         return raw_data.decode(encoding, errors="ignore")
         except Exception as e:
-            logger.error(f"Failed to read file {file_path} with charset_normalizer: {e}")
+            logger.error(
+                f"Failed to read file {file_path} with charset_normalizer: {e}"
+            )
 
         encodings = ["utf-8", "utf-8-sig", "latin-1", "cp1252", "iso-8859-1"]
         return self._read_file_with_encodings(file_path, encodings)

--- a/app/utils/files.py
+++ b/app/utils/files.py
@@ -35,7 +35,9 @@ def subfolder_contains_candidate_path(
 
     subfolder_paths = [subfolder]
     try:
-        subfolder_paths.extend([subfolder / folder for folder in subfolder.iterdir() if folder.is_dir()])
+        subfolder_paths.extend(
+            [subfolder / folder for folder in subfolder.iterdir() if folder.is_dir()]
+        )
     except Exception:
         # Could not list subdirectories, return False
         return False
@@ -61,10 +63,14 @@ def cleanup_old_backups(backup_dir: Path, keep: int) -> None:
     Deletes old backups, keeping only the specified number of recent ones.
     """
     if keep == -1:
-        logger.info("Skipping backup cleanup because retention count is set to -1 (keep all).")
+        logger.info(
+            "Skipping backup cleanup because retention count is set to -1 (keep all)."
+        )
         return
     try:
-        logger.info(f"Cleaning up old backups in {backup_dir}. Keeping the most recent {keep}.")
+        logger.info(
+            f"Cleaning up old backups in {backup_dir}. Keeping the most recent {keep}."
+        )
         backups = sorted(
             [p for p in backup_dir.glob("Saves_*.zip")],
             key=lambda p: p.stat().st_mtime,
@@ -86,7 +92,9 @@ def cleanup_old_backups(backup_dir: Path, keep: int) -> None:
         logger.error(f"An error occurred during backup cleanup: {e}")
 
 
-def create_saves_backup(saves_path: Path, backup_dir: Path, settings: Settings) -> str | None:
+def create_saves_backup(
+    saves_path: Path, backup_dir: Path, settings: Settings
+) -> str | None:
     """
     Creates a compressed backup of the specified number of recent save files and cleans up old backups.
     """
@@ -104,7 +112,9 @@ def create_saves_backup(saves_path: Path, backup_dir: Path, settings: Settings) 
         if compression_count == -1:
             recent_files = all_files
         elif compression_count == 0:
-            logger.info("No save files will be backed up because compression count is set to 0.")
+            logger.info(
+                "No save files will be backed up because compression count is set to 0."
+            )
             return None
         else:
             recent_files = all_files[:compression_count]
@@ -120,8 +130,12 @@ def create_saves_backup(saves_path: Path, backup_dir: Path, settings: Settings) 
         backup_filename = f"Saves_{timestamp}.zip"
         backup_archive_path = backup_dir / backup_filename
 
-        logger.info(f"Compressing {len(recent_files)} most recent save(s) to {backup_archive_path} using DEFLATED...")
-        with zipfile.ZipFile(backup_archive_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        logger.info(
+            f"Compressing {len(recent_files)} most recent save(s) to {backup_archive_path} using DEFLATED..."
+        )
+        with zipfile.ZipFile(
+            backup_archive_path, "w", compression=zipfile.ZIP_DEFLATED
+        ) as zf:
             for file_path in recent_files:
                 arc_name = file_path.relative_to(saves_path)
                 zf.write(file_path, arc_name)
@@ -154,7 +168,9 @@ def create_backup_in_thread(settings: Settings) -> None:
 
     current_instance = settings.instances.get(settings.current_instance)
     if not current_instance or not current_instance.config_folder:
-        logger.warning("No active instance or config folder path found. Cannot perform backup.")
+        logger.warning(
+            "No active instance or config folder path found. Cannot perform backup."
+        )
         return
 
     config_path = Path(current_instance.config_folder)

--- a/app/utils/generic.py
+++ b/app/utils/generic.py
@@ -116,8 +116,12 @@ def rmtree(path: str | Path, **kwargs: Any) -> bool:
         logger.error(f"Tried to delete directory that does not exist: {path}")
         dialogue.show_warning(
             title=translate("rmtree", "Failed to remove directory"),
-            text=translate("rmtree", "RimSort tried to remove a directory that does not exist."),
-            details=translate("rmtree", "Directory does not exist: {path}").format(path=path),
+            text=translate(
+                "rmtree", "RimSort tried to remove a directory that does not exist."
+            ),
+            details=translate("rmtree", "Directory does not exist: {path}").format(
+                path=path
+            ),
         )
         return False
 
@@ -125,8 +129,12 @@ def rmtree(path: str | Path, **kwargs: Any) -> bool:
         logger.error(f"rmtree path is not a directory: {path}")
         dialogue.show_warning(
             title=translate("rmtree", "Failed to remove directory"),
-            text=translate("rmtree", "RimSort tried to remove a directory that is not a directory."),
-            details=translate("rmtree", "Path is not a directory: {path}").format(path=path),
+            text=translate(
+                "rmtree", "RimSort tried to remove a directory that is not a directory."
+            ),
+            details=translate("rmtree", "Path is not a directory: {path}").format(
+                path=path
+            ),
         )
         return False
 
@@ -140,7 +148,9 @@ def rmtree(path: str | Path, **kwargs: Any) -> bool:
         logger.error(f"Failed to remove directory: {e}")
         dialogue.show_warning(
             title=translate("rmtree", "Failed to remove directory"),
-            text=translate("rmtree", "An OSError occurred while trying to remove a directory."),
+            text=translate(
+                "rmtree", "An OSError occurred while trying to remove a directory."
+            ),
             information=translate(
                 "rmtree",
                 "{e.strerror} occurred at {e.filename} with error code {error_code}.",
@@ -155,7 +165,9 @@ def rmtree(path: str | Path, **kwargs: Any) -> bool:
     return True
 
 
-def delete_files_with_condition(directory: Path | str, condition: Callable[[str], bool]) -> bool:
+def delete_files_with_condition(
+    directory: Path | str, condition: Callable[[str], bool]
+) -> bool:
     # Check if directory exists
     if not os.path.exists(directory):
         logger.warning(f"Directory does not exist: {directory}")
@@ -195,7 +207,9 @@ def delete_files_with_condition(directory: Path | str, condition: Callable[[str]
 
 
 def delete_files_except_extension(directory: Path | str, extension: str) -> bool:
-    return delete_files_with_condition(directory, lambda file: not file.endswith(extension))
+    return delete_files_with_condition(
+        directory, lambda file: not file.endswith(extension)
+    )
 
 
 def delete_files_only_extension(directory: Path | str, extension: str) -> bool:
@@ -266,15 +280,22 @@ def directories(mods_path: Path | str) -> list[str]:
         return []
 
 
-def attempt_chmod(func: Callable[[str], Any], path: str, excinfo: BaseException) -> bool:
+def attempt_chmod(
+    func: Callable[[str], Any], path: str, excinfo: BaseException
+) -> bool:
     if excinfo is not None and isinstance(excinfo, OSError):
-        if func in (os.rmdir, os.remove, os.unlink, os.listdir) and excinfo.errno == EACCES:
+        if (
+            func in (os.rmdir, os.remove, os.unlink, os.listdir)
+            and excinfo.errno == EACCES
+        ):
             os.chmod(path, S_IRWXU | S_IRWXG | S_IRWXO)  # 0777
             try:
                 func(path)
                 return True
             except Exception as e:
-                logger.warning(f"attempt_chmod for {func.__name__} double failure at {path}: {e}")
+                logger.warning(
+                    f"attempt_chmod for {func.__name__} double failure at {path}: {e}"
+                )
                 return False
 
     return False
@@ -316,12 +337,17 @@ def get_executable_path(game_install_path: Path) -> str | None:
                     p / "RimWorldWin64.exe",
                     p / "RimWorldWin.exe",
                 ]
-                if exe.exists() and (exe.name != "RimWorldLinux" or os.access(exe, os.X_OK))
+                if exe.exists()
+                and (exe.name != "RimWorldLinux" or os.access(exe, os.X_OK))
             ),
             None,
         ),
         "Windows": lambda p: next(
-            (str(exe) for exe in [p / "RimWorldWin64.exe", p / "RimWorldWin.exe"] if exe.exists()),
+            (
+                str(exe)
+                for exe in [p / "RimWorldWin64.exe", p / "RimWorldWin.exe"]
+                if exe.exists()
+            ),
             None,
         ),
     }
@@ -405,7 +431,9 @@ def launch_game_process(game_install_path: Path, args: list[str]) -> None:
         env_vars=env_vars,
         wrapper_commands=wrapper_commands,
     )
-    logger.info(f"Launched independent RimWorld game process with PID {pid} using args {popen_args}")
+    logger.info(
+        f"Launched independent RimWorld game process with PID {pid} using args {popen_args}"
+    )
 
 
 def validate_game_executable(game_folder: str) -> bool:
@@ -421,7 +449,9 @@ def validate_game_executable(game_folder: str) -> bool:
 
     game_install_path = Path(game_folder)
     if not game_install_path.exists() or not game_install_path.is_dir():
-        logger.info(f"Game folder does not exist or is not a directory: {game_install_path}")
+        logger.info(
+            f"Game folder does not exist or is not a directory: {game_install_path}"
+        )
         return False
 
     # Use the new get_executable_path function for validation
@@ -431,7 +461,9 @@ def validate_game_executable(game_folder: str) -> bool:
         return True
 
     system_name = platform.system()
-    logger.info(f"No valid RimWorld executable found for {system_name} in: {game_install_path}")
+    logger.info(
+        f"No valid RimWorld executable found for {system_name} in: {game_install_path}"
+    )
     return False
 
 
@@ -540,7 +572,9 @@ def platform_specific_open(path: str | Path) -> None:
         except OSError as e:
             # Handle cases where no default application is associated
             if e.winerror == -2147221003:  # Application not found
-                logger.warning(f"No default application found for {path}, trying notepad")
+                logger.warning(
+                    f"No default application found for {path}, trying notepad"
+                )
                 # Try to open with notepad as fallback
                 try:
                     subprocess.Popen(["notepad.exe", path])
@@ -686,7 +720,9 @@ def check_valid_http_git_url(url: str) -> bool:
     return url and url != "" and url.startswith("http://") or url.startswith("https://")
 
 
-def get_path_up_to_string(path: Path, stop_string: str, exclude: bool = False) -> Path | str:
+def get_path_up_to_string(
+    path: Path, stop_string: str, exclude: bool = False
+) -> Path | str:
     """
     Returns a Path up to the stop_string.
 
@@ -782,7 +818,9 @@ def check_internet_connection(timeout: float = 10) -> bool:
             logger.debug(f"Connection to {url} failed: {e}")
             failed_urls.append(url)
 
-    logger.error(f"No internet connection detected. Failed to reach: {', '.join(failed_urls)}")
+    logger.error(
+        f"No internet connection detected. Failed to reach: {', '.join(failed_urls)}"
+    )
     dialogue.show_internet_connection_error(failed_urls=failed_urls)
     return False
 

--- a/app/utils/git_utils.py
+++ b/app/utils/git_utils.py
@@ -68,7 +68,9 @@ class GitOperationType(Enum):
 class GitNotificationHandler(Protocol):
     """Protocol for handling git operation notifications."""
 
-    def show_error(self, title: str, message: str, details: Optional[str] = None) -> None:
+    def show_error(
+        self, title: str, message: str, details: Optional[str] = None
+    ) -> None:
         """Show error notification to user."""
         ...
 
@@ -76,7 +78,9 @@ class GitNotificationHandler(Protocol):
 class DefaultNotificationHandler:
     """Default implementation using QMessageBox for notifications."""
 
-    def show_error(self, title: str, message: str, details: Optional[str] = None) -> None:
+    def show_error(
+        self, title: str, message: str, details: Optional[str] = None
+    ) -> None:
         """Show error notification using InformationBox."""
         InformationBox(
             title=title,
@@ -109,12 +113,16 @@ class GitOperationConfig:
         return cls(notify_errors=False)
 
     @classmethod
-    def create_with_handler(cls, handler: GitNotificationHandler) -> "GitOperationConfig":
+    def create_with_handler(
+        cls, handler: GitNotificationHandler
+    ) -> "GitOperationConfig":
         """Create a config with a specific notification handler."""
         return cls(notify_errors=True, notification_handler=handler)
 
     @classmethod
-    def create_with_timeout(cls, fetch_timeout: int = 30, connection_timeout: int = 10) -> "GitOperationConfig":
+    def create_with_timeout(
+        cls, fetch_timeout: int = 30, connection_timeout: int = 10
+    ) -> "GitOperationConfig":
         """Create a config with custom timeout values."""
         return cls(fetch_timeout=fetch_timeout, connection_timeout=connection_timeout)
 
@@ -235,14 +243,20 @@ def _attempt_repository_repair(
                 delete_files_with_condition(repo_path_str, lambda _: True)
 
                 if not repo_path_obj.exists():
-                    logger.info(f"Successfully deleted corrupted repository at: {repo_path_str}")
+                    logger.info(
+                        f"Successfully deleted corrupted repository at: {repo_path_str}"
+                    )
                     break
 
                 if attempt < max_retries - 1:
-                    logger.warning(f"Deletion attempt {attempt + 1} failed, retrying... ({repo_path_str})")
+                    logger.warning(
+                        f"Deletion attempt {attempt + 1} failed, retrying... ({repo_path_str})"
+                    )
                     time.sleep(0.5 * (attempt + 1))  # Exponential backoff
                 else:
-                    logger.error(f"Failed to delete corrupted repository: {repo_path_str}")
+                    logger.error(
+                        f"Failed to delete corrupted repository: {repo_path_str}"
+                    )
                     return False
         else:
             logger.info(f"Repository directory already gone: {repo_path_str}")
@@ -295,7 +309,9 @@ def _handle_git_error(
         True if the error was due to corruption and repair was attempted, False otherwise.
     """
     error_msg = str(error)
-    logger.error(f"Git {operation.value} operation failed{f' ({context})' if context else ''}: {error_msg}")
+    logger.error(
+        f"Git {operation.value} operation failed{f' ({context})' if context else ''}: {error_msg}"
+    )
 
     # Check for repository corruption
     corruption_indicators = [
@@ -306,7 +322,10 @@ def _handle_git_error(
         "pack corruption",
     ]
 
-    if any(indicator in error_msg.lower() for indicator in corruption_indicators) and repo_path:
+    if (
+        any(indicator in error_msg.lower() for indicator in corruption_indicators)
+        and repo_path
+    ):
         logger.warning(f"Detected repository corruption in: {repo_path}")
         if _attempt_repository_repair(repo_path, repo_url, repo):
             logger.info(f"Repository corruption repair successful: {repo_path}")
@@ -518,7 +537,9 @@ def get_config(config: Optional[GitOperationConfig]) -> GitOperationConfig:
     return config
 
 
-def git_discover(path: str | Path, config: Optional[GitOperationConfig] = None) -> Optional[Repository]:
+def git_discover(
+    path: str | Path, config: Optional[GitOperationConfig] = None
+) -> Optional[Repository]:
     """Discover a git repository at a given path.
 
     Args:
@@ -543,7 +564,9 @@ def git_discover(path: str | Path, config: Optional[GitOperationConfig] = None) 
         return Repository(repo_path)
 
     except pygit2.GitError as e:
-        _handle_git_error(GitOperationType.DISCOVER, e, config, context=f"repository at: {path_str}")
+        _handle_git_error(
+            GitOperationType.DISCOVER, e, config, context=f"repository at: {path_str}"
+        )
         return None
 
 
@@ -623,7 +646,9 @@ def git_clone(
     # Validate path
     if repo_path_obj.exists() and not repo_path_obj.is_dir():
         error_msg = "The path is not a directory."
-        logger.error(f"Failed to clone repository: {repo_url} to {repo_path} - {error_msg}")
+        logger.error(
+            f"Failed to clone repository: {repo_url} to {repo_path} - {error_msg}"
+        )
         _handle_git_error(
             GitOperationType.CLONE,
             ValueError(error_msg),
@@ -636,7 +661,9 @@ def git_clone(
     if repo_path_obj.exists() and any(repo_path_obj.iterdir()):
         if not force:
             error_msg = f"The path is not empty: {repo_path}"
-            logger.error(f"Failed to clone repository: {repo_url} to {repo_path} - {error_msg}")
+            logger.error(
+                f"Failed to clone repository: {repo_url} to {repo_path} - {error_msg}"
+            )
             _handle_git_error(
                 GitOperationType.CLONE,
                 ValueError(error_msg),
@@ -646,19 +673,27 @@ def git_clone(
             return None, GitCloneResult.PATH_NOT_EMPTY
         else:
             # Force the clone operation by deleting the directory
-            logger.warning(f"Force cloning repository by deleting the local directory: {repo_path}")
+            logger.warning(
+                f"Force cloning repository by deleting the local directory: {repo_path}"
+            )
 
             # Attempt deletion
-            success = delete_files_with_condition(repo_path_str, lambda file: not file.endswith(".dds"))
+            success = delete_files_with_condition(
+                repo_path_str, lambda file: not file.endswith(".dds")
+            )
 
             if not success:
                 logger.error(f"Failed to delete the local directory: {repo_path}")
 
                 # If deletion failed, try alternative approaches
                 # 1. Attempt corruption repair
-                logger.warning(f"Attempting automatic corruption repair due to deletion failure: {repo_path}")
+                logger.warning(
+                    f"Attempting automatic corruption repair due to deletion failure: {repo_path}"
+                )
                 if _attempt_repository_repair(repo_path_str, repo_url, repo=None):
-                    logger.info(f"Successfully repaired and recovered corrupted repository: {repo_path}")
+                    logger.info(
+                        f"Successfully repaired and recovered corrupted repository: {repo_path}"
+                    )
                     # Try clone again after repair
                     try:
                         repo = pygit2.clone_repository(
@@ -674,7 +709,9 @@ def git_clone(
                         return None, GitCloneResult.GIT_ERROR
                 else:
                     # 2. If repair failed, try renaming the old directory and cloning fresh
-                    logger.warning(f"Repair failed, attempting to rename old directory and clone fresh: {repo_path}")
+                    logger.warning(
+                        f"Repair failed, attempting to rename old directory and clone fresh: {repo_path}"
+                    )
                     try:
                         timestamp = int(time.time())
                         backup_path = f"{repo_path_str}_backup_{timestamp}"
@@ -689,14 +726,18 @@ def git_clone(
                             depth=depth,
                         )
                         repo = Repository(repo_path_str)
-                        logger.info(f"Successfully cloned after renaming backup: {repo_path}")
+                        logger.info(
+                            f"Successfully cloned after renaming backup: {repo_path}"
+                        )
                         return repo, GitCloneResult.CLONED
                     except Exception as e:
                         logger.error(f"Failed to clone after renaming backup: {e}")
                         return None, GitCloneResult.PATH_DELETE_ERROR
 
     try:
-        repo = pygit2.clone_repository(repo_url, repo_path_str, checkout_branch=checkout_branch, depth=depth)
+        repo = pygit2.clone_repository(
+            repo_url, repo_path_str, checkout_branch=checkout_branch, depth=depth
+        )
         # Wrap the returned repo in the Python wrapper class for type consistency
         repo = Repository(repo_path_str)
         return repo, GitCloneResult.CLONED
@@ -710,7 +751,9 @@ def git_clone(
         return None, GitCloneResult.GIT_ERROR
 
 
-def git_check_updates(repo: Repository, config: Optional[GitOperationConfig] = None) -> Optional[pygit2.Walker]:
+def git_check_updates(
+    repo: Repository, config: Optional[GitOperationConfig] = None
+) -> Optional[pygit2.Walker]:
     """Check for updates in a git repository in the current branch.
 
     Args:
@@ -738,7 +781,9 @@ def git_check_updates(repo: Repository, config: Optional[GitOperationConfig] = N
             return None  # Fetch updates from remote with timeout
         try:
             if not _fetch_with_timeout(remote, config.fetch_timeout):
-                logger.error(f"Fetch operation timed out after {config.fetch_timeout} seconds")
+                logger.error(
+                    f"Fetch operation timed out after {config.fetch_timeout} seconds"
+                )
                 return None
         except Exception as e:
             logger.error(f"Fetch operation failed: {str(e)}")
@@ -839,7 +884,9 @@ def git_pull(
         # Fetch updates from remote with timeout
         try:
             if not _fetch_with_timeout(remote, config.fetch_timeout):
-                logger.error(f"Fetch operation timed out after {config.fetch_timeout} seconds")
+                logger.error(
+                    f"Fetch operation timed out after {config.fetch_timeout} seconds"
+                )
                 return GitPullResult.GIT_ERROR
         except Exception as e:
             logger.error(f"Fetch operation failed: {str(e)}")
@@ -887,7 +934,9 @@ def git_pull(
 
         if merge_result & pygit2.enums.MergeAnalysis.UP_TO_DATE:
             if reset_working_tree:
-                logger.debug("Working tree is up to date, but reset requested — performing hard reset")
+                logger.debug(
+                    "Working tree is up to date, but reset requested — performing hard reset"
+                )
                 repo.reset(repo.head.target, ResetMode.HARD)
             logger.info("Repository is already up to date.")
             return GitPullResult.UP_TO_DATE
@@ -935,7 +984,9 @@ def git_pull(
 
                 if config.notify_errors:
                     if conflict_files:
-                        logger.error(f"Git merge conflicts in files: {', '.join(conflict_files)}")
+                        logger.error(
+                            f"Git merge conflicts in files: {', '.join(conflict_files)}"
+                        )
                     else:
                         logger.error("Multiple git merge conflicts detected")
 
@@ -943,7 +994,9 @@ def git_pull(
                 try:
                     repo.state_cleanup()
                     repo.checkout_head(strategy=CheckoutStrategy.FORCE)
-                    logger.info("Aborted merge due to conflicts and reset repository state.")
+                    logger.info(
+                        "Aborted merge due to conflicts and reset repository state."
+                    )
                 except Exception as e:
                     logger.error(f"Failed to abort merge and reset state: {e}")
 
@@ -1182,7 +1235,9 @@ def git_stage_commit(
                 # This might be the first commit (no HEAD yet)
                 pass
 
-            commit_id = repo.create_commit("HEAD", author, committer, message, tree_id, parents)
+            commit_id = repo.create_commit(
+                "HEAD", author, committer, message, tree_id, parents
+            )
 
             logger.info(f"Changes staged and committed in the repository: {repo.path}")
             logger.debug(f"Created commit: {commit_id}")
@@ -1198,7 +1253,9 @@ def git_stage_commit(
             return GitStageCommitResult.COMMIT_FAILED
 
     except pygit2.GitError as e:
-        _handle_git_error(GitOperationType.STAGE_COMMIT, e, config, context=f"repository: {repo.path}")
+        _handle_git_error(
+            GitOperationType.STAGE_COMMIT, e, config, context=f"repository: {repo.path}"
+        )
         return GitStageCommitResult.GIT_ERROR
 
 
@@ -1259,11 +1316,15 @@ def git_get_status(
             if flags & pygit2.GIT_STATUS_IGNORED:
                 status_dict["ignored"].append(filepath)
 
-        logger.debug(f"Repository status: {sum(len(v) for v in status_dict.values())} files with changes")
+        logger.debug(
+            f"Repository status: {sum(len(v) for v in status_dict.values())} files with changes"
+        )
         return status_dict
 
     except pygit2.GitError as e:
-        _handle_git_error(GitOperationType.STATUS, e, config, context=f"repository: {repo.path}")
+        _handle_git_error(
+            GitOperationType.STATUS, e, config, context=f"repository: {repo.path}"
+        )
         return None
 
 
@@ -1392,7 +1453,9 @@ def git_stash(
                         conflict_files.append(filepath)
 
                 if conflict_files:
-                    logger.warning(f"Conflicts detected during stash pop in files: {conflict_files}")
+                    logger.warning(
+                        f"Conflicts detected during stash pop in files: {conflict_files}"
+                    )
                     return GitStashResult.STASH_POP_CONFLICT
 
                 logger.info("Stash popped successfully")
@@ -1435,7 +1498,9 @@ def git_stash(
         return GitStashResult.GIT_ERROR
 
 
-def git_stash_list(repo: Repository, config: Optional[GitOperationConfig] = None) -> List[str]:
+def git_stash_list(
+    repo: Repository, config: Optional[GitOperationConfig] = None
+) -> List[str]:
     """List stashes in the repository.
 
     Args:
@@ -1500,7 +1565,9 @@ def git_stash_drop(
         return GitStashResult.GIT_ERROR
 
 
-def git_has_uncommitted_changes(repo: Repository, config: Optional[GitOperationConfig] = None) -> bool:
+def git_has_uncommitted_changes(
+    repo: Repository, config: Optional[GitOperationConfig] = None
+) -> bool:
     """Check if the repository has uncommitted changes.
 
     Args:
@@ -1566,7 +1633,9 @@ def git_is_repository(path: str | Path) -> bool:
         return False
 
 
-def git_get_current_branch(repo: Repository, config: Optional[GitOperationConfig] = None) -> Optional[str]:
+def git_get_current_branch(
+    repo: Repository, config: Optional[GitOperationConfig] = None
+) -> Optional[str]:
     """Get the current branch name.
 
     Args:
@@ -1656,7 +1725,9 @@ def get_latest_commit_info(repo: Repository, short_format: bool = True) -> str:
         if isinstance(commit, pygit2.Commit):
             if short_format:
                 short_hash = str(commit.id)[:7]
-                message = commit.message.split("\n")[0]  # Only the first line of the message
+                message = commit.message.split("\n")[
+                    0
+                ]  # Only the first line of the message
                 return f"{short_hash} {message}"
             else:
                 short_hash = str(commit.id)[:7]

--- a/app/utils/git_worker.py
+++ b/app/utils/git_worker.py
@@ -78,7 +78,9 @@ def handle_worker_error(operation_name: str, repo_path: str, error: Exception) -
     return error_msg
 
 
-def validate_repository(repo_path: Path, config: GitOperationConfig, operation_name: str) -> Optional[str]:
+def validate_repository(
+    repo_path: Path, config: GitOperationConfig, operation_name: str
+) -> Optional[str]:
     """Validate repository and return error message if invalid"""
     with git_utils.git_repository(repo_path, config) as repo:
         if repo is None:
@@ -119,15 +121,21 @@ def process_batch_repository(
             "corrupted",
             "pack corruption",
         ]
-        is_corrupted = any(indicator in error_lower for indicator in corruption_indicators)
+        is_corrupted = any(
+            indicator in error_lower for indicator in corruption_indicators
+        )
 
         if is_corrupted:
-            logger.warning(f"Detected repository corruption in {repo_path}, attempting repair")
+            logger.warning(
+                f"Detected repository corruption in {repo_path}, attempting repair"
+            )
             try:
                 # Attempt to repair the corrupted repository
                 repo_path_str = str(repo_path)
                 if git_utils._attempt_repository_repair(repo_path_str, repo=None):
-                    logger.info(f"Successfully repaired corrupted repository: {repo_path}")
+                    logger.info(
+                        f"Successfully repaired corrupted repository: {repo_path}"
+                    )
                     # Try the operation again after repair
                     try:
                         with git_utils.git_repository(repo_path, config) as repo:
@@ -163,11 +171,15 @@ def process_batch_repository(
 class BaseBatchWorker(QRunnable):
     """Base class for batch git operations"""
 
-    def __init__(self, repos_paths: List[Path], config: Optional[GitOperationConfig] = None):
+    def __init__(
+        self, repos_paths: List[Path], config: Optional[GitOperationConfig] = None
+    ):
         super().__init__()
         self.repos_paths = repos_paths
         # Create config with reasonable timeouts for batch operations
-        self.config = config or GitOperationConfig.create_with_timeout(fetch_timeout=30, connection_timeout=10)
+        self.config = config or GitOperationConfig.create_with_timeout(
+            fetch_timeout=30, connection_timeout=10
+        )
         self.signals = BaseBatchSignals()
 
     def execute_batch_operation(
@@ -199,11 +211,15 @@ class BaseGitWorker(QThread):
     progress = Signal(str)  # status message
     error = Signal(str)  # error message
 
-    def __init__(self, repo_path: str | Path, config: Optional[GitOperationConfig] = None):
+    def __init__(
+        self, repo_path: str | Path, config: Optional[GitOperationConfig] = None
+    ):
         super().__init__()
         self.repo_path = repo_path
         # Create config with reasonable timeouts
-        self.config = config or GitOperationConfig.create_with_timeout(fetch_timeout=30, connection_timeout=10)
+        self.config = config or GitOperationConfig.create_with_timeout(
+            fetch_timeout=30, connection_timeout=10
+        )
         self._is_cancelled = False
 
     def cancel(self) -> None:
@@ -259,7 +275,9 @@ class GitCloneWorker(BaseGitWorker):
         """Execute the git clone operation in background"""
         repo: Optional[Any] = None  # Initialize repo to None
         try:
-            logger.info(f"Starting git clone in thread: {self.repo_url} to {self.repo_path}")
+            logger.info(
+                f"Starting git clone in thread: {self.repo_url} to {self.repo_path}"
+            )
 
             if self.isInterruptionRequested():
                 return
@@ -279,7 +297,9 @@ class GitCloneWorker(BaseGitWorker):
                 return
 
             if result.is_successful():
-                self.emit_success(f"Repository cloned successfully to: {self.repo_path}")
+                self.emit_success(
+                    f"Repository cloned successfully to: {self.repo_path}"
+                )
             else:
                 self.emit_error(f"Clone failed: {result}")
 
@@ -344,7 +364,9 @@ class GitPushWorker(BaseGitWorker):
                     return
 
                 if result.is_successful():
-                    self.emit_success(f"Changes pushed successfully from: {self.repo_path}")
+                    self.emit_success(
+                        f"Changes pushed successfully from: {self.repo_path}"
+                    )
                 else:
                     self.emit_error(f"Push failed: {result}")
 
@@ -372,7 +394,9 @@ class GitStageCommitWorker(BaseGitWorker):
     def run(self) -> None:
         """Execute the git stage and commit operation in background"""
         try:
-            logger.info(f"Starting git stage and commit in thread for: {self.repo_path}")
+            logger.info(
+                f"Starting git stage and commit in thread for: {self.repo_path}"
+            )
 
             if self.isInterruptionRequested():
                 return
@@ -399,7 +423,9 @@ class GitStageCommitWorker(BaseGitWorker):
                     return
 
                 if result.is_successful():
-                    self.emit_success(f"Changes staged and committed successfully in: {self.repo_path}")
+                    self.emit_success(
+                        f"Changes staged and committed successfully in: {self.repo_path}"
+                    )
                 else:
                     self.emit_error(f"Stage and commit failed: {result}")
 
@@ -458,7 +484,9 @@ class GitCheckUpdatesWorker(BaseBatchWorker):
         errors: Dict[Path, str] = {}
 
         for repo_path in self.repos_paths:
-            success, commit_msgs, error_msg = check_repository_updates(repo_path, self.config)
+            success, commit_msgs, error_msg = check_repository_updates(
+                repo_path, self.config
+            )
 
             if not success:
                 if "Invalid git repository" in (error_msg or ""):
@@ -468,7 +496,9 @@ class GitCheckUpdatesWorker(BaseBatchWorker):
             elif commit_msgs:  # Only add if there are actual updates
                 updates[repo_path] = commit_msgs
 
-        results = GitCheckResults(updates=updates, invalid_paths=invalid_paths, error=errors)
+        results = GitCheckResults(
+            updates=updates, invalid_paths=invalid_paths, error=errors
+        )
         self.signals.finished.emit(results)
 
 
@@ -498,12 +528,14 @@ class GitBatchUpdateWorker(BaseBatchWorker):
         commit_info: Dict[str, str] = {}
 
         for repo_path in self.repos_paths:
-            success, error_msg = process_batch_repository(repo_path, self.config, git_utils.git_pull, "pull")
+            success, error_msg = process_batch_repository(
+                repo_path, self.config, git_utils.git_pull, "pull"
+            )
 
             if success:
                 successful.append(repo_path)
-                commit_success, latest_commit, commit_error = git_utils.get_repository_latest_commit(
-                    repo_path, self.config
+                commit_success, latest_commit, commit_error = (
+                    git_utils.get_repository_latest_commit(repo_path, self.config)
                 )
                 if commit_success and latest_commit:
                     commit_info[str(repo_path)] = latest_commit
@@ -512,7 +544,9 @@ class GitBatchUpdateWorker(BaseBatchWorker):
             else:
                 failed.append((repo_path, error_msg or "Unknown error"))
 
-        results = GitBatchUpdateResults(successful=successful, failed=failed, commit_info=commit_info)
+        results = GitBatchUpdateResults(
+            successful=successful, failed=failed, commit_info=commit_info
+        )
         self.signals.finished.emit(results)
 
 

--- a/app/utils/gui_info.py
+++ b/app/utils/gui_info.py
@@ -51,8 +51,12 @@ class GUIInfo:
         self._smaller_font: QFont = QFont(self._default_font)
         self._smaller_font.setPointSize(self._smaller_font.pointSize() - 1)
 
-        self._default_font_line_height: int = QFontMetrics(self._default_font).lineSpacing()
-        self._default_font_average_char_width: int = QFontMetrics(self._default_font).averageCharWidth()
+        self._default_font_line_height: int = QFontMetrics(
+            self._default_font
+        ).lineSpacing()
+        self._default_font_average_char_width: int = QFontMetrics(
+            self._default_font
+        ).averageCharWidth()
 
         self._text_field_margins: QMargins = QMargins(4, 4, 4, 4)
 
@@ -196,7 +200,9 @@ def show_dialogue_file(
             return dialog.selectedFiles()[0]
     else:
         if is_save:
-            file_path, _ = QFileDialog.getSaveFileName(parent=None, caption=title, dir=directory, filter=file_filter)
+            file_path, _ = QFileDialog.getSaveFileName(
+                parent=None, caption=title, dir=directory, filter=file_filter
+            )
             return file_path if file_path else None
         else:
             dialog.setFileMode(QFileDialog.FileMode.ExistingFile)

--- a/app/utils/launch_command_parser.py
+++ b/app/utils/launch_command_parser.py
@@ -97,4 +97,6 @@ def parse_launch_command(command_string: str) -> ParsedLaunchCommand:
     # If there are multiple %command% placeholders, subsequent ones become literal args
     game_args = tokens[command_index + 1 :]
 
-    return ParsedLaunchCommand(env_vars=env_vars, wrapper_commands=wrapper_commands, game_args=game_args)
+    return ParsedLaunchCommand(
+        env_vars=env_vars, wrapper_commands=wrapper_commands, game_args=game_args
+    )

--- a/app/utils/metadata.py
+++ b/app/utils/metadata.py
@@ -127,7 +127,11 @@ class MetadataManager(QObject):
             self.workshop_acf_path: str = str(
                 # This is just getting the path 2 directories up from content/294100,
                 # so that we can find workshop/appworkshop_294100.acf
-                Path(self.settings_controller.settings.instances[current_instance].workshop_folder).parent.parent
+                Path(
+                    self.settings_controller.settings.instances[
+                        current_instance
+                    ].workshop_folder
+                ).parent.parent
                 / "appworkshop_294100.acf",
             )
             self.workshop_acf_data: dict[str, Any] = {}
@@ -154,12 +158,20 @@ class MetadataManager(QObject):
 
         if version_file_path.exists():
             try:
-                self.game_version = version_file_path.read_text(encoding="utf-8").strip()
-                logger.info(f"Retrieved game version from Version.txt: {self.game_version}")
+                self.game_version = version_file_path.read_text(
+                    encoding="utf-8"
+                ).strip()
+                logger.info(
+                    f"Retrieved game version from Version.txt: {self.game_version}"
+                )
             except Exception as e:
-                logger.error(f"Unable to parse Version.txt from game folder: {version_file_path}: {e}")
+                logger.error(
+                    f"Unable to parse Version.txt from game folder: {version_file_path}: {e}"
+                )
         else:
-            logger.error(f"The provided Version.txt path does not exist: {version_file_path}")
+            logger.error(
+                f"The provided Version.txt path does not exist: {version_file_path}"
+            )
             self.show_warning_signal.emit(
                 self.tr("Missing Version.txt"),
                 self.tr(
@@ -184,10 +196,24 @@ class MetadataManager(QObject):
         futures = []
         with ThreadPoolExecutor(max_workers=4) as executor:
             futures.append(executor.submit(self.external_loader._load_user_rules))
-            futures.append(executor.submit(self.external_loader._load_steam_metadata, settings))
-            futures.append(executor.submit(self.external_loader._load_community_rules_metadata, settings))
-            futures.append(executor.submit(self.external_loader._load_no_version_warning_metadata, settings))
-            futures.append(executor.submit(self.external_loader._load_use_this_instead_metadata, settings))
+            futures.append(
+                executor.submit(self.external_loader._load_steam_metadata, settings)
+            )
+            futures.append(
+                executor.submit(
+                    self.external_loader._load_community_rules_metadata, settings
+                )
+            )
+            futures.append(
+                executor.submit(
+                    self.external_loader._load_no_version_warning_metadata, settings
+                )
+            )
+            futures.append(
+                executor.submit(
+                    self.external_loader._load_use_this_instead_metadata, settings
+                )
+            )
 
         # Wait for all threads to complete with error handling
         loader_names = [
@@ -206,9 +232,13 @@ class MetadataManager(QObject):
             except TimeoutError:
                 logger.error(f"External metadata loader timed out: {loader_names[idx]}")
             except Exception as e:
-                logger.error(f"External metadata loader failed ({loader_names[idx]}): {e}")
+                logger.error(
+                    f"External metadata loader failed ({loader_names[idx]}): {e}"
+                )
 
-        logger.info(f"External metadata refresh completed ({completed_count}/{len(futures)} loaders successful)")
+        logger.info(
+            f"External metadata refresh completed ({completed_count}/{len(futures)} loaders successful)"
+        )
 
     def __refresh_internal_metadata(self, is_initial: bool = False) -> None:
         """
@@ -234,7 +264,9 @@ class MetadataManager(QObject):
                               If False (default), purge metadata for mods no longer present on disk.
         """
 
-        def batch_by_data_source(data_source: str, mod_directories: list[str]) -> dict[str, str]:
+        def batch_by_data_source(
+            data_source: str, mod_directories: list[str]
+        ) -> dict[str, str]:
             """
             Create a batch of mod path <-> uuid mappings for discovered directories.
 
@@ -254,7 +286,9 @@ class MetadataManager(QObject):
             mapper = self.mod_metadata_dir_mapper
             return {path: mapper.get(path, str(uuid4())) for path in mod_directories}
 
-        def purge_by_data_source(data_source: str, batch: dict[str, str] | None = None) -> None:
+        def purge_by_data_source(
+            data_source: str, batch: dict[str, str] | None = None
+        ) -> None:
             """
             Remove metadata for mods that no longer exist in the file system.
 
@@ -286,21 +320,26 @@ class MetadataManager(QObject):
             if batch_uuids is None:
                 # Full purge: remove all metadata for this data_source
                 uuids_to_remove = [
-                    uuid for uuid, metadata in internal_meta.items() if metadata.get("data_source") == data_source
+                    uuid
+                    for uuid, metadata in internal_meta.items()
+                    if metadata.get("data_source") == data_source
                 ]
             else:
                 # Selective purge: remove only metadata NOT in current batch (file system state)
                 uuids_to_remove = [
                     uuid
                     for uuid, metadata in internal_meta.items()
-                    if metadata.get("data_source") == data_source and uuid not in batch_uuids
+                    if metadata.get("data_source") == data_source
+                    and uuid not in batch_uuids
                 ]
 
             # Early return if nothing to purge
             if not uuids_to_remove:
                 return
 
-            logger.debug(f"[{data_source}] Purging {len(uuids_to_remove)} leftover metadata entries")
+            logger.debug(
+                f"[{data_source}] Purging {len(uuids_to_remove)} leftover metadata entries"
+            )
 
             # Remove metadata entries and update reverse indices
             packageid_to_uuids = self.packageid_to_uuids
@@ -308,7 +347,9 @@ class MetadataManager(QObject):
                 deleted_mod = internal_meta.pop(uuid, None)
                 if deleted_mod is None:
                     # Race condition: another thread may have already deleted this entry
-                    logger.warning(f"Unable to find metadata for {uuid} in internal metadata. Possible race condition!")
+                    logger.warning(
+                        f"Unable to find metadata for {uuid} in internal metadata. Possible race condition!"
+                    )
                     continue
 
                 # Maintain packageid_to_uuids reverse index consistency
@@ -327,7 +368,9 @@ class MetadataManager(QObject):
         # Game version is already loaded by __read_game_version() before this method is called.
         # This ensures external metadata loaders can use it for path construction (e.g., No Version Warning).
 
-        def process_data_source_folder(data_source: str, folder_path: Path | str | None, subfolder: str = "") -> None:
+        def process_data_source_folder(
+            data_source: str, folder_path: Path | str | None, subfolder: str = ""
+        ) -> None:
             """
             Scan a data source folder and update metadata for all discovered mods.
 
@@ -355,7 +398,9 @@ class MetadataManager(QObject):
             # Check if folder path is empty
             if not folder_path or folder_path == Path():
                 log_func = logger.error if data_source == "expansion" else logger.debug
-                log_func(f"Skipping parsing data from empty {data_source} path. Is the {data_source} path configured?")
+                log_func(
+                    f"Skipping parsing data from empty {data_source} path. Is the {data_source} path configured?"
+                )
                 purge_by_data_source(data_source)
                 return
 
@@ -412,14 +457,22 @@ class MetadataManager(QObject):
         self.mod_metadata_dir_mapper = dir_mapper
 
     def __update_from_settings(self) -> None:
-        self.community_rules_repo = self.settings_controller.settings.external_community_rules_repo
+        self.community_rules_repo = (
+            self.settings_controller.settings.external_community_rules_repo
+        )
         self.dbs_path = AppInfo().databases_folder
         self.external_community_rules_metadata_source = (
             self.settings_controller.settings.external_community_rules_metadata_source
         )
-        self.external_community_rules_file_path = self.settings_controller.settings.external_community_rules_file_path
-        self.external_steam_metadata_file_path = self.settings_controller.settings.external_steam_metadata_file_path
-        self.external_steam_metadata_source = self.settings_controller.settings.external_steam_metadata_source
+        self.external_community_rules_file_path = (
+            self.settings_controller.settings.external_community_rules_file_path
+        )
+        self.external_steam_metadata_file_path = (
+            self.settings_controller.settings.external_steam_metadata_file_path
+        )
+        self.external_steam_metadata_source = (
+            self.settings_controller.settings.external_steam_metadata_source
+        )
         self.steamcmd_acf_path = self.steamcmd_wrapper.steamcmd_appworkshop_acf_path
         self.user_rules_file_path = str(AppInfo().user_rules_file)
 
@@ -440,14 +493,20 @@ class MetadataManager(QObject):
         if not isinstance(package_id, str):
             return
         # Map packageId -> appid
-        package_to_app = {v["packageid"]: appid for appid, v in RIMWORLD_DLC_METADATA.items()}
+        package_to_app = {
+            v["packageid"]: appid for appid, v in RIMWORLD_DLC_METADATA.items()
+        }
         appid = package_to_app.get(package_id)
         if not appid:
             return
         dlc_meta = RIMWORLD_DLC_METADATA[appid]
         # Ensure supportedversions exists and is sane
         if not isinstance(mod.get("supportedversions"), dict):
-            version = ".".join(self.game_version.split(".")[:2]) if self.game_version else None
+            version = (
+                ".".join(self.game_version.split(".")[:2])
+                if self.game_version
+                else None
+            )
             if version:
                 mod["supportedversions"] = {"li": version}
             else:
@@ -495,7 +554,9 @@ class MetadataManager(QObject):
             # Toggle: prefer versioned About.xml tags over base tags
             prefer_versioned = False
             try:
-                prefer_versioned = self.settings_controller.settings.prefer_versioned_about_tags
+                prefer_versioned = (
+                    self.settings_controller.settings.prefer_versioned_about_tags
+                )
             except Exception:
                 prefer_versioned = False
             # Normalize DLC/base game entries so they always show canonical names
@@ -503,20 +564,31 @@ class MetadataManager(QObject):
                 self.supplement_dlc_metadata(uuid)
             except Exception as e:
                 logger.debug(f"supplement_dlc_metadata failed for {uuid}: {e}")
-            logger.debug(f"UUID: {uuid} packageid: " + self.internal_local_metadata[uuid].get("packageid"))
+            logger.debug(
+                f"UUID: {uuid} packageid: "
+                + self.internal_local_metadata[uuid].get("packageid")
+            )
             # Prefer descriptionsByVersion over base description if enabled
-            if prefer_versioned and self.internal_local_metadata[uuid].get("descriptionsbyversion"):
+            if prefer_versioned and self.internal_local_metadata[uuid].get(
+                "descriptionsbyversion"
+            ):
                 try:
                     major, minor = self.game_version.split(".")[:2]
                     version_regex = rf"v{major}\.{minor}"
                 except Exception:
                     version_regex = None
                 if version_regex:
-                    for version, desc_by_ver in self.internal_local_metadata[uuid]["descriptionsbyversion"].items():
+                    for version, desc_by_ver in self.internal_local_metadata[uuid][
+                        "descriptionsbyversion"
+                    ].items():
                         if match(version_regex, version):
                             if isinstance(desc_by_ver, str):
-                                self.internal_local_metadata[uuid]["description"] = desc_by_ver
-                                logger.debug("Prefer versioned tags: using descriptionsByVersion over base description")
+                                self.internal_local_metadata[uuid]["description"] = (
+                                    desc_by_ver
+                                )
+                                logger.debug(
+                                    "Prefer versioned tags: using descriptionsByVersion over base description"
+                                )
                             else:
                                 # Empty or invalid means override to empty description
                                 self.internal_local_metadata[uuid]["description"] = ""
@@ -527,10 +599,18 @@ class MetadataManager(QObject):
             # modDependencies and modDependenciesByVersion with precedence
             base_deps = None
             if self.internal_local_metadata[uuid].get("moddependencies"):
-                if isinstance(self.internal_local_metadata[uuid]["moddependencies"], dict):
-                    base_deps = self.internal_local_metadata[uuid]["moddependencies"].get("li")
-                elif isinstance(self.internal_local_metadata[uuid]["moddependencies"], list):
-                    for potential_dependencies in self.internal_local_metadata[uuid]["moddependencies"]:
+                if isinstance(
+                    self.internal_local_metadata[uuid]["moddependencies"], dict
+                ):
+                    base_deps = self.internal_local_metadata[uuid][
+                        "moddependencies"
+                    ].get("li")
+                elif isinstance(
+                    self.internal_local_metadata[uuid]["moddependencies"], list
+                ):
+                    for potential_dependencies in self.internal_local_metadata[uuid][
+                        "moddependencies"
+                    ]:
                         if (
                             potential_dependencies
                             and isinstance(potential_dependencies, dict)
@@ -547,10 +627,16 @@ class MetadataManager(QObject):
                 except Exception:
                     version_regex = None
                 if version_regex:
-                    for version, deps_by_ver in self.internal_local_metadata[uuid]["moddependenciesbyversion"].items():
+                    for version, deps_by_ver in self.internal_local_metadata[uuid][
+                        "moddependenciesbyversion"
+                    ].items():
                         if match(version_regex, version):
                             version_key_matched = True
-                            if deps_by_ver and isinstance(deps_by_ver, dict) and deps_by_ver.get("li"):
+                            if (
+                                deps_by_ver
+                                and isinstance(deps_by_ver, dict)
+                                and deps_by_ver.get("li")
+                            ):
                                 matched_versioned_deps = deps_by_ver.get("li")
                             else:
                                 matched_versioned_deps = []
@@ -558,7 +644,9 @@ class MetadataManager(QObject):
 
             if prefer_versioned and version_key_matched:
                 if matched_versioned_deps:
-                    logger.debug(f"Current mod requires these mods by version to work: {matched_versioned_deps}")
+                    logger.debug(
+                        f"Current mod requires these mods by version to work: {matched_versioned_deps}"
+                    )
                     add_dependency_to_mod(
                         self.internal_local_metadata[uuid],
                         matched_versioned_deps,
@@ -570,7 +658,9 @@ class MetadataManager(QObject):
                     )
             else:
                 if base_deps:
-                    logger.debug(f"Current mod requires these mods to work: {base_deps}")
+                    logger.debug(
+                        f"Current mod requires these mods to work: {base_deps}"
+                    )
                     add_dependency_to_mod(
                         self.internal_local_metadata[uuid],
                         base_deps,
@@ -580,10 +670,14 @@ class MetadataManager(QObject):
             # incompatibleWith + incompatibleWithByVersion precedence
             # Found an example: 'incompatiblewith': {'li': ['majorhoff.rimthreaded', 'nova.rimworldtogether']}
             base_incompat = None
-            if self.internal_local_metadata[uuid].get("incompatiblewith") and isinstance(
+            if self.internal_local_metadata[uuid].get(
+                "incompatiblewith"
+            ) and isinstance(
                 self.internal_local_metadata[uuid].get("incompatiblewith"), dict
             ):
-                base_incompat = self.internal_local_metadata[uuid]["incompatiblewith"].get("li")
+                base_incompat = self.internal_local_metadata[uuid][
+                    "incompatiblewith"
+                ].get("li")
 
             matched_versioned_incompat = None
             version_key_matched_incompat = False
@@ -594,10 +688,16 @@ class MetadataManager(QObject):
                 except Exception:
                     version_regex = None
                 if version_regex:
-                    for version, inc_by_ver in self.internal_local_metadata[uuid]["incompatiblewithbyversion"].items():
+                    for version, inc_by_ver in self.internal_local_metadata[uuid][
+                        "incompatiblewithbyversion"
+                    ].items():
                         if match(version_regex, version):
                             version_key_matched_incompat = True
-                            if inc_by_ver and isinstance(inc_by_ver, dict) and inc_by_ver.get("li"):
+                            if (
+                                inc_by_ver
+                                and isinstance(inc_by_ver, dict)
+                                and inc_by_ver.get("li")
+                            ):
                                 matched_versioned_incompat = inc_by_ver.get("li")
                             else:
                                 matched_versioned_incompat = []
@@ -619,7 +719,9 @@ class MetadataManager(QObject):
                     )
             else:
                 if base_incompat:
-                    logger.debug(f"Current mod is incompatible with these mods: {base_incompat}")
+                    logger.debug(
+                        f"Current mod is incompatible with these mods: {base_incompat}"
+                    )
                     add_incompatibility_to_mod(
                         self.internal_local_metadata[uuid],
                         base_incompat,
@@ -631,9 +733,13 @@ class MetadataManager(QObject):
             base_after = None
             if self.internal_local_metadata[uuid].get("loadafter"):
                 try:
-                    base_after = self.internal_local_metadata[uuid]["loadafter"].get("li")
+                    base_after = self.internal_local_metadata[uuid]["loadafter"].get(
+                        "li"
+                    )
                 except Exception as e:
-                    mod_metadata_path = self.internal_local_metadata[uuid]["metadata_file_path"]
+                    mod_metadata_path = self.internal_local_metadata[uuid][
+                        "metadata_file_path"
+                    ]
                     logger.warning(
                         f"About.xml syntax error. Unable to read <loadafter> tag from XML: {mod_metadata_path}"
                     )
@@ -651,7 +757,9 @@ class MetadataManager(QObject):
                     for (
                         version,
                         load_these_before_by_ver,
-                    ) in self.internal_local_metadata[uuid]["loadafterbyversion"].items():
+                    ) in self.internal_local_metadata[uuid][
+                        "loadafterbyversion"
+                    ].items():
                         if match(version_regex, version):
                             version_key_matched_after = True
                             if (
@@ -666,7 +774,9 @@ class MetadataManager(QObject):
 
             if prefer_versioned and version_key_matched_after:
                 if matched_after:
-                    logger.debug(f"Current mod should load after these mods by version: {matched_after}")
+                    logger.debug(
+                        f"Current mod should load after these mods by version: {matched_after}"
+                    )
                     add_load_rule_to_mod(
                         self.internal_local_metadata[uuid],
                         matched_after,
@@ -681,7 +791,9 @@ class MetadataManager(QObject):
                     )
             else:
                 if base_after:
-                    logger.debug(f"Current mod should load after these mods: {base_after}")
+                    logger.debug(
+                        f"Current mod should load after these mods: {base_after}"
+                    )
                     add_load_rule_to_mod(
                         self.internal_local_metadata[uuid],
                         base_after,
@@ -695,9 +807,13 @@ class MetadataManager(QObject):
             # Always respect forceloadafter regardless of precedence flag
             if self.internal_local_metadata[uuid].get("forceloadafter"):
                 try:
-                    force_load_these_before = self.internal_local_metadata[uuid]["forceloadafter"].get("li")
+                    force_load_these_before = self.internal_local_metadata[uuid][
+                        "forceloadafter"
+                    ].get("li")
                     if force_load_these_before:
-                        logger.debug(f"Current mod should force load after these mods: {force_load_these_before}")
+                        logger.debug(
+                            f"Current mod should force load after these mods: {force_load_these_before}"
+                        )
                         add_load_rule_to_mod(
                             self.internal_local_metadata[uuid],
                             force_load_these_before,
@@ -707,7 +823,9 @@ class MetadataManager(QObject):
                             self.packageid_to_uuids,
                         )
                 except Exception as e:
-                    mod_metadata_path = self.internal_local_metadata[uuid].get("metadata_file_path")
+                    mod_metadata_path = self.internal_local_metadata[uuid].get(
+                        "metadata_file_path"
+                    )
                     logger.warning(
                         f"About.xml syntax error. Unable to read <forceloadafter> tag from XML: {mod_metadata_path}"
                     )
@@ -718,9 +836,13 @@ class MetadataManager(QObject):
             base_before = None
             if self.internal_local_metadata[uuid].get("loadbefore"):
                 try:
-                    base_before = self.internal_local_metadata[uuid]["loadbefore"].get("li")
+                    base_before = self.internal_local_metadata[uuid]["loadbefore"].get(
+                        "li"
+                    )
                 except Exception as e:
-                    mod_metadata_path = self.internal_local_metadata[uuid]["metadata_file_path"]
+                    mod_metadata_path = self.internal_local_metadata[uuid][
+                        "metadata_file_path"
+                    ]
                     logger.warning(
                         f"About.xml syntax error. Unable to read <loadbefore> tag from XML: {mod_metadata_path}"
                     )
@@ -728,9 +850,13 @@ class MetadataManager(QObject):
 
             if self.internal_local_metadata[uuid].get("forceloadbefore"):
                 try:
-                    force_load_these_after = self.internal_local_metadata[uuid]["forceloadbefore"].get("li")
+                    force_load_these_after = self.internal_local_metadata[uuid][
+                        "forceloadbefore"
+                    ].get("li")
                     if force_load_these_after:
-                        logger.debug(f"Current mod should force load before these mods: {force_load_these_after}")
+                        logger.debug(
+                            f"Current mod should force load before these mods: {force_load_these_after}"
+                        )
                         add_load_rule_to_mod(
                             self.internal_local_metadata[uuid],
                             force_load_these_after,
@@ -740,7 +866,9 @@ class MetadataManager(QObject):
                             self.packageid_to_uuids,
                         )
                 except Exception as e:
-                    mod_metadata_path = self.internal_local_metadata[uuid]["metadata_file_path"]
+                    mod_metadata_path = self.internal_local_metadata[uuid][
+                        "metadata_file_path"
+                    ]
                     logger.warning(
                         f"About.xml syntax error. Unable to read <forceloadbefore> tag from XML: {mod_metadata_path}"
                     )
@@ -755,7 +883,9 @@ class MetadataManager(QObject):
                 except Exception:
                     version_regex = None
                 if version_regex:
-                    for version, loadbefore_by_ver in self.internal_local_metadata[uuid]["loadbeforebyversion"].items():
+                    for version, loadbefore_by_ver in self.internal_local_metadata[
+                        uuid
+                    ]["loadbeforebyversion"].items():
                         if match(version_regex, version):
                             version_key_matched_before = True
                             if (
@@ -770,7 +900,9 @@ class MetadataManager(QObject):
 
             if prefer_versioned and version_key_matched_before:
                 if matched_before:
-                    logger.debug(f"Current mod should load before these mods by version: {matched_before}")
+                    logger.debug(
+                        f"Current mod should load before these mods by version: {matched_before}"
+                    )
                     add_load_rule_to_mod(
                         self.internal_local_metadata[uuid],
                         matched_before,
@@ -785,7 +917,9 @@ class MetadataManager(QObject):
                     )
             else:
                 if base_before:
-                    logger.debug(f"Current mod should load before these mods: {base_before}")
+                    logger.debug(
+                        f"Current mod should load before these mods: {base_before}"
+                    )
                     add_load_rule_to_mod(
                         self.internal_local_metadata[uuid],
                         base_before,
@@ -814,12 +948,24 @@ class MetadataManager(QObject):
                     potential_uuids = self.packageid_to_uuids.get(db_packageid)
                     if potential_uuids:  # Potential uuids is a set
                         for uuid in potential_uuids:
-                            if uuid and self.internal_local_metadata[uuid].get("publishedfileid") == publishedfileid:
+                            if (
+                                uuid
+                                and self.internal_local_metadata[uuid].get(
+                                    "publishedfileid"
+                                )
+                                == publishedfileid
+                            ):
                                 dependencies = mod_data.get("dependencies")
                                 if dependencies:
-                                    tracking_dict.setdefault(uuid, set()).update(dependencies.keys())
-            logger.debug(f"Tracking {len(steam_id_to_package_id)} SteamDB packageids for lookup")
-            logger.debug(f"Tracking Steam dependency data for {len(tracking_dict)} installed mods")
+                                    tracking_dict.setdefault(uuid, set()).update(
+                                        dependencies.keys()
+                                    )
+            logger.debug(
+                f"Tracking {len(steam_id_to_package_id)} SteamDB packageids for lookup"
+            )
+            logger.debug(
+                f"Tracking Steam dependency data for {len(tracking_dict)} installed mods"
+            )
             # For each mod that exists in self.internal_local_metadata -> dependencies (in Steam ID form)
             for (
                 installed_mod_uuid,
@@ -855,40 +1001,58 @@ class MetadataManager(QObject):
                 # if the mod doesn't exist self.internal_local_metadata, then either mod_data or dependency_id
                 # will be None, and then we don't insert a dependency
                 if package_id.lower() in self.packageid_to_uuids:
-                    potential_uuids = self.packageid_to_uuids.get(package_id.lower(), set())
-                    load_these_after = self.external_community_rules[package_id].get("loadBefore")
+                    potential_uuids = self.packageid_to_uuids.get(
+                        package_id.lower(), set()
+                    )
+                    load_these_after = self.external_community_rules[package_id].get(
+                        "loadBefore"
+                    )
                     if load_these_after:
-                        logger.debug(f"Current mod should load before these mods: {load_these_after}")
+                        logger.debug(
+                            f"Current mod should load before these mods: {load_these_after}"
+                        )
                         # In Alphabetical, load_these_after is at least an empty dict
                         # Cannot call add_load_rule_to_mod outside of this for loop,
                         # as that expects a list
                         for load_this_after in load_these_after:
                             for uuid in potential_uuids:
                                 add_load_rule_to_mod(
-                                    self.internal_local_metadata[uuid],  # Already checked above
+                                    self.internal_local_metadata[
+                                        uuid
+                                    ],  # Already checked above
                                     load_this_after,  # Lower() done in call
                                     "loadTheseAfter",
                                     "loadTheseBefore",
                                     self.internal_local_metadata,
                                     self.packageid_to_uuids,
                                 )
-                    load_these_before = self.external_community_rules[package_id].get("loadAfter")
+                    load_these_before = self.external_community_rules[package_id].get(
+                        "loadAfter"
+                    )
                     if load_these_before:
-                        logger.debug(f"Current mod should load after these mods: {load_these_before}")
+                        logger.debug(
+                            f"Current mod should load after these mods: {load_these_before}"
+                        )
                         # In Alphabetical, load_these_before is at least an empty dict
                         for load_this_before in load_these_before:
                             for uuid in potential_uuids:
                                 add_load_rule_to_mod(
-                                    self.internal_local_metadata[uuid],  # Already checked above
+                                    self.internal_local_metadata[
+                                        uuid
+                                    ],  # Already checked above
                                     load_this_before,  # lower() done in call
                                     "loadTheseBefore",
                                     "loadTheseAfter",
                                     self.internal_local_metadata,
                                     self.packageid_to_uuids,
                                 )
-                    incompatibilities = self.external_community_rules[package_id].get("incompatibleWith")
+                    incompatibilities = self.external_community_rules[package_id].get(
+                        "incompatibleWith"
+                    )
                     if incompatibilities:
-                        logger.debug(f"Current mod is incompatible with these mods: {incompatibilities}")
+                        logger.debug(
+                            f"Current mod is incompatible with these mods: {incompatibilities}"
+                        )
                         for incompatibilities in incompatibilities:
                             for uuid in potential_uuids:
                                 add_incompatibility_to_mod(
@@ -896,14 +1060,18 @@ class MetadataManager(QObject):
                                     incompatibilities,
                                     self.internal_local_metadata,
                                 )
-                    load_this_top = self.external_community_rules[package_id].get("loadTop")
+                    load_this_top = self.external_community_rules[package_id].get(
+                        "loadTop"
+                    )
                     if load_this_top:
                         logger.debug(
                             "Current mod should load at the top of a mods list, and will be considered a 'tier 1' mod"
                         )
                         for uuid in potential_uuids:
                             self.internal_local_metadata[uuid]["loadTop"] = True
-                    load_this_bottom = self.external_community_rules[package_id].get("loadBottom")
+                    load_this_bottom = self.external_community_rules[package_id].get(
+                        "loadBottom"
+                    )
                     if load_this_bottom:
                         logger.debug(
                             'Current mod should load at the bottom of a mods list, and will be considered a "tier 3" mod'
@@ -913,7 +1081,9 @@ class MetadataManager(QObject):
             logger.info("Finished adding dependencies from Community Rules")
             log_deps_order_info(self.internal_local_metadata)
         else:
-            logger.info("No Community Rules database supplied from external metadata. skipping.")
+            logger.info(
+                "No Community Rules database supplied from external metadata. skipping."
+            )
         # Add load order rules to installed mods based on rules from user rules
         if self.external_user_rules:
             logger.info("Started compiling metadata from User Rules")
@@ -922,17 +1092,25 @@ class MetadataManager(QObject):
                 # if the mod doesn't exist self.internal_local_metadata, then either mod_data or dependency_id
                 # will be None, and then we don't insert a dependency
                 if package_id.lower() in self.packageid_to_uuids:
-                    potential_uuids = self.packageid_to_uuids.get(package_id.lower(), set())
-                    load_these_after = self.external_user_rules[package_id].get("loadBefore")
+                    potential_uuids = self.packageid_to_uuids.get(
+                        package_id.lower(), set()
+                    )
+                    load_these_after = self.external_user_rules[package_id].get(
+                        "loadBefore"
+                    )
                     if load_these_after:
-                        logger.debug(f"Current mod should load before these mods: {load_these_after}")
+                        logger.debug(
+                            f"Current mod should load before these mods: {load_these_after}"
+                        )
                         # In Alphabetical, load_these_after is at least an empty dict
                         # Cannot call add_load_rule_to_mod outside of this for loop,
                         # as that expects a list
                         for load_this_after in load_these_after:
                             for uuid in potential_uuids:
                                 add_load_rule_to_mod(
-                                    self.internal_local_metadata[uuid],  # Already checked above
+                                    self.internal_local_metadata[
+                                        uuid
+                                    ],  # Already checked above
                                     load_this_after,  # lower() done in call
                                     "loadTheseAfter",
                                     "loadTheseBefore",
@@ -940,23 +1118,33 @@ class MetadataManager(QObject):
                                     self.packageid_to_uuids,
                                 )
 
-                    load_these_before = self.external_user_rules[package_id].get("loadAfter")
+                    load_these_before = self.external_user_rules[package_id].get(
+                        "loadAfter"
+                    )
                     if load_these_before:
-                        logger.debug(f"Current mod should load after these mods: {load_these_before}")
+                        logger.debug(
+                            f"Current mod should load after these mods: {load_these_before}"
+                        )
                         # In Alphabetical, load_these_before is at least an empty dict
                         for load_this_before in load_these_before:
                             for uuid in potential_uuids:
                                 add_load_rule_to_mod(
-                                    self.internal_local_metadata[uuid],  # Already checked above
+                                    self.internal_local_metadata[
+                                        uuid
+                                    ],  # Already checked above
                                     load_this_before,  # lower() done in call
                                     "loadTheseBefore",
                                     "loadTheseAfter",
                                     self.internal_local_metadata,
                                     self.packageid_to_uuids,
                                 )
-                    incompatibilities = self.external_user_rules[package_id].get("incompatibleWith")
+                    incompatibilities = self.external_user_rules[package_id].get(
+                        "incompatibleWith"
+                    )
                     if incompatibilities:
-                        logger.debug(f"Current mod is incompatible with these mods: {incompatibilities}")
+                        logger.debug(
+                            f"Current mod is incompatible with these mods: {incompatibilities}"
+                        )
                         for incompatibilities in incompatibilities:
                             for uuid in potential_uuids:
                                 add_incompatibility_to_mod(
@@ -971,7 +1159,9 @@ class MetadataManager(QObject):
                         )
                         for uuid in potential_uuids:
                             self.internal_local_metadata[uuid]["loadTop"] = True
-                    load_this_bottom = self.external_user_rules[package_id].get("loadBottom")
+                    load_this_bottom = self.external_user_rules[package_id].get(
+                        "loadBottom"
+                    )
                     if load_this_bottom:
                         logger.debug(
                             'Current mod should load at the bottom of a mods list, and will be considered a "tier 3" mod'
@@ -981,7 +1171,9 @@ class MetadataManager(QObject):
             logger.info("Finished adding dependencies from User Rules")
             log_deps_order_info(self.internal_local_metadata)
         else:
-            logger.info("No User Rules database supplied from external metadata. skipping.")
+            logger.info(
+                "No User Rules database supplied from external metadata. skipping."
+            )
 
         if self.external_use_this_instead_replacements:
             logger.info("Flagging obsoleted mods from the Use This Instead database")
@@ -1005,16 +1197,24 @@ class MetadataManager(QObject):
         mod_data = self.internal_local_metadata.get(uuid, {})
 
         # check if mod_data exists and packageid is included in the external "No Version Warning" list
-        if mod_data and self.external_no_version_warning and mod_data["packageid"] in self.external_no_version_warning:
+        if (
+            mod_data
+            and self.external_no_version_warning
+            and mod_data["packageid"] in self.external_no_version_warning
+        ):
             logger.info(
                 f'mod with id "{mod_data["packageid"]}" was found on the "No Version Warning" list. Skipping version mismatch check!'
             )
             return False
         elif (  # Check if game_version exists and mod_data exists and mod_data contains 'supportedversions' with 'li' key
-            self.game_version and mod_data and mod_data.get("supportedversions", {}).get("li")
+            self.game_version
+            and mod_data
+            and mod_data.get("supportedversions", {}).get("li")
         ):
             # Get supported versions
-            supported_versions = self.internal_local_metadata[uuid]["supportedversions"]["li"]
+            supported_versions = self.internal_local_metadata[uuid][
+                "supportedversions"
+            ]["li"]
 
             # Check if supported versions is a string or a list
             if isinstance(supported_versions, str):
@@ -1023,10 +1223,18 @@ class MetadataManager(QObject):
                     result = False
             elif isinstance(supported_versions, list):
                 # If any version from supported_versions starts with game_version, result is False
-                result = not any([ver for ver in supported_versions if self.game_version.startswith(ver)])
+                result = not any(
+                    [
+                        ver
+                        for ver in supported_versions
+                        if self.game_version.startswith(ver)
+                    ]
+                )
             else:
                 # If supported_versions is not a string or a list, log error and return True
-                logger.error(f"supportedversions value not str or list: {supported_versions}")
+                logger.error(
+                    f"supportedversions value not str or list: {supported_versions}"
+                )
                 result = True
 
         # Return result
@@ -1109,7 +1317,9 @@ class MetadataManager(QObject):
         )
         deleted_mod = self.internal_local_metadata.get(uuid)
         if deleted_mod is None:
-            logger.debug(f"Mod {uuid} not found in metadata, skipping deletion. Possible race condition!")
+            logger.debug(
+                f"Mod {uuid} not found in metadata, skipping deletion. Possible race condition!"
+            )
             return
 
         deleted_mod_packageid = deleted_mod.get("packageid")
@@ -1198,13 +1408,18 @@ class MetadataManager(QObject):
                 return mod_data.get("name", package_id)
         return package_id
 
-    def get_missing_dependencies(self, active_mods_uuids: set[str]) -> dict[str, set[str]]:
+    def get_missing_dependencies(
+        self, active_mods_uuids: set[str]
+    ) -> dict[str, set[str]]:
         """
         Check for missing dependencies among active mods
         Returns a dict mapping mod package IDs to sets of missing dependency package IDs
         """
         missing_deps = {}
-        active_mod_ids = {self.internal_local_metadata[uuid]["packageid"] for uuid in active_mods_uuids}
+        active_mod_ids = {
+            self.internal_local_metadata[uuid]["packageid"]
+            for uuid in active_mods_uuids
+        }
 
         # check each active mod's dependencies
         for uuid in active_mods_uuids:
@@ -1228,9 +1443,7 @@ class MetadataManager(QObject):
                     else:
                         dep_id = dep_entry
 
-                    consider_alternatives = (
-                        self.settings_controller.settings.use_alternative_package_ids_as_satisfying_dependencies
-                    )
+                    consider_alternatives = self.settings_controller.settings.use_alternative_package_ids_as_satisfying_dependencies
                     satisfied = dep_id in active_mod_ids
                     if not satisfied and consider_alternatives:
                         satisfied = any(alt in active_mod_ids for alt in alt_ids)
@@ -1291,14 +1504,20 @@ class ModParser(QRunnable):
         about_file_name = "About.xml"
         # Look for a case-insensitive "About" folder
         for temp_file in scanpath(mod_directory):
-            if temp_file.name.lower() == about_folder_name.lower() and temp_file.is_dir():
+            if (
+                temp_file.name.lower() == about_folder_name.lower()
+                and temp_file.is_dir()
+            ):
                 about_folder_name = temp_file.name
                 invalid_about_folder_path_found = False
                 break
             # Look for a case-insensitive "About.xml" file
         if not invalid_about_folder_path_found:
             for temp_file in scanpath(str((directory_path / about_folder_name))):
-                if temp_file.name.lower() == about_file_name.lower() and temp_file.is_file():
+                if (
+                    temp_file.name.lower() == about_file_name.lower()
+                    and temp_file.is_file()
+                ):
                     about_file_name = temp_file.name
                     invalid_about_file_path_found = False
                     break
@@ -1319,9 +1538,14 @@ class ModParser(QRunnable):
         elif not pfid and not invalid_about_folder_path_found:
             pfid_file_name = "PublishedFileId.txt"
             for temp_file in scanpath(str((directory_path / about_folder_name))):
-                if temp_file.name.lower() == pfid_file_name.lower() and temp_file.is_file():
+                if (
+                    temp_file.name.lower() == pfid_file_name.lower()
+                    and temp_file.is_file()
+                ):
                     pfid_file_name = temp_file.name
-                    pfid_path = str((directory_path / about_folder_name / pfid_file_name))
+                    pfid_path = str(
+                        (directory_path / about_folder_name / pfid_file_name)
+                    )
                     try:
                         with open(pfid_path, encoding="utf-8-sig") as pfid_file:
                             pfid = pfid_file.read()
@@ -1339,7 +1563,9 @@ class ModParser(QRunnable):
                 mod_data = xml_path_to_json(mod_data_path)
             except Exception:
                 # If there was an issue parsing the .xml, track and exit
-                logger.error(f"Unable to parse {about_file_name} with the exception: {traceback.format_exc()}")
+                logger.error(
+                    f"Unable to parse {about_file_name} with the exception: {traceback.format_exc()}"
+                )
                 data_malformed = True
             else:
                 # Case-insensitive `ModMetaData` key.
@@ -1353,11 +1579,15 @@ class ModParser(QRunnable):
                         not mod_metadata.get("name")
                         and self.metadata_manager.external_steam_metadata  # ... try to find it in Steam DB
                         and pfid
-                        and self.metadata_manager.external_steam_metadata.get(pfid, {}).get("steamName")
+                        and self.metadata_manager.external_steam_metadata.get(
+                            pfid, {}
+                        ).get("steamName")
                     ):
                         mod_metadata.setdefault(
                             "name",
-                            self.metadata_manager.external_steam_metadata[pfid]["steamName"],
+                            self.metadata_manager.external_steam_metadata[pfid][
+                                "steamName"
+                            ],
                         )
                         # This is so that DB builder shows we do not have local metadata
                         mod_metadata.setdefault("DB_BUILDER_NO_NAME", True)
@@ -1365,7 +1595,8 @@ class ModParser(QRunnable):
                         mod_metadata.setdefault("name", "Missing XML: <name>")
                     # Rename author tag appropriately to normalize it in usage and lookups
                     mod_metadata = {
-                        ("authors" if key.lower() == "author" else key): value for key, value in mod_metadata.items()
+                        ("authors" if key.lower() == "author" else key): value
+                        for key, value in mod_metadata.items()
                     }
                     # Normalize authors to a string
                     authors = mod_metadata.get("authors")
@@ -1388,18 +1619,24 @@ class ModParser(QRunnable):
                     elif mod_data.get("supportedversions", {}).get("li"):
                         if isinstance(mod_data["supportedversions"]["li"], str):
                             mod_data["supportedversions"]["li"] = (
-                                ".".join(mod_data["supportedversions"]["li"].split(".")[:2])
+                                ".".join(
+                                    mod_data["supportedversions"]["li"].split(".")[:2]
+                                )
                                 if mod_data["supportedversions"]["li"].count(".") > 1
                                 else mod_data["supportedversions"]["li"]
                             )
                         elif isinstance(mod_data["supportedversions"]["li"], list):
-                            for mod_data["supportedversions"]["li"] in mod_data["supportedversions"]["li"]:
+                            for mod_data["supportedversions"]["li"] in mod_data[
+                                "supportedversions"
+                            ]["li"]:
                                 li = mod_data["supportedversions"]["li"]
                                 if not isinstance(li, str):
                                     logger.error(f"Failed to parse {li} as a string")
                                     continue
                                 mod_data["supportedversions"]["li"] = (
-                                    ".".join(li.split(".")[:2]) if li.count(".") > 1 and isinstance(li, str) else li
+                                    ".".join(li.split(".")[:2])
+                                    if li.count(".") > 1 and isinstance(li, str)
+                                    else li
                                 )
 
                     if mod_metadata.get("supportedversions", {}).get("li"):
@@ -1409,7 +1646,9 @@ class ModParser(QRunnable):
                         elif isinstance(li, list):
                             for i, version in enumerate(li):
                                 if not isinstance(version, str):
-                                    logger.error(f"Failed to parse {version} as a string")
+                                    logger.error(
+                                        f"Failed to parse {version} as a string"
+                                    )
                                     continue
                                 li[i] = version.strip()
 
@@ -1427,26 +1666,36 @@ class ModParser(QRunnable):
                         if isinstance(mod_metadata["packageid"], list):
                             # Loop through the list and find str. If we find one, use it.
                             for potential_packageid in mod_metadata["packageid"]:
-                                if potential_packageid and isinstance(potential_packageid, str):
+                                if potential_packageid and isinstance(
+                                    potential_packageid, str
+                                ):
                                     mod_metadata["packageid"] = potential_packageid
                                     break
                         # Normalize package ID in metadata
                         if isinstance(mod_metadata["packageid"], str):
-                            mod_metadata["packageid"] = mod_metadata["packageid"].lower()
+                            mod_metadata["packageid"] = mod_metadata[
+                                "packageid"
+                            ].lower()
                         elif isinstance(mod_metadata["packageid"], dict):
                             # Handle dict packageid (from malformed XML), try to extract text
                             if mod_metadata["packageid"].get("#text"):
-                                mod_metadata["packageid"] = mod_metadata["packageid"]["#text"].lower()
+                                mod_metadata["packageid"] = mod_metadata["packageid"][
+                                    "#text"
+                                ].lower()
                     else:  # ...otherwise, we don't have one from About.xml, and we can check Steam DB...
                         # ...this can be needed if a mod depends on a RW generated packageid via built-in hashing mechanism.
                         if (
                             pfid
                             and self.metadata_manager.external_steam_metadata
-                            and self.metadata_manager.external_steam_metadata.get(pfid, {}).get("packageId")
+                            and self.metadata_manager.external_steam_metadata.get(
+                                pfid, {}
+                            ).get("packageId")
                         ):
-                            mod_metadata["packageid"] = self.metadata_manager.external_steam_metadata[pfid][
-                                "packageId"
-                            ].lower()
+                            mod_metadata["packageid"] = (
+                                self.metadata_manager.external_steam_metadata[pfid][
+                                    "packageId"
+                                ].lower()
+                            )
                     # Log warning if packageid is missing and assign DEFAULT_MISSING_PACKAGEID
                     if not mod_metadata.get("packageid"):
                         mod_metadata["packageid"] = DEFAULT_MISSING_PACKAGEID
@@ -1454,18 +1703,31 @@ class ModParser(QRunnable):
                     # Track pfid if we parsed one earlier
                     if pfid:  # Make some assumptions if we have a pfid
                         mod_metadata["publishedfileid"] = pfid
-                        mod_metadata["steam_uri"] = f"steam://url/CommunityFilePage/{pfid}"
-                        mod_metadata["steam_url"] = f"https://steamcommunity.com/sharedfiles/filedetails/?id={pfid}"
+                        mod_metadata["steam_uri"] = (
+                            f"steam://url/CommunityFilePage/{pfid}"
+                        )
+                        mod_metadata["steam_url"] = (
+                            f"https://steamcommunity.com/sharedfiles/filedetails/?id={pfid}"
+                        )
                     # If a mod contains C# assemblies, we want to tag the mod
                     assemblies_path = str(directory_path / "Assemblies")
                     # Check if the 'Assemblies' directory exists and is a directory
-                    if os.path.exists(assemblies_path) and os.path.isdir(assemblies_path):
+                    if os.path.exists(assemblies_path) and os.path.isdir(
+                        assemblies_path
+                    ):
                         try:
                             # Check if there are any .dll files in the 'Assemblies' directory
-                            if any(filename.endswith((".dll", ".DLL")) for filename in os.listdir(assemblies_path)):
-                                mod_metadata["csharp"] = True  # Tag the mod as containing C# code
+                            if any(
+                                filename.endswith((".dll", ".DLL"))
+                                for filename in os.listdir(assemblies_path)
+                            ):
+                                mod_metadata["csharp"] = (
+                                    True  # Tag the mod as containing C# code
+                                )
                         except Exception as e:
-                            logger.error(f"Failed to list directory {assemblies_path}: {e}")
+                            logger.error(
+                                f"Failed to list directory {assemblies_path}: {e}"
+                            )
                     else:
                         # If no 'Assemblies' directory in the main folder, check in subfolders
                         subfolder_paths = [
@@ -1478,15 +1740,24 @@ class ModParser(QRunnable):
                             # Check if the 'Assemblies' directory exists in the subfolder
                             if os.path.exists(assemblies_path):
                                 # Check if there are any .dll files in this 'Assemblies' directory
-                                if any(filename.endswith((".dll", ".DLL")) for filename in os.listdir(assemblies_path)):
-                                    mod_metadata["csharp"] = True  # Tag the mod as containing C# code
+                                if any(
+                                    filename.endswith((".dll", ".DLL"))
+                                    for filename in os.listdir(assemblies_path)
+                                ):
+                                    mod_metadata["csharp"] = (
+                                        True  # Tag the mod as containing C# code
+                                    )
                     # data_source will be used with setIcon later
                     mod_metadata["data_source"] = data_source
                     mod_metadata["folder"] = directory_name
                     # This is overwritten if acf data is parsed for Steam/SteamCMD mods
-                    mod_metadata["internal_time_touched"] = int(os.path.getmtime(mod_directory))
+                    mod_metadata["internal_time_touched"] = int(
+                        os.path.getmtime(mod_directory)
+                    )
                     mod_metadata["path"] = mod_directory
-                    mod_metadata["metadata_file_mtime"] = int(os.path.getmtime(mod_data_path))
+                    mod_metadata["metadata_file_mtime"] = int(
+                        os.path.getmtime(mod_data_path)
+                    )
                     mod_metadata["metadata_file_path"] = mod_data_path
                     # Grab our mod's publishedfileid
                     publishedfileid = mod_metadata.get("publishedfileid")
@@ -1497,25 +1768,36 @@ class ModParser(QRunnable):
                             if data_source == "workshop"
                             else self.metadata_manager.steamcmd_acf_data
                         )
-                        workshop_item_details = workshop_acf_data.get("AppWorkshop", {}).get("WorkshopItemDetails", {})
-                        workshop_items_installed = workshop_acf_data.get("AppWorkshop", {}).get(
-                            "WorkshopItemsInstalled", {}
-                        )
+                        workshop_item_details = workshop_acf_data.get(
+                            "AppWorkshop", {}
+                        ).get("WorkshopItemDetails", {})
+                        workshop_items_installed = workshop_acf_data.get(
+                            "AppWorkshop", {}
+                        ).get("WorkshopItemsInstalled", {})
                         # Edit our metadata, append values
                         if (
-                            workshop_item_details.get(publishedfileid, {}).get("timetouched")
-                            and workshop_item_details.get(publishedfileid, {}).get("timetouched") != "0"
+                            workshop_item_details.get(publishedfileid, {}).get(
+                                "timetouched"
+                            )
+                            and workshop_item_details.get(publishedfileid, {}).get(
+                                "timetouched"
+                            )
+                            != "0"
                         ):
                             # The last time SteamCMD/Steam client touched a mod according to its entry
                             mod_metadata["internal_time_touched"] = int(
                                 workshop_item_details[publishedfileid]["timetouched"]
                             )
-                        if publishedfileid and workshop_item_details.get(publishedfileid, {}).get("timeupdated"):
+                        if publishedfileid and workshop_item_details.get(
+                            publishedfileid, {}
+                        ).get("timeupdated"):
                             # The last time SteamCMD/Steam client updated a mod according to its entry
                             mod_metadata["internal_time_updated"] = int(
                                 workshop_item_details[publishedfileid]["timeupdated"]
                             )
-                        if publishedfileid and workshop_items_installed.get(publishedfileid, {}).get("timeupdated"):
+                        if publishedfileid and workshop_items_installed.get(
+                            publishedfileid, {}
+                        ).get("timeupdated"):
                             # The last time SteamCMD/Steam client updated a mod according to its entry
                             mod_metadata["internal_time_updated"] = int(
                                 workshop_items_installed[publishedfileid]["timeupdated"]
@@ -1523,7 +1805,9 @@ class ModParser(QRunnable):
                     # Assign our metadata to the UUID
                     metadata[uuid] = mod_metadata
                 else:
-                    logger.error(f"Key <modmetadata> does not exist in this data: {mod_data}")
+                    logger.error(
+                        f"Key <modmetadata> does not exist in this data: {mod_data}"
+                    )
                     data_malformed = True
         # ...or, if we didn't find an About.xml, but we have a RimWorld scenario .rsc to parse...
         elif invalid_about_file_path_found and scenario_rsc_found:
@@ -1534,31 +1818,47 @@ class ModParser(QRunnable):
                 scenario_data = xml_path_to_json(scenario_data_path)
             except Exception:
                 # If there was an issue parsing the .rsc, track and exit
-                logger.error(f"Unable to parse {scenario_rsc_file} with the exception: {traceback.format_exc()}")
+                logger.error(
+                    f"Unable to parse {scenario_rsc_file} with the exception: {traceback.format_exc()}"
+                )
                 data_malformed = True
             else:
                 # Case-insensitive `savedscenario` key.
                 scenario_data = {k.lower(): v for k, v in scenario_data.items()}
-                if scenario_data.get("savedscenario", {}).get("scenario"):  # If our .rsc metadata has a packageid key
+                if scenario_data.get("savedscenario", {}).get(
+                    "scenario"
+                ):  # If our .rsc metadata has a packageid key
                     # Initialize our dict from the formatted .rsc metadata
                     scenario_metadata = scenario_data["savedscenario"]["scenario"]
                     # Case-insensitive keys.
-                    scenario_metadata = {k.lower(): v for k, v in scenario_metadata.items()}
+                    scenario_metadata = {
+                        k.lower(): v for k, v in scenario_metadata.items()
+                    }
                     scenario_metadata.setdefault("packageid", "scenario.rsc")
                     scenario_metadata["scenario"] = True
                     scenario_metadata.pop("playerfaction", None)
                     scenario_metadata.pop("parts", None)
-                    if scenario_data["savedscenario"].get("meta", {}).get("gameVersion"):
+                    if (
+                        scenario_data["savedscenario"]
+                        .get("meta", {})
+                        .get("gameVersion")
+                    ):
                         scenario_metadata["supportedversions"] = {
                             "li": scenario_data["savedscenario"]["meta"]["gameVersion"]
                         }
                     else:
-                        logger.warning(f"Unable to parse [gameversion] from this scenario [meta] tag: {scenario_data}")
+                        logger.warning(
+                            f"Unable to parse [gameversion] from this scenario [meta] tag: {scenario_data}"
+                        )
                     # Track pfid if we parsed one earlier and don't already have one from metadata
                     if pfid and not scenario_data.get("publishedfileid"):
                         scenario_data["publishedfileid"] = pfid
-                    if scenario_metadata.get("publishedfileid"):  # Make some assumptions if we have a pfid
-                        scenario_metadata["steam_uri"] = f"steam://url/CommunityFilePage/{pfid}"
+                    if scenario_metadata.get(
+                        "publishedfileid"
+                    ):  # Make some assumptions if we have a pfid
+                        scenario_metadata["steam_uri"] = (
+                            f"steam://url/CommunityFilePage/{pfid}"
+                        )
                         scenario_metadata["steam_url"] = (
                             f"https://steamcommunity.com/sharedfiles/filedetails/?id={pfid}"
                         )
@@ -1567,21 +1867,30 @@ class ModParser(QRunnable):
                     scenario_metadata["folder"] = directory_name
                     scenario_metadata["path"] = mod_directory
                     # This is overwritten if acf data is parsed for Steam/SteamCMD mods
-                    scenario_metadata["internal_time_touched"] = int(os.path.getmtime(mod_directory))
+                    scenario_metadata["internal_time_touched"] = int(
+                        os.path.getmtime(mod_directory)
+                    )
                     scenario_metadata["metadata_file_path"] = scenario_data_path
-                    scenario_metadata["metadata_file_mtime"] = int(os.path.getmtime(scenario_data_path))
+                    scenario_metadata["metadata_file_mtime"] = int(
+                        os.path.getmtime(scenario_data_path)
+                    )
                     # Track source & uuid in case metadata becomes detached
                     scenario_metadata["uuid"] = uuid
                     # Assign our metadata to the UUID
                     metadata[uuid] = scenario_metadata
                 else:
-                    logger.error(f"Key <savedscenario><scenario> does not exist in this data: {scenario_metadata}")
+                    logger.error(
+                        f"Key <savedscenario><scenario> does not exist in this data: {scenario_metadata}"
+                    )
                     data_malformed = True
         if (invalid_about_file_path_found and not scenario_rsc_found) or data_malformed:
             # Final simple check to see if the leftover dir contains ONLY .dds files.
             # This is likely after a steam unsubscribe and is safe to delete to prevent invalid items
             if directory_path.is_dir():
-                has_non_dds = any(f.is_file() and f.suffix != ".dds" for f in directory_path.rglob("*"))
+                has_non_dds = any(
+                    f.is_file() and f.suffix != ".dds"
+                    for f in directory_path.rglob("*")
+                )
 
                 if not has_non_dds:
                     logger.debug(
@@ -1591,7 +1900,9 @@ class ModParser(QRunnable):
                     return {}
 
             # If we don't have any metadata parsed, populate invalid mod entry for visibility
-            logger.debug(f"Invalid dir. Populating invalid mod for path: {mod_directory}")
+            logger.debug(
+                f"Invalid dir. Populating invalid mod for path: {mod_directory}"
+            )
             # Assign our metadata to the UUID
             metadata[uuid] = {
                 "invalid": True,
@@ -1619,7 +1930,9 @@ class ModParser(QRunnable):
             if os.path.exists(str((directory_path / ".git"))):
                 local_mod_metadata["git_repo"] = True
             # Check for local mods that are SteamCMD mods, tag appropriately
-            if local_mod_metadata.get("folder") == local_mod_metadata.get("publishedfileid"):
+            if local_mod_metadata.get("folder") == local_mod_metadata.get(
+                "publishedfileid"
+            ):
                 local_mod_metadata["steamcmd"] = True
         return metadata
 
@@ -1629,12 +1942,16 @@ class ModParser(QRunnable):
                 self.data_source, self.mod_directory, self.metadata_manager, self.uuid
             )
             if not mod_metadata:
-                logger.debug(f"No metadata parsed for {self.mod_directory}, skipping update.")
+                logger.debug(
+                    f"No metadata parsed for {self.mod_directory}, skipping update."
+                )
                 return
             packageid = mod_metadata[self.uuid].get("packageid")
             self.metadata_manager.internal_local_metadata.update(mod_metadata)
             # Track packageid -> uuid relationships for future uses
-            self.metadata_manager.packageid_to_uuids.setdefault(packageid, set()).add(self.uuid)
+            self.metadata_manager.packageid_to_uuids.setdefault(packageid, set()).add(
+                self.uuid
+            )
         except Exception as e:
             error_message = f"{type(e).__name__}: {str(e)}\n{traceback.format_exc()}"
             logger.error(f"ERROR: Unable to initialize ModParser {error_message}")
@@ -1667,7 +1984,9 @@ def add_dependency_to_mod(
         # - If a tuple for the same dep already exists, merge the alternatives into it.
         # - If only a plain string exists for that dep, upgrade it to the tuple form.
         # - Otherwise append a new tuple entry.
-        def _ensure_dep_with_alts(dep_list: list[Any], dep_id: str, alt_ids: set[str]) -> None:
+        def _ensure_dep_with_alts(
+            dep_list: list[Any], dep_id: str, alt_ids: set[str]
+        ) -> None:
             """Add or merge a dependency with alternatives into dep_list.
 
             Typical sources that may converge here:
@@ -1679,7 +1998,11 @@ def add_dependency_to_mod(
             for i, existing in enumerate(dep_list):
                 if isinstance(existing, tuple) and existing and existing[0] == dep_id:
                     # Merge alternatives into existing set if present
-                    alt = existing[1].get("alternatives") if isinstance(existing[1], dict) else None
+                    alt = (
+                        existing[1].get("alternatives")
+                        if isinstance(existing[1], dict)
+                        else None
+                    )
                     if isinstance(alt, set):
                         alt.update(alt_ids)
                     else:
@@ -1710,7 +2033,11 @@ def add_dependency_to_mod(
                     for v in li:
                         if isinstance(v, str):
                             alt_ids.add(v.lower())
-                        elif isinstance(v, dict) and "#text" in v and isinstance(v["#text"], str):
+                        elif (
+                            isinstance(v, dict)
+                            and "#text" in v
+                            and isinstance(v["#text"], str)
+                        ):
                             alt_ids.add(v["#text"].lower())
                 elif isinstance(li, str):
                     alt_ids.add(li.lower())
@@ -1727,7 +2054,9 @@ def add_dependency_to_mod(
             pkg = dependency_or_dependency_ids.get("packageId")
             if pkg and not isinstance(pkg, (list, dict)):
                 dep_id = str(pkg).lower()
-                alt_ids = _parse_alt_ids(dependency_or_dependency_ids.get("alternativePackageIds"))
+                alt_ids = _parse_alt_ids(
+                    dependency_or_dependency_ids.get("alternativePackageIds")
+                )
                 if alt_ids:
                     _ensure_dep_with_alts(mod_data["dependencies"], dep_id, alt_ids)
                 else:
@@ -1738,27 +2067,45 @@ def add_dependency_to_mod(
                 )
         # If the value is a LIST of dicts
         elif isinstance(dependency_or_dependency_ids, list):
-            if dependency_or_dependency_ids and isinstance(dependency_or_dependency_ids[0], dict):
+            if dependency_or_dependency_ids and isinstance(
+                dependency_or_dependency_ids[0], dict
+            ):
                 for dependency in dependency_or_dependency_ids:
-                    pkg = dependency.get("packageId") if isinstance(dependency, dict) else None
+                    pkg = (
+                        dependency.get("packageId")
+                        if isinstance(dependency, dict)
+                        else None
+                    )
                     if pkg:
                         dep_id = str(pkg).lower()
                         alt_ids = set()
                         if isinstance(dependency, dict):
-                            alt_ids = _parse_alt_ids(dependency.get("alternativePackageIds"))
+                            alt_ids = _parse_alt_ids(
+                                dependency.get("alternativePackageIds")
+                            )
                         if alt_ids:
-                            _ensure_dep_with_alts(mod_data["dependencies"], dep_id, alt_ids)
+                            _ensure_dep_with_alts(
+                                mod_data["dependencies"], dep_id, alt_ids
+                            )
                         else:
                             _ensure_plain_dep(mod_data["dependencies"], dep_id)
                     else:
-                        logger.error(f"Dependency dict does not contain packageId: [{dependency_or_dependency_ids}]")
+                        logger.error(
+                            f"Dependency dict does not contain packageId: [{dependency_or_dependency_ids}]"
+                        )
             else:
-                logger.error(f"List of dependencies does not contain dicts: [{dependency_or_dependency_ids}]")
+                logger.error(
+                    f"List of dependencies does not contain dicts: [{dependency_or_dependency_ids}]"
+                )
         else:
-            logger.error(f"Dependencies is not a single dict or a list of dicts: [{dependency_or_dependency_ids}]")
+            logger.error(
+                f"Dependencies is not a single dict or a list of dicts: [{dependency_or_dependency_ids}]"
+            )
 
 
-def add_dependency_to_mod_from_steamdb(mod_data: dict[str, Any], dependency_id: Any, all_mods: dict[str, Any]) -> None:
+def add_dependency_to_mod_from_steamdb(
+    mod_data: dict[str, Any], dependency_id: Any, all_mods: dict[str, Any]
+) -> None:
     mod_name = mod_data.get("name")
     # Store dependencies as a list to support rich entries
     mod_data.setdefault("dependencies", [])
@@ -1769,7 +2116,12 @@ def add_dependency_to_mod_from_steamdb(mod_data: dict[str, Any], dependency_id: 
         dep_list = mod_data["dependencies"]
         if all(
             not (
-                existing == dependency_id or (isinstance(existing, tuple) and existing and existing[0] == dependency_id)
+                existing == dependency_id
+                or (
+                    isinstance(existing, tuple)
+                    and existing
+                    and existing[0] == dependency_id
+                )
             )
             for existing in dep_list
         ):
@@ -1821,7 +2173,9 @@ def add_incompatibility_to_mod(
                         if dependency_id in all_package_ids:
                             mod_data["incompatibilities"].add(dependency_id)
             else:
-                logger.error(f"List of incompatibilities does not contain strings: [{dependency_or_dependency_ids}]")
+                logger.error(
+                    f"List of incompatibilities does not contain strings: [{dependency_or_dependency_ids}]"
+                )
         else:
             logger.error(
                 f"Incompatibilities is not a single string or a list of strings: [{dependency_or_dependency_ids}]"
@@ -1885,7 +2239,9 @@ def add_load_rule_to_mod(
             mod_data[explicit_key].add((dep, True))
             potential_dep_uuids = packageid_to_uuids[dep]
             for dep_uuid in potential_dep_uuids:
-                all_mods[dep_uuid].setdefault(indirect_key, set()).add((mod_data["packageid"], False))
+                all_mods[dep_uuid].setdefault(indirect_key, set()).add(
+                    (mod_data["packageid"], False)
+                )
 
 
 def get_mods_from_list(
@@ -1927,7 +2283,9 @@ def get_mods_from_list(
             logger.debug("Creating an empty list with available expansions...")
             metadata_manager = MetadataManager.instance()
             game_version = metadata_manager.game_version
-            generated_xml = generate_rimworld_mods_list(game_version, ["Ludeon.RimWorld"])
+            generated_xml = generate_rimworld_mods_list(
+                game_version, ["Ludeon.RimWorld"]
+            )
             logger.debug(f"Saving new mods list to: {mod_list}")
             json_to_xml_write(generated_xml, mod_list)
         # Parse the ModsConfig.xml activeMods list
@@ -1939,10 +2297,14 @@ def get_mods_from_list(
         package_ids_to_import = mod_list
     # Parse the ModsConfig.xml data
     logger.info("Generating active mod list")
-    for package_id in package_ids_to_import:  # Go through active mods, handle packageids
+    for (
+        package_id
+    ) in package_ids_to_import:  # Go through active mods, handle packageids
         package_id_normalized = package_id.lower()
         package_id_steam_suffix = "_steam"
-        package_id_normalized_stripped = package_id_normalized.replace(package_id_steam_suffix, "")
+        package_id_normalized_stripped = package_id_normalized.replace(
+            package_id_steam_suffix, ""
+        )
         # bool to determine whether or not _steam suffix present in ModsConfig entry
         is_steam = package_id_steam_suffix in package_id_normalized
         # Determine target_id based on whether suffix exists
@@ -1963,18 +2325,25 @@ def get_mods_from_list(
         # Loop through all mods
         for uuid, metadata in all_mods.items():
             metadata_package_id = metadata["packageid"]
-            if metadata_package_id in [  # If we have a match with or without _steam present
-                package_id_normalized,
-                package_id_normalized_stripped,
-            ]:
+            if (
+                metadata_package_id
+                in [  # If we have a match with or without _steam present
+                    package_id_normalized,
+                    package_id_normalized_stripped,
+                ]
+            ):
                 # Add non-duplicates to active mods
                 if target_id not in duplicate_mods.keys():
                     populated_mods.append(target_id)
                     active_mods_uuids.append(uuid)
                 else:  # Otherwise, duplicate needs calculated
-                    if target_id in duplicates_processed:  # Skip duplicates that have already been processed
+                    if (
+                        target_id in duplicates_processed
+                    ):  # Skip duplicates that have already been processed
                         continue
-                    logger.info(f"Found duplicate mod present in active mods list: {target_id}")
+                    logger.info(
+                        f"Found duplicate mod present in active mods list: {target_id}"
+                    )
                     # Loop through sorted paths and determine which duplicate to used based on priority
                     for source in sources_order:
                         logger.debug(f"Checking for duplicate with source: {source}")
@@ -1982,12 +2351,16 @@ def get_mods_from_list(
                         paths_to_uuid = {}
                         for duplicate_uuid in duplicate_mods[target_id]:
                             if source in all_mods[duplicate_uuid]["data_source"]:
-                                paths_to_uuid[all_mods[duplicate_uuid]["path"]] = duplicate_uuid
+                                paths_to_uuid[all_mods[duplicate_uuid]["path"]] = (
+                                    duplicate_uuid
+                                )
                         # Sort duplicate mod paths from current source priority using natsort
                         source_paths_sorted = natsorted(paths_to_uuid.keys())
                         if source_paths_sorted:  # If we have paths returned
                             # If we are here, we've found our calculated duplicate, log and use this mod
-                            calculated_duplicate_uuid = paths_to_uuid[source_paths_sorted[0]]
+                            calculated_duplicate_uuid = paths_to_uuid[
+                                source_paths_sorted[0]
+                            ]
                             logger.debug(
                                 f"Using duplicate {source} mod for {target_id}: {all_mods[calculated_duplicate_uuid]['path']}"
                             )
@@ -2003,7 +2376,9 @@ def get_mods_from_list(
     logger.debug(f"Generated active mods dict with {len(active_mods_uuids)} mods")
     # Get the inactive mods by subtracting active mods from workshop + expansions
     logger.info("Generating inactive mod list")
-    inactive_mods_uuids = [uuid for uuid in all_mods.keys() if uuid not in active_mods_uuids]
+    inactive_mods_uuids = [
+        uuid for uuid in all_mods.keys() if uuid not in active_mods_uuids
+    ]
     logger.info(f"# active mods: {len(active_mods_uuids)}")
     logger.info(f"# inactive mods: {len(inactive_mods_uuids)}")
     logger.info(f"# duplicate mods: {len(duplicate_mods)}")
@@ -2013,10 +2388,18 @@ def get_mods_from_list(
 
 def log_deps_order_info(all_mods: dict[str, Any]) -> None:
     """This block is used quite a bit - deserves own function"""
-    logger.info(f"Total number of loadTheseBefore rules: {get_num_dependencies(all_mods, 'loadTheseBefore')}")
-    logger.info(f"Total number of loadTheseAfter rules: {get_num_dependencies(all_mods, 'loadTheseAfter')}")
-    logger.info(f"Total number of dependencies: {get_num_dependencies(all_mods, 'dependencies')}")
-    logger.info(f"Total number of incompatibilities: {get_num_dependencies(all_mods, 'incompatibilities')}")
+    logger.info(
+        f"Total number of loadTheseBefore rules: {get_num_dependencies(all_mods, 'loadTheseBefore')}"
+    )
+    logger.info(
+        f"Total number of loadTheseAfter rules: {get_num_dependencies(all_mods, 'loadTheseAfter')}"
+    )
+    logger.info(
+        f"Total number of dependencies: {get_num_dependencies(all_mods, 'dependencies')}"
+    )
+    logger.info(
+        f"Total number of incompatibilities: {get_num_dependencies(all_mods, 'incompatibilities')}"
+    )
 
 
 # DB Builder
@@ -2079,7 +2462,9 @@ class SteamDatabaseBuilder(QThread):
             f"\nInitiating RimSort Steam Database Builder with mode : {self.mode}\n"
         )
         if len(self.apikey) == 32:  # If supplied WebAPI key is 32 characters
-            self.db_builder_message_output_signal.emit("Received valid Steam WebAPI key from settings")
+            self.db_builder_message_output_signal.emit(
+                "Received valid Steam WebAPI key from settings"
+            )
             # Since the key is valid, we try to launch a live query
             if self.mode == "all_mods":
                 if not self.mods:
@@ -2097,17 +2482,23 @@ class SteamDatabaseBuilder(QThread):
                         publishedfileids = []
                         for publishedfileid, metadata in database["database"].items():
                             if not metadata.get("appid"):  # If it's not an appid
-                                publishedfileids.append(publishedfileid)  # Add it to our list
+                                publishedfileids.append(
+                                    publishedfileid
+                                )  # Add it to our list
                         dynamic_query = DynamicQuery(
                             apikey=self.apikey,
                             appid=self.appid,
                             life=self.database_expiry,
                             get_appid_deps=self.get_appid_deps,
                         )
-                        dynamic_query.dq_messaging_signal.connect(self.db_builder_message_output_signal.emit)
+                        dynamic_query.dq_messaging_signal.connect(
+                            self.db_builder_message_output_signal.emit
+                        )
                         dynamic_query.create_steam_db(database, publishedfileids)
                         self._output_database(dynamic_query.database)
-                        self.db_builder_message_output_signal.emit("SteamDatabasebuilder: Completed!")
+                        self.db_builder_message_output_signal.emit(
+                            "SteamDatabasebuilder: Completed!"
+                        )
                     else:
                         self.db_builder_message_output_signal.emit(
                             "Tried to generate DynamicQuery with 0 mods...? Unable to initialize DynamicQuery for live metadata..."
@@ -2120,16 +2511,26 @@ class SteamDatabaseBuilder(QThread):
                 # Create query
                 dynamic_query = DynamicQuery(self.apikey, self.appid)
                 # Connect messaging signal
-                dynamic_query.dq_messaging_signal.connect(self.db_builder_message_output_signal.emit)
+                dynamic_query.dq_messaging_signal.connect(
+                    self.db_builder_message_output_signal.emit
+                )
                 # Compile PublishedFileIds
                 dynamic_query.pfids_by_appid()
                 self.publishedfileids = dynamic_query.publishedfileids.copy()
-                self.db_builder_message_output_signal.emit("SteamDatabasebuilder: Completed!")
+                self.db_builder_message_output_signal.emit(
+                    "SteamDatabasebuilder: Completed!"
+                )
             else:
-                self.db_builder_message_output_signal.emit("SteamDatabaseBuilder: Invalid mode specified.")
+                self.db_builder_message_output_signal.emit(
+                    "SteamDatabaseBuilder: Invalid mode specified."
+                )
         else:  # Otherwise, API key is not valid
-            self.db_builder_message_output_signal.emit(f"SteamDatabaseBuilder ({self.mode}): Invalid Steam WebAPI key!")
-            self.db_builder_message_output_signal.emit(f"SteamDatabaseBuilder ({self.mode}): Exiting...")
+            self.db_builder_message_output_signal.emit(
+                f"SteamDatabaseBuilder ({self.mode}): Invalid Steam WebAPI key!"
+            )
+            self.db_builder_message_output_signal.emit(
+                f"SteamDatabaseBuilder ({self.mode}): Exiting..."
+            )
 
     def _init_db_from_local_metadata(self) -> dict[str, Any]:
         db_from_local_metadata = {
@@ -2143,7 +2544,9 @@ class SteamDatabaseBuilder(QThread):
                         "name": v.get("name"),
                         "authors": (
                             ", ".join(v.get("authors").get("li"))
-                            if v.get("authors") and isinstance(v.get("authors"), dict) and v.get("authors").get("li")
+                            if v.get("authors")
+                            and isinstance(v.get("authors"), dict)
+                            and v.get("authors").get("li")
                             else v.get("authors", "Missing XML: <author(s)>")
                         ),
                     }
@@ -2154,15 +2557,23 @@ class SteamDatabaseBuilder(QThread):
                     v["publishedfileid"]: {
                         "url": f"https://steamcommunity.com/sharedfiles/filedetails/?id={v['publishedfileid']}",
                         "packageId": v.get("packageid"),
-                        "name": (v.get("name") if not v.get("DB_BUILDER_NO_NAME") else "Missing XML: <name>"),
+                        "name": (
+                            v.get("name")
+                            if not v.get("DB_BUILDER_NO_NAME")
+                            else "Missing XML: <name>"
+                        ),
                         "authors": (
                             ", ".join(v.get("authors").get("li"))
-                            if v.get("authors") and isinstance(v.get("authors"), dict) and v.get("authors").get("li")
+                            if v.get("authors")
+                            and isinstance(v.get("authors"), dict)
+                            and v.get("authors").get("li")
                             else v.get("authors", "Missing XML: <author(s)>")
                         ),
                         "gameVersions": (
                             v.get("supportedversions").get("li")
-                            if isinstance(v.get("supportedversions", {}).get("li"), list)
+                            if isinstance(
+                                v.get("supportedversions", {}).get("li"), list
+                            )
                             else [
                                 (
                                     v.get("supportedversions", {}).get(
@@ -2188,11 +2599,14 @@ class SteamDatabaseBuilder(QThread):
             else 0
         )
         self.db_builder_message_output_signal.emit(
-            f"Populated {total} items from locally found metadata into initial database for " + f"{self.appid}"
+            f"Populated {total} items from locally found metadata into initial database for "
+            + f"{self.appid}"
         )
         return db_from_local_metadata
 
-    def _init_empty_db_from_publishedfileids(self, publishedfileids: list[str]) -> dict[str, Any]:
+    def _init_empty_db_from_publishedfileids(
+        self, publishedfileids: list[str]
+    ) -> dict[str, Any]:
         database: dict[str, int | dict[str, Any]] = {
             "version": 0,
             "database": {
@@ -2213,7 +2627,11 @@ class SteamDatabaseBuilder(QThread):
                 },
             },
         }
-        total = len(database["database"].keys()) if isinstance(database["database"], dict) else 0
+        total = (
+            len(database["database"].keys())
+            if isinstance(database["database"], dict)
+            else 0
+        )
         self.db_builder_message_output_signal.emit(
             f"\nPopulated {total} items queried from Steam Workshop into initial database for AppId {self.appid}"
         )
@@ -2228,9 +2646,13 @@ class SteamDatabaseBuilder(QThread):
             if self.output_database_path and os.path.exists(self.output_database_path):
                 with open(self.output_database_path, encoding="utf-8") as f:
                     json_string = f.read()
-                    self.db_builder_message_output_signal.emit("\nReading info from file...")
+                    self.db_builder_message_output_signal.emit(
+                        "\nReading info from file..."
+                    )
                     db_to_update = json.loads(json_string)
-                    self.db_builder_message_output_signal.emit("Retrieved cached database!\n")
+                    self.db_builder_message_output_signal.emit(
+                        "Retrieved cached database!\n"
+                    )
                 self.db_builder_message_output_signal.emit(
                     "Recursively updating previous database with new metadata...\n"
                 )
@@ -2247,13 +2669,18 @@ class SteamDatabaseBuilder(QThread):
                     "Unable to load database from specified path! Does the file exist...?"
                 )
                 appended_path = str(
-                    Path(self.output_database_path).parent / ("NEW_" + Path(self.output_database_path).name)
+                    Path(self.output_database_path).parent
+                    / ("NEW_" + Path(self.output_database_path).name)
                 )
-                self.db_builder_message_output_signal.emit(f"\nCaching DynamicQuery result:\n\n{appended_path}")
+                self.db_builder_message_output_signal.emit(
+                    f"\nCaching DynamicQuery result:\n\n{appended_path}"
+                )
                 with open(appended_path, "w", encoding="utf-8") as output:
                     json.dump(database, output, indent=4)
         else:  # Dump new db to specified path, effectively "overwriting" the db with fresh data
-            self.db_builder_message_output_signal.emit(f"\nCaching DynamicQuery result:\n{self.output_database_path}")
+            self.db_builder_message_output_signal.emit(
+                f"\nCaching DynamicQuery result:\n{self.output_database_path}"
+            )
             with open(self.output_database_path, "w", encoding="utf-8") as output:
                 json.dump(database, output, indent=4)
 
@@ -2261,7 +2688,9 @@ class SteamDatabaseBuilder(QThread):
 # Misc helper functions
 
 
-def check_if_pfids_blacklisted(publishedfileids: list[str], steamdb: dict[str, Any]) -> list[str]:
+def check_if_pfids_blacklisted(
+    publishedfileids: list[str], steamdb: dict[str, Any]
+) -> list[str]:
     # None-check for steamdb
     if not steamdb:
         show_warning(
@@ -2279,7 +2708,9 @@ def check_if_pfids_blacklisted(publishedfileids: list[str], steamdb: dict[str, A
                 "name": steamdb[publishedfileid]["steamName"],
                 "comment": steamdb[publishedfileid]["blacklist"]["comment"],
             }
-        elif steamdb.get(str(publishedfileid), {}).get("blacklist"):  # TODO: Is this needed?
+        elif steamdb.get(str(publishedfileid), {}).get(
+            "blacklist"
+        ):  # TODO: Is this needed?
             blacklisted_mods[publishedfileid] = {
                 "name": steamdb[str(publishedfileid)]["steamName"],
                 "comment": steamdb[str(publishedfileid)]["blacklist"]["comment"],
@@ -2288,7 +2719,9 @@ def check_if_pfids_blacklisted(publishedfileids: list[str], steamdb: dict[str, A
     if blacklisted_mods:
         blacklisted_mods_report = ""
         for publishedfileid in blacklisted_mods:
-            blacklisted_mods_report += f"{blacklisted_mods[publishedfileid]['name']} ({publishedfileid})\n"
+            blacklisted_mods_report += (
+                f"{blacklisted_mods[publishedfileid]['name']} ({publishedfileid})\n"
+            )
             blacklisted_mods_report += f"Reason for blacklisting: {blacklisted_mods[publishedfileid]['comment']}"
         answer = show_dialogue_conditional(
             title="Blacklisted mods found",
@@ -2296,21 +2729,31 @@ def check_if_pfids_blacklisted(publishedfileids: list[str], steamdb: dict[str, A
             information="Are you sure you want to download these mods? These mods are known mods that are recommended to be avoided.",
             details=blacklisted_mods_report,
             button_text_override=[
-                QCoreApplication.translate("check_if_pfids_blacklisted", "Download blacklisted mods"),
-                QCoreApplication.translate("check_if_pfids_blacklisted", "Skip blacklisted mods"),
+                QCoreApplication.translate(
+                    "check_if_pfids_blacklisted", "Download blacklisted mods"
+                ),
+                QCoreApplication.translate(
+                    "check_if_pfids_blacklisted", "Skip blacklisted mods"
+                ),
             ],
         )
         # Remove blacklisted mods from list if user wants to download them still
         answer_str = str(answer)
-        download_text = QCoreApplication.translate("check_if_pfids_blacklisted", "Download blacklisted mods")
+        download_text = QCoreApplication.translate(
+            "check_if_pfids_blacklisted", "Download blacklisted mods"
+        )
         if download_text in answer_str:
             publishedfileids.remove(publishedfileid)
-            logger.debug(f"Skipping download of blacklisted Workshop mod: {publishedfileid}")
+            logger.debug(
+                f"Skipping download of blacklisted Workshop mod: {publishedfileid}"
+            )
 
     return publishedfileids
 
 
-def import_steamcmd_acf_data(rimsort_storage_path: str, steamcmd_appworkshop_acf_path: str) -> None:
+def import_steamcmd_acf_data(
+    rimsort_storage_path: str, steamcmd_appworkshop_acf_path: str
+) -> None:
     logger.info(f"SteamCMD acf data path to update: {steamcmd_appworkshop_acf_path}")
     if os.path.exists(steamcmd_appworkshop_acf_path):
         logger.debug("Reading info...")
@@ -2335,9 +2778,13 @@ def import_steamcmd_acf_data(rimsort_storage_path: str, steamcmd_appworkshop_acf
         logger.warning("Specified SteamCMD acf file not found! Nothing was done...")
         return
     # Output
-    items_installed_before = len(steamcmd_appworkshop_acf["AppWorkshop"]["WorkshopItemsInstalled"].keys())
+    items_installed_before = len(
+        steamcmd_appworkshop_acf["AppWorkshop"]["WorkshopItemsInstalled"].keys()
+    )
     logger.debug(f"WorkshopItemsInstalled beforehand: {items_installed_before}")
-    item_details_before = len(steamcmd_appworkshop_acf["AppWorkshop"]["WorkshopItemDetails"].keys())
+    item_details_before = len(
+        steamcmd_appworkshop_acf["AppWorkshop"]["WorkshopItemDetails"].keys()
+    )
     logger.debug(f"WorkshopItemDetails beforehand: {item_details_before}")
     recursively_update_dict(
         steamcmd_appworkshop_acf["AppWorkshop"]["WorkshopItemsInstalled"],
@@ -2347,9 +2794,13 @@ def import_steamcmd_acf_data(rimsort_storage_path: str, steamcmd_appworkshop_acf
         steamcmd_appworkshop_acf["AppWorkshop"]["WorkshopItemDetails"],
         acf_to_import["AppWorkshop"]["WorkshopItemDetails"],
     )
-    items_installed_after = len(steamcmd_appworkshop_acf["AppWorkshop"]["WorkshopItemsInstalled"].keys())
+    items_installed_after = len(
+        steamcmd_appworkshop_acf["AppWorkshop"]["WorkshopItemsInstalled"].keys()
+    )
     logger.debug(f"WorkshopItemsInstalled after: {items_installed_after}")
-    item_details_after = len(steamcmd_appworkshop_acf["AppWorkshop"]["WorkshopItemDetails"].keys())
+    item_details_after = len(
+        steamcmd_appworkshop_acf["AppWorkshop"]["WorkshopItemDetails"].keys()
+    )
     logger.debug(f"WorkshopItemDetails after: {item_details_after}")
     logger.info("Successfully imported data!")
     logger.info(f"Writing updated data back to path: {steamcmd_appworkshop_acf_path}")
@@ -2371,17 +2822,24 @@ def query_workshop_update_data(mods: dict[str, Any]) -> str | None:
     workshop_mods_pfid_to_uuid = {
         metadata["publishedfileid"]: uuid
         for uuid, metadata in mods.items()
-        if (metadata.get("steamcmd") or metadata.get("data_source") == "workshop") and metadata.get("publishedfileid")
+        if (metadata.get("steamcmd") or metadata.get("data_source") == "workshop")
+        and metadata.get("publishedfileid")
     }
 
-    workshop_mods_query_updates = ISteamRemoteStorage_GetPublishedFileDetails(list(workshop_mods_pfid_to_uuid.keys()))
+    workshop_mods_query_updates = ISteamRemoteStorage_GetPublishedFileDetails(
+        list(workshop_mods_pfid_to_uuid.keys())
+    )
     if workshop_mods_query_updates and len(workshop_mods_query_updates) > 0:
         for workshop_mod_metadata in workshop_mods_query_updates:
             uuid = workshop_mods_pfid_to_uuid[workshop_mod_metadata["publishedfileid"]]
             if workshop_mod_metadata.get("time_created"):
-                mods[uuid]["external_time_created"] = workshop_mod_metadata["time_created"]
+                mods[uuid]["external_time_created"] = workshop_mod_metadata[
+                    "time_created"
+                ]
             if workshop_mod_metadata.get("time_updated"):
-                mods[uuid]["external_time_updated"] = workshop_mod_metadata["time_updated"]
+                mods[uuid]["external_time_updated"] = workshop_mod_metadata[
+                    "time_updated"
+                ]
     else:
         return "failed"
 
@@ -2404,7 +2862,9 @@ def recursively_update_dict(
         if recurse_exceptions and key in recurse_exceptions:
             # If the key is an exception, update its value directly from B
             a_dict[key] = value
-        elif key in a_dict and isinstance(a_dict[key], dict) and isinstance(value, dict):
+        elif (
+            key in a_dict and isinstance(a_dict[key], dict) and isinstance(value, dict)
+        ):
             # If the key exists in both dictionaries and the values are dictionaries,
             # recursively update the nested dictionaries except for the recurse exceptions list
             recursively_update_dict(
@@ -2421,7 +2881,9 @@ def recursively_update_dict(
     keys_to_delete = [
         key
         for key, value in a_dict.items()
-        if isinstance(value, dict) and not value and (prune_exceptions is None or key not in prune_exceptions)
+        if isinstance(value, dict)
+        and not value
+        and (prune_exceptions is None or key not in prune_exceptions)
     ]
     for key in keys_to_delete:
         del a_dict[key]

--- a/app/utils/mod_info.py
+++ b/app/utils/mod_info.py
@@ -44,15 +44,23 @@ class ModInfo:
         try:
             name = cls._parse_name(metadata)
             authors = cls._parse_authors(metadata)
-            packageid = str(metadata.get("packageid", ""))  # make sure packageid is a string
-            published_file_id = str(metadata.get("publishedfileid", ""))  # make sure published_file_id is a string
-            supported_versions = cls._parse_supported_versions_static(metadata.get("supportedversions"))
+            packageid = str(
+                metadata.get("packageid", "")
+            )  # make sure packageid is a string
+            published_file_id = str(
+                metadata.get("publishedfileid", "")
+            )  # make sure published_file_id is a string
+            supported_versions = cls._parse_supported_versions_static(
+                metadata.get("supportedversions")
+            )
             source = ""
             if metadata.get("steamcmd"):
                 source = STEAM_CMD
             elif metadata.get("data_source") == "workshop":
                 source = STEAM
-            elif metadata.get("data_source") == "local" and not metadata.get("steamcmd"):
+            elif metadata.get("data_source") == "local" and not metadata.get(
+                "steamcmd"
+            ):
                 source = LOCAL
             else:
                 source = DATABASE
@@ -65,7 +73,9 @@ class ModInfo:
 
             # Input validation for required fields
             if not isinstance(packageid, str) or not packageid.strip():
-                logger.warning(f"Invalid or missing packageid in metadata for UUID {uuid}")
+                logger.warning(
+                    f"Invalid or missing packageid in metadata for UUID {uuid}"
+                )
             if not isinstance(name, str) or not name.strip():
                 logger.warning(f"Invalid or missing name in metadata for UUID {uuid}")
             if not isinstance(published_file_id, str):
@@ -88,8 +98,14 @@ class ModInfo:
             )
         except Exception as e:
             # Log detailed error information and raise exception instead of returning minimal ModInfo
-            metadata_keys = list(metadata.keys()) if isinstance(metadata, dict) else "Invalid metadata type"
-            logger.error(f"Error creating ModInfo from metadata for UUID {uuid}: {e}. Metadata keys: {metadata_keys}")
+            metadata_keys = (
+                list(metadata.keys())
+                if isinstance(metadata, dict)
+                else "Invalid metadata type"
+            )
+            logger.error(
+                f"Error creating ModInfo from metadata for UUID {uuid}: {e}. Metadata keys: {metadata_keys}"
+            )
             raise ValueError(f"Failed to create ModInfo from metadata: {e}") from e
 
     @staticmethod

--- a/app/utils/rentry/wrapper.py
+++ b/app/utils/rentry/wrapper.py
@@ -103,10 +103,14 @@ class RentryUpload:
             RentryError().show_request_exception(e)
         except Exception as e:
             # Handle any other exceptions that occur during the process
-            logger.error(f"An error occurred while Uploading rentry.co content: {str(e)}")
+            logger.error(
+                f"An error occurred while Uploading rentry.co content: {str(e)}"
+            )
             show_fatal_error(
                 title=translate("RentryUpload", "Error"),
-                text=translate("RentryUpload", "An error occurred: {e}").format(e=str(e)),
+                text=translate("RentryUpload", "An error occurred: {e}").format(
+                    e=str(e)
+                ),
             )
 
     def handle_response(self, response: dict[str, Any]) -> None:
@@ -155,10 +159,16 @@ class RentryUpload:
 class RentryImport:
     """Class to handle importing Rentry.co links and extracting package IDs."""
 
-    def __init__(self, settings_controller: SettingsController, rentry_auth_code: bool = False) -> None:
+    def __init__(
+        self, settings_controller: SettingsController, rentry_auth_code: bool = False
+    ) -> None:
         """Initialize the Rentry Import instance and prompt for a link."""
-        self.package_ids: list[str] = []  # Initialize an empty list to store package IDs
-        self.publishedfileids: list[str] = []  # Initialize an empty list for publishedfileids
+        self.package_ids: list[
+            str
+        ] = []  # Initialize an empty list to store package IDs
+        self.publishedfileids: list[
+            str
+        ] = []  # Initialize an empty list for publishedfileids
         self.settings_controller = settings_controller
         self.rentry_auth_code = rentry_auth_code
 
@@ -169,7 +179,9 @@ class RentryImport:
             self.input_dialog()  # Call the input_dialog method to set up the UI
         else:
             # Retrieve auth code from user settings
-            _HEADERS.update({"rentry-auth": settings_controller.settings.rentry_auth_code})
+            _HEADERS.update(
+                {"rentry-auth": settings_controller.settings.rentry_auth_code}
+            )
             self.rentry_auth_code = True
             self.input_dialog()  # Call the input_dialog method to set up the UI
 
@@ -220,31 +232,55 @@ class RentryImport:
             # Determine the raw URL based on the provided link
             if self.rentry_auth_code:
                 logger.debug("Using rentry-auth code to fetch rentry.co content.")
-                raw_url = rentry_link if rentry_link.endswith("/raw") else f"{rentry_link}/raw"
-                response = requests.get(raw_url, headers=_HEADERS)  # Fetch the content from the raw URL
+                raw_url = (
+                    rentry_link
+                    if rentry_link.endswith("/raw")
+                    else f"{rentry_link}/raw"
+                )
+                response = requests.get(
+                    raw_url, headers=_HEADERS
+                )  # Fetch the content from the raw URL
             else:
                 logger.debug("Fetching rentry.co content without rentry-auth.")
-                raw_url = rentry_link if rentry_link.endswith("/edit") else f"{rentry_link}/edit"
+                raw_url = (
+                    rentry_link
+                    if rentry_link.endswith("/edit")
+                    else f"{rentry_link}/edit"
+                )
                 response = requests.get(raw_url)  # Fetch the content from the edit URL
 
             if response.status_code == 200:
                 # Decode the content using UTF-8
                 page_content = response.content.decode("utf-8")
-                logger.debug(f"Fetched rentry.co content successfully. Content: {page_content}")
+                logger.debug(
+                    f"Fetched rentry.co content successfully. Content: {page_content}"
+                )
 
                 # Define regex pattern for both variations of 'packageid' and 'packageId'
-                packageid_pattern = r"(?i){packageid:\s*([\w.]+)\}|packageid:\s*([\w.]+)"
+                packageid_pattern = (
+                    r"(?i){packageid:\s*([\w.]+)\}|packageid:\s*([\w.]+)"
+                )
                 matches = re.findall(packageid_pattern, page_content)
                 # Find all matches in the content
-                self.package_ids = [match[0] if match[0] else match[1] for match in matches if match[0] or match[1]]
+                self.package_ids = [
+                    match[0] if match[0] else match[1]
+                    for match in matches
+                    if match[0] or match[1]
+                ]
                 logger.info("Parsed package_ids successfully.")
-                logger.debug(f"Number of package_ids found: {str(len(self.package_ids))}")
+                logger.debug(
+                    f"Number of package_ids found: {str(len(self.package_ids))}"
+                )
                 # Define regex pattern for publishedfileid in format '?id=digits'
                 publishedfileid_pattern = r"\?id=(\d+)"
                 # Find all publishedfileid matches in the content
-                self.publishedfileids = re.findall(publishedfileid_pattern, page_content)
+                self.publishedfileids = re.findall(
+                    publishedfileid_pattern, page_content
+                )
                 logger.info("Parsed publishedfileid successfully.")
-                logger.debug(f"Number of publishedfileid found: {str(len(self.publishedfileids))}")
+                logger.debug(
+                    f"Number of publishedfileid found: {str(len(self.publishedfileids))}"
+                )
             else:
                 # Handle non-200 responses
                 RentryError().show_response_error(response)
@@ -254,10 +290,14 @@ class RentryImport:
             RentryError().show_request_exception(e)
         except Exception as e:
             # Handle any other exceptions that occur during the process
-            logger.error(f"An error occurred while fetching rentry.co content: {str(e)}")
+            logger.error(
+                f"An error occurred while fetching rentry.co content: {str(e)}"
+            )
             show_fatal_error(
                 title=translate("RentryImport", "Error"),
-                text=translate("RentryImport", "An error occurred: {e}").format(e=str(e)),
+                text=translate("RentryImport", "An error occurred: {e}").format(
+                    e=str(e)
+                ),
             )
 
 
@@ -272,9 +312,15 @@ class RentryError:
             response (dict[str, Any]): A dictionary containing the response details from the upload attempt.
         """
         error_content = response.get("content", "Unknown")  # Extract error content
-        errors = [error.strip() for error in response.get("errors", "").split(".") if error.strip()]
+        errors = [
+            error.strip()
+            for error in response.get("errors", "").split(".")
+            if error.strip()
+        ]
 
-        logger.error(f"Rentry upload process failed with Error: {error_content}")  # Log main error
+        logger.error(
+            f"Rentry upload process failed with Error: {error_content}"
+        )  # Log main error
 
         if errors:
             for error in errors:
@@ -293,10 +339,14 @@ class RentryError:
         Args:
             response (requests.Response): The response object containing status code and reason.
         """
-        logger.warning(f"Rentry returned status code: {response.status_code}. Reason: {response.reason}")
+        logger.warning(
+            f"Rentry returned status code: {response.status_code}. Reason: {response.reason}"
+        )
         InformationBox(
             title=translate("RentryError", "Failed to fetch Rentry Content"),
-            text=translate("RentryError", "Rentry returned status code: {code}").format(code=response.status_code),
+            text=translate("RentryError", "Rentry returned status code: {code}").format(
+                code=response.status_code
+            ),
             information=translate(
                 "RentryError",
                 "RimSort failed to fetch the content from the provided Rentry link. This may be due to an invalid link, your internet connection, or Rentry.co being down. It may also be the result of a captcha. Please try again later.",

--- a/app/utils/schema.py
+++ b/app/utils/schema.py
@@ -25,7 +25,8 @@ def generate_rimworld_mods_list(
                 "li": [
                     packageid
                     for packageid in dlc_ids
-                    if packageid.lower() in RIMWORLD_PACKAGE_IDS and packageid.lower() != "ludeon.rimworld"
+                    if packageid.lower() in RIMWORLD_PACKAGE_IDS
+                    and packageid.lower() != "ludeon.rimworld"
                 ],
             },
         },
@@ -43,7 +44,11 @@ def validate_rimworld_mods_list(
     logger.debug("Validating RimWorld mods list")
     try:
         # RimWorld Config/ModsConfig.xml format
-        if mods_config_data.get("ModsConfigData", {}).get("activeMods", {}).get("li", {}):
+        if (
+            mods_config_data.get("ModsConfigData", {})
+            .get("activeMods", {})
+            .get("li", {})
+        ):
             logger.info("Validated XML formatting (RimWorld Config/ModsConfig.xml)")
             active_mods = mods_config_data["ModsConfigData"]["activeMods"]["li"]
             if isinstance(active_mods, list):
@@ -51,11 +56,21 @@ def validate_rimworld_mods_list(
             elif isinstance(active_mods, str):
                 return [active_mods]
         # RimWorld .rws XML save file format
-        elif mods_config_data.get("savegame", {}).get("meta", {}).get("modIds", {}).get("li", {}):
+        elif (
+            mods_config_data.get("savegame", {})
+            .get("meta", {})
+            .get("modIds", {})
+            .get("li", {})
+        ):
             logger.info("Validated XML formatting (RimWorld .rws savegame)")
             return mods_config_data["savegame"]["meta"]["modIds"]["li"]
         # RimWorld .rws XML file format
-        elif mods_config_data.get("savedModList", {}).get("meta", {}).get("modIds", {}).get("li", {}):
+        elif (
+            mods_config_data.get("savedModList", {})
+            .get("meta", {})
+            .get("modIds", {})
+            .get("li", {})
+        ):
             logger.info("Validated XML formatting (RimWorld .rml modlist)")
             return mods_config_data["savedModList"]["meta"]["modIds"]["li"]
     except Exception as e:

--- a/app/utils/steam/steambrowser/browser.py
+++ b/app/utils/steam/steambrowser/browser.py
@@ -94,7 +94,9 @@ class SteamBrowser(QWidget):
         # Create persistent profile (persists cookies, localStorage, indexedDB, service workers)
         self.web_profile = QWebEngineProfile("SteamBrowserProfile", self)
         self.web_profile.setPersistentStoragePath(self._web_profile_storage)
-        self.web_profile.setPersistentCookiesPolicy(QWebEngineProfile.PersistentCookiesPolicy.ForcePersistentCookies)
+        self.web_profile.setPersistentCookiesPolicy(
+            QWebEngineProfile.PersistentCookiesPolicy.ForcePersistentCookies
+        )
         self.current_html = ""
         self.current_title = "RimSort - Steam Browser"
         self.current_url = startpage
@@ -105,8 +107,12 @@ class SteamBrowser(QWidget):
 
         self.searchtext_string = "&searchtext="
         self.url_prefix_steam = "https://steamcommunity.com"
-        self.url_prefix_sharedfiles = "https://steamcommunity.com/sharedfiles/filedetails/?id="
-        self.url_prefix_workshop = "https://steamcommunity.com/workshop/filedetails/?id="
+        self.url_prefix_sharedfiles = (
+            "https://steamcommunity.com/sharedfiles/filedetails/?id="
+        )
+        self.url_prefix_workshop = (
+            "https://steamcommunity.com/workshop/filedetails/?id="
+        )
         self.section_readytouseitems = "section=readytouseitems"
         self.section_collections = "section=collections"
 
@@ -121,31 +127,45 @@ class SteamBrowser(QWidget):
         self.downloader_list = QListWidget()
         self.downloader_list.setFixedWidth(200)
         self.downloader_list.setItemAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.downloader_list.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
-        self.downloader_list.customContextMenuRequested.connect(self._downloader_item_contextmenu_event)
+        self.downloader_list.setContextMenuPolicy(
+            Qt.ContextMenuPolicy.CustomContextMenu
+        )
+        self.downloader_list.customContextMenuRequested.connect(
+            self._downloader_item_contextmenu_event
+        )
         self.downloader_list.itemDoubleClicked.connect(self._open_mod_url)
         self.add_to_list2_button = QPushButton(self.tr("Add to List"))
         self.add_to_list2_button.clicked.connect(self._add_collection_or_mod_to_list)
         self.clear_list_button = QPushButton(self.tr("Clear List"))
         self.clear_list_button.setObjectName("browserPanelClearList")
         self.clear_list_button.clicked.connect(self._clear_downloader_list)
-        self.download_steamcmd_button = QPushButton(self.tr("Download mod(s) (SteamCMD)"))
+        self.download_steamcmd_button = QPushButton(
+            self.tr("Download mod(s) (SteamCMD)")
+        )
         self.download_steamcmd_button.clicked.connect(
             partial(
                 EventBus().do_steamcmd_download.emit,
                 self.downloader_list_mods_tracking,
             )
         )
-        self.download_steamworks_button = QPushButton(self.tr("Download mod(s) (Steam app)"))
-        self.download_steamworks_button.clicked.connect(self._subscribe_to_mods_from_list)
+        self.download_steamworks_button = QPushButton(
+            self.tr("Download mod(s) (Steam app)")
+        )
+        self.download_steamworks_button.clicked.connect(
+            self._subscribe_to_mods_from_list
+        )
 
         # BROWSER WIDGETS
         # "Loading..." placeholder
         self.web_view_loading_placeholder = ImageLabel()
         self.web_view_loading_placeholder.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.web_view_loading_placeholder.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+        self.web_view_loading_placeholder.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding
+        )
         self.web_view_loading_placeholder.setPixmap(
-            QPixmap(str(AppInfo().theme_data_folder / "default-icons" / "AppIcon_b.png"))
+            QPixmap(
+                str(AppInfo().theme_data_folder / "default-icons" / "AppIcon_b.png")
+            )
         )
         # WebEngineView
         self.web_view = QWebEngineView()
@@ -178,7 +198,9 @@ class SteamBrowser(QWidget):
 
         # Location box
         self.location = QLineEdit()
-        self.location.setSizePolicy(QSizePolicy.Policy.Expanding, self.location.sizePolicy().verticalPolicy())
+        self.location.setSizePolicy(
+            QSizePolicy.Policy.Expanding, self.location.sizePolicy().verticalPolicy()
+        )
         self.location.setText(self.startpage.url())
         self.location.returnPressed.connect(self.__browse_to_location)
 
@@ -188,9 +210,13 @@ class SteamBrowser(QWidget):
         self.nav_bar = QToolBar()
         self.nav_bar.setObjectName("browserPanelnav_bar")
         self.nav_bar.addAction(self.web_view.pageAction(QWebEnginePage.WebAction.Back))
-        self.nav_bar.addAction(self.web_view.pageAction(QWebEnginePage.WebAction.Forward))
+        self.nav_bar.addAction(
+            self.web_view.pageAction(QWebEnginePage.WebAction.Forward)
+        )
         self.nav_bar.addAction(self.web_view.pageAction(QWebEnginePage.WebAction.Stop))
-        self.nav_bar.addAction(self.web_view.pageAction(QWebEnginePage.WebAction.Reload))
+        self.nav_bar.addAction(
+            self.web_view.pageAction(QWebEnginePage.WebAction.Reload)
+        )
         # self.nav_bar.addSeparator()
         self.progress_bar = QProgressBar()
         self.progress_bar.setObjectName("browser")
@@ -232,12 +258,18 @@ class SteamBrowser(QWidget):
         from app.utils.window_launch_state import apply_window_launch_state
 
         assert self.settings_controller is not None
-        browser_window_launch_state = self.settings_controller.settings.browser_window_launch_state
+        browser_window_launch_state = (
+            self.settings_controller.settings.browser_window_launch_state
+        )
         custom_width = self.settings_controller.settings.browser_window_custom_width
         custom_height = self.settings_controller.settings.browser_window_custom_height
 
-        apply_window_launch_state(self, browser_window_launch_state, custom_width, custom_height)
-        logger.info(f"Browser window started with launch state: {browser_window_launch_state}")
+        apply_window_launch_state(
+            self, browser_window_launch_state, custom_width, custom_height
+        )
+        logger.info(
+            f"Browser window started with launch state: {browser_window_launch_state}"
+        )
 
     def __browse_to_location(self) -> None:
         assert self.web_view is not None
@@ -252,10 +284,14 @@ class SteamBrowser(QWidget):
         elif self.url_prefix_workshop in self.current_url:
             publishedfileid = self.current_url.split(self.url_prefix_workshop, 1)[1]
         else:
-            logger.error(f"Unable to parse publishedfileid from url: {self.current_url}")
+            logger.error(
+                f"Unable to parse publishedfileid from url: {self.current_url}"
+            )
             show_warning(
                 title=self.tr("No publishedfileid found"),
-                text=self.tr("Unable to parse publishedfileid from url, Please check if url is in the correct format"),
+                text=self.tr(
+                    "Unable to parse publishedfileid from url, Please check if url is in the correct format"
+                ),
                 information=f"Url: {self.current_url}",
             )
             return None
@@ -267,10 +303,14 @@ class SteamBrowser(QWidget):
             self._add_mod_to_list(publishedfileid)
         else:
             # Use WebAPI to get titles for all the mods
-            collection_mods_pfid_to_title = self.__compile_collection_datas(publishedfileid)
+            collection_mods_pfid_to_title = self.__compile_collection_datas(
+                publishedfileid
+            )
             if len(collection_mods_pfid_to_title) == 0:
                 # Fallback to scraping HTML if WebAPI returns empty
-                collection_mods_pfid_to_title = self.__scrape_collection_mods_from_html(self.current_html)
+                collection_mods_pfid_to_title = self.__scrape_collection_mods_from_html(
+                    self.current_html
+                )
             if len(collection_mods_pfid_to_title) > 0:
                 # ask user whether to add all mods or only missing ones
                 answer = show_dialogue_conditional(
@@ -295,10 +335,14 @@ class SteamBrowser(QWidget):
                         if not self._is_mod_installed(pfid):
                             self._add_mod_to_list(publishedfileid=pfid, title=title)
             else:
-                logger.warning("Empty list of mods returned, unable to add collection to list!")
+                logger.warning(
+                    "Empty list of mods returned, unable to add collection to list!"
+                )
                 show_warning(
                     title=self.tr("SteamCMD downloader"),
-                    text=self.tr("Empty list of mods returned, unable to add collection to list!"),
+                    text=self.tr(
+                        "Empty list of mods returned, unable to add collection to list!"
+                    ),
                     information=self.tr(
                         "Please reach out to us on Github Issues page or\n#rimsort-testing on the Rocketman/CAI discord"
                     ),
@@ -312,14 +356,18 @@ class SteamBrowser(QWidget):
             show_warning(
                 title=self.tr("SteamCMD downloader"),
                 text=self.tr("You already have these mods in your download list!"),
-                information=self.tr("Skipping the following mods which are already present in your download list!"),
+                information=self.tr(
+                    "Skipping the following mods which are already present in your download list!"
+                ),
                 details=dupe_report,
             )
             self.downloader_list_dupe_tracking = {}
 
     def __compile_collection_datas(self, publishedfileid: str) -> dict[str, Any]:
         collection_mods_pfid_to_title: dict[str, Any] = {}
-        collection_webapi_result = ISteamRemoteStorage_GetCollectionDetails([publishedfileid])
+        collection_webapi_result = ISteamRemoteStorage_GetCollectionDetails(
+            [publishedfileid]
+        )
         collection_pfids = []
 
         if collection_webapi_result is not None and len(collection_webapi_result) > 0:
@@ -327,7 +375,9 @@ class SteamBrowser(QWidget):
                 if mod.get("publishedfileid"):
                     collection_pfids.append(mod["publishedfileid"])
             if len(collection_pfids) > 0:
-                collection_mods_webapi_response = ISteamRemoteStorage_GetPublishedFileDetails(collection_pfids)
+                collection_mods_webapi_response = (
+                    ISteamRemoteStorage_GetPublishedFileDetails(collection_pfids)
+                )
             else:
                 return collection_mods_pfid_to_title
 
@@ -353,13 +403,17 @@ class SteamBrowser(QWidget):
             re.DOTALL | re.IGNORECASE,
         )
         matches = pattern.findall(html)
-        logger.debug(f"Found {len(matches)} matches in fallback HTML scraping for collection mods")
+        logger.debug(
+            f"Found {len(matches)} matches in fallback HTML scraping for collection mods"
+        )
         if matches:
             for pfid, title in matches:
                 logger.debug(f"Scraped mod: {pfid} - {title}")
                 collection_mods_pfid_to_title[pfid] = title
         else:
-            logger.warning("No matches found in fallback HTML scraping for collection mods")
+            logger.warning(
+                "No matches found in fallback HTML scraping for collection mods"
+            )
         return collection_mods_pfid_to_title
 
     def _add_mod_to_list(
@@ -369,7 +423,9 @@ class SteamBrowser(QWidget):
     ) -> None:
         # Try to extract the mod name from the page title, fallback to current_title
         extracted_page_title = extract_page_title_steam_browser(self.current_title)
-        page_title = extracted_page_title if extracted_page_title else self.current_title
+        page_title = (
+            extracted_page_title if extracted_page_title else self.current_title
+        )
         # Check if the mod is already in the list
         if publishedfileid not in self.downloader_list_mods_tracking:
             # Add pfid to tracking list
@@ -384,7 +440,9 @@ class SteamBrowser(QWidget):
                 item.setToolTip(f"{label.text()}\n--> {self.current_url}")
             else:  # If the title passed, use it
                 label = QLabel(title)
-                item.setToolTip(f"{label.text()}\n--> {self.url_prefix_sharedfiles}{publishedfileid}")
+                item.setToolTip(
+                    f"{label.text()}\n--> {self.url_prefix_sharedfiles}{publishedfileid}"
+                )
             label.setObjectName("ListItemLabel")
             # Set the size hint of the item to be the size of the label
             item.setSizeHint(label.sizeHint())
@@ -392,13 +450,15 @@ class SteamBrowser(QWidget):
             self.downloader_list.setItemWidget(item, label)
             self._update_badge_js(publishedfileid, BadgeState.ADDED)
         else:
-            logger.debug(f"Tried to add duplicate PFID to downloader list: {publishedfileid}")
+            logger.debug(
+                f"Tried to add duplicate PFID to downloader list: {publishedfileid}"
+            )
             if publishedfileid not in self.downloader_list_dupe_tracking.keys():
                 if not title:
                     self.downloader_list_dupe_tracking[publishedfileid] = page_title
                 else:
                     self.downloader_list_dupe_tracking[publishedfileid] = title
-    
+
     def _open_mod_url(self, item: QListWidgetItem) -> None:
         publishedfileid = item.data(Qt.ItemDataRole.UserRole)
         if publishedfileid and self.web_view is not None:
@@ -422,7 +482,9 @@ class SteamBrowser(QWidget):
 
             context_menu = QMenu(self)  # Downloader item context menu event
             remove_item = context_menu.addAction(self.tr("Remove mod from list"))
-            remove_item.triggered.connect(partial(self._remove_mod_from_list, publishedfileid))
+            remove_item.triggered.connect(
+                partial(self._remove_mod_from_list, publishedfileid)
+            )
             context_menu.exec_(self.downloader_list.mapToGlobal(point))
 
     def _remove_mod_from_list(self, publishedfileid: str) -> None:
@@ -443,14 +505,20 @@ class SteamBrowser(QWidget):
                     break
 
             if not item_found_in_ui:
-                logger.warning(f"Mod {publishedfileid} removed from tracking, but corresponding UI item was not found.")
+                logger.warning(
+                    f"Mod {publishedfileid} removed from tracking, but corresponding UI item was not found."
+                )
 
             self._update_badge_js(publishedfileid, BadgeState.DEFAULT)
         else:
-            logger.warning(f"Mod {publishedfileid} not found in download tracking list, cannot remove.")
+            logger.warning(
+                f"Mod {publishedfileid} not found in download tracking list, cannot remove."
+            )
 
     def _subscribe_to_mods_from_list(self) -> None:
-        logger.debug(f"Signaling Steamworks subscription handler with {len(self.downloader_list_mods_tracking)} mods")
+        logger.debug(
+            f"Signaling Steamworks subscription handler with {len(self.downloader_list_mods_tracking)} mods"
+        )
         EventBus().do_steamworks_api_call.emit(
             [
                 "subscribe",
@@ -500,7 +568,9 @@ class SteamBrowser(QWidget):
                 elements[0].parentNode.removeChild(elements[0]);
             }
             """
-            self.web_view.page().runJavaScript(install_button_removal_script, 0, lambda result: None)
+            self.web_view.page().runJavaScript(
+                install_button_removal_script, 0, lambda result: None
+            )
             # remove_top_banner = """
             # var element = document.getElementById("global_header");
             # var elements = document.getElementsByClassName("responsive_header")
@@ -525,7 +595,9 @@ class SteamBrowser(QWidget):
                 elements[i].target = "_self";
             }
             """
-            self.web_view.page().runJavaScript(change_target_a_script, 0, lambda result: None)
+            self.web_view.page().runJavaScript(
+                change_target_a_script, 0, lambda result: None
+            )
             # Remove "Login" button
             # login_button_removal_script = """
             # var elements = document.getElementsByClassName("global_action_link");
@@ -546,7 +618,9 @@ class SteamBrowser(QWidget):
                 added_mods=json.dumps(added_mods_list),
                 badge_state_js=json.dumps(js_badge_state),
             )
-            self.web_view.page().runJavaScript(setup_web_channel_script, 0, lambda result: None)
+            self.web_view.page().runJavaScript(
+                setup_web_channel_script, 0, lambda result: None
+            )
 
             is_item_page = self.url_prefix_sharedfiles in self.current_url
             is_collection_page = self.url_prefix_workshop in self.current_url
@@ -559,11 +633,17 @@ class SteamBrowser(QWidget):
                 if is_item_page or is_collection_page:
                     # get mod id from steam workshop url
                     if self.url_prefix_sharedfiles in self.current_url:
-                        publishedfileid = self.current_url.split(self.url_prefix_sharedfiles, 1)[1]
+                        publishedfileid = self.current_url.split(
+                            self.url_prefix_sharedfiles, 1
+                        )[1]
                     else:
-                        publishedfileid = self.current_url.split(self.url_prefix_workshop, 1)[1]
+                        publishedfileid = self.current_url.split(
+                            self.url_prefix_workshop, 1
+                        )[1]
                     if self.searchtext_string in publishedfileid:
-                        publishedfileid = publishedfileid.split(self.searchtext_string)[0]
+                        publishedfileid = publishedfileid.split(self.searchtext_string)[
+                            0
+                        ]
                     # check if mod is installed
                     is_installed = self._is_mod_installed(publishedfileid)
                     # Remove area that shows "Subscribe to download" and "Subscribe"/"Unsubscribe" button for mods
@@ -573,7 +653,9 @@ class SteamBrowser(QWidget):
                         elements[0].parentNode.removeChild(elements[0]);
                     }
                     """
-                    self.web_view.page().runJavaScript(mod_subscribe_area_removal_script, 0, lambda result: None)
+                    self.web_view.page().runJavaScript(
+                        mod_subscribe_area_removal_script, 0, lambda result: None
+                    )
                     # Remove area that shows "Subscribe to all" and "Unsubscribe to all" buttons for collections
                     mod_unsubscribe_button_removal_script = """
                     var elements = document.getElementsByClassName("subscribeCollection");
@@ -581,7 +663,9 @@ class SteamBrowser(QWidget):
                         elements[0].parentNode.removeChild(elements[0]);
                     }
                     """
-                    self.web_view.page().runJavaScript(mod_unsubscribe_button_removal_script, 0, lambda result: None)
+                    self.web_view.page().runJavaScript(
+                        mod_unsubscribe_button_removal_script, 0, lambda result: None
+                    )
                     # Remove "Subscribe" buttons from any mods shown in a collection
                     subscribe_buttons_removal_script = """
                     var elements = document.getElementsByClassName("general_btn subscribe");
@@ -589,7 +673,9 @@ class SteamBrowser(QWidget):
                         elements[0].parentNode.removeChild(elements[0]);
                     }
                     """
-                    self.web_view.page().runJavaScript(subscribe_buttons_removal_script, 0, lambda result: None)
+                    self.web_view.page().runJavaScript(
+                        subscribe_buttons_removal_script, 0, lambda result: None
+                    )
                     # add buttons for collection items
                     add_collection_buttons_script = """
                     // find all collection items
@@ -652,7 +738,9 @@ class SteamBrowser(QWidget):
                         }
                     }
                     """
-                    self.web_view.page().runJavaScript(add_collection_buttons_script, 0, lambda result: None)
+                    self.web_view.page().runJavaScript(
+                        add_collection_buttons_script, 0, lambda result: None
+                    )
                     # add installed indicator if mod is installed
                     if is_installed:
                         add_installed_indicator_script = """
@@ -672,7 +760,9 @@ class SteamBrowser(QWidget):
                             contentDiv.parentNode.insertBefore(installedDiv, contentDiv);
                         }
                         """
-                        self.web_view.page().runJavaScript(add_installed_indicator_script, 0, lambda result: None)
+                        self.web_view.page().runJavaScript(
+                            add_installed_indicator_script, 0, lambda result: None
+                        )
                     # Show the add_to_list_button
                     self.nav_bar.addAction(self.add_to_list_button)
 
@@ -722,14 +812,14 @@ class SteamBrowser(QWidget):
     def closeEvent(self, event: QCloseEvent) -> None:
         """Properly clean up web engine resources to prevent memory leaks and hanging processes"""
         logger.debug("Cleaning up SteamBrowser resources...")
-        
+
         # Delete on close flag
         self.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose)
-        
+
         # Stop any loading
         if self.web_view is not None:
             self.web_view.stop()
-            
+
             # Disconnect all web view signals
             try:
                 self.web_view.loadStarted.disconnect()
@@ -737,41 +827,41 @@ class SteamBrowser(QWidget):
                 self.web_view.loadFinished.disconnect()
             except Exception:
                 pass
-            
+
             # Clean up page
             if self.web_view.page():
                 # Delete web channel
                 if self.js_bridge is not None and hasattr(self, "channel"):
                     self.channel.deregisterObject(self.js_bridge)
                     self.channel.deleteLater()
-                
+
                 # Clear scripts
                 self.web_view.page().profile().scripts().clear()
-                
+
                 # Delete page
                 self.web_view.page().deleteLater()
-            
+
             # Delete web view
             self.web_view.deleteLater()
             self.web_view = None
-        
+
         # Clean up web profile
         if self.web_profile is not None:
             self.web_profile.deleteLater()
             self.web_profile = None
-        
+
         # Clear all references
         self.metadata_manager = None
         self.settings_controller = None
         self.js_bridge = None
         self.downloader_list_mods_tracking.clear()
         self.downloader_list_dupe_tracking.clear()
-        
+
         # Clear layouts
         self.clear_layout(self.window_layout)
-        
+
         logger.debug("SteamBrowser cleanup completed")
-        
+
         event.accept()
 
     def clear_layout(self, layout: QLayout | None) -> None:

--- a/app/utils/steam/steambrowser/js_bridge.py
+++ b/app/utils/steam/steambrowser/js_bridge.py
@@ -12,7 +12,9 @@ class JavaScriptBridge(QObject):
     and the Python SteamBrowser class, exposing only specific methods.
     """
 
-    def __init__(self, browser_instance: "SteamBrowser", parent: Optional[QObject] = None) -> None:
+    def __init__(
+        self, browser_instance: "SteamBrowser", parent: Optional[QObject] = None
+    ) -> None:
         super().__init__(parent)
         self._browser_instance = browser_instance
 
@@ -21,7 +23,9 @@ class JavaScriptBridge(QObject):
         """
         Slot callable from JavaScript to add a mod to the download list.
         """
-        self._browser_instance._add_mod_to_list(publishedfileid=publishedfileid, title=mod_title)
+        self._browser_instance._add_mod_to_list(
+            publishedfileid=publishedfileid, title=mod_title
+        )
 
     @Slot(str)
     def remove_mod_from_js(self, mod_id: str) -> None:

--- a/app/utils/steam/steamcmd/wrapper.py
+++ b/app/utils/steam/steamcmd/wrapper.py
@@ -369,8 +369,7 @@ class SteamcmdInterface:
         num_batches = len(batches)
         first_batch = batches[0]
         runner.message(
-            f"\nBatch {batch_num}/{num_batches}: "
-            f"downloading {len(first_batch)} mod(s)..."
+            f"\nBatch {batch_num}/{num_batches}: downloading {len(first_batch)} mod(s)..."
         )
         script_path = self._build_download_script(first_batch)
         runner.message(f"Compiled & using script: {script_path}")

--- a/app/utils/steam/steamworks/wrapper.py
+++ b/app/utils/steam/steamworks/wrapper.py
@@ -50,7 +50,9 @@ from steamworks import STEAMWORKS  # type: ignore
 RESUBSCRIBE_UNSUBSCRIBE_WAIT = 4  # Seconds to wait for Steam to uninstall files
 RESUBSCRIBE_SUBSCRIBE_WAIT = 2  # Seconds to wait for Steam to register subscriptions
 API_CALL_GAP = 0.5  # Seconds between API calls to space them out
-SUBSCRIBE_UNSUBSCRIBE_INTERVAL = 0.5  # Seconds between operations in subscribe/unsubscribe
+SUBSCRIBE_UNSUBSCRIBE_INTERVAL = (
+    0.5  # Seconds between operations in subscribe/unsubscribe
+)
 
 
 class SteamworksInterface:
@@ -101,7 +103,9 @@ class SteamworksInterface:
         if self.callbacks:
             logger.debug("Callbacks enabled!")
             self.end_callbacks = False  # Signal used to end the _callbacks Thread
-            if self.callbacks_total:  # Pass this if you want to do multiple actions with 1 initialization
+            if (
+                self.callbacks_total
+            ):  # Pass this if you want to do multiple actions with 1 initialization
                 logger.debug(f"Callbacks total : {self.callbacks_total}")
                 self.multiple_queries = True
             else:
@@ -113,8 +117,12 @@ class SteamworksInterface:
         try:
             self.steamworks.initialize()  # Init the Steamworks API
         except Exception as e:
-            logger.warning(f"Unable to initialize Steamworks API due to exception: {e.__class__.__name__}")
-            logger.warning("If you are a Steam user, please check that Steam running and that you are logged in...")
+            logger.warning(
+                f"Unable to initialize Steamworks API due to exception: {e.__class__.__name__}"
+            )
+            logger.warning(
+                "If you are a Steam user, please check that Steam running and that you are logged in..."
+            )
             self.steam_not_running = True
         if not self.steam_not_running:  # Skip if True
             if self.callbacks:
@@ -143,7 +151,9 @@ class SteamworksInterface:
             self.steamworks.run_callbacks()
             sleep(0.1)
         else:
-            logger.info(f"{self.callbacks_count} callback(s) received. Ending thread...")
+            logger.info(
+                f"{self.callbacks_count} callback(s) received. Ending thread..."
+            )
 
     # TODO: Rework this for proper static type checking
     def _cb_app_dependencies_result_callback(self, *args: Any, **kwargs: Any) -> None:
@@ -214,7 +224,9 @@ class SteamworksAppDependenciesQuery:
                             OR is a list of int that corresponds with multiple Steam mod PublishedFileIds
         :param interval: time in seconds to sleep between multiple subsequent API calls
         """
-        logger.info(f"Creating SteamworksInterface and passing PublishedFileID(s) {self.pfid_or_pfids}")
+        logger.info(
+            f"Creating SteamworksInterface and passing PublishedFileID(s) {self.pfid_or_pfids}"
+        )
         # If the chunk passed is a single int, convert it into a list in an effort to simplify procedure
         if isinstance(self.pfid_or_pfids, int):
             self.pfid_or_pfids = [self.pfid_or_pfids]
@@ -223,9 +235,7 @@ class SteamworksAppDependenciesQuery:
             callbacks=True, callbacks_total=len(self.pfid_or_pfids), _libs=self._libs
         )
         if not steamworks_interface.steam_not_running:  # Skip if True
-            while (
-                not steamworks_interface.steamworks.loaded()
-            ):  # Ensure that Steamworks API is initialized before attempting any instruction
+            while not steamworks_interface.steamworks.loaded():  # Ensure that Steamworks API is initialized before attempting any instruction
                 break
             else:
                 for pfid in self.pfid_or_pfids:
@@ -243,7 +253,9 @@ class SteamworksAppDependenciesQuery:
                 logger.info("Thread completed. Unloading Steamworks...")
                 steamworks_interface.steamworks_thread.join()
                 # Grab the data and return it
-                logger.warning(f"Returning {len(steamworks_interface.get_app_deps_query_result.keys())} results...")
+                logger.warning(
+                    f"Returning {len(steamworks_interface.get_app_deps_query_result.keys())} results..."
+                )
                 return steamworks_interface.get_app_deps_query_result
         else:
             steamworks_interface.steamworks.unload()
@@ -252,7 +264,9 @@ class SteamworksAppDependenciesQuery:
 
 
 class SteamworksGameLaunch(Process):
-    def __init__(self, game_install_path: str, args: list[str], _libs: str | None = None) -> None:
+    def __init__(
+        self, game_install_path: str, args: list[str], _libs: str | None = None
+    ) -> None:
         Process.__init__(self)
         self._libs = _libs
         self.game_install_path = game_install_path
@@ -270,9 +284,14 @@ class SteamworksGameLaunch(Process):
         steamworks_interface = SteamworksInterface(callbacks=False, _libs=self._libs)
 
         # Launch the game
-        launch_game_process(game_install_path=Path(self.game_install_path), args=self.args)
+        launch_game_process(
+            game_install_path=Path(self.game_install_path), args=self.args
+        )
         # If we had an API initialization, try to unload it
-        if not steamworks_interface.steam_not_running and steamworks_interface.steamworks:
+        if (
+            not steamworks_interface.steam_not_running
+            and steamworks_interface.steamworks
+        ):
             # Unload Steamworks API
             steamworks_interface.steamworks.unload()
 
@@ -325,7 +344,9 @@ class SteamworksSubscriptionHandler(Process):
         self._libs = _libs
         self.action = action
         # Normalize to list for consistent handling
-        self.pfid_or_pfids = pfid_or_pfids if isinstance(pfid_or_pfids, list) else [pfid_or_pfids]
+        self.pfid_or_pfids = (
+            pfid_or_pfids if isinstance(pfid_or_pfids, list) else [pfid_or_pfids]
+        )
         self.interval = interval
 
     def run(self) -> None:
@@ -359,7 +380,9 @@ class SteamworksSubscriptionHandler(Process):
 
         logger.warning(f"Expected {callbacks_total} callback(s)")
 
-        steamworks_interface = SteamworksInterface(callbacks=True, callbacks_total=callbacks_total, _libs=self._libs)
+        steamworks_interface = SteamworksInterface(
+            callbacks=True, callbacks_total=callbacks_total, _libs=self._libs
+        )
 
         if steamworks_interface.steam_not_running:
             logger.error("Steam is not running. Aborting subscription handler.")
@@ -386,16 +409,27 @@ class SteamworksSubscriptionHandler(Process):
             # Wait for all callbacks to complete
             # Resubscribe may take longer due to unsub + resub per mod
             timeout = 60 if self.action == "resubscribe" else 30
-            logger.warning(f"Waiting up to {timeout}s for callbacks to complete (expecting {callbacks_total})...")
+            logger.warning(
+                f"Waiting up to {timeout}s for callbacks to complete (expecting {callbacks_total})..."
+            )
             steamworks_interface._wait_for_callbacks(timeout=timeout)
-            logger.warning(f"✓ All callbacks completed! ({steamworks_interface.callbacks_count}/{callbacks_total})")
+            logger.warning(
+                f"✓ All callbacks completed! ({steamworks_interface.callbacks_count}/{callbacks_total})"
+            )
 
         except Exception as e:
-            logger.error(f"✗ Error during subscription action {self.action}: {e}", exc_info=True)
+            logger.error(
+                f"✗ Error during subscription action {self.action}: {e}", exc_info=True
+            )
         finally:
             # Cleanup
-            logger.warning("=== SteamworksSubscriptionHandler END: Unloading Steamworks ===")
-            if hasattr(steamworks_interface, "steamworks_thread") and steamworks_interface.steamworks_thread.is_alive():
+            logger.warning(
+                "=== SteamworksSubscriptionHandler END: Unloading Steamworks ==="
+            )
+            if (
+                hasattr(steamworks_interface, "steamworks_thread")
+                and steamworks_interface.steamworks_thread.is_alive()
+            ):
                 steamworks_interface.steamworks_thread.join(timeout=5)
             steamworks_interface.steamworks.unload()
 
@@ -419,7 +453,9 @@ class SteamworksSubscriptionHandler(Process):
         Without proper staging, Steam may queue subscribe before unsubscribe
         completes, resulting in mods subscribed but not downloaded.
         """
-        logger.warning(f">>> RESUBSCRIBE: Starting for {len(self.pfid_or_pfids)} mod(s)")
+        logger.warning(
+            f">>> RESUBSCRIBE: Starting for {len(self.pfid_or_pfids)} mod(s)"
+        )
 
         # Register callbacks for all unsub/resub operations
         # These fire asynchronously as Steam processes each operation
@@ -441,7 +477,9 @@ class SteamworksSubscriptionHandler(Process):
                 sleep(API_CALL_GAP)
 
         # STAGE 2: Wait for Steam to uninstall all mod files
-        logger.warning(f"  Waiting {RESUBSCRIBE_UNSUBSCRIBE_WAIT}s for all unsubscribes to complete...")
+        logger.warning(
+            f"  Waiting {RESUBSCRIBE_UNSUBSCRIBE_WAIT}s for all unsubscribes to complete..."
+        )
         sleep(RESUBSCRIBE_UNSUBSCRIBE_WAIT)
 
         # STAGE 3: Subscribe ALL mods
@@ -454,11 +492,15 @@ class SteamworksSubscriptionHandler(Process):
                 sleep(API_CALL_GAP)
 
         # STAGE 4: Wait for Steam to register all subscriptions
-        logger.warning(f"  Waiting {RESUBSCRIBE_SUBSCRIBE_WAIT}s for all subscribes to register...")
+        logger.warning(
+            f"  Waiting {RESUBSCRIBE_SUBSCRIBE_WAIT}s for all subscribes to register..."
+        )
         sleep(RESUBSCRIBE_SUBSCRIBE_WAIT)
 
         # STAGE 5: Force download ALL mods with high priority
-        logger.warning(f">>> STAGE 3: Initiating downloads for {len(self.pfid_or_pfids)} mod(s)")
+        logger.warning(
+            f">>> STAGE 3: Initiating downloads for {len(self.pfid_or_pfids)} mod(s)"
+        )
         for idx, pfid in enumerate(self.pfid_or_pfids, 1):
             try:
                 logger.warning(f"  [{idx}] Download: {pfid}")
@@ -473,7 +515,9 @@ class SteamworksSubscriptionHandler(Process):
                         override_callback=True,
                     )
                 else:
-                    logger.warning(f"DownloadItem skipped: not supported by SteamworksPy library.")
+                    logger.warning(
+                        "DownloadItem skipped: not supported by SteamworksPy library."
+                    )
             except Exception as e:
                 logger.error(f"Failed to trigger download for {pfid}: {e}")
 
@@ -491,7 +535,9 @@ class SteamworksSubscriptionHandler(Process):
         logger.warning("Callback registered for subscribe")
 
         for idx, pfid in enumerate(self.pfid_or_pfids, 1):
-            logger.warning(f">>> Subscribing to mod {idx}/{len(self.pfid_or_pfids)}: {pfid}")
+            logger.warning(
+                f">>> Subscribing to mod {idx}/{len(self.pfid_or_pfids)}: {pfid}"
+            )
             steamworks_interface.steamworks.Workshop.SubscribeItem(pfid)
 
             if len(self.pfid_or_pfids) > 1 and idx < len(self.pfid_or_pfids):
@@ -504,7 +550,9 @@ class SteamworksSubscriptionHandler(Process):
         """
         Unsubscribe from mods
         """
-        logger.warning(f">>> UNSUBSCRIBE: Starting for {len(self.pfid_or_pfids)} mod(s)")
+        logger.warning(
+            f">>> UNSUBSCRIBE: Starting for {len(self.pfid_or_pfids)} mod(s)"
+        )
 
         steamworks_interface.steamworks.Workshop.SetItemUnsubscribedCallback(
             self._create_unsub_callback(steamworks_interface)
@@ -512,7 +560,9 @@ class SteamworksSubscriptionHandler(Process):
         logger.warning("Callback registered for unsubscribe")
 
         for idx, pfid in enumerate(self.pfid_or_pfids, 1):
-            logger.warning(f">>> Unsubscribing from mod {idx}/{len(self.pfid_or_pfids)}: {pfid}")
+            logger.warning(
+                f">>> Unsubscribing from mod {idx}/{len(self.pfid_or_pfids)}: {pfid}"
+            )
             steamworks_interface.steamworks.Workshop.UnsubscribeItem(pfid)
 
             if len(self.pfid_or_pfids) > 1 and idx < len(self.pfid_or_pfids):
@@ -521,7 +571,9 @@ class SteamworksSubscriptionHandler(Process):
 
         logger.warning(">>> All mods queued. Waiting for callbacks...")
 
-    def _create_unsub_callback(self, steamworks_interface: SteamworksInterface) -> Callable[[Any, Any], None]:
+    def _create_unsub_callback(
+        self, steamworks_interface: SteamworksInterface
+    ) -> Callable[[Any, Any], None]:
         """
         Create unsubscribe callback handler.
 
@@ -543,7 +595,8 @@ class SteamworksSubscriptionHandler(Process):
             if (
                 steamworks_interface.multiple_queries
                 and steamworks_interface.callbacks_total is not None
-                and steamworks_interface.callbacks_count >= steamworks_interface.callbacks_total
+                and steamworks_interface.callbacks_count
+                >= steamworks_interface.callbacks_total
             ):
                 steamworks_interface.end_callbacks = True
             elif not steamworks_interface.multiple_queries:
@@ -551,7 +604,9 @@ class SteamworksSubscriptionHandler(Process):
 
         return callback
 
-    def _create_resub_callback(self, steamworks_interface: SteamworksInterface) -> Callable[[Any, Any], None]:
+    def _create_resub_callback(
+        self, steamworks_interface: SteamworksInterface
+    ) -> Callable[[Any, Any], None]:
         """
         Create subscribe callback handler.
 
@@ -573,7 +628,8 @@ class SteamworksSubscriptionHandler(Process):
             if (
                 steamworks_interface.multiple_queries
                 and steamworks_interface.callbacks_total is not None
-                and steamworks_interface.callbacks_count >= steamworks_interface.callbacks_total
+                and steamworks_interface.callbacks_count
+                >= steamworks_interface.callbacks_total
             ):
                 steamworks_interface.end_callbacks = True
             elif not steamworks_interface.multiple_queries:
@@ -581,7 +637,9 @@ class SteamworksSubscriptionHandler(Process):
 
         return callback
 
-    def _create_download_callback(self, steamworks_interface: SteamworksInterface) -> Callable[[Any, Any], None]:
+    def _create_download_callback(
+        self, steamworks_interface: SteamworksInterface
+    ) -> Callable[[Any, Any], None]:
         """
         Create download callback handler.
 
@@ -606,7 +664,8 @@ class SteamworksSubscriptionHandler(Process):
             if (
                 steamworks_interface.multiple_queries
                 and steamworks_interface.callbacks_total is not None
-                and steamworks_interface.callbacks_count >= steamworks_interface.callbacks_total
+                and steamworks_interface.callbacks_count
+                >= steamworks_interface.callbacks_total
             ):
                 steamworks_interface.end_callbacks = True
             elif not steamworks_interface.multiple_queries:

--- a/app/utils/steam/webapi/wrapper.py
+++ b/app/utils/steam/webapi/wrapper.py
@@ -51,7 +51,9 @@ class CollectionImport:
         """
         self.metadata_manager = metadata_manager
         self.translate = QCoreApplication.translate
-        self.package_ids: list[str] = []  # Initialize an empty list to store package IDs
+        self.package_ids: list[
+            str
+        ] = []  # Initialize an empty list to store package IDs
         self.publishedfileids: list[str] = []  # Initialize an empty list to store pfids
         self.input_dialog()  # Call the input_dialog method to set up the UI
 
@@ -79,7 +81,9 @@ class CollectionImport:
         Returns:
             bool: True if the link is valid, False otherwise.
         """
-        return link.startswith(BASE_URL) and (BASE_URL_STEAMFILES in link or BASE_URL_WORKSHOP in link)
+        return link.startswith(BASE_URL) and (
+            BASE_URL_STEAMFILES in link or BASE_URL_WORKSHOP in link
+        )
 
     def import_collection_link(self) -> None:
         # Handle the import button click event
@@ -88,7 +92,9 @@ class CollectionImport:
 
         # Check if the input link is a valid workshop collection link
         if not self.is_valid_collection_link(collection_link):
-            logger.error("Invalid Workshop collection link. Please enter a valid Workshop collection link.")
+            logger.error(
+                "Invalid Workshop collection link. Please enter a valid Workshop collection link."
+            )
             # Show warning message box
             show_warning(
                 title=self.translate("CollectionImport", "Invalid Link"),
@@ -104,8 +110,13 @@ class CollectionImport:
                 collection_link = collection_link.split(BASE_URL_STEAMFILES, 1)[1]
             elif BASE_URL_WORKSHOP in collection_link:
                 collection_link = collection_link.split(BASE_URL_WORKSHOP, 1)[1]
-            collection_webapi_result = ISteamRemoteStorage_GetCollectionDetails([collection_link])
-            if collection_webapi_result is not None and len(collection_webapi_result) > 0:
+            collection_webapi_result = ISteamRemoteStorage_GetCollectionDetails(
+                [collection_link]
+            )
+            if (
+                collection_webapi_result is not None
+                and len(collection_webapi_result) > 0
+            ):
                 self.publishedfileids = [
                     pfid
                     for mod in collection_webapi_result[0]["children"]
@@ -156,7 +167,9 @@ class CollectionImport:
                         details="\n".join(failed_mods),
                     )
         except Exception as e:
-            logger.error(f"An error occurred while fetching collection content: {str(e)}")
+            logger.error(
+                f"An error occurred while fetching collection content: {str(e)}"
+            )
 
     def _get_package_id_from_pfid(self, pfid: str | int | None) -> str | None:
         """Map published id to package id if possible
@@ -171,7 +184,9 @@ class CollectionImport:
             return None
         pfid_str = str(pfid).strip()
         if not pfid_str.isdigit():
-            raise ValueError(f"PublishedFileId (pfid) is expected to be a numeric sequence, not {pfid_str}")
+            raise ValueError(
+                f"PublishedFileId (pfid) is expected to be a numeric sequence, not {pfid_str}"
+            )
         return (
             self._get_package_id_from_pfid_using_steamdb(pfid_str)
             or self._get_package_id_from_pfid_using_metadata(pfid_str)
@@ -193,7 +208,11 @@ class CollectionImport:
         )
 
     def _get_package_id_from_pfid_using_steamdb(self, pfid: str) -> str | None:
-        steamdb = self.metadata_manager.external_steam_metadata if self.metadata_manager else None
+        steamdb = (
+            self.metadata_manager.external_steam_metadata
+            if self.metadata_manager
+            else None
+        )
         if not steamdb:
             return None
         mod = steamdb.get(pfid)
@@ -307,15 +326,20 @@ class DynamicQuery(QObject):
             pattern = "&key="
             if pattern in stacktrace:
                 stacktrace = stacktrace[
-                    : len(stacktrace) - (len(stacktrace) - (stacktrace.find(pattern) + len(pattern)))
+                    : len(stacktrace)
+                    - (len(stacktrace) - (stacktrace.find(pattern) + len(pattern)))
                 ]  # If an HTTPError/SSLError from steam/urllib3 module(s) somehow is uncaught, try to remove the Steam API key from the stacktrace
-            logger.warning(f"Dynamic Query received an uncaught exception: {e.__class__.__name__}")
+            logger.warning(
+                f"Dynamic Query received an uncaught exception: {e.__class__.__name__}"
+            )
             self._emit_message(
                 "\nDynamicQuery failed to initialize WebAPI query!"
                 + "\nAre you connected to the internet?\nIs your configured key invalid or revoked?\n"
             )
 
-    def create_steam_db(self, database: Dict[str, Any], publishedfileids: list[str]) -> None:
+    def create_steam_db(
+        self, database: Dict[str, Any], publishedfileids: list[str]
+    ) -> None:
         """
         Builds a database using a chunked WebAPI query of all available
         PublishedFileIds supplied.
@@ -342,10 +366,14 @@ class DynamicQuery(QObject):
             # Returns WHAT we can get remotely, FROM what we have locally
             query, missing_children = result
 
-            if missing_children and len(missing_children) > 0:  # If we have missing data for any dependency...
+            if (
+                missing_children and len(missing_children) > 0
+            ):  # If we have missing data for any dependency...
                 # Uncomment to see the contents of missing_children
                 # logger.debug(missing_children)
-                self._emit_message(f"\nRetrieving dependency information for {len(missing_children)} missing children")
+                self._emit_message(
+                    f"\nRetrieving dependency information for {len(missing_children)} missing children"
+                )
                 # Extend publishedfileids with the missing_children PublishedFileIds for final query
                 publishedfileids.extend(missing_children)
                 # Launch a separate query from the initial, to recursively append
@@ -375,11 +403,17 @@ class DynamicQuery(QObject):
                 querying = False
 
         if self.get_appid_deps:
-            self._emit_message("\nAppID dependency retrieval enabled. Starting Steamworks API call(s)")
+            self._emit_message(
+                "\nAppID dependency retrieval enabled. Starting Steamworks API call(s)"
+            )
             # ISteamUGC/GetAppDependencies
-            self.ISteamUGC_GetAppDependencies(publishedfileids=publishedfileids, query=query)
+            self.ISteamUGC_GetAppDependencies(
+                publishedfileids=publishedfileids, query=query
+            )
         else:
-            self._emit_message("\nAppID dependency retrieval disabled. Skipping Steamworks API call(s)!")
+            self._emit_message(
+                "\nAppID dependency retrieval disabled. Skipping Steamworks API call(s)!"
+            )
 
         # Notify & return
         total = len(query["database"])
@@ -400,7 +434,9 @@ class DynamicQuery(QObject):
                 if self.pagenum > self.pages:
                     query = False
                     break
-                self.next_cursor = self.IPublishedFileService_QueryFiles(self.next_cursor)
+                self.next_cursor = self.IPublishedFileService_QueryFiles(
+                    self.next_cursor
+                )
         else:
             self._emit_message("AppIDQuery: WebAPI failed to initialize!")
 
@@ -424,7 +460,9 @@ class DynamicQuery(QObject):
         """
         chunks_processed = 0
         total = len(publishedfileids)
-        self._emit_message(f"\nSteam WebAPI: IPublishedFileService/GetDetails initializing for {total} mods\n\n")
+        self._emit_message(
+            f"\nSteam WebAPI: IPublishedFileService/GetDetails initializing for {total} mods\n\n"
+        )
         self._emit_message(f"IPublishedFileService/GetDetails chunk [0/{total}]")
         if not self.api:  # If we don't have API initialized
             return None  # Exit query
@@ -467,7 +505,9 @@ class DynamicQuery(QObject):
                     # logger.debug(f"{publishedfileid}: {metadata}")
                     # If the mod is no longer published
                     if metadata["result"] != 1:
-                        if not result["database"].get(
+                        if not result[
+                            "database"
+                        ].get(
                             publishedfileid
                         ):  # If we don't already have a ["database"] entry for this pfid
                             result["database"][publishedfileid] = {}
@@ -481,18 +521,26 @@ class DynamicQuery(QObject):
                         # This case is mostly intended for any missing_children passed back thru
                         # If this is part of an AppIDQuery, then it is useful for population of
                         # child_name and/or child_url below as part of the dependency data being collected
-                        if not result["database"].get(
+                        if not result[
+                            "database"
+                        ].get(
                             publishedfileid
                         ):  # If we don't already have a ["database"] entry for this pfid
-                            result["database"][publishedfileid] = {}  # Add in skeleton data
+                            result["database"][
+                                publishedfileid
+                            ] = {}  # Add in skeleton data
                         # We populate the data
-                        result["database"][publishedfileid]["steamName"] = metadata["title"]
+                        result["database"][publishedfileid]["steamName"] = metadata[
+                            "title"
+                        ]
                         result["database"][publishedfileid]["url"] = (
                             f"https://steamcommunity.com/sharedfiles/filedetails/?id={publishedfileid}"
                         )
                         # Save tags information
                         if metadata.get("tags"):
-                            result["database"][publishedfileid]["tags"] = metadata["tags"]
+                            result["database"][publishedfileid]["tags"] = metadata[
+                                "tags"
+                            ]
                         # Track time publishing created
                         # result["database"][publishedfileid][
                         #     "external_time_created"
@@ -504,23 +552,37 @@ class DynamicQuery(QObject):
                         result["database"][publishedfileid]["dependencies"] = {}
                         # If the publishing has listed mod dependencies
                         if metadata.get("children"):
-                            for children in metadata["children"]:  # Check if children present in database
+                            for children in metadata[
+                                "children"
+                            ]:  # Check if children present in database
                                 child_pfid = children["publishedfileid"]
-                                if result["database"].get(child_pfid):  # If we have data for this child already cached
+                                if result["database"].get(
+                                    child_pfid
+                                ):  # If we have data for this child already cached
                                     if not result["database"][child_pfid].get(
                                         "unpublished"
                                     ):  # ... and the mod is published, populate it
                                         if result["database"][child_pfid].get(
                                             "name"
                                         ):  # Use local name over Steam name if possible
-                                            child_name = result["database"][child_pfid]["name"]
-                                        elif result["database"][child_pfid].get("steamName"):
-                                            child_name = result["database"][child_pfid]["steamName"]
+                                            child_name = result["database"][child_pfid][
+                                                "name"
+                                            ]
+                                        elif result["database"][child_pfid].get(
+                                            "steamName"
+                                        ):
+                                            child_name = result["database"][child_pfid][
+                                                "steamName"
+                                            ]
                                         else:  # This is a stub value used in-memory only (hopefully)
                                             # and is intended for AppIdQuery first pass
                                             child_name = "UNKNOWN"
-                                        child_url = result["database"][child_pfid]["url"]
-                                        result["database"][publishedfileid]["dependencies"][child_pfid] = [
+                                        child_url = result["database"][child_pfid][
+                                            "url"
+                                        ]
+                                        result["database"][publishedfileid][
+                                            "dependencies"
+                                        ][child_pfid] = [
                                             child_name,
                                             child_url,
                                         ]
@@ -533,20 +595,26 @@ class DynamicQuery(QObject):
             except Exception as e:
                 stacktrace = traceback.format_exc()
                 if (
-                    e.__class__.__name__ == "HTTPError" or e.__class__.__name__ == "SSLError"
+                    e.__class__.__name__ == "HTTPError"
+                    or e.__class__.__name__ == "SSLError"
                 ):  # requests.exceptions.HTTPError OR urllib3.exceptions.SSLError
                     # If an HTTPError from steam/urllib3 module(s) somehow is uncaught,
                     # try to remove the Steam API key from the stacktrace
                     pattern = "&key="
                     stacktrace = stacktrace[
-                        : len(stacktrace) - (len(stacktrace) - (stacktrace.find(pattern) + len(pattern)))
+                        : len(stacktrace)
+                        - (len(stacktrace) - (stacktrace.find(pattern) + len(pattern)))
                     ]
                 logger.error(
                     f"IPublishedFileService/GetDetails errored querying batch [{chunks_processed}/{total}]: {stacktrace}"
                 )
-            self._emit_message(f"IPublishedFileService/GetDetails chunk [{chunks_processed}/{total}]")
+            self._emit_message(
+                f"IPublishedFileService/GetDetails chunk [{chunks_processed}/{total}]"
+            )
         for missing_child in missing_children:
-            if result["database"].get(missing_child) and result["database"][missing_child].get(
+            if result["database"].get(missing_child) and result["database"][
+                missing_child
+            ].get(
                 "unpublished"
             ):  # If there is somehow an unpublished mod in missing_children, remove it
                 missing_children.remove(missing_child)
@@ -572,7 +640,9 @@ class DynamicQuery(QObject):
         WebAPI.call() results that are being are parsing
         """
         if self.api is None:
-            raise Exception("Tried to query files while API was not properly initialized.")  # Exit query
+            raise Exception(
+                "Tried to query files while API was not properly initialized."
+            )  # Exit query
 
         result = self.api.call(
             method_path="IPublishedFileService.QueryFiles",
@@ -613,15 +683,24 @@ class DynamicQuery(QObject):
             admin_query=False,
         )
         # Print total mods found we need to iter through paginations to get info for
-        if self.pagenum and self.total == 0:  # If True, this is initial loop; we properly set them in initial loop
+        if (
+            self.pagenum and self.total == 0
+        ):  # If True, this is initial loop; we properly set them in initial loop
             if result["response"]["total"]:
                 self.pagenum = 1
                 self.total = result["response"]["total"]
-                self.pages = ceil(self.total / len(result["response"]["publishedfiledetails"]))
+                self.pages = ceil(
+                    self.total / len(result["response"]["publishedfiledetails"])
+                )
                 # Since this is only run during the initial loop, we print out the 0
                 # needed for RunnerPanel progress bar calculations
-                self._emit_message("IPublishedFileService/QueryFiles page [0" + f"/{str(self.pages)}]")
-        self._emit_message(f"IPublishedFileService/QueryFiles page [{str(self.pagenum)}" + f"/{str(self.pages)}]")
+                self._emit_message(
+                    "IPublishedFileService/QueryFiles page [0" + f"/{str(self.pages)}]"
+                )
+        self._emit_message(
+            f"IPublishedFileService/QueryFiles page [{str(self.pagenum)}"
+            + f"/{str(self.pages)}]"
+        )
         ids_from_page = []
         for item in result["response"]["publishedfiledetails"]:
             self.publishedfileids.append(item["publishedfileid"])
@@ -629,7 +708,9 @@ class DynamicQuery(QObject):
         self.pagenum += 1
         return result["response"]["next_cursor"]
 
-    def ISteamUGC_GetAppDependencies(self, publishedfileids: list[str], query: Dict[str, Any]) -> None:
+    def ISteamUGC_GetAppDependencies(
+        self, publishedfileids: list[str], query: Dict[str, Any]
+    ) -> None:
         """
         Given a list of PublishedFileIds and a query, return the query after looking up
         and appending DLC dependency data from the Steamworks API.
@@ -708,7 +789,9 @@ def ISteamRemoteStorage_GetCollectionDetails(
     # Construct arguments to pass to the API call
     metadata = []
     for chunk in list(chunks(_list=publishedfileids, limit=5000)):
-        logger.debug(f"Querying details for {len(chunk)} collection(s) via Steam WebAPI")
+        logger.debug(
+            f"Querying details for {len(chunk)} collection(s) via Steam WebAPI"
+        )
         # Construct arguments to pass to the API call
         data = {"collectioncount": f"{str(len(chunk))}"}
         for publishedfileid in chunk:

--- a/app/utils/symlink.py
+++ b/app/utils/symlink.py
@@ -11,7 +11,9 @@ from app.utils.generic import handle_remove_read_only
 class SymlinkCreationError(Exception):
     """Exception related to creating a symlink/junction."""
 
-    def __init__(self, message: str, src_path: str | Path, dst_path: str | Path) -> None:
+    def __init__(
+        self, message: str, src_path: str | Path, dst_path: str | Path
+    ) -> None:
         super().__init__(message)
         self.src_path = Path(src_path)
         self.dst_path = Path(dst_path)
@@ -81,7 +83,9 @@ def create_symlink(
     :param force: Force the creation of the symlink/junction, even if the dst_path exists. Default is False.
     """
     if not os.path.exists(src_path):
-        logger.warning(f"Provided source path {src_path} does not exist, abandoning symlink creation.")
+        logger.warning(
+            f"Provided source path {src_path} does not exist, abandoning symlink creation."
+        )
         raise SymlinkSrcNotExistError(
             f"Provided source path {src_path} does not exist, abandoning symlink creation.",
             src_path,
@@ -89,7 +93,9 @@ def create_symlink(
         )
 
     if not os.path.isdir(src_path):
-        logger.warning(f"Provided source path {src_path} is not a directory, abandoning symlink creation.")
+        logger.warning(
+            f"Provided source path {src_path} is not a directory, abandoning symlink creation."
+        )
         raise SymlinkSrcNotDirError(
             f"Provided source path {src_path} is not a directory, abandoning symlink creation.",
             src_path,
@@ -97,7 +103,9 @@ def create_symlink(
         )
 
     if os.path.exists(dst_path):
-        logger.debug(f"Potential existing link at {dst_path}. Will attempt to recreate to source: {src_path}")
+        logger.debug(
+            f"Potential existing link at {dst_path}. Will attempt to recreate to source: {src_path}"
+        )
         # Remove by type
         if is_junction_or_link(dst_path) or os.path.ismount(dst_path):
             os.unlink(dst_path)
@@ -162,4 +170,6 @@ def create_symlink(
         CreateJunction(src_path, dst_path)
 
     else:
-        raise NotImplementedError(f"Platform {sys.platform} is not supported for symlink/junction creation")
+        raise NotImplementedError(
+            f"Platform {sys.platform} is not supported for symlink/junction creation"
+        )

--- a/app/utils/system_info.py
+++ b/app/utils/system_info.py
@@ -73,7 +73,9 @@ class SystemInfo:
         elif platform.system() in ["Darwin"]:
             self._operating_system = SystemInfo.OperatingSystem.MACOS
         else:
-            raise UnsupportedOperatingSystemError(f"Unsupported operating system detected: {platform.system()}.")
+            raise UnsupportedOperatingSystemError(
+                f"Unsupported operating system detected: {platform.system()}."
+            )
 
         arch = platform.machine().lower()
         if arch in ["x86_64", "amd64"]:
@@ -83,7 +85,9 @@ class SystemInfo:
         elif arch in ["arm64", "aarch64", "arm64e"]:
             self._architecture = SystemInfo.Architecture.ARM64
         else:
-            raise UnsupportedArchitectureError(f"Unsupported architecture detected: {platform.machine()}.")
+            raise UnsupportedArchitectureError(
+                f"Unsupported architecture detected: {platform.machine()}."
+            )
 
         self._is_initialized: bool = True
 

--- a/app/utils/todds/wrapper.py
+++ b/app/utils/todds/wrapper.py
@@ -128,7 +128,9 @@ class ToddsInterface:
             logger.warning(f"Executing todds with arguments: {args} in {self.cwd}")
         else:
             logger.error("Todds executable not found.")
-            development_guide_url = "https://rimsort.github.io/RimSort/development-guide/development-setup"
+            development_guide_url = (
+                "https://rimsort.github.io/RimSort/development-guide/development-setup"
+            )
             support_url = "https://github.com/RimSort/RimSort/issues"
             todds_error_message = QCoreApplication.translate(
                 "ToddsInterface",

--- a/app/utils/update_utils.py
+++ b/app/utils/update_utils.py
@@ -164,7 +164,12 @@ class ScriptConfig:
     def get_script_path(self) -> Path:
         """Get the script path for this platform."""
         if self.platform == "Darwin":
-            return Path(sys.argv[0]).parent.parent.parent / "Contents" / "MacOS" / self.script_name
+            return (
+                Path(sys.argv[0]).parent.parent.parent
+                / "Contents"
+                / "MacOS"
+                / self.script_name
+            )
         else:
             return AppInfo().application_folder / self.script_name
 
@@ -197,7 +202,9 @@ class ScriptConfig:
         elif install_dir and self.platform == "Linux":
             base_args.append(str(install_dir))
 
-        return self._build_platform_args(base_args, script_path, needs_elevation, update_manager)
+        return self._build_platform_args(
+            base_args, script_path, needs_elevation, update_manager
+        )
 
     @staticmethod
     def _build_bash_command(base_args: List[str], needs_elevation: bool) -> str:
@@ -219,7 +226,9 @@ class ScriptConfig:
             return quoted_args
 
     @staticmethod
-    def _build_terminal_command(terminal: str, base_args: List[str], needs_elevation: bool) -> str:
+    def _build_terminal_command(
+        terminal: str, base_args: List[str], needs_elevation: bool
+    ) -> str:
         """
         Build terminal-specific command string for launching update script.
         Used as fallback if direct bash execution is not available.
@@ -290,7 +299,9 @@ class ScriptConfig:
         """
         if self.platform == "Darwin":
             quoted_args = " ".join(shlex.quote(arg) for arg in base_args)
-            terminal_cmd = f'/bin/bash {quoted_args}; read -p \\"Press enter to close\\"'
+            terminal_cmd = (
+                f'/bin/bash {quoted_args}; read -p \\"Press enter to close\\"'
+            )
             script_cmd = f"sudo {terminal_cmd}" if needs_elevation else terminal_cmd
             return f'osascript -e \'tell app "Terminal" to do script "{script_cmd}"\''
         elif self.platform == "Windows":
@@ -398,10 +409,14 @@ class UpdateManager(QObject):
         self._arch = platform.architecture()[0]
         # Cache platform patterns for performance
         self._cached_patterns = (
-            self._platform_patterns[self._system] if self._system in self._platform_patterns else None
+            self._platform_patterns[self._system]
+            if self._system in self._platform_patterns
+            else None
         )
         self._download_cancelled = False
-        self._detected_terminal: Optional[str] = None  # Cache detected terminal emulator (for fallback only)
+        self._detected_terminal: Optional[str] = (
+            None  # Cache detected terminal emulator (for fallback only)
+        )
         # Progress window for update operations
         self._progress_widget: Optional[TaskProgressWindow] = None
 
@@ -430,7 +445,9 @@ class UpdateManager(QObject):
                 return True
         else:
             # For non-Windows, use the original check
-            self._elevation_needed = not os.access(AppInfo().application_folder, os.W_OK)
+            self._elevation_needed = not os.access(
+                AppInfo().application_folder, os.W_OK
+            )
             return self._elevation_needed
 
     def _is_in_protected_path(self) -> bool:
@@ -440,7 +457,9 @@ class UpdateManager(QObject):
 
         for protected in WINDOWS_PROTECTED_PATHS:
             if protected in app_path_str:
-                logger.info(f"Application in protected path: {protected} - elevation required")
+                logger.info(
+                    f"Application in protected path: {protected} - elevation required"
+                )
                 return True
         return False
 
@@ -542,12 +561,16 @@ class UpdateManager(QObject):
         """
         # Check for disable flag
         if os.getenv("RIMSORT_DISABLE_UPDATER"):
-            logger.debug("RIMSORT_DISABLE_UPDATER is set, skipping update check silently.")
+            logger.debug(
+                "RIMSORT_DISABLE_UPDATER is set, skipping update check silently."
+            )
             return False
 
         # Check if running from compiled binary built by Nuitka or running from Python interpreter
         if "__compiled__" not in globals():
-            logger.debug("You are running from Python interpreter. Skipping update check...")
+            logger.debug(
+                "You are running from Python interpreter. Skipping update check..."
+            )
             dialogue.show_warning(
                 title=ERR_UPDATE_SKIPPED_TITLE,
                 text=ERR_UPDATE_SKIPPED_TEXT,
@@ -621,7 +644,9 @@ class UpdateManager(QObject):
         """
         try:
             if current_version == "Unknown version":
-                logger.warning(f"Current version is: {current_version}, assuming custom build")
+                logger.warning(
+                    f"Current version is: {current_version}, assuming custom build"
+                )
                 answer = dialogue.show_dialogue_conditional(
                     title=self.tr(UNKNOWN_VERSION_TITLE),
                     text=self.tr(UNKNOWN_VERSION_TEXT),
@@ -641,7 +666,9 @@ class UpdateManager(QObject):
             logger.warning(f"Failed to parse version '{current_version}': {e}")
             return version.parse("0.0.0")
 
-    def _prompt_user_for_update(self, latest_tag_name: str, current_version: str) -> bool:
+    def _prompt_user_for_update(
+        self, latest_tag_name: str, current_version: str
+    ) -> bool:
         """
         Prompt the user to confirm the update.
 
@@ -654,12 +681,12 @@ class UpdateManager(QObject):
         """
         answer = dialogue.show_dialogue_conditional(
             title=self.tr("RimSort update found"),
-            text=self.tr("An update to RimSort has been released: {latest_tag_name}").format(
-                latest_tag_name=latest_tag_name
-            ),
-            information=self.tr("You are running RimSort {current_version}\nDo you want to update now?").format(
-                current_version=current_version
-            ),
+            text=self.tr(
+                "An update to RimSort has been released: {latest_tag_name}"
+            ).format(latest_tag_name=latest_tag_name),
+            information=self.tr(
+                "You are running RimSort {current_version}\nDo you want to update now?"
+            ).format(current_version=current_version),
         )
         return answer == QMessageBox.StandardButton.Yes
 
@@ -684,7 +711,9 @@ class UpdateManager(QObject):
             logger.error(f"Unexpected error during update: {e}")
             raise UpdateError(f"Update failed: {e}") from e
 
-    def _get_latest_release_info(self, needs_elevation: bool = False) -> ReleaseInfo | None:
+    def _get_latest_release_info(
+        self, needs_elevation: bool = False
+    ) -> ReleaseInfo | None:
         """
         Get the latest release information from GitHub API.
 
@@ -713,12 +742,16 @@ class UpdateManager(QObject):
                 return None
 
             # Get platform-specific download URL
-            download_info = self._get_platform_download_url(release_data.get("assets", []), needs_elevation)
+            download_info = self._get_platform_download_url(
+                release_data.get("assets", []), needs_elevation
+            )
             if not download_info:
                 system_info = f"{platform.system()} {platform.architecture()[0]} {platform.processor()}"
                 dialogue.show_warning(
                     title=self.tr(ERR_NO_VALID_RELEASE_TITLE),
-                    text=self.tr(ERR_NO_VALID_RELEASE_TEXT).format(system_info=system_info),
+                    text=self.tr(ERR_NO_VALID_RELEASE_TEXT).format(
+                        system_info=system_info
+                    ),
                 )
                 return None
 
@@ -779,7 +812,9 @@ class UpdateManager(QObject):
 
         # If architecture is required, check arch patterns
         if require_arch and arch_patterns:
-            if not any(pattern.lower() in asset_name_lower for pattern in arch_patterns):
+            if not any(
+                pattern.lower() in asset_name_lower for pattern in arch_patterns
+            ):
                 return False
 
         return True
@@ -802,21 +837,29 @@ class UpdateManager(QObject):
             return None
 
         system_patterns = cast(List[str], self._cached_patterns["patterns"])
-        arch_patterns_dict = cast(Dict[str, List[str]], self._cached_patterns["arch_patterns"])
+        arch_patterns_dict = cast(
+            Dict[str, List[str]], self._cached_patterns["arch_patterns"]
+        )
         arch_patterns = arch_patterns_dict.get(self._arch, [])
 
         # Determine preferred extension order
         if self._system == "Windows" and self._is_in_protected_path():
             preferred_order = [MSI_EXTENSION, ZIP_EXTENSION]
         else:
-            preferred_order = [ZIP_EXTENSION, MSI_EXTENSION] if self._system == "Windows" else [ZIP_EXTENSION]
+            preferred_order = (
+                [ZIP_EXTENSION, MSI_EXTENSION]
+                if self._system == "Windows"
+                else [ZIP_EXTENSION]
+            )
 
         logger.debug(
             f"Looking for asset matching system={self._system}, arch={self._arch}, patterns={system_patterns + arch_patterns}, order={preferred_order}"
         )
 
         for ext in preferred_order:
-            candidate = self._find_best_asset_match(assets, system_patterns, arch_patterns, ext)
+            candidate = self._find_best_asset_match(
+                assets, system_patterns, arch_patterns, ext
+            )
             if candidate:
                 return candidate
 
@@ -862,7 +905,9 @@ class UpdateManager(QObject):
                     arch_patterns=arch_patterns,
                 )
             ):
-                logger.debug(f"Found arch-specific matching asset: {asset_name} -> {download_url}")
+                logger.debug(
+                    f"Found arch-specific matching asset: {asset_name} -> {download_url}"
+                )
                 return cast(
                     DownloadInfo,
                     {
@@ -871,8 +916,12 @@ class UpdateManager(QObject):
                         "is_msi": preferred_extension == MSI_EXTENSION,
                     },
                 )
-            elif download_url and self._asset_matches(asset, system_patterns, preferred_extension, require_arch=False):
-                logger.debug(f"Found system-only matching asset: {asset_name} -> {download_url}")
+            elif download_url and self._asset_matches(
+                asset, system_patterns, preferred_extension, require_arch=False
+            ):
+                logger.debug(
+                    f"Found system-only matching asset: {asset_name} -> {download_url}"
+                )
                 if candidate is None:  # Only set if no arch-specific found
                     candidate = cast(
                         DownloadInfo,
@@ -904,7 +953,9 @@ class UpdateManager(QObject):
             tag_name: Tag name of the release
         """
         try:
-            logger.debug(f"Downloading & extracting RimSort release from: {download_url}")
+            logger.debug(
+                f"Downloading & extracting RimSort release from: {download_url}"
+            )
 
             # Download with progress widget
             self._download_cancelled = False
@@ -915,7 +966,9 @@ class UpdateManager(QObject):
             )
             self._progress_widget.update_progress(
                 0,
-                self.tr("Downloading RimSort {tag_name} release...").format(tag_name=tag_name),
+                self.tr("Downloading RimSort {tag_name} release...").format(
+                    tag_name=tag_name
+                ),
             )
             self._progress_widget.cancel_requested.connect(self._on_download_cancel)
             self.update_progress.connect(self._progress_widget.update_progress)
@@ -932,13 +985,17 @@ class UpdateManager(QObject):
                         self._progress_widget.close()
                         # Remove from panel if it was added there
                         if self.mod_info_panel:
-                            self.mod_info_panel.panel.removeWidget(self._progress_widget)
+                            self.mod_info_panel.panel.removeWidget(
+                                self._progress_widget
+                            )
                 except Exception:
                     pass
 
             self.download_complete.connect(on_complete)
 
-            worker = threading.Thread(target=self._download_update_worker, args=(download_url,), daemon=True)
+            worker = threading.Thread(
+                target=self._download_update_worker, args=(download_url,), daemon=True
+            )
             worker.start()
 
             # Show progress widget in panel or as standalone window
@@ -957,7 +1014,9 @@ class UpdateManager(QObject):
             if not download_result["success"] or self._update_content is None:
                 if self._download_cancelled:
                     raise UpdateDownloadError("Download cancelled by user")
-                raise UpdateDownloadError(download_result["error"] or "Download did not complete successfully")
+                raise UpdateDownloadError(
+                    download_result["error"] or "Download did not complete successfully"
+                )
 
             # Extract or save with progress window
             try:
@@ -970,7 +1029,9 @@ class UpdateManager(QObject):
             logger.info(f"Update extracted to: {update_source_path}")
 
             if update_source_path is None:
-                raise UpdateExtractionError("Extraction/preparation did not complete successfully")
+                raise UpdateExtractionError(
+                    "Extraction/preparation did not complete successfully"
+                )
 
             # Confirm installation
             answer = dialogue.show_dialogue_conditional(
@@ -1001,7 +1062,9 @@ class UpdateManager(QObject):
             needs_elevation = self._check_needs_elevation()
 
             # Launch update script or MSI installer
-            self._launch_update_script(update_source_path, log_path, needs_elevation, is_msi)
+            self._launch_update_script(
+                update_source_path, log_path, needs_elevation, is_msi
+            )
 
         except UpdateDownloadError as e:
             logger.error(f"Update download failed: {e}")
@@ -1053,7 +1116,9 @@ class UpdateManager(QObject):
             File size in bytes, or 0 if unable to determine
         """
         try:
-            head_response = requests.head(url, timeout=API_TIMEOUT, allow_redirects=True)
+            head_response = requests.head(
+                url, timeout=API_TIMEOUT, allow_redirects=True
+            )
             return int(head_response.headers.get("content-length", 0))
         except Exception as e:
             logger.debug(f"Failed to get file size: {e}")
@@ -1070,7 +1135,9 @@ class UpdateManager(QObject):
             return f"{int(size)} {units[i]}"
         return f"{size:.1f} {units[i]}"
 
-    def _download_with_progress(self, response: requests.Response, total_size: int) -> bytes:
+    def _download_with_progress(
+        self, response: requests.Response, total_size: int
+    ) -> bytes:
         """
         Download content with progress tracking.
 
@@ -1134,7 +1201,9 @@ class UpdateManager(QObject):
         if total_size > 0:
             self.update_progress.emit(100, "Download complete")
         else:
-            self.update_progress.emit(100, f"Download complete ({self._format_size(len(content))})")
+            self.update_progress.emit(
+                100, f"Download complete ({self._format_size(len(content))})"
+            )
         return bytes(content)
 
     def _validate_download(self, content: bytes) -> None:
@@ -1150,7 +1219,9 @@ class UpdateManager(QObject):
         if len(content) == 0:
             raise UpdateDownloadError("Downloaded file is empty")
         if len(content) < MIN_UPDATE_SIZE:
-            raise UpdateDownloadError(f"Downloaded file too small ({len(content)} bytes)")
+            raise UpdateDownloadError(
+                f"Downloaded file too small ({len(content)} bytes)"
+            )
 
     def _download_update(self, url: str) -> None:
         """
@@ -1198,7 +1269,10 @@ class UpdateManager(QObject):
         Returns:
             Path to the created temporary directory
         """
-        temp_base = Path(gettempdir()) / f"RimSort_update_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+        temp_base = (
+            Path(gettempdir())
+            / f"RimSort_update_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+        )
         temp_base.mkdir(exist_ok=True)
         return temp_base
 
@@ -1272,7 +1346,9 @@ class UpdateManager(QObject):
                         self._progress_widget.close()
                         # Remove from panel if it was added there
                         if self.mod_info_panel:
-                            self.mod_info_panel.panel.removeWidget(self._progress_widget)
+                            self.mod_info_panel.panel.removeWidget(
+                                self._progress_widget
+                            )
                             # Restore panel visibility
                             self.mod_info_panel.info_panel_frame.show()
                 except Exception as e:
@@ -1294,12 +1370,16 @@ class UpdateManager(QObject):
             # Ensure thread is properly cleaned up before continuing
             extract_thread.wait(EXTRACTION_THREAD_TIMEOUT_MS)
             if extract_thread.isRunning():
-                logger.warning("Extraction thread still running after timeout, forcing quit")
+                logger.warning(
+                    "Extraction thread still running after timeout, forcing quit"
+                )
                 extract_thread.quit()
                 extract_thread.wait(2000)  # Final attempt to stop thread
 
             if not extraction_result["success"]:
-                raise UpdateExtractionError(f"Extraction failed: {extraction_result['error']}")
+                raise UpdateExtractionError(
+                    f"Extraction failed: {extraction_result['error']}"
+                )
 
             logger.info(f"Extracted {extracted_files} files from ZIP")
             return extracted_files
@@ -1374,7 +1454,9 @@ class UpdateManager(QObject):
             error = normalization_result["error"]
             if isinstance(error, UpdateExtractionError):
                 raise error
-            raise UpdateExtractionError(f"Structure normalization failed: {error}") from error
+            raise UpdateExtractionError(
+                f"Structure normalization failed: {error}"
+            ) from error
 
         logger.debug(f"Normalized update ready at: {temp_base}")
 
@@ -1393,7 +1475,9 @@ class UpdateManager(QObject):
         try:
             if self._update_content is None:
                 logger.error("No update content available")
-                raise UpdateExtractionError("No update content available for extraction")
+                raise UpdateExtractionError(
+                    "No update content available for extraction"
+                )
 
             if is_msi:
                 # For MSI, just save the file to temp location
@@ -1421,7 +1505,9 @@ class UpdateManager(QObject):
 
         except BadZipFile as e:
             logger.error(f"Invalid ZIP file: {e}")
-            raise UpdateExtractionError(f"Downloaded file is not a valid ZIP archive: {e}") from e
+            raise UpdateExtractionError(
+                f"Downloaded file is not a valid ZIP archive: {e}"
+            ) from e
         except UpdateError:
             raise
         except Exception as e:
@@ -1441,7 +1527,9 @@ class UpdateManager(QObject):
         top_dir_name = top_dir.name.lower()
 
         # Common wrapper patterns
-        if any(keyword in top_dir_name for keyword in ["app", "application", "release"]):
+        if any(
+            keyword in top_dir_name for keyword in ["app", "application", "release"]
+        ):
             return True
 
         # Version-like directory names
@@ -1489,7 +1577,9 @@ class UpdateManager(QObject):
                 continue
         return moved_items
 
-    def _validate_executable_presence(self, extract_path: Path, children: List[Path]) -> None:
+    def _validate_executable_presence(
+        self, extract_path: Path, children: List[Path]
+    ) -> None:
         """
         Validate that the expected executable is present in the extracted structure.
 
@@ -1508,14 +1598,18 @@ class UpdateManager(QObject):
             for child in children:
                 if child.is_dir() and child.name.endswith(".app"):
                     app_bundle = child
-                    executable_path = app_bundle / "Contents" / "MacOS" / expected_executable
+                    executable_path = (
+                        app_bundle / "Contents" / "MacOS" / expected_executable
+                    )
                     if executable_path.exists():
                         executable_found = True
                         logger.info("Found macOS executable")
                         break
             if not executable_found:
                 logger.error("RimSort.app bundle not found")
-                raise UpdateExtractionError("Expected RimSort.app bundle with executable not found after normalization")
+                raise UpdateExtractionError(
+                    "Expected RimSort.app bundle with executable not found after normalization"
+                )
         else:
             # Look for executable directly
             executable_path = extract_path / expected_executable
@@ -1540,14 +1634,20 @@ class UpdateManager(QObject):
                 all_files = []
                 for root, dirs, files in os.walk(extract_path):
                     for file in files:
-                        rel_path = os.path.relpath(os.path.join(root, file), extract_path)
+                        rel_path = os.path.relpath(
+                            os.path.join(root, file), extract_path
+                        )
                         all_files.append(rel_path)
-                logger.error(f"All files in extract_path: {all_files[:50]}...")  # Limit to first 50
+                logger.error(
+                    f"All files in extract_path: {all_files[:50]}..."
+                )  # Limit to first 50
                 raise UpdateExtractionError(
                     f"Expected executable '{expected_executable}' not found at expected location after normalization"
                 )
 
-    def _normalize_extracted_structure(self, extract_path: Path, num_files: int) -> None:
+    def _normalize_extracted_structure(
+        self, extract_path: Path, num_files: int
+    ) -> None:
         """
         Normalize the extracted ZIP structure by moving contents to root if wrapped.
 
@@ -1560,7 +1660,9 @@ class UpdateManager(QObject):
         """
         try:
             if not extract_path.exists():
-                raise UpdateExtractionError("Extracted path does not exist after extraction")
+                raise UpdateExtractionError(
+                    "Extracted path does not exist after extraction"
+                )
 
             children = list(extract_path.iterdir())
             logger.debug(f"Initial extracted children: {[c.name for c in children]}")
@@ -1572,17 +1674,25 @@ class UpdateManager(QObject):
                 top_dir = children[0]
 
                 if not self._should_unwrap_directory(top_dir):
-                    logger.debug(f"No unwrapping needed for '{top_dir.name}'; using existing structure")
+                    logger.debug(
+                        f"No unwrapping needed for '{top_dir.name}'; using existing structure"
+                    )
                     break
 
-                logger.debug(f"Detected wrapped structure in '{top_dir.name}'; normalizing")
-                logger.debug(f"Wrapper '{top_dir.name}' children: {[c.name for c in top_dir.iterdir()]}")
+                logger.debug(
+                    f"Detected wrapped structure in '{top_dir.name}'; normalizing"
+                )
+                logger.debug(
+                    f"Wrapper '{top_dir.name}' children: {[c.name for c in top_dir.iterdir()]}"
+                )
 
                 # Move all contents from top_dir to extract_path
                 moved_items = self._move_directory_contents(top_dir, extract_path)
 
                 if moved_items == 0:
-                    logger.warning("No items were successfully moved during normalization")
+                    logger.warning(
+                        "No items were successfully moved during normalization"
+                    )
                     break
 
                 # Remove empty top_dir if possible
@@ -1594,15 +1704,21 @@ class UpdateManager(QObject):
 
                 # Refresh children list after unwrapping
                 children = list(extract_path.iterdir())
-                logger.debug(f"Post-normalization children: {[c.name for c in children]}")
+                logger.debug(
+                    f"Post-normalization children: {[c.name for c in children]}"
+                )
 
             # Validate expected structure based on platform
             self._validate_executable_presence(extract_path, children)
         except Exception as e:
             logger.error(f"Unexpected error during structure normalization: {e}")
             logger.error(f"Extract path: {extract_path}")
-            logger.error(f"Children: {[c.name for c in extract_path.iterdir()] if extract_path.exists() else 'N/A'}")
-            raise UpdateExtractionError(f"Structure normalization failed: {str(e)}") from e
+            logger.error(
+                f"Children: {[c.name for c in extract_path.iterdir()] if extract_path.exists() else 'N/A'}"
+            )
+            raise UpdateExtractionError(
+                f"Structure normalization failed: {str(e)}"
+            ) from e
 
     def _launch_update_script(
         self,
@@ -1623,16 +1739,20 @@ class UpdateManager(QObject):
 
         if is_msi:
             if self._system != "Windows":
-                raise UpdateScriptLaunchError("MSI installers are only supported on Windows")
+                raise UpdateScriptLaunchError(
+                    "MSI installers are only supported on Windows"
+                )
             # Validate MSI path
             if not update_source_path.exists() or not update_source_path.is_file():
-                raise UpdateScriptLaunchError(f"MSI file not found or is not a file: {update_source_path}")
+                raise UpdateScriptLaunchError(
+                    f"MSI file not found or is not a file: {update_source_path}"
+                )
             self._launch_msi_installer(update_source_path, log_path, needs_elevation)
             return
 
         try:
-            script_path, args_repr, start_new_session, install_dir = self._get_script_info(
-                update_source_path, log_path, needs_elevation
+            script_path, args_repr, start_new_session, install_dir = (
+                self._get_script_info(update_source_path, log_path, needs_elevation)
             )
 
             # Validate script exists before proceeding
@@ -1647,7 +1767,9 @@ class UpdateManager(QObject):
                 # Copy update.bat to app storage folder
                 try:
                     shutil.copy2(str(script_path), str(temp_script_path))
-                    logger.debug(f"Copied update.bat to app storage: {temp_script_path}")
+                    logger.debug(
+                        f"Copied update.bat to app storage: {temp_script_path}"
+                    )
                     script_path = temp_script_path
 
                     # Rebuild args with new script path
@@ -1662,10 +1784,14 @@ class UpdateManager(QObject):
                     )
                     logger.debug(f"Updated script path to: {script_path}")
                 except Exception as e:
-                    logger.warning(f"Failed to copy update.bat to app storage, using original: {e}")
+                    logger.warning(
+                        f"Failed to copy update.bat to app storage, using original: {e}"
+                    )
 
             if self._system == "Windows":
-                p = self._launch_windows_update_script(script_path, args_repr, needs_elevation)
+                p = self._launch_windows_update_script(
+                    script_path, args_repr, needs_elevation
+                )
             else:
                 p = self._launch_posix_update_script(
                     script_path,
@@ -1789,7 +1915,9 @@ class UpdateManager(QObject):
 
         # For systems requiring elevation, copy script to temp location to avoid permission issues
         if needs_elevation:
-            fd, temp_script_path = tempfile.mkstemp(suffix=".sh", prefix="rimsort_update_")
+            fd, temp_script_path = tempfile.mkstemp(
+                suffix=".sh", prefix="rimsort_update_"
+            )
             os.close(fd)
             shutil.copy2(str(script_path), temp_script_path)
             os.chmod(temp_script_path, 0o700)
@@ -1814,12 +1942,16 @@ class UpdateManager(QObject):
                 shell=True,
                 cwd=str(AppInfo().application_folder),
             )
-            logger.info(f"Successfully launched update script with primary method (PID: {p.pid})")
+            logger.info(
+                f"Successfully launched update script with primary method (PID: {p.pid})"
+            )
             return p
         except Exception as e:
             # Fallback for Linux only - try terminal emulator if direct bash fails
             if self._system == "Linux":
-                logger.warning(f"Primary method failed on Linux ({e}), attempting terminal emulator fallback...")
+                logger.warning(
+                    f"Primary method failed on Linux ({e}), attempting terminal emulator fallback..."
+                )
                 try:
                     terminal = self._detect_terminal_emulator()
                     base_args = [
@@ -1831,7 +1963,9 @@ class UpdateManager(QObject):
                         base_args.append(str(install_dir))
 
                     config = self._script_configs["Linux"]
-                    fallback_cmd = config._build_terminal_command(terminal, base_args, needs_elevation)
+                    fallback_cmd = config._build_terminal_command(
+                        terminal, base_args, needs_elevation
+                    )
                     logger.info(f"Using terminal emulator fallback: {terminal}")
 
                     p = subprocess.Popen(
@@ -1839,19 +1973,27 @@ class UpdateManager(QObject):
                         shell=True,
                         cwd=str(AppInfo().application_folder),
                     )
-                    logger.info(f"Successfully launched update script with terminal fallback (PID: {p.pid})")
+                    logger.info(
+                        f"Successfully launched update script with terminal fallback (PID: {p.pid})"
+                    )
                     return p
                 except Exception as fallback_err:
-                    logger.error(f"Both primary and fallback methods failed: {e} -> {fallback_err}")
+                    logger.error(
+                        f"Both primary and fallback methods failed: {e} -> {fallback_err}"
+                    )
                     raise UpdateScriptLaunchError(
                         f"Failed to launch update script. Primary method: {e}. Fallback: {fallback_err}"
                     ) from fallback_err
             else:
                 # For macOS, no fallback - just raise the error
                 logger.error(f"Failed to launch update script on {self._system}: {e}")
-                raise UpdateScriptLaunchError(f"Failed to launch update script on {self._system}: {e}") from e
+                raise UpdateScriptLaunchError(
+                    f"Failed to launch update script on {self._system}: {e}"
+                ) from e
 
-    def _launch_msi_installer(self, msi_path: Path, log_path: Path, needs_elevation: bool) -> None:
+    def _launch_msi_installer(
+        self, msi_path: Path, log_path: Path, needs_elevation: bool
+    ) -> None:
         """
         Launch the MSI installer on Windows.
 
@@ -1880,7 +2022,15 @@ class UpdateManager(QObject):
             logger.warning(f"Could not create log directory: {e}")
 
         # Build msiexec command
-        cmd = ["msiexec", "/i", str(msi_path), "/passive", "/norestart", "/log", str(log_path)]
+        cmd = [
+            "msiexec",
+            "/i",
+            str(msi_path),
+            "/passive",
+            "/norestart",
+            "/log",
+            str(log_path),
+        ]
 
         try:
             logger.info(f"Launching MSI installer: {msi_path}")
@@ -1972,7 +2122,9 @@ class UpdateManager(QObject):
         """Worker thread for extraction."""
         return self._extract_update(is_msi)
 
-    def _show_progress_widget(self, progress_widget: TaskProgressWindow, cancellable: bool = True) -> None:
+    def _show_progress_widget(
+        self, progress_widget: TaskProgressWindow, cancellable: bool = True
+    ) -> None:
         """Show progress widget in panel or as standalone window."""
         progress_widget.set_cancel_enabled(cancellable)
 
@@ -1985,7 +2137,9 @@ class UpdateManager(QObject):
         else:
             progress_widget.show()
 
-    def _hide_progress_widget(self, progress_widget: Optional[TaskProgressWindow]) -> None:
+    def _hide_progress_widget(
+        self, progress_widget: Optional[TaskProgressWindow]
+    ) -> None:
         """Close and remove progress widget from panel."""
         try:
             if progress_widget:
@@ -2003,7 +2157,9 @@ class UpdateManager(QObject):
             show_message=True,
             show_percent=True,
         )
-        self._progress_widget.set_message(self.tr("Creating backup... (this may take several minutes)"))
+        self._progress_widget.set_message(
+            self.tr("Creating backup... (this may take several minutes)")
+        )
 
         # Show progress widget (backup cannot be cancelled)
         self._show_progress_widget(self._progress_widget, cancellable=False)
@@ -2058,12 +2214,16 @@ class UpdateManager(QObject):
 
         try:
             # Create ZIP backup of the application folder with progress updates
-            create_zip_backup(app_folder, backup_path, progress_callback=update_backup_progress)
+            create_zip_backup(
+                app_folder, backup_path, progress_callback=update_backup_progress
+            )
 
             # Verify backup was created
             if backup_path.exists():
                 backup_size = backup_path.stat().st_size
-                logger.info(f"Backup created successfully ({backup_size / (1024 * 1024):.2f} MB)")
+                logger.info(
+                    f"Backup created successfully ({backup_size / (1024 * 1024):.2f} MB)"
+                )
             else:
                 logger.warning("Backup file not created")
 
@@ -2092,7 +2252,9 @@ class UpdateManager(QObject):
             # Get all backup files
             backup_files = list(app_backup_folder.glob("RimSort_Backup_*.zip"))
             if len(backup_files) <= max_backups:
-                logger.debug(f"Backup count ({len(backup_files)}) is within limit ({max_backups})")
+                logger.debug(
+                    f"Backup count ({len(backup_files)}) is within limit ({max_backups})"
+                )
                 return
 
             # Sort by modification time (newest first)
@@ -2105,9 +2267,13 @@ class UpdateManager(QObject):
                     backup_file.unlink()
                     logger.info(f"Removed old backup: {backup_file.name}")
                 except Exception as e:
-                    logger.warning(f"Failed to remove old backup {backup_file.name}: {e}")
+                    logger.warning(
+                        f"Failed to remove old backup {backup_file.name}: {e}"
+                    )
 
-            logger.info(f"Cleaned up {len(backups_to_remove)} old backups, keeping {max_backups} most recent")
+            logger.info(
+                f"Cleaned up {len(backups_to_remove)} old backups, keeping {max_backups} most recent"
+            )
 
         except Exception as e:
             logger.warning(f"Failed to cleanup old backups: {e}")

--- a/app/utils/watchdog.py
+++ b/app/utils/watchdog.py
@@ -22,7 +22,9 @@ class WatchdogHandler(FileSystemEventHandler, QObject):
     mod_deleted = Signal(str, str, str)
     mod_updated = Signal(bool, bool, str, str, str)
 
-    def __init__(self, settings_controller: SettingsController, targets: list[str]) -> None:
+    def __init__(
+        self, settings_controller: SettingsController, targets: list[str]
+    ) -> None:
         """Initialize the WatchdogHandler.
 
         The WatchdogHandler is a subclass of :class:`watchdog.events.FileSystemEventHandler`
@@ -42,7 +44,9 @@ class WatchdogHandler(FileSystemEventHandler, QObject):
         logger.info("Initializing WatchdogHandler")
         self.metadata_manager: MetadataManager = MetadataManager.instance()
         self.workshop_acf_path = self.metadata_manager.workshop_acf_path
-        self.steamcmd_appworkshop_acf_path = self.metadata_manager.steamcmd_wrapper.steamcmd_appworkshop_acf_path
+        self.steamcmd_appworkshop_acf_path = (
+            self.metadata_manager.steamcmd_wrapper.steamcmd_appworkshop_acf_path
+        )
         self.settings_controller: SettingsController = settings_controller
         # Steam .acf file monitoring
         self.watchdog_acf_observer: BaseObserver | None
@@ -110,7 +114,9 @@ class WatchdogHandler(FileSystemEventHandler, QObject):
         # Normalize the paths that are being compared
         event_scr_path = event_scr_path.resolve()
         workshop_acf_path = Path(self.workshop_acf_path).resolve()
-        steamcmd_appworkshop_acf_path = Path(self.steamcmd_appworkshop_acf_path).resolve()
+        steamcmd_appworkshop_acf_path = Path(
+            self.steamcmd_appworkshop_acf_path
+        ).resolve()
         # Explicitly check if the file created is an .acf file that we track metadata from
         if (
             not event.is_directory
@@ -127,7 +133,9 @@ class WatchdogHandler(FileSystemEventHandler, QObject):
             return True
         return False
 
-    def __cooldown_uuid_change(self, callback: dict[str, str], delay: float = 3.0) -> None:
+    def __cooldown_uuid_change(
+        self, callback: dict[str, str], delay: float = 3.0
+    ) -> None:
         """Execute a callback after a cooldown period. A cooldown period is used
         to prevent rapid-fire events from triggering multiple callbacks.
 
@@ -141,10 +149,15 @@ class WatchdogHandler(FileSystemEventHandler, QObject):
         operation = callback["operation"]
         mod_directory = callback["path"]
         uuid = callback["uuid"]
-        data_source = callback.get(
-            "data_source"  # This is resolved upon new mod creation, or we use the existing value for
-        ) or self.metadata_manager.internal_local_metadata.get(uuid, {}).get(  # an existing mod
-            "data_source"
+        data_source = (
+            callback.get(
+                "data_source"  # This is resolved upon new mod creation, or we use the existing value for
+            )
+            or self.metadata_manager.internal_local_metadata.get(
+                uuid, {}
+            ).get(  # an existing mod
+                "data_source"
+            )
         )
         # Cancel any existing timers for this key
         timer = self.cooldown_timers.get(uuid)
@@ -192,7 +205,10 @@ class WatchdogHandler(FileSystemEventHandler, QObject):
         # Generate a UUID after confirming we don't already have one for this path
         uuid = (
             str(uuid4())
-            if event.is_directory and not self.metadata_manager.mod_metadata_dir_mapper.get(event_scr_path_str)
+            if event.is_directory
+            and not self.metadata_manager.mod_metadata_dir_mapper.get(
+                event_scr_path_str
+            )
             else None
         )
         # If we know the intent, and have a UUID generated, proceed to create the mod
@@ -225,14 +241,20 @@ class WatchdogHandler(FileSystemEventHandler, QObject):
         if self.__check_acf_file(event, Path(event_scr_path_str)):
             return
         # If we are still here, assume we need to try to resolve an existing UUID from our mod path -> UUID mapper
-        uuid = self.metadata_manager.mod_metadata_dir_mapper.get(event_scr_path_str) if event.is_directory else None
+        uuid = (
+            self.metadata_manager.mod_metadata_dir_mapper.get(event_scr_path_str)
+            if event.is_directory
+            else None
+        )
         # If we have a UUID resolved, proceed to delete the mod
         if uuid is not None:
             # Remove the mod's metadata file from our mapper
-            mod_metadata_file_path = self.metadata_manager.internal_local_metadata.get(uuid, {}).get(
-                "metadata_file_path"
+            mod_metadata_file_path = self.metadata_manager.internal_local_metadata.get(
+                uuid, {}
+            ).get("metadata_file_path")
+            self.metadata_manager.mod_metadata_file_mapper.pop(
+                mod_metadata_file_path, None
             )
-            self.metadata_manager.mod_metadata_file_mapper.pop(mod_metadata_file_path, None)
             # Remove the mod directory from our mod mapper
             self.metadata_manager.mod_metadata_dir_mapper.pop(event_scr_path_str, None)
             logger.debug(f"Mod directory deleted: {event_scr_path_str}")
@@ -258,11 +280,15 @@ class WatchdogHandler(FileSystemEventHandler, QObject):
             return
         # If we are still here, assume we need to try to resolve an existing UUID from our mod path -> UUID mapper
         uuid = (
-            self.metadata_manager.mod_metadata_file_mapper.get(event_scr_path_str) if not event.is_directory else None
+            self.metadata_manager.mod_metadata_file_mapper.get(event_scr_path_str)
+            if not event.is_directory
+            else None
         )
         if uuid is not None:
             # Try to resolve a mod path from the from metadata
-            mod_path = self.metadata_manager.internal_local_metadata.get(uuid, {}).get("path")
+            mod_path = self.metadata_manager.internal_local_metadata.get(uuid, {}).get(
+                "path"
+            )
             # If we have a UUID and mod path resolved, proceed to update the mod
             logger.debug(f"Mod metadata modified: {event_scr_path_str}")
             self.__cooldown_uuid_change(

--- a/app/utils/win_find_steam.py
+++ b/app/utils/win_find_steam.py
@@ -32,7 +32,9 @@ if sys.platform == "win32":
                     if os.path.isfile(candidate_path):
                         return value[0], True
 
-                    logger.warning(f"Steam executable not found at path defined by registry: {candidate_path}")
+                    logger.warning(
+                        f"Steam executable not found at path defined by registry: {candidate_path}"
+                    )
             except FileNotFoundError:
                 # Registry key not found. Continue to the next candidate key
                 continue

--- a/app/utils/window_launch_state.py
+++ b/app/utils/window_launch_state.py
@@ -5,7 +5,9 @@ from loguru import logger
 from app.models.settings import Settings
 
 
-def apply_window_launch_state(window: Any, launch_state: str, custom_width: int, custom_height: int) -> None:
+def apply_window_launch_state(
+    window: Any, launch_state: str, custom_width: int, custom_height: int
+) -> None:
     """
     Apply the window launch state to the given window.
 
@@ -21,7 +23,9 @@ def apply_window_launch_state(window: Any, launch_state: str, custom_width: int,
         window.showNormal()
     elif launch_state == "custom":
         # Validate custom size values
-        custom_width, custom_height = Settings.validate_window_custom_size(custom_width, custom_height)
+        custom_width, custom_height = Settings.validate_window_custom_size(
+            custom_width, custom_height
+        )
         window.resize(custom_width, custom_height)
         window.show()
     else:

--- a/app/utils/xml.py
+++ b/app/utils/xml.py
@@ -110,7 +110,9 @@ def xml_path_to_json(path: str) -> dict[str, Any]:
             with __open_file_maybe_compressed(path) as f:
                 soup = BeautifulSoup(f.read(), "lxml-xml")
                 # Find and remove empty tags
-                empty_tags = soup.find_all(lambda tag: not tag.text.strip() or len(tag) == 0)
+                empty_tags = soup.find_all(
+                    lambda tag: not tag.text.strip() or len(tag) == 0
+                )
                 for empty_tag in empty_tags:
                     empty_tag.extract()
                 # Convert the BeautifulSoup object to a dictionary
@@ -125,7 +127,9 @@ def xml_path_to_json(path: str) -> dict[str, Any]:
     return data
 
 
-def json_to_xml_write(data: dict[str, Any], path: str, raise_errs: bool = False) -> None:
+def json_to_xml_write(
+    data: dict[str, Any], path: str, raise_errs: bool = False
+) -> None:
     """
     Write dictionary data to an XML file.
 
@@ -226,7 +230,9 @@ def fast_rimworld_xml_save_validation(path: str) -> bool:
                 if stack == ["savegame", "meta", "modIds", "li"]:
                     return True
 
-                if event == "end" and (elem.tag == "modIds" or elem.tag == "meta" or elem.tag == "savegame"):
+                if event == "end" and (
+                    elem.tag == "modIds" or elem.tag == "meta" or elem.tag == "savegame"
+                ):
                     # No package ids or save file format is not right
                     return False
 

--- a/app/views/acf_log_reader.py
+++ b/app/views/acf_log_reader.py
@@ -105,7 +105,9 @@ class AcfLogReader(BaseModsPanel):
         # Set up BaseModsPanel buttons (Refresh, etc.)
         button_configs = self._get_base_button_configs()
         self._extend_button_configs_with_steam_actions(button_configs)
-        button_configs.append(self._create_delete_button_config(self.tr("Delete Selected Mods")))
+        button_configs.append(
+            self._create_delete_button_config(self.tr("Delete Selected Mods"))
+        )
         self._setup_buttons_from_config(button_configs)
 
         # Set up custom ACF buttons above the table
@@ -135,12 +137,16 @@ class AcfLogReader(BaseModsPanel):
         for col_idx in self.SEARCHABLE_COLUMNS:
             col_name = ColumnIndex(col_idx).name.replace("_", " ").title()
             self.search_column_filter.addItem(col_name, col_idx)
-        self.search_column_filter.currentIndexChanged.connect(self._on_search_column_changed)
+        self.search_column_filter.currentIndexChanged.connect(
+            self._on_search_column_changed
+        )
         acf_buttons_layout.addWidget(self.search_column_filter)
 
         self.search_input = QLineEdit()
         self.search_input.setPlaceholderText(
-            self.tr("Searches selected column or all searchable columns if set to 'All'")
+            self.tr(
+                "Searches selected column or all searchable columns if set to 'All'"
+            )
         )
         self.search_input.textChanged.connect(self._on_search_text_changed)
         acf_buttons_layout.addWidget(self.search_input, 1)
@@ -201,16 +207,30 @@ class AcfLogReader(BaseModsPanel):
                 name = metadata.get("name", f"Unknown (PFID: {pfid})")
                 authors = metadata.get("authors", "")
                 packageid = metadata.get("packageid", pfid)
-                supported_versions = ModInfo._parse_supported_versions_static(metadata.get("supportedversions"))
+                supported_versions = ModInfo._parse_supported_versions_static(
+                    metadata.get("supportedversions")
+                )
                 path = metadata.get("path", "")
 
                 # Format time displays
                 downloaded_time_raw = metadata.get("internal_time_touched")
-                downloaded_time = format_time_display(int(downloaded_time_raw))[0] if downloaded_time_raw else ""
+                downloaded_time = (
+                    format_time_display(int(downloaded_time_raw))[0]
+                    if downloaded_time_raw
+                    else ""
+                )
 
                 # Use timeupdated from ACF if provided, otherwise use metadata
-                update_time_raw = timeupdated if timeupdated else metadata.get("external_time_updated")
-                updated_time = format_time_display(int(update_time_raw))[0] if update_time_raw else ""
+                update_time_raw = (
+                    timeupdated
+                    if timeupdated
+                    else metadata.get("external_time_updated")
+                )
+                updated_time = (
+                    format_time_display(int(update_time_raw))[0]
+                    if update_time_raw
+                    else ""
+                )
 
                 workshop_url = ModInfo._generate_workshop_url(pfid)
 
@@ -262,13 +282,19 @@ class AcfLogReader(BaseModsPanel):
             path, workshop_url = row_metadata[i]
             if path and path.strip():
                 path_link = self._create_path_link(path, "pathLink")
-                path_index = self.editor_model.item(row_idx, ColumnIndex.PATH.value).index()
+                path_index = self.editor_model.item(
+                    row_idx, ColumnIndex.PATH.value
+                ).index()
                 self.editor_table_view.setIndexWidget(path_index, path_link)
 
             # Add workshop button if workshop URL exists
             if workshop_url:
-                workshop_button = self._create_workshop_button(workshop_url, "workshopButton")
-                workshop_index = self.editor_model.item(row_idx, ColumnIndex.WORKSHOP_PAGE.value).index()
+                workshop_button = self._create_workshop_button(
+                    workshop_url, "workshopButton"
+                )
+                workshop_index = self.editor_model.item(
+                    row_idx, ColumnIndex.WORKSHOP_PAGE.value
+                ).index()
                 self.editor_table_view.setIndexWidget(workshop_index, workshop_button)
 
     def _apply_sort_and_enable(self) -> None:
@@ -283,7 +309,9 @@ class AcfLogReader(BaseModsPanel):
         self.editor_table_view.setSortingEnabled(True)
 
         # Set sort indicator on the header (rows are already in correct order)
-        self.editor_table_view.horizontalHeader().setSortIndicator(self.DEFAULT_SORT_COLUMN, self.DEFAULT_SORT_ORDER)
+        self.editor_table_view.horizontalHeader().setSortIndicator(
+            self.DEFAULT_SORT_COLUMN, self.DEFAULT_SORT_ORDER
+        )
 
     def _update_active_pfids(self) -> None:
         """
@@ -346,7 +374,9 @@ class AcfLogReader(BaseModsPanel):
             )
 
             # Extract workshop items from both sources
-            acf_entries = self._extract_acf_entries(steamcmd_acf_data, workshop_acf_data)
+            acf_entries = self._extract_acf_entries(
+                steamcmd_acf_data, workshop_acf_data
+            )
 
             logger.info(f"ACF Log Reader: Populating with {len(acf_entries)} entries")
 
@@ -367,7 +397,9 @@ class AcfLogReader(BaseModsPanel):
             add_start = time.time()
             self._batch_add_acf_rows(acf_entries, pfid_to_mod)
             add_elapsed = time.time() - add_start
-            logger.info(f"ACF Log Reader: Added {self.editor_model.rowCount()} rows in {add_elapsed:.3f}s")
+            logger.info(
+                f"ACF Log Reader: Added {self.editor_model.rowCount()} rows in {add_elapsed:.3f}s"
+            )
 
             # Re-enable updates
             self.editor_table_view.setUpdatesEnabled(True)
@@ -409,7 +441,12 @@ class AcfLogReader(BaseModsPanel):
 
         # Extract from SteamCMD ACF
         if steamcmd_acf_data:
-            steamcmd_items = steamcmd_acf_data.get("AppWorkshop", {}).get("WorkshopItemsInstalled", {}) or {}
+            steamcmd_items = (
+                steamcmd_acf_data.get("AppWorkshop", {}).get(
+                    "WorkshopItemsInstalled", {}
+                )
+                or {}
+            )
             logger.debug(f"Found {len(steamcmd_items)} items in SteamCMD ACF")
             for pfid, item_data in steamcmd_items.items():
                 if isinstance(item_data, dict):
@@ -423,7 +460,12 @@ class AcfLogReader(BaseModsPanel):
 
         # Extract from Workshop ACF (avoid duplicates)
         if workshop_acf_data:
-            workshop_items = workshop_acf_data.get("AppWorkshop", {}).get("WorkshopItemsInstalled", {}) or {}
+            workshop_items = (
+                workshop_acf_data.get("AppWorkshop", {}).get(
+                    "WorkshopItemsInstalled", {}
+                )
+                or {}
+            )
             logger.debug(f"Found {len(workshop_items)} items in Workshop ACF")
             for pfid, item_data in workshop_items.items():
                 if pfid not in seen_pfids:
@@ -438,7 +480,9 @@ class AcfLogReader(BaseModsPanel):
 
         return entries
 
-    def _get_acf_mods_from_metadata(self, acf_pfids: set[str]) -> dict[str, tuple[str, dict[str, Any]]]:
+    def _get_acf_mods_from_metadata(
+        self, acf_pfids: set[str]
+    ) -> dict[str, tuple[str, dict[str, Any]]]:
         """
         Extract mod metadata for ACF PFIDs.
 

--- a/app/views/deletion_menu.py
+++ b/app/views/deletion_menu.py
@@ -70,7 +70,9 @@ class ModDeletionMenu(QMenu):
         self._actions_initialized = False
 
         # Debug logging for remove_from_uuids
-        logger.debug(f"ModDeletionMenu initialized with remove_from_uuids: {self.remove_from_uuids}")
+        logger.debug(
+            f"ModDeletionMenu initialized with remove_from_uuids: {self.remove_from_uuids}"
+        )
 
         # Synchronize remove_from_uuids with selected mods' UUIDs
         self._sync_remove_from_uuids_with_selected_mods()
@@ -99,7 +101,9 @@ class ModDeletionMenu(QMenu):
             if not uuid:
                 mod_path = mod.get("path")
                 if mod_path:
-                    uuid = self.metadata_manager.mod_metadata_dir_mapper.get(str(mod_path))
+                    uuid = self.metadata_manager.mod_metadata_dir_mapper.get(
+                        str(mod_path)
+                    )
             if uuid:
                 uuids.append(uuid)
         # Remove duplicates and update the list
@@ -116,7 +120,9 @@ class ModDeletionMenu(QMenu):
     ) -> None:
         """Build the list of available deletion actions."""
         if enable_delete_mod:
-            self.delete_actions.append((QAction(self.tr("Delete mod completely")), self.delete_mod_completely))
+            self.delete_actions.append(
+                (QAction(self.tr("Delete mod completely")), self.delete_mod_completely)
+            )
 
         if enable_delete_keep_dds:
             self.delete_actions.append(
@@ -241,7 +247,9 @@ class ModDeletionMenu(QMenu):
         # Synchronize remove_from_uuids with current selected mods before deletion
         self._sync_remove_from_uuids_with_selected_mods()
 
-        if self._confirm_deletion(confirmation_title, confirmation_text, confirmation_info):
+        if self._confirm_deletion(
+            confirmation_title, confirmation_text, confirmation_info
+        ):
             result = self._iterate_mods(
                 deletion_fn,
                 selected_mods,
@@ -252,7 +260,9 @@ class ModDeletionMenu(QMenu):
 
     def _is_official_expansion(self, mod_metadata: ModMetadata) -> bool:
         """Check if the mod is an official expansion that should not be deleted."""
-        return mod_metadata.get("data_source") == self.EXPANSION_DATA_SOURCE and mod_metadata.get(
+        return mod_metadata.get(
+            "data_source"
+        ) == self.EXPANSION_DATA_SOURCE and mod_metadata.get(
             "packageid", ""
         ).startswith(self.LUDEON_PACKAGE_PREFIX)
 
@@ -272,14 +282,18 @@ class ModDeletionMenu(QMenu):
         if result.success_count > 0:
             show_information(
                 title=self.tr("RimSort"),
-                text=self.tr(f"Successfully deleted {result.success_count} selected mods."),
+                text=self.tr(
+                    f"Successfully deleted {result.success_count} selected mods."
+                ),
             )
 
             # Show failure message if any deletions failed
             if result.failed_count > 0:
                 show_warning(
                     title=self.tr("Deletion Incomplete"),
-                    text=self.tr(f"Failed to delete {result.failed_count} mod(s). Check logs for details."),
+                    text=self.tr(
+                        f"Failed to delete {result.failed_count} mod(s). Check logs for details."
+                    ),
                 )
 
         # Call completion callback if provided
@@ -316,14 +330,22 @@ class ModDeletionMenu(QMenu):
 
             # Skip official expansions
             if self._is_official_expansion(mod_metadata):
-                logger.info(f"Skipping official expansion: {mod_metadata.get('name', 'Unknown')}")
-                self._log_progress_if_enabled(processed_count, total_mods, show_progress)
+                logger.info(
+                    f"Skipping official expansion: {mod_metadata.get('name', 'Unknown')}"
+                )
+                self._log_progress_if_enabled(
+                    processed_count, total_mods, show_progress
+                )
                 continue
 
             # Process the mod deletion
-            if self._process_single_mod_deletion(mod_metadata, deletion_fn, result, collect_for_unsubscribe, update_db):
+            if self._process_single_mod_deletion(
+                mod_metadata, deletion_fn, result, collect_for_unsubscribe, update_db
+            ):
                 # Handle successful deletion tasks
-                self._handle_successful_deletion(mod_metadata, result, collect_for_unsubscribe)
+                self._handle_successful_deletion(
+                    mod_metadata, result, collect_for_unsubscribe
+                )
 
             self._log_progress_if_enabled(processed_count, total_mods, show_progress)
 
@@ -358,12 +380,18 @@ class ModDeletionMenu(QMenu):
                 uuid = self.metadata_manager.mod_metadata_dir_mapper.get(mod_path)
                 if uuid:
                     mod_metadata["uuid"] = uuid
-                    logger.debug(f"Retrieved UUID {uuid} for mod {mod_name} before deletion")
+                    logger.debug(
+                        f"Retrieved UUID {uuid} for mod {mod_name} before deletion"
+                    )
                 else:
-                    logger.warning(f"Could not retrieve UUID for mod {mod_name} with path {mod_path} before deletion")
+                    logger.warning(
+                        f"Could not retrieve UUID for mod {mod_name} with path {mod_path} before deletion"
+                    )
 
             # Perform the deletion operation
-            return self._execute_deletion_operation(mod_metadata, deletion_fn, result, mod_name)
+            return self._execute_deletion_operation(
+                mod_metadata, deletion_fn, result, mod_name
+            )
 
         except Exception as general_error:
             logger.error(f"Critical error processing mod {mod_name}: {general_error}")
@@ -402,12 +430,16 @@ class ModDeletionMenu(QMenu):
             return False
 
         except (ValueError, TypeError) as data_error:
-            logger.error(f"Data validation error processing mod {mod_name}: {data_error}")
+            logger.error(
+                f"Data validation error processing mod {mod_name}: {data_error}"
+            )
             result.failed_count += 1
             return False
 
         except Exception as deletion_error:
-            logger.error(f"Unexpected error during deletion of mod {mod_name}: {deletion_error}")
+            logger.error(
+                f"Unexpected error during deletion of mod {mod_name}: {deletion_error}"
+            )
             result.failed_count += 1
             return False
 
@@ -430,7 +462,9 @@ class ModDeletionMenu(QMenu):
 
     def _handle_uuid_removal(self, mod_metadata: ModMetadata) -> None:
         """Handle UUID removal from tracking list and emit signals."""
-        logger.debug(f"_handle_uuid_removal called for mod: {mod_metadata.get('name', 'Unknown')}")
+        logger.debug(
+            f"_handle_uuid_removal called for mod: {mod_metadata.get('name', 'Unknown')}"
+        )
         logger.debug(f"mod_metadata keys: {list(mod_metadata.keys())}")
         if self.remove_from_uuids is None:
             logger.debug("remove_from_uuids is None, skipping UUID removal")
@@ -442,17 +476,23 @@ class ModDeletionMenu(QMenu):
                 uuid = self.metadata_manager.mod_metadata_dir_mapper.get(str(mod_path))
                 if uuid:
                     mod_metadata["uuid"] = uuid
-                    logger.debug(f"Retrieved UUID {uuid} for mod {mod_metadata.get('name', 'Unknown')} from path")
+                    logger.debug(
+                        f"Retrieved UUID {uuid} for mod {mod_metadata.get('name', 'Unknown')} from path"
+                    )
                 else:
                     logger.debug(
                         f"Could not retrieve UUID for mod {mod_metadata.get('name', 'Unknown')} with path {mod_path}"
                     )
                     return
             else:
-                logger.debug(f"Mod {mod_metadata.get('name', 'Unknown')} has no path, cannot retrieve UUID")
+                logger.debug(
+                    f"Mod {mod_metadata.get('name', 'Unknown')} has no path, cannot retrieve UUID"
+                )
                 return
         if mod_metadata["uuid"] not in self.remove_from_uuids:
-            logger.debug(f"UUID {mod_metadata['uuid']} not in remove_from_uuids list, skipping removal")
+            logger.debug(
+                f"UUID {mod_metadata['uuid']} not in remove_from_uuids list, skipping removal"
+            )
             return
 
         try:
@@ -461,14 +501,20 @@ class ModDeletionMenu(QMenu):
             logger.debug(f"Removing UUID {mod_metadata['uuid']} from tracking list")
             self.remove_from_uuids.remove(mod_metadata["uuid"])
         except (ValueError, AttributeError) as uuid_error:
-            logger.warning(f"Failed to remove UUID for mod {mod_metadata.get('name', 'Unknown')}: {uuid_error}")
+            logger.warning(
+                f"Failed to remove UUID for mod {mod_metadata.get('name', 'Unknown')}: {uuid_error}"
+            )
 
-    def _track_steamcmd_mod(self, mod_metadata: ModMetadata, result: DeletionResult) -> None:
+    def _track_steamcmd_mod(
+        self, mod_metadata: ModMetadata, result: DeletionResult
+    ) -> None:
         """Track SteamCMD mods for metadata purging."""
         if mod_metadata.get("steamcmd") and "publishedfileid" in mod_metadata:
             result.steamcmd_purge_ids.add(mod_metadata["publishedfileid"])
 
-    def _log_progress_if_enabled(self, processed_count: int, total_mods: int, show_progress: bool) -> None:
+    def _log_progress_if_enabled(
+        self, processed_count: int, total_mods: int, show_progress: bool
+    ) -> None:
         """Log progress if progress tracking is enabled."""
         if show_progress and total_mods > 0:
             progress_percentage = (processed_count / total_mods) * 100
@@ -538,7 +584,9 @@ class ModDeletionMenu(QMenu):
         selected_count = len(self.get_selected_mod_metadata())
         self._perform_deletion_operation(
             confirmation_title=self.tr("Confirm Complete Deletion"),
-            confirmation_text=self.tr(f"You have selected {selected_count} mod(s) for complete deletion."),
+            confirmation_text=self.tr(
+                f"You have selected {selected_count} mod(s) for complete deletion."
+            ),
             confirmation_info=self.tr(
                 "\nThis operation will permanently delete the selected mod directories from the filesystem.\n\nDo you want to proceed?"
             ),
@@ -550,7 +598,9 @@ class ModDeletionMenu(QMenu):
         selected_count = len(self.get_selected_mod_metadata())
         self._perform_deletion_operation(
             confirmation_title=self.tr("Confirm DDS Deletion"),
-            confirmation_text=self.tr(f"You have selected {selected_count} mod(s) for DDS texture deletion."),
+            confirmation_text=self.tr(
+                f"You have selected {selected_count} mod(s) for DDS texture deletion."
+            ),
             confirmation_info=self.tr(
                 "\nThis operation will only delete optimized textures (.dds files) from the selected mods.\n\nDo you want to proceed?"
             ),
@@ -573,7 +623,9 @@ class ModDeletionMenu(QMenu):
         selected_count = len(self.get_selected_mod_metadata())
         self._perform_deletion_operation(
             confirmation_title=self.tr("Confirm Selective Deletion"),
-            confirmation_text=self.tr(f"You have selected {selected_count} mod(s) for selective deletion."),
+            confirmation_text=self.tr(
+                f"You have selected {selected_count} mod(s) for selective deletion."
+            ),
             confirmation_info=self.tr(
                 "\nThis operation will delete all mod files except for .dds texture files.\nThe .dds files will be preserved.\n\nDo you want to proceed?"
             ),
@@ -596,7 +648,9 @@ class ModDeletionMenu(QMenu):
         """
         self._delete_mods_and_manage_steam("unsubscribe")
 
-    def _handle_steam_action(self, action: str, deleted_mods: list[ModMetadata]) -> None:
+    def _handle_steam_action(
+        self, action: str, deleted_mods: list[ModMetadata]
+    ) -> None:
         """
         Handle Steam Workshop unsubscription or resubscription for successfully deleted mods.
 
@@ -618,7 +672,9 @@ class ModDeletionMenu(QMenu):
                     # Convert string to integer as required by Steam API
                     publishedfileids.append(int(pfid))
                 except ValueError:
-                    logger.debug(f"Invalid publishedfileid format: {pfid} for mod {mod.get('name', 'Unknown')}")
+                    logger.debug(
+                        f"Invalid publishedfileid format: {pfid} for mod {mod.get('name', 'Unknown')}"
+                    )
                     # Continue processing other mods even if one ID is invalid
                     continue
 
@@ -627,7 +683,9 @@ class ModDeletionMenu(QMenu):
             return
 
         try:
-            logger.info(f"{action.capitalize()}ing {len(publishedfileids)} Steam Workshop mods.")
+            logger.info(
+                f"{action.capitalize()}ing {len(publishedfileids)} Steam Workshop mods."
+            )
 
             # Emit the Steam API call
             EventBus().do_steamworks_api_call.emit(
@@ -639,7 +697,9 @@ class ModDeletionMenu(QMenu):
 
             # Show success message
             show_information(
-                title=self.tr("Steam {action}").format(action=self.tr(action).capitalize()),
+                title=self.tr("Steam {action}").format(
+                    action=self.tr(action).capitalize()
+                ),
                 text=self.tr(
                     "Successfully initiated {action} from {len} Steam Workshop mod(s).\n"
                     "The process may take a few moments to complete."
@@ -649,15 +709,19 @@ class ModDeletionMenu(QMenu):
                 ),
             )
 
-            logger.info(f"Successfully initiated {action} for {len(publishedfileids)} mods.")
+            logger.info(
+                f"Successfully initiated {action} for {len(publishedfileids)} mods."
+            )
 
         except Exception as e:
             logger.error(f"Failed to initiate Steam {action}: {e}")
             show_warning(
-                title=self.tr("{action} Error").format(action=self.tr(action).capitalize()),
-                text=self.tr("An error occurred while trying to {action} from Steam Workshop mods.").format(
-                    action=self.tr(action)
+                title=self.tr("{action} Error").format(
+                    action=self.tr(action).capitalize()
                 ),
+                text=self.tr(
+                    "An error occurred while trying to {action} from Steam Workshop mods."
+                ).format(action=self.tr(action)),
                 information=str(e),
             )
 
@@ -685,7 +749,10 @@ class ModDeletionMenu(QMenu):
 
         # Filter mods that can be managed (have Steam Workshop IDs)
         steam_mods = [
-            mod for mod in selected_mods if mod.get("publishedfileid") and isinstance(mod.get("publishedfileid"), str)
+            mod
+            for mod in selected_mods
+            if mod.get("publishedfileid")
+            and isinstance(mod.get("publishedfileid"), str)
         ]
 
         selected_count = len(selected_mods)
@@ -706,7 +773,9 @@ class ModDeletionMenu(QMenu):
             self._sync_remove_from_uuids_with_selected_mods()
 
             # Perform deletion and collect successfully deleted mods
-            result = self._iterate_mods(self._delete_mod_directory, selected_mods, collect_for_unsubscribe=True)
+            result = self._iterate_mods(
+                self._delete_mod_directory, selected_mods, collect_for_unsubscribe=True
+            )
 
             # Process regular deletion results
             self._process_deletion_result(result)
@@ -722,7 +791,9 @@ class ModDeletionMenu(QMenu):
         """
         time_limit = self.settings_controller.settings.aux_db_time_limit
         if time_limit < 0:
-            logger.debug("Not deleting or setting item as outdated in Aux Metadata DB as time limit is negative.")
+            logger.debug(
+                "Not deleting or setting item as outdated in Aux Metadata DB as time limit is negative."
+            )
             return
 
         aux_metadata_controller = AuxMetadataController.get_or_create_cached_instance(

--- a/app/views/description_widget.py
+++ b/app/views/description_widget.py
@@ -101,14 +101,18 @@ class DescriptionWidget(QTextBrowser):
 
         # Span text size
         span_size_pattern = r'<span style="font-size:(\d+)px">(.*?)</span>'
-        html_text = re.sub(span_size_pattern, r'<span style="font-size:\1px">\2</span>', html_text)
+        html_text = re.sub(
+            span_size_pattern, r'<span style="font-size:\1px">\2</span>', html_text
+        )
 
         # Convert explicit string \n to <br>
         html_text = html_text.replace("\\n", "<br>")
 
         # Image tags
         img_pattern = r"\[img\](.*?)\[/img\]"
-        html_text = re.sub(img_pattern, "" if remove_img else r'<img src="\1">', html_text)
+        html_text = re.sub(
+            img_pattern, "" if remove_img else r'<img src="\1">', html_text
+        )
         html_text = html_text.strip()
 
         # Remove empty tr, td, tables and lists if they exist
@@ -117,6 +121,8 @@ class DescriptionWidget(QTextBrowser):
 
         # If there are any html tags, wrap with html
         if re.search(r"<[^>]+>", html_text):
-            html_text = f'<html style="white-space: {white_space}">' + html_text + "</html>"
+            html_text = (
+                f'<html style="white-space: {white_space}">' + html_text + "</html>"
+            )
 
         return html_text

--- a/app/views/dialogue.py
+++ b/app/views/dialogue.py
@@ -86,14 +86,18 @@ def show_dialogue_conditional(
         # Add custom buttons
         custom_btns = []
         for btn_text in button_text_override:
-            custom_btn_text = QCoreApplication.translate("show_dialogue_conditional", btn_text)
+            custom_btn_text = QCoreApplication.translate(
+                "show_dialogue_conditional", btn_text
+            )
             custom_btn = QPushButton(custom_btn_text)
             custom_btn.setFixedWidth(custom_btn.sizeHint().width())
             custom_btns.append(custom_btn)
             dialogue.addButton(custom_btn, QMessageBox.ButtonRole.ActionRole)
     else:
         # Configure buttons
-        dialogue.setStandardButtons(QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No)
+        dialogue.setStandardButtons(
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No
+        )
         dialogue.setEscapeButton(QMessageBox.StandardButton.No)
 
     # Add data
@@ -163,7 +167,9 @@ def show_information(
     :type parent: QWidget | None
     """
     # jscpd:ignore-end
-    logger.info(f"Showing information box with input: [{title}], [{text}], [{information}], [{details}]")
+    logger.info(
+        f"Showing information box with input: [{title}], [{text}], [{information}], [{details}]"
+    )
 
     parent = _get_parent_if_constrain_enabled(parent)
 
@@ -212,7 +218,9 @@ def show_warning(
     :type parent: QWidget | None
     """
     # jscpd:ignore-end
-    logger.info(f"Showing warning box with input: [{title}], [{text}], [{information}], [{details}]")
+    logger.info(
+        f"Showing warning box with input: [{title}], [{text}], [{information}], [{details}]"
+    )
 
     parent = _get_parent_if_constrain_enabled(parent)
 
@@ -258,7 +266,9 @@ def show_fatal_error(
     :param details: text to pass to setDetailedText
     :param parent: The parent widget
     """
-    logger.info(f"Showing fatal error box with input: [{title}], [{text}], [{information}], [{details}]")
+    logger.info(
+        f"Showing fatal error box with input: [{title}], [{text}], [{information}], [{details}]"
+    )
 
     parent = _get_parent_if_constrain_enabled(parent)
 
@@ -266,7 +276,9 @@ def show_fatal_error(
     diag.exec_()
 
 
-def show_internet_connection_error(failed_urls: list[str] | None = None, parent: QWidget | None = None) -> None:
+def show_internet_connection_error(
+    failed_urls: list[str] | None = None, parent: QWidget | None = None
+) -> None:
     """Show a warning dialog for no internet connection, with firewall info and user information for help.
 
     :param failed_urls: Optional list of URLs that failed to connect
@@ -276,7 +288,9 @@ def show_internet_connection_error(failed_urls: list[str] | None = None, parent:
     logger.info("Showing no internet connection error dialog")
 
     failed_urls_str = (
-        f"Failed to reach: {', '.join(failed_urls)}" if failed_urls else "Unable to reach internet services"
+        f"Failed to reach: {', '.join(failed_urls)}"
+        if failed_urls
+        else "Unable to reach internet services"
     )
 
     show_information(
@@ -318,7 +332,9 @@ class _BaseDialogue(QDialog):
         self.setObjectName("dialogue")
 
         # Dynamic sizing
-        self.setSizePolicy(QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding))
+        self.setSizePolicy(
+            QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+        )
 
     def exec(self) -> int:
         """Executes the message box and returns the result.
@@ -328,7 +344,9 @@ class _BaseDialogue(QDialog):
         """
         logger.info(f"Showing {self._dialogue_type} with title: {self.windowTitle()}")
         result = super().exec()
-        logger.info(f"Finished showing {self._dialogue_type} [{self.windowTitle()}] with result: {result}")
+        logger.info(
+            f"Finished showing {self._dialogue_type} [{self.windowTitle()}] with result: {result}"
+        )
         return result
 
     def exec_(self) -> int:
@@ -371,7 +389,9 @@ class _BaseMessageBox(QMessageBox):
             self.setDetailedText(details)
 
         # Dynamic sizing
-        self.setSizePolicy(QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding))
+        self.setSizePolicy(
+            QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+        )
         self.setMinimumWidth(400)
 
     def exec(self) -> int:
@@ -384,7 +404,9 @@ class _BaseMessageBox(QMessageBox):
             f"Showing {self._dialogue_type} with title: [{self.windowTitle()}], text: [{self.text()}], information: [{self.informativeText()}], details: [{self.detailedText()}]"
         )
         result = super().exec()
-        logger.info(f"Finished showing {self._dialogue_type} [{self.windowTitle()}] with result: {result}")
+        logger.info(
+            f"Finished showing {self._dialogue_type} [{self.windowTitle()}] with result: {result}"
+        )
         return result
 
     def exec_(self) -> int:
@@ -428,7 +450,9 @@ class InformationBox(_BaseMessageBox):
         :param parent: The parent widget
         :type parent: QWidget | None, optional
         """
-        super().__init__(title, text, information, icon, details, modal=modal, parent=parent)
+        super().__init__(
+            title, text, information, icon, details, modal=modal, parent=parent
+        )
 
         self.setStandardButtons(QMessageBox.StandardButton.Ok)
         self.setDefaultButton(QMessageBox.StandardButton.Ok)
@@ -481,7 +505,9 @@ class BinaryChoiceDialog(_BaseMessageBox):
         :type parent: QWidget | None, optional
         :raises ValueError: If the positive and negative buttons are the same
         """
-        super().__init__(title, text, information, icon, details, modal=modal, parent=parent)
+        super().__init__(
+            title, text, information, icon, details, modal=modal, parent=parent
+        )
 
         if positive_btn == negative_btn:
             raise ValueError("Positive and negative buttons cannot be the same")
@@ -604,7 +630,9 @@ class FatalErrorDialog(_BaseDialogue):
             self.adjustSize()
 
         self.close_btn.clicked.connect(self.close)
-        self.open_log_btn.clicked.connect(lambda: generic.platform_specific_open(AppInfo().user_log_folder))
+        self.open_log_btn.clicked.connect(
+            lambda: generic.platform_specific_open(AppInfo().user_log_folder)
+        )
 
         def _upload_log(parent: FatalErrorDialog) -> None:
             """Helper function to upload the log file to 0x0. Displays a loading dialog while doing so. When finished, copy the URL to the clipboard and display the link."""
@@ -642,7 +670,9 @@ class _UploadLogDialog(QDialog):
                 generic.copy_to_clipboard_safely(url)
                 show_information(
                     title=self.tr("Log Upload Successful"),
-                    text=self.tr("Log file uploaded successfully! Copied URL to clipboard."),
+                    text=self.tr(
+                        "Log file uploaded successfully! Copied URL to clipboard."
+                    ),
                     information=f"URL: <a href='{url}'>{url}</a>",
                     parent=parent,
                 )
@@ -650,7 +680,9 @@ class _UploadLogDialog(QDialog):
                 show_warning(
                     title=self.tr("Log Upload Failed"),
                     text=self.tr("Log file upload failed!"),
-                    information=self.tr("Please check your internet connection and try again."),
+                    information=self.tr(
+                        "Please check your internet connection and try again."
+                    ),
                     parent=parent,
                 )
 
@@ -665,7 +697,9 @@ class UploadLogTask(QRunnable):
     @Slot()
     def run(self) -> None:
         # Perform the upload task
-        result, url = generic.upload_data_to_0x0_st(str(AppInfo().user_log_folder / "RimSort.log"))
+        result, url = generic.upload_data_to_0x0_st(
+            str(AppInfo().user_log_folder / "RimSort.log")
+        )
 
         # Emit signal on completion
         self.parent._upload_finished_signal.emit(result, url)
@@ -724,7 +758,9 @@ class SettingsFailureDialog(QDialog):
         self.setObjectName("dialogue")
 
         # Dynamic sizing
-        self.setSizePolicy(QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding))
+        self.setSizePolicy(
+            QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+        )
 
         # Add data
         self.text = self.tr(
@@ -792,7 +828,9 @@ class SettingsFailureDialog(QDialog):
         sys.exit()
 
 
-def _setup_error_icon(diag: QDialog, details_btn: QPushButton | None = None) -> QVBoxLayout:
+def _setup_error_icon(
+    diag: QDialog, details_btn: QPushButton | None = None
+) -> QVBoxLayout:
     l_layout = QVBoxLayout()
     piximap = getattr(QStyle, "SP_MessageBoxCritical")
     icon = diag.style().standardIcon(piximap)

--- a/app/views/file_search_dialog.py
+++ b/app/views/file_search_dialog.py
@@ -76,7 +76,9 @@ class FileSearchDialog(QDialog):
         search_input_layout.addWidget(search_label)
 
         self.search_input = QLineEdit()
-        self.search_input.setPlaceholderText(self.tr("Enter text to search for in files"))
+        self.search_input.setPlaceholderText(
+            self.tr("Enter text to search for in files")
+        )
         search_input_layout.addWidget(self.search_input)
 
         self.recent_searches_button = QPushButton("▼")
@@ -170,7 +172,9 @@ class FileSearchDialog(QDialog):
 
         self.skip_translations = QCheckBox(self.tr("Skip translations"))
         self.skip_translations.setChecked(True)
-        self.skip_translations.setToolTip(self.tr("Skip translation files to improve search speed"))
+        self.skip_translations.setToolTip(
+            self.tr("Skip translation files to improve search speed")
+        )
 
         self.skip_git = QCheckBox(self.tr("Skip .git folder"))
         self.skip_git.setChecked(True)
@@ -182,7 +186,9 @@ class FileSearchDialog(QDialog):
 
         self.skip_textures = QCheckBox(self.tr("Skip Textures folder"))
         self.skip_textures.setChecked(True)
-        self.skip_textures.setToolTip(self.tr("Skip Textures folders containing images"))
+        self.skip_textures.setToolTip(
+            self.tr("Skip Textures folders containing images")
+        )
 
         skip_options_column.addWidget(self.skip_translations)
         skip_options_column.addWidget(self.skip_git)
@@ -202,7 +208,9 @@ class FileSearchDialog(QDialog):
         buttons_layout.setSpacing(10)
 
         # Add a note about search method
-        search_method_info = QLabel(self.tr("Search method is automatically selected based on options"))
+        search_method_info = QLabel(
+            self.tr("Search method is automatically selected based on options")
+        )
         buttons_layout.addWidget(search_method_info)
 
         # Add spacer to push buttons to the right
@@ -250,7 +258,9 @@ class FileSearchDialog(QDialog):
 
         # Statistics
         self.stats_label = QLabel(self.tr("Ready to search"))
-        self.stats_label.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter)
+        self.stats_label.setAlignment(
+            Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter
+        )
         status_row.addWidget(self.stats_label)
 
         progress_layout.addLayout(status_row)
@@ -268,7 +278,9 @@ class FileSearchDialog(QDialog):
         filter_layout.addWidget(filter_label)
 
         self.filter_input = QLineEdit()
-        self.filter_input.setPlaceholderText(self.tr("Filter results by mod name, file name, or path"))
+        self.filter_input.setPlaceholderText(
+            self.tr("Filter results by mod name, file name, or path")
+        )
         filter_layout.addWidget(self.filter_input)
 
         results_layout.addWidget(filter_group)
@@ -304,7 +316,9 @@ class FileSearchDialog(QDialog):
 
         # Set table properties for better appearance
         self.results_table.setAlternatingRowColors(True)
-        self.results_table.setSelectionBehavior(QTableWidget.SelectionBehavior.SelectRows)
+        self.results_table.setSelectionBehavior(
+            QTableWidget.SelectionBehavior.SelectRows
+        )
         self.results_table.setSelectionMode(QTableWidget.SelectionMode.SingleSelection)
         self.results_table.setSortingEnabled(True)
         self.results_table.verticalHeader().setVisible(False)
@@ -313,7 +327,9 @@ class FileSearchDialog(QDialog):
         self.results_table.setMinimumHeight(300)
 
         # Configure columns: full-width fit + manual resizing using proportional weights
-        self.results_table.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.results_table.setHorizontalScrollBarPolicy(
+            Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+        )
         header = self.results_table.horizontalHeader()
         header.setSectionResizeMode(QHeaderView.ResizeMode.Interactive)
         header.setMinimumSectionSize(40)
@@ -338,7 +354,9 @@ class FileSearchDialog(QDialog):
         results_layout.addWidget(results_table_group)
 
         # Add results section to main layout with stretch factor
-        main_layout.addWidget(results_section, 1)  # Give it a stretch factor of 1 to take available space
+        main_layout.addWidget(
+            results_section, 1
+        )  # Give it a stretch factor of 1 to take available space
 
         # Connect filter input to filter method
         self.filter_input.textChanged.connect(self._on_filter_changed)
@@ -387,7 +405,11 @@ class FileSearchDialog(QDialog):
         result_count = self.results_table.rowCount()
 
         if result_count > 0:
-            self.stats_label.setText(self.tr("Found {result_count} results").format(result_count=result_count))
+            self.stats_label.setText(
+                self.tr("Found {result_count} results").format(
+                    result_count=result_count
+                )
+            )
         else:
             self.stats_label.setText(self.tr("No results found"))
 
@@ -511,7 +533,10 @@ class FileSearchDialog(QDialog):
         col_count = self.results_table.columnCount()
         if col_count <= 0:
             return
-        if not getattr(self, "_results_col_weights", None) or len(self._results_col_weights) != col_count:
+        if (
+            not getattr(self, "_results_col_weights", None)
+            or len(self._results_col_weights) != col_count
+        ):
             # Initialize equal weights
             self._results_col_weights = [1.0 / col_count for _ in range(col_count)]
 
@@ -572,9 +597,15 @@ class FileSearchDialog(QDialog):
         # Handle keyboard shortcuts
         if event.key() == Qt.Key.Key_Return:
             self._open_file(path)
-        elif event.key() == Qt.Key.Key_C and event.modifiers() == Qt.KeyboardModifier.ControlModifier:
+        elif (
+            event.key() == Qt.Key.Key_C
+            and event.modifiers() == Qt.KeyboardModifier.ControlModifier
+        ):
             self._copy_path(path)
-        elif event.key() == Qt.Key.Key_O and event.modifiers() == Qt.KeyboardModifier.ControlModifier:
+        elif (
+            event.key() == Qt.Key.Key_O
+            and event.modifiers() == Qt.KeyboardModifier.ControlModifier
+        ):
             self._open_folder(path)
         else:
             super().keyPressEvent(event)
@@ -647,7 +678,9 @@ class FileSearchDialog(QDialog):
         if text.startswith("Found ") and " results" in text:
             self._on_search_complete()
 
-    def add_result(self, mod_name: str, file_name: str, path: str, preview: str = "") -> None:
+    def add_result(
+        self, mod_name: str, file_name: str, path: str, preview: str = ""
+    ) -> None:
         """Add a search result to the table with improved performance and error handling."""
         try:
             # Batch insertion for better performance
@@ -666,7 +699,9 @@ class FileSearchDialog(QDialog):
             max_preview_length = 1000
             if len(preview) > max_preview_length:
                 cutoff = preview.rfind("\n", 0, max_preview_length)
-                cutoff = cutoff if cutoff > max_preview_length // 2 else max_preview_length
+                cutoff = (
+                    cutoff if cutoff > max_preview_length // 2 else max_preview_length
+                )
                 preview = preview[:cutoff] + "\n... [Preview truncated]"
 
             # Create table items
@@ -690,7 +725,10 @@ class FileSearchDialog(QDialog):
             self.results_table.setItem(row, 3, preview_item)
 
             # Re-enable updates and sorting at batch boundaries
-            if current_row % batch_size == batch_size - 1 or current_row == self.results_table.rowCount() - 1:
+            if (
+                current_row % batch_size == batch_size - 1
+                or current_row == self.results_table.rowCount() - 1
+            ):
                 self.results_table.setUpdatesEnabled(True)
                 self.results_table.setSortingEnabled(True)
 
@@ -720,7 +758,9 @@ class FileSearchDialog(QDialog):
         # Add recent searches to menu
         for search in self._recent_searches:
             action = menu.addAction(search)
-            action.triggered.connect(lambda checked=False, text=search: self._use_recent_search(text))
+            action.triggered.connect(
+                lambda checked=False, text=search: self._use_recent_search(text)
+            )
 
         # Add a separator and clear action
         if self._recent_searches:
@@ -729,7 +769,11 @@ class FileSearchDialog(QDialog):
             clear_action.triggered.connect(self._clear_recent_searches)
 
         # Show menu below the button
-        menu.exec(self.recent_searches_button.mapToGlobal(self.recent_searches_button.rect().bottomLeft()))
+        menu.exec(
+            self.recent_searches_button.mapToGlobal(
+                self.recent_searches_button.rect().bottomLeft()
+            )
+        )
 
     def _use_recent_search(self, text: str) -> None:
         """Use a recent search"""
@@ -803,11 +847,13 @@ class FileSearchDialog(QDialog):
         # Update the stats label to show filter results
         if text:
             self.update_stats(
-                self.tr("Filter: {visible_rows} of {total_rows} results visible").format(
-                    visible_rows=visible_rows, total_rows=total_rows
-                )
+                self.tr(
+                    "Filter: {visible_rows} of {total_rows} results visible"
+                ).format(visible_rows=visible_rows, total_rows=total_rows)
             )
         elif total_rows > 0:
-            self.update_stats(self.tr("Found {total_rows} results").format(total_rows=total_rows))
+            self.update_stats(
+                self.tr("Found {total_rows} results").format(total_rows=total_rows)
+            )
         else:
             self.update_stats(self.tr("Ready to search"))

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -125,21 +125,41 @@ class MainContent(QObject):
             self.settings_controller = settings_controller
 
             EventBus().settings_have_changed.connect(self._on_settings_have_changed)
-            EventBus().do_check_for_application_update.connect(self._do_check_for_update)
+            EventBus().do_check_for_application_update.connect(
+                self._do_check_for_update
+            )
             EventBus().do_open_mod_list.connect(self._do_import_list_file_xml)
-            EventBus().do_import_mod_list_from_rentry.connect(self._do_import_list_rentry)
-            EventBus().do_import_mod_list_from_workshop_collection.connect(self._do_import_list_workshop_collection)
-            EventBus().do_import_mod_list_from_save_file.connect(self._do_import_list_from_save_file)
+            EventBus().do_import_mod_list_from_rentry.connect(
+                self._do_import_list_rentry
+            )
+            EventBus().do_import_mod_list_from_workshop_collection.connect(
+                self._do_import_list_workshop_collection
+            )
+            EventBus().do_import_mod_list_from_save_file.connect(
+                self._do_import_list_from_save_file
+            )
             EventBus().do_save_mod_list_as.connect(self._do_export_list_file_xml)
-            EventBus().do_export_mod_list_to_clipboard.connect(self._do_export_list_clipboard)
+            EventBus().do_export_mod_list_to_clipboard.connect(
+                self._do_export_list_clipboard
+            )
             EventBus().do_export_mod_list_to_rentry.connect(self._do_upload_list_rentry)
             EventBus().do_upload_log.connect(self._upload_file)
             EventBus().do_open_default_editor.connect(self._open_in_default_editor)
-            EventBus().do_download_all_mods_via_steamcmd.connect(self._on_do_download_all_mods_via_steamcmd)
-            EventBus().do_download_all_mods_via_steam.connect(self._on_do_download_all_mods_via_steam)
-            EventBus().do_compare_steam_workshop_databases.connect(self._do_generate_metadata_comparison_report)
-            EventBus().do_merge_steam_workshop_databases.connect(self._do_merge_databases)
-            EventBus().do_build_steam_workshop_database.connect(self._on_do_build_steam_workshop_database)
+            EventBus().do_download_all_mods_via_steamcmd.connect(
+                self._on_do_download_all_mods_via_steamcmd
+            )
+            EventBus().do_download_all_mods_via_steam.connect(
+                self._on_do_download_all_mods_via_steam
+            )
+            EventBus().do_compare_steam_workshop_databases.connect(
+                self._do_generate_metadata_comparison_report
+            )
+            EventBus().do_merge_steam_workshop_databases.connect(
+                self._do_merge_databases
+            )
+            EventBus().do_build_steam_workshop_database.connect(
+                self._on_do_build_steam_workshop_database
+            )
             EventBus().do_import_acf.connect(self._do_import_steamcmd_acf_data)
             EventBus().do_export_acf.connect(self._do_export_steamcmd_acf_data)
             EventBus().do_delete_acf.connect(self._do_reset_steamcmd_acf_data)
@@ -154,30 +174,56 @@ class MainContent(QObject):
 
             # Shortcuts submenu Eventbus
             EventBus().do_open_app_directory.connect(self._do_open_app_directory)
-            EventBus().do_open_settings_directory.connect(self._do_open_settings_directory)
-            EventBus().do_open_rimsort_logs_directory.connect(self._do_open_rimsort_logs_directory)
-            EventBus().do_open_rimworld_directory.connect(self._do_open_rimworld_directory)
-            EventBus().do_open_rimworld_config_directory.connect(self._do_open_rimworld_config_directory)
-            EventBus().do_open_rimworld_logs_directory.connect(self._do_open_rimworld_logs_directory)
-            EventBus().do_open_local_mods_directory.connect(self._do_open_local_mods_directory)
-            EventBus().do_open_steam_mods_directory.connect(self._do_open_steam_mods_directory)
+            EventBus().do_open_settings_directory.connect(
+                self._do_open_settings_directory
+            )
+            EventBus().do_open_rimsort_logs_directory.connect(
+                self._do_open_rimsort_logs_directory
+            )
+            EventBus().do_open_rimworld_directory.connect(
+                self._do_open_rimworld_directory
+            )
+            EventBus().do_open_rimworld_config_directory.connect(
+                self._do_open_rimworld_config_directory
+            )
+            EventBus().do_open_rimworld_logs_directory.connect(
+                self._do_open_rimworld_logs_directory
+            )
+            EventBus().do_open_local_mods_directory.connect(
+                self._do_open_local_mods_directory
+            )
+            EventBus().do_open_steam_mods_directory.connect(
+                self._do_open_steam_mods_directory
+            )
 
-            EventBus().do_steamcmd_download.connect(self._do_download_mods_with_steamcmd)
+            EventBus().do_steamcmd_download.connect(
+                self._do_download_mods_with_steamcmd
+            )
 
-            EventBus().do_steamworks_api_call.connect(self._do_steamworks_api_call_animated)
+            EventBus().do_steamworks_api_call.connect(
+                self._do_steamworks_api_call_animated
+            )
 
             # Edit Menu bar Eventbus
             EventBus().do_rule_editor.connect(
-                lambda: self._do_open_rule_editor(compact=False, initial_mode="community_rules")
+                lambda: self._do_open_rule_editor(
+                    compact=False, initial_mode="community_rules"
+                )
             )
             EventBus().do_ignore_json_editor.connect(self._do_open_ignore_json_editor)
-            EventBus().do_check_missing_mod_properties.connect(self.__check_and_warn_missing_mod_properties)
+            EventBus().do_check_missing_mod_properties.connect(
+                self.__check_and_warn_missing_mod_properties
+            )
 
             # Download Menu bar Eventbus
             EventBus().do_add_zip_mod.connect(self._do_add_zip_mod)
             EventBus().do_browse_workshop.connect(self._do_browse_workshop)
-            EventBus().do_check_for_workshop_updates.connect(self._do_check_for_workshop_updates)
-            EventBus().do_steam_verify_game_files.connect(self.do_steam_verify_game_files)
+            EventBus().do_check_for_workshop_updates.connect(
+                self._do_check_for_workshop_updates
+            )
+            EventBus().do_steam_verify_game_files.connect(
+                self.do_steam_verify_game_files
+            )
 
             # Textures Menu bar Eventbus
             EventBus().do_optimize_textures.connect(self._do_optimize_textures)
@@ -194,7 +240,9 @@ class MainContent(QObject):
 
             # BASE LAYOUT
             self.main_layout = QHBoxLayout()
-            self.main_layout.setContentsMargins(5, 5, 5, 5)  # Space between widgets and Frame border
+            self.main_layout.setContentsMargins(
+                5, 5, 5, 5
+            )  # Space between widgets and Frame border
             self.main_layout.setSpacing(5)  # Space between mod lists and action buttons
 
             self.main_splitter = QSplitter(Qt.Orientation.Horizontal)
@@ -238,26 +286,44 @@ class MainContent(QObject):
             self.metadata_manager.mod_metadata_updated_signal.connect(
                 self.mods_panel.on_mod_metadata_updated  # Connect MetadataManager to ModPanel for mod metadata updates
             )
-            self.mods_panel.active_mods_list.key_press_signal.connect(self.__handle_active_mod_key_press)
-            self.mods_panel.inactive_mods_list.key_press_signal.connect(self.__handle_inactive_mod_key_press)
-            self.mods_panel.active_mods_list.mod_info_signal.connect(self.__mod_list_slot)
-            self.mods_panel.inactive_mods_list.mod_info_signal.connect(self.__mod_list_slot)
+            self.mods_panel.active_mods_list.key_press_signal.connect(
+                self.__handle_active_mod_key_press
+            )
+            self.mods_panel.inactive_mods_list.key_press_signal.connect(
+                self.__handle_inactive_mod_key_press
+            )
+            self.mods_panel.active_mods_list.mod_info_signal.connect(
+                self.__mod_list_slot
+            )
+            self.mods_panel.inactive_mods_list.mod_info_signal.connect(
+                self.__mod_list_slot
+            )
             self.mods_panel.active_mods_list.item_added_signal.connect(
                 self.mods_panel.inactive_mods_list.handle_other_list_row_added
             )
             self.mods_panel.inactive_mods_list.item_added_signal.connect(
                 self.mods_panel.active_mods_list.handle_other_list_row_added
             )
-            self.mods_panel.active_mods_list.edit_rules_signal.connect(self._do_open_rule_editor)
-            self.mods_panel.inactive_mods_list.edit_rules_signal.connect(self._do_open_rule_editor)
-            self.mods_panel.active_mods_list.steamdb_blacklist_signal.connect(self._do_blacklist_action_steamdb)
-            self.mods_panel.inactive_mods_list.steamdb_blacklist_signal.connect(self._do_blacklist_action_steamdb)
+            self.mods_panel.active_mods_list.edit_rules_signal.connect(
+                self._do_open_rule_editor
+            )
+            self.mods_panel.inactive_mods_list.edit_rules_signal.connect(
+                self._do_open_rule_editor
+            )
+            self.mods_panel.active_mods_list.steamdb_blacklist_signal.connect(
+                self._do_blacklist_action_steamdb
+            )
+            self.mods_panel.inactive_mods_list.steamdb_blacklist_signal.connect(
+                self._do_blacklist_action_steamdb
+            )
             self.mods_panel.active_mods_list.refresh_signal.connect(self._do_refresh)
             self.mods_panel.inactive_mods_list.refresh_signal.connect(self._do_refresh)
 
             EventBus().use_this_instead_clicked.connect(self._use_this_instead_clicked)
 
-            EventBus().do_threaded_loading_animation.connect(self.do_threaded_loading_animation)
+            EventBus().do_threaded_loading_animation.connect(
+                self.do_threaded_loading_animation
+            )
 
             EventBus().do_metadata_refresh_cache.connect(self.do_metadata_refresh_cache)
 
@@ -304,8 +370,12 @@ class MainContent(QObject):
         user has had a chance to set paths.
         """
         current_instance = self.settings_controller.settings.current_instance
-        game_folder_path = self.settings_controller.settings.instances[current_instance].game_folder
-        config_folder_path = self.settings_controller.settings.instances[current_instance].config_folder
+        game_folder_path = self.settings_controller.settings.instances[
+            current_instance
+        ].game_folder
+        config_folder_path = self.settings_controller.settings.instances[
+            current_instance
+        ].config_folder
         logger.debug(f"Game folder: {game_folder_path}")
         logger.debug(f"Config folder: {config_folder_path}")
         if (
@@ -454,7 +524,9 @@ class MainContent(QObject):
                     count += 1
         # List error/warnings are automatically recalculated when a mod is inserted/removed from a list
 
-    def _insert_data_into_lists(self, active_mods_uuids: list[str], inactive_mods_uuids: list[str]) -> None:
+    def _insert_data_into_lists(
+        self, active_mods_uuids: list[str], inactive_mods_uuids: list[str]
+    ) -> None:
         """
         Insert active mods and inactive mods into respective mod list widgets.
 
@@ -464,7 +536,9 @@ class MainContent(QObject):
         logger.info(
             f"Inserting mod data into active [{len(active_mods_uuids)}] and inactive [{len(inactive_mods_uuids)}] mod lists"
         )
-        self.mods_panel.active_mods_list.recreate_mod_list(list_type="active", uuids=active_mods_uuids)
+        self.mods_panel.active_mods_list.recreate_mod_list(
+            list_type="active", uuids=active_mods_uuids
+        )
         # Determine sort key and descending for inactive mods
         if self.settings_controller.settings.inactive_mods_sorting:
             # Use current UI state from the combobox and button
@@ -491,7 +565,9 @@ class MainContent(QObject):
         Opens the DuplicateModsPanel to allow user to resolve duplicate mods.
         """
         if not self.settings_controller.settings.duplicate_mods_warning:
-            logger.warning("User preference is not configured to display duplicate mods. Skipping...")
+            logger.warning(
+                "User preference is not configured to display duplicate mods. Skipping..."
+            )
             return
         elif (
             self.settings_controller.settings.duplicate_mods_warning
@@ -499,8 +575,12 @@ class MainContent(QObject):
             and len(self.duplicate_mods) > 0
         ):
             duplicate_mods_count = len(self.duplicate_mods)
-            logger.info(f"Found {duplicate_mods_count} duplicate mods. Opening DuplicateModsPanel...")
-            duplicate_mods_panel = DuplicateModsPanel(self.duplicate_mods, self.settings_controller)
+            logger.info(
+                f"Found {duplicate_mods_count} duplicate mods. Opening DuplicateModsPanel..."
+            )
+            duplicate_mods_panel = DuplicateModsPanel(
+                self.duplicate_mods, self.settings_controller
+            )
             duplicate_mods_panel.setWindowModality(Qt.WindowModality.ApplicationModal)
             duplicate_mods_panel.show()
         else:
@@ -509,7 +589,9 @@ class MainContent(QObject):
     def __missing_mods_prompt(self) -> None:
         """Open the MissingModsPrompt to allow user to download missing mods."""
         if not self.settings_controller.settings.try_download_missing_mods:
-            logger.warning("User preference is not configured to attempt downloading missing mods. Skipping...")
+            logger.warning(
+                "User preference is not configured to attempt downloading missing mods. Skipping..."
+            )
             return
         elif (
             self.settings_controller.settings.try_download_missing_mods
@@ -517,11 +599,15 @@ class MainContent(QObject):
             and len(self.missing_mods) > 0
         ):
             missing_mods_count = len(self.missing_mods)
-            logger.info(f"Found {missing_mods_count} missing mods. Opening MissingModsPrompt...")
+            logger.info(
+                f"Found {missing_mods_count} missing mods. Opening MissingModsPrompt..."
+            )
             # Always open the MissingModsPrompt panel, allowing manual entry if Steam database is unavailable
             self.missing_mods_prompt = MissingModsPrompt(packageids=self.missing_mods)
             self.missing_mods_prompt._populate_from_metadata()
-            self.missing_mods_prompt.setWindowModality(Qt.WindowModality.ApplicationModal)
+            self.missing_mods_prompt.setWindowModality(
+                Qt.WindowModality.ApplicationModal
+            )
             self.missing_mods_prompt.show()
         else:
             logger.info("No missing mods found. Skipping...")
@@ -603,7 +689,9 @@ class MainContent(QObject):
                 settings_controller=self.settings_controller,
             )
             # Make the panel modal to ensure user acknowledges the issues
-            missing_mod_properties_panel.setWindowModality(Qt.WindowModality.ApplicationModal)
+            missing_mod_properties_panel.setWindowModality(
+                Qt.WindowModality.ApplicationModal
+            )
             missing_mod_properties_panel.show()
         except Exception as e:
             logger.error(f"Error checking mod properties: {e}")
@@ -667,7 +755,9 @@ class MainContent(QObject):
         """
         Check for RimSort updates using UpdateManager.
         """
-        update_manager = UpdateManager(self.settings_controller, self, self.mod_info_panel)
+        update_manager = UpdateManager(
+            self.settings_controller, self, self.mod_info_panel
+        )
         update_manager.do_check_for_update()
 
     def __do_get_github_release_info(self) -> dict[str, Any]:
@@ -682,7 +772,9 @@ class MainContent(QObject):
             logger.warning(f"GitHub API returned status code {raw.status_code}")
             if raw.status_code == 403:
                 logger.warning("Possible rate limiting by GitHub API")
-            raise Exception(f"GitHub API returned status code {raw.status_code}: {raw.text}")
+            raise Exception(
+                f"GitHub API returned status code {raw.status_code}: {raw.text}"
+            )
 
         # Try to parse JSON response
         try:
@@ -697,7 +789,9 @@ class MainContent(QObject):
     # INFO PANEL ANIMATIONS
 
     @Slot(str, object, str)
-    def do_threaded_loading_animation(self, gif_path: str, target: Callable[..., Any], text: str | None = None) -> Any:
+    def do_threaded_loading_animation(
+        self, gif_path: str, target: Callable[..., Any], text: str | None = None
+    ) -> Any:
         # Hide the info panel widgets
         self.mod_info_panel.info_panel_frame.hide()
         # Disable widgets while loading
@@ -743,21 +837,31 @@ class MainContent(QObject):
             # Reset the data source filters to default and clear searches
             # Avoid recalculating warnings/errors when clearing search
             # Recalculation for each list will be triggered by mods being reinserted into inactive and active lists automatically
-            self.mods_panel.active_mods_filter_data_source_index = len(self.mods_panel.data_source_filter_icons)
+            self.mods_panel.active_mods_filter_data_source_index = len(
+                self.mods_panel.data_source_filter_icons
+            )
             self.mods_panel.signal_clear_search(
                 list_type="Active",
             )
-            self.mods_panel.inactive_mods_filter_data_source_index = len(self.mods_panel.data_source_filter_icons)
+            self.mods_panel.inactive_mods_filter_data_source_index = len(
+                self.mods_panel.data_source_filter_icons
+            )
             self.mods_panel.signal_clear_search(
                 list_type="Inactive",
             )
-            self.mods_panel.active_mods_filter_data_source_index = len(self.mods_panel.data_source_filter_icons)
+            self.mods_panel.active_mods_filter_data_source_index = len(
+                self.mods_panel.data_source_filter_icons
+            )
         # Check if paths are set
         if self.check_if_essential_paths_are_set(prompt=is_initial):
             # Run expensive calculations to set cache data
             self.do_threaded_loading_animation(
-                gif_path=str(AppInfo().theme_data_folder / "default-icons" / "rimsort.gif"),
-                target=partial(self.metadata_manager.refresh_cache, is_initial=is_initial),
+                gif_path=str(
+                    AppInfo().theme_data_folder / "default-icons" / "rimsort.gif"
+                ),
+                target=partial(
+                    self.metadata_manager.refresh_cache, is_initial=is_initial
+                ),
                 text=self.tr("Scanning mod sources and populating metadata..."),
             )
 
@@ -778,10 +882,14 @@ class MainContent(QObject):
                 logger.info("Checking Workshop mods for updates...")
                 self._do_check_for_workshop_updates()
             else:
-                logger.info("User preference is not configured to check Workshop mod for updates. Skipping..")
+                logger.info(
+                    "User preference is not configured to check Workshop mod for updates. Skipping.."
+                )
         else:
             self._insert_data_into_lists([], [])
-            logger.warning("Essential paths have not been set. Passing refresh and resetting mod lists")
+            logger.warning(
+                "Essential paths have not been set. Passing refresh and resetting mod lists"
+            )
             # Wait for settings dialog to be closed before continuing.
             # This is to ensure steamcmd check and other ops are done after the user has a chance to set paths
             if not self.settings_controller.settings_dialog.isHidden():
@@ -797,9 +905,13 @@ class MainContent(QObject):
         Method to clear all the non-base, non-DLC mods from the active
         list widget and put them all into the inactive list widget.
         """
-        self.mods_panel.active_mods_filter_data_source_index = len(self.mods_panel.data_source_filter_icons)
+        self.mods_panel.active_mods_filter_data_source_index = len(
+            self.mods_panel.data_source_filter_icons
+        )
         self.mods_panel.signal_clear_search(list_type="Active")
-        self.mods_panel.inactive_mods_filter_data_source_index = len(self.mods_panel.data_source_filter_icons)
+        self.mods_panel.inactive_mods_filter_data_source_index = len(
+            self.mods_panel.data_source_filter_icons
+        )
         self.mods_panel.signal_clear_search(list_type="Inactive")
         # Metadata to insert
         active_mods_uuids: list[str] = []
@@ -821,7 +933,8 @@ class MainContent(QObject):
             package_ids_to_keep_active = package_id_order
         # Create a set of all package IDs from mod_data
         package_ids_set = set(
-            mod_data["packageid"] for mod_data in self.metadata_manager.internal_local_metadata.values()
+            mod_data["packageid"]
+            for mod_data in self.metadata_manager.internal_local_metadata.values()
         )
         # Iterate over the package IDs we want to keep active
         for package_id in package_ids_to_keep_active:
@@ -830,11 +943,14 @@ class MainContent(QObject):
                 active_mods_uuids.extend(
                     uuid
                     for uuid, mod_data in self.metadata_manager.internal_local_metadata.items()
-                    if mod_data["data_source"] == "expansion" and mod_data["packageid"] == package_id
+                    if mod_data["data_source"] == "expansion"
+                    and mod_data["packageid"] == package_id
                 )
         # Append the remaining UUIDs to inactive_mods_uuids
         inactive_mods_uuids.extend(
-            uuid for uuid in self.metadata_manager.internal_local_metadata.keys() if uuid not in active_mods_uuids
+            uuid
+            for uuid in self.metadata_manager.internal_local_metadata.keys()
+            if uuid not in active_mods_uuids
         )
         # Disable widgets while inserting
         self.disable_enable_widgets_signal.emit(False)
@@ -852,10 +968,14 @@ class MainContent(QObject):
         # will likely sort before saving.
         logger.debug("Starting sorting mods")
         self.mods_panel.signal_clear_search(list_type="Active")
-        self.mods_panel.active_mods_filter_data_source_index = len(self.mods_panel.data_source_filter_icons)
+        self.mods_panel.active_mods_filter_data_source_index = len(
+            self.mods_panel.data_source_filter_icons
+        )
         self.mods_panel.on_active_mods_search_data_source_filter()
         self.mods_panel.signal_clear_search(list_type="Inactive")
-        self.mods_panel.inactive_mods_filter_data_source_index = len(self.mods_panel.data_source_filter_icons)
+        self.mods_panel.inactive_mods_filter_data_source_index = len(
+            self.mods_panel.data_source_filter_icons
+        )
         self.mods_panel.on_inactive_mods_search_data_source_filter()
 
         # Get active mods
@@ -887,7 +1007,9 @@ class MainContent(QObject):
         # Get package IDs for active mods
         active_package_ids = set()
         for uuid in active_mods:
-            active_package_ids.add(self.metadata_manager.internal_local_metadata[uuid]["packageid"])
+            active_package_ids.add(
+                self.metadata_manager.internal_local_metadata[uuid]["packageid"]
+            )
 
         # Get the current order of active mods list and create a copy for comparison
         current_order = active_mods
@@ -917,22 +1039,32 @@ class MainContent(QObject):
         success, new_order = sorter.sort()
 
         # Log the sort result and the order
-        logger.debug(f"Sort result: {success}, new order: {new_order}, current order: {current_order}")
+        logger.debug(
+            f"Sort result: {success}, new order: {new_order}, current order: {current_order}"
+        )
         # Check if successful and orders differ
         if success and new_order != current_order:
-            logger.info("Finished combining all tiers of mods. Inserting into mod lists!")
+            logger.info(
+                "Finished combining all tiers of mods. Inserting into mod lists!"
+            )
             # Disable widgets while inserting
             self.disable_enable_widgets_signal.emit(False)
             # Insert data into lists
             self._insert_data_into_lists(
                 new_order,
-                [uuid for uuid in self.metadata_manager.internal_local_metadata if uuid not in set(new_order)],
+                [
+                    uuid
+                    for uuid in self.metadata_manager.internal_local_metadata
+                    if uuid not in set(new_order)
+                ],
             )
             # Enable widgets again after inserting
             self.disable_enable_widgets_signal.emit(True)
             logger.info("Insertion finished!")
         elif success and new_order == current_order:
-            logger.info("Sort completed, but the order of mods has not changed. No insertion needed.")
+            logger.info(
+                "Sort completed, but the order of mods has not changed. No insertion needed."
+            )
         elif not success:
             logger.warning("Failed to sort mods. Skipping insertion.")
         else:
@@ -953,10 +1085,14 @@ class MainContent(QObject):
         logger.info(f"Selected path: {file_path}")
         if file_path:
             self.mods_panel.signal_clear_search(list_type="Active")
-            self.mods_panel.active_mods_filter_data_source_index = len(self.mods_panel.data_source_filter_icons)
+            self.mods_panel.active_mods_filter_data_source_index = len(
+                self.mods_panel.data_source_filter_icons
+            )
             self.mods_panel.signal_search_source_filter(list_type="Active")
             self.mods_panel.signal_clear_search(list_type="Inactive")
-            self.mods_panel.inactive_mods_filter_data_source_index = len(self.mods_panel.data_source_filter_icons)
+            self.mods_panel.inactive_mods_filter_data_source_index = len(
+                self.mods_panel.data_source_filter_icons
+            )
             self.mods_panel.signal_search_source_filter(list_type="Inactive")
             logger.info(f"Trying to import mods list from XML: {file_path}")
             (
@@ -993,22 +1129,35 @@ class MainContent(QObject):
             logger.info("Exporting current active mods to ModsConfig.xml format")
             active_mods = []
             for uuid in self.mods_panel.active_mods_list.uuids:
-                package_id = self.metadata_manager.internal_local_metadata[uuid]["packageid"]
+                package_id = self.metadata_manager.internal_local_metadata[uuid][
+                    "packageid"
+                ]
                 if package_id in active_mods:  # This should NOT be happening
                     logger.critical(
                         f"Tried to export more than 1 identical package ids to the same mod list. Skipping duplicate {package_id}"
                     )
                     continue
                 else:  # Otherwise, proceed with adding the mod package_id
-                    if package_id in self.duplicate_mods.keys():  # Check if mod has duplicates
-                        if self.metadata_manager.internal_local_metadata[uuid]["data_source"] == "workshop":
+                    if (
+                        package_id in self.duplicate_mods.keys()
+                    ):  # Check if mod has duplicates
+                        if (
+                            self.metadata_manager.internal_local_metadata[uuid][
+                                "data_source"
+                            ]
+                            == "workshop"
+                        ):
                             active_mods.append(package_id + "_steam")
                             continue  # Append `_steam` suffix if Steam mod, continue to next mod
                     active_mods.append(package_id)
             logger.info(f"Collected {len(active_mods)} active mods for export")
-            mods_config_data = generate_rimworld_mods_list(self.metadata_manager.game_version, active_mods)
+            mods_config_data = generate_rimworld_mods_list(
+                self.metadata_manager.game_version, active_mods
+            )
             try:
-                logger.info(f"Saving generated ModsConfig.xml style list to selected path: {file_path}")
+                logger.info(
+                    f"Saving generated ModsConfig.xml style list to selected path: {file_path}"
+                )
                 if not file_path.endswith(".xml"):
                     json_to_xml_write(mods_config_data, file_path + ".xml")
                 else:
@@ -1046,10 +1195,14 @@ class MainContent(QObject):
             return
         # Clear Active and Inactive search and data source filter
         self.mods_panel.signal_clear_search(list_type="Active")
-        self.mods_panel.active_mods_filter_data_source_index = len(self.mods_panel.data_source_filter_icons)
+        self.mods_panel.active_mods_filter_data_source_index = len(
+            self.mods_panel.data_source_filter_icons
+        )
         self.mods_panel.signal_search_source_filter(list_type="Active")
         self.mods_panel.signal_clear_search(list_type="Inactive")
-        self.mods_panel.inactive_mods_filter_data_source_index = len(self.mods_panel.data_source_filter_icons)
+        self.mods_panel.inactive_mods_filter_data_source_index = len(
+            self.mods_panel.data_source_filter_icons
+        )
         self.mods_panel.signal_search_source_filter(list_type="Inactive")
 
         if rentry_import.publishedfileids:
@@ -1061,7 +1214,11 @@ class MainContent(QObject):
             }
             # Filter out publishedfileids that already exist locally
             filtered_publishedfileids = list(
-                {pfid for pfid in rentry_import.publishedfileids if pfid not in existing_publishedfileids}
+                {
+                    pfid
+                    for pfid in rentry_import.publishedfileids
+                    if pfid not in existing_publishedfileids
+                }
             )
 
             def notify_user() -> None:
@@ -1129,7 +1286,9 @@ class MainContent(QObject):
                 answer = dialogue.show_dialogue_conditional(
                     title=self.tr("Download Rentry Mods"),
                     text=self.tr("Please select a download method."),
-                    information=self.tr("Select which method you want to use to download missing Rentry mods."),
+                    information=self.tr(
+                        "Select which method you want to use to download missing Rentry mods."
+                    ),
                     button_text_override=[
                         "Steam",
                         "SteamCMD",
@@ -1149,7 +1308,9 @@ class MainContent(QObject):
                     return
 
         # Log the attempt to import mods list from Rentry.co
-        logger.info(f"Trying to import {len(rentry_import.package_ids)} mods from Rentry.co list")
+        logger.info(
+            f"Trying to import {len(rentry_import.package_ids)} mods from Rentry.co list"
+        )
 
         # Generate uuids based on existing mods, calculate duplicates, and missing mods
         (
@@ -1182,14 +1343,20 @@ class MainContent(QObject):
             return
         # Clear Active and Inactive search and data source filter
         self.mods_panel.signal_clear_search(list_type="Active")
-        self.mods_panel.active_mods_filter_data_source_index = len(self.mods_panel.data_source_filter_icons)
+        self.mods_panel.active_mods_filter_data_source_index = len(
+            self.mods_panel.data_source_filter_icons
+        )
         self.mods_panel.signal_search_source_filter(list_type="Active")
         self.mods_panel.signal_clear_search(list_type="Inactive")
-        self.mods_panel.inactive_mods_filter_data_source_index = len(self.mods_panel.data_source_filter_icons)
+        self.mods_panel.inactive_mods_filter_data_source_index = len(
+            self.mods_panel.data_source_filter_icons
+        )
         self.mods_panel.signal_search_source_filter(list_type="Inactive")
 
         # Log the attempt to import mods list from Workshop collection
-        logger.info(f"Trying to import {len(collection_import.package_ids)} mods from Workshop collection list")
+        logger.info(
+            f"Trying to import {len(collection_import.package_ids)} mods from Workshop collection list"
+        )
 
         # Generate uuids based on existing mods, calculate duplicates, and missing mods
         (
@@ -1219,7 +1386,9 @@ class MainContent(QObject):
         active_mods = []
         active_mods_packageid_to_uuid = {}
         for uuid in self.mods_panel.active_mods_list.uuids:
-            package_id = self.metadata_manager.internal_local_metadata[uuid]["packageid"]
+            package_id = self.metadata_manager.internal_local_metadata[uuid][
+                "packageid"
+            ]
             if package_id in active_mods:  # This should NOT be happening
                 logger.critical(
                     "Tried to export more than 1 identical package ids to the same mod list. "
@@ -1248,7 +1417,12 @@ class MainContent(QObject):
                 url = self.metadata_manager.internal_local_metadata[uuid]["steam_url"]
             else:
                 url = "No url specified"
-            active_mods_clipboard_report = active_mods_clipboard_report + f"\n{name} " + f"[{package_id}]" + f"[{url}]"
+            active_mods_clipboard_report = (
+                active_mods_clipboard_report
+                + f"\n{name} "
+                + f"[{package_id}]"
+                + f"[{url}]"
+            )
         # Copy report to clipboard
         dialogue.show_information(
             title=self.tr("Export active mod list"),
@@ -1284,15 +1458,21 @@ class MainContent(QObject):
                 name = "No name specified"
             if (
                 self.metadata_manager.internal_local_metadata[uuid].get("steamcmd")
-                or self.metadata_manager.internal_local_metadata[uuid]["data_source"] == "workshop"
+                or self.metadata_manager.internal_local_metadata[uuid]["data_source"]
+                == "workshop"
             ) and active_steam_mods_packageid_to_pfid.get(package_id):
                 pfid = active_steam_mods_packageid_to_pfid[package_id]
                 if active_steam_mods_pfid_to_preview_url.get(pfid):
-                    preview_url = active_steam_mods_pfid_to_preview_url[pfid] + "?imw=100&imh=100&impolicy=Letterbox"
+                    preview_url = (
+                        active_steam_mods_pfid_to_preview_url[pfid]
+                        + "?imw=100&imh=100&impolicy=Letterbox"
+                    )
                 else:
                     preview_url = "https://github.com/RimSort/RimSort/blob/main/docs/rentry_steam_icon.png?raw=true"
                 if self.metadata_manager.internal_local_metadata[uuid].get("steam_url"):
-                    url = self.metadata_manager.internal_local_metadata[uuid]["steam_url"]
+                    url = self.metadata_manager.internal_local_metadata[uuid][
+                        "steam_url"
+                    ]
                 elif self.metadata_manager.internal_local_metadata[uuid].get("url"):
                     url = self.metadata_manager.internal_local_metadata[uuid]["url"]
                 else:
@@ -1312,8 +1492,12 @@ class MainContent(QObject):
             else:
                 if self.metadata_manager.internal_local_metadata[uuid].get("url"):
                     url = self.metadata_manager.internal_local_metadata[uuid]["url"]
-                elif self.metadata_manager.internal_local_metadata[uuid].get("steam_url"):
-                    url = self.metadata_manager.internal_local_metadata[uuid]["steam_url"]
+                elif self.metadata_manager.internal_local_metadata[uuid].get(
+                    "steam_url"
+                ):
+                    url = self.metadata_manager.internal_local_metadata[uuid][
+                        "steam_url"
+                    ]
                 else:
                     url = None
                 if url is None:
@@ -1347,7 +1531,9 @@ class MainContent(QObject):
         pfids = []
         # Build our lists
         for uuid in self.mods_panel.active_mods_list.uuids:
-            package_id = MetadataManager.instance().internal_local_metadata[uuid]["packageid"]
+            package_id = MetadataManager.instance().internal_local_metadata[uuid][
+                "packageid"
+            ]
             if package_id in active_mods:  # This should NOT be happening
                 logger.critical(
                     "Tried to export more than 1 identical package ids to the same mod list. "
@@ -1359,9 +1545,16 @@ class MainContent(QObject):
                 active_mods_packageid_to_uuid[package_id] = uuid
                 if (
                     self.metadata_manager.internal_local_metadata[uuid].get("steamcmd")
-                    or self.metadata_manager.internal_local_metadata[uuid]["data_source"] == "workshop"
-                ) and self.metadata_manager.internal_local_metadata[uuid].get("publishedfileid"):
-                    publishedfileid = self.metadata_manager.internal_local_metadata[uuid]["publishedfileid"]
+                    or self.metadata_manager.internal_local_metadata[uuid][
+                        "data_source"
+                    ]
+                    == "workshop"
+                ) and self.metadata_manager.internal_local_metadata[uuid].get(
+                    "publishedfileid"
+                ):
+                    publishedfileid = self.metadata_manager.internal_local_metadata[
+                        uuid
+                    ]["publishedfileid"]
                     active_steam_mods_packageid_to_pfid[package_id] = publishedfileid
                     pfids.append(publishedfileid)
         logger.info(f"Collected {len(active_mods)} active mods for export")
@@ -1374,10 +1567,14 @@ class MainContent(QObject):
                     pfid = metadata["publishedfileid"]
                     if metadata["result"] != 1:
                         logger.warning("Rentry.co export: Unable to get data for mod!")
-                        logger.warning(f"Invalid result returned from WebAPI for mod {pfid}")
+                        logger.warning(
+                            f"Invalid result returned from WebAPI for mod {pfid}"
+                        )
                     else:
                         # Retrieve the preview image URL from the response
-                        active_steam_mods_pfid_to_preview_url[pfid] = metadata["preview_url"]
+                        active_steam_mods_pfid_to_preview_url[pfid] = metadata[
+                            "preview_url"
+                        ]
         # Build our report using the helper method
         active_mods_rentry_report = self._build_rentry_report(
             active_mods,
@@ -1405,7 +1602,9 @@ class MainContent(QObject):
             if max_mods == 0:
                 dialogue.show_warning(
                     title=self.tr("Report too long"),
-                    text=self.tr("Even the first mod exceeds the 200,000 character limit."),
+                    text=self.tr(
+                        "Even the first mod exceeds the 200,000 character limit."
+                    ),
                     information=self.tr("Cannot upload this report to Rentry.co."),
                 )
                 return
@@ -1415,9 +1614,15 @@ class MainContent(QObject):
                 information=self.tr(
                     "Rentry.co may reject uploads that are too long. Would you like to truncate the report to the first {max_mods} mods or cancel the upload?"
                 ).format(max_mods=max_mods),
-                button_text_override=[self.tr("Truncate to the first {max_mods} mods").format(max_mods=max_mods)],
+                button_text_override=[
+                    self.tr("Truncate to the first {max_mods} mods").format(
+                        max_mods=max_mods
+                    )
+                ],
             )
-            if answer == self.tr("Truncate to the first {max_mods} mods").format(max_mods=max_mods):
+            if answer == self.tr("Truncate to the first {max_mods} mods").format(
+                max_mods=max_mods
+            ):
                 # Rebuild report with the maximum number of mods that fit
                 truncated_mods = active_mods[:max_mods]
                 active_mods_rentry_report = self._build_rentry_report(
@@ -1433,7 +1638,11 @@ class MainContent(QObject):
         # Upload the report to Rentry.co
         rentry_uploader = RentryUpload(active_mods_rentry_report)
         successful = rentry_uploader.upload_success
-        host = urlparse(rentry_uploader.url).hostname if successful and (rentry_uploader.url is not None) else None
+        host = (
+            urlparse(rentry_uploader.url).hostname
+            if successful and (rentry_uploader.url is not None)
+            else None
+        )
         if rentry_uploader.url and host and host.endswith("rentry.co"):
             copy_to_clipboard_safely(rentry_uploader.url)
             dialogue.show_information(
@@ -1480,10 +1689,14 @@ class MainContent(QObject):
 
         # Clear searches and data source filters just like XML import
         self.mods_panel.signal_clear_search(list_type="Active")
-        self.mods_panel.active_mods_filter_data_source_index = len(self.mods_panel.data_source_filter_icons)
+        self.mods_panel.active_mods_filter_data_source_index = len(
+            self.mods_panel.data_source_filter_icons
+        )
         self.mods_panel.signal_search_source_filter(list_type="Active")
         self.mods_panel.signal_clear_search(list_type="Inactive")
-        self.mods_panel.inactive_mods_filter_data_source_index = len(self.mods_panel.data_source_filter_icons)
+        self.mods_panel.inactive_mods_filter_data_source_index = len(
+            self.mods_panel.data_source_filter_icons
+        )
         self.mods_panel.signal_search_source_filter(list_type="Inactive")
 
         logger.info(f"Trying to import mods list from save file: {file_path}")
@@ -1528,11 +1741,17 @@ class MainContent(QObject):
         user_home = Path.home()
         logs_directory = None
         if SystemInfo().operating_system == SystemInfo.OperatingSystem.MACOS:
-            logs_directory = user_home / "Library/Logs/Ludeon Studios/RimWorld by Ludeon Studios"
+            logs_directory = (
+                user_home / "Library/Logs/Ludeon Studios/RimWorld by Ludeon Studios"
+            )
         elif SystemInfo().operating_system == SystemInfo.OperatingSystem.LINUX:
-            logs_directory = user_home / ".config/unity3d/Ludeon Studios/RimWorld by Ludeon Studios"
+            logs_directory = (
+                user_home / ".config/unity3d/Ludeon Studios/RimWorld by Ludeon Studios"
+            )
         elif SystemInfo().operating_system == SystemInfo.OperatingSystem.WINDOWS:
-            logs_directory = user_home / "AppData/LocalLow/Ludeon Studios/RimWorld by Ludeon Studios"
+            logs_directory = (
+                user_home / "AppData/LocalLow/Ludeon Studios/RimWorld by Ludeon Studios"
+            )
 
         if logs_directory and logs_directory.exists():
             logger.info(f"Opening RimWorld logs directory: {logs_directory}")
@@ -1563,7 +1782,9 @@ class MainContent(QObject):
         logger.error(f"Could not open {directory_name} directory")
         answer = dialogue.show_dialogue_conditional(
             title=self.tr("Could not open directory"),
-            text=self.tr("{directory_name} path does not exist or is not set.").format(directory_name=directory_name),
+            text=self.tr("{directory_name} path does not exist or is not set.").format(
+                directory_name=directory_name
+            ),
             information=self.tr("Would you like to set the path now?"),
             button_text_override=[self.tr("Open settings")],
         )
@@ -1591,8 +1812,12 @@ class MainContent(QObject):
             copy_to_clipboard_safely(ret)
             dialogue.show_information(
                 title=self.tr("Uploaded file"),
-                text=self.tr("Uploaded {path.name} to https://0x0.st/").format(path=path),
-                information=self.tr("The URL has been copied to your clipboard:\n\n{ret}").format(ret=ret),
+                text=self.tr("Uploaded {path.name} to https://0x0.st/").format(
+                    path=path
+                ),
+                information=self.tr(
+                    "The URL has been copied to your clipboard:\n\n{ret}"
+                ).format(ret=ret),
             )
             webbrowser.open(ret)
         else:
@@ -1607,13 +1832,16 @@ class MainContent(QObject):
             logger.info(f"Opening file in default editor: {path}")
             launch_process(
                 self.settings_controller.settings.text_editor_location,
-                self.settings_controller.settings.text_editor_folder_arg.split(" ") + [str(path)],
+                self.settings_controller.settings.text_editor_folder_arg.split(" ")
+                + [str(path)],
                 str(AppInfo().application_folder),
             )
         else:
             dialogue.show_warning(
                 title=self.tr("Failed to open file."),
-                text=self.tr("Failed to open the file with default text editor. It may not exist."),
+                text=self.tr(
+                    "Failed to open the file with default text editor. It may not exist."
+                ),
             )
 
     def _do_save(self) -> None:
@@ -1623,23 +1851,36 @@ class MainContent(QObject):
         logger.info("Saving current active mods to ModsConfig.xml")
         active_mods = []
         for uuid in self.mods_panel.active_mods_list.uuids:
-            package_id = self.metadata_manager.internal_local_metadata[uuid]["packageid"]
+            package_id = self.metadata_manager.internal_local_metadata[uuid][
+                "packageid"
+            ]
             if package_id in active_mods:  # This should NOT be happening
                 logger.critical(
                     f"Tried to export more than 1 identical package ids to the same mod list. Skipping duplicate {package_id}"
                 )
                 continue
             else:  # Otherwise, proceed with adding the mod package_id
-                if package_id in self.duplicate_mods.keys():  # Check if mod has duplicates
-                    if self.metadata_manager.internal_local_metadata[uuid]["data_source"] == "workshop":
+                if (
+                    package_id in self.duplicate_mods.keys()
+                ):  # Check if mod has duplicates
+                    if (
+                        self.metadata_manager.internal_local_metadata[uuid][
+                            "data_source"
+                        ]
+                        == "workshop"
+                    ):
                         active_mods.append(package_id + "_steam")
                         continue  # Append `_steam` suffix if Steam mod, continue to next mod
                 active_mods.append(package_id)
-        active_mods_uuids, inactive_mods_uuids, _, _ = metadata.get_mods_from_list(mod_list=active_mods)
+        active_mods_uuids, inactive_mods_uuids, _, _ = metadata.get_mods_from_list(
+            mod_list=active_mods
+        )
         self.active_mods_uuids_last_save = active_mods_uuids
         logger.info(f"Collected {len(active_mods)} active mods for saving")
 
-        mods_config_data = generate_rimworld_mods_list(self.metadata_manager.game_version, active_mods)
+        mods_config_data = generate_rimworld_mods_list(
+            self.metadata_manager.game_version, active_mods
+        )
         mods_config_path = str(
             Path(
                 self.settings_controller.settings.instances[
@@ -1670,12 +1911,19 @@ class MainContent(QObject):
         TODO: restoring after clearing will cause a few harmless lines of
         'Inactive mod count changed to: 0' to appear.
         """
-        if self.active_mods_uuids_restore_state and self.inactive_mods_uuids_restore_state:
+        if (
+            self.active_mods_uuids_restore_state
+            and self.inactive_mods_uuids_restore_state
+        ):
             self.mods_panel.signal_clear_search("Active")
-            self.mods_panel.active_mods_filter_data_source_index = len(self.mods_panel.data_source_filter_icons)
+            self.mods_panel.active_mods_filter_data_source_index = len(
+                self.mods_panel.data_source_filter_icons
+            )
             self.mods_panel.on_active_mods_search_data_source_filter()
             self.mods_panel.signal_clear_search("Inactive")
-            self.mods_panel.inactive_mods_filter_data_source_index = len(self.mods_panel.data_source_filter_icons)
+            self.mods_panel.inactive_mods_filter_data_source_index = len(
+                self.mods_panel.data_source_filter_icons
+            )
             self.mods_panel.on_inactive_mods_search_data_source_filter()
             logger.info(
                 f"Restoring cached mod lists with active list [{len(self.active_mods_uuids_restore_state)}] and inactive list [{len(self.inactive_mods_uuids_restore_state)}]"
@@ -1763,9 +2011,7 @@ class MainContent(QObject):
             logger.error("No valid mod paths found for todds texture optimization.")
             dialogue.show_warning(
                 title=self.tr("No valid paths for todds"),
-                text=self.tr(
-                    "todds could not find any valid mod folders to process."
-                ),
+                text=self.tr("todds could not find any valid mod folders to process."),
                 information=self.tr(
                     "None of the configured mod folder paths exist on disk. "
                     "Please verify your Local Mods and Workshop folders are correctly "
@@ -1834,12 +2080,16 @@ class MainContent(QObject):
         return success, exit_code
 
     @overload  # Blocking call: returns (success, exit_code)
-    def _do_optimize_textures(self, block_until_complete: Literal[True]) -> tuple[bool, int]: ...
+    def _do_optimize_textures(
+        self, block_until_complete: Literal[True]
+    ) -> tuple[bool, int]: ...
 
     @overload  # Async call (default): returns None immediately
     def _do_optimize_textures(self) -> None: ...
 
-    def _do_optimize_textures(self, block_until_complete: bool = False) -> tuple[bool, int] | None:
+    def _do_optimize_textures(
+        self, block_until_complete: bool = False
+    ) -> tuple[bool, int] | None:
         """
         Run todds texture optimization with optional blocking.
 
@@ -1878,7 +2128,11 @@ class MainContent(QObject):
         todds_interface.execute_todds_cmd(todds_txt_path, todds_runner)
 
         # Block and return status if needed, otherwise return immediately
-        return self._wait_for_todds_completion(todds_runner) if block_until_complete else None
+        return (
+            self._wait_for_todds_completion(todds_runner)
+            if block_until_complete
+            else None
+        )
 
     def _do_delete_dds_textures(self) -> None:
         """
@@ -1921,7 +2175,9 @@ class MainContent(QObject):
         answer = dialogue.show_dialogue_conditional(
             title=self.tr("Confirm ACF import"),
             text=self.tr("This will replace your current steamcmd .acf file"),
-            information=self.tr("Are you sure you want to import .acf? This only works for steamcmd"),
+            information=self.tr(
+                "Are you sure you want to import .acf? This only works for steamcmd"
+            ),
             button_text_override=[
                 self.tr("Import .acf"),
             ],
@@ -1952,7 +2208,9 @@ class MainContent(QObject):
             logger.error(f"Export failed: ACF file not found: {acf_path_str}")
             dialogue.show_warning(
                 title=self.tr("Export Error"),
-                text=self.tr("ACF file not found at: {acf_path}").format(acf_path=acf_path_str),
+                text=self.tr("ACF file not found at: {acf_path}").format(
+                    acf_path=acf_path_str
+                ),
             )
             return
 
@@ -1971,10 +2229,14 @@ class MainContent(QObject):
             logger.debug(f"Successfully exported ACF to {file_path}")
             dialogue.show_information(
                 title=self.tr("Export Success"),
-                text=self.tr("Successfully exported ACF to {file_path}").format(file_path=file_path),
+                text=self.tr("Successfully exported ACF to {file_path}").format(
+                    file_path=file_path
+                ),
             )
         except PermissionError:
-            error_msg = self.tr("Export failed: Permission denied - check file permissions")
+            error_msg = self.tr(
+                "Export failed: Permission denied - check file permissions"
+            )
             logger.error(f"Export failed due to Permission: {error_msg}")
             dialogue.show_warning(title=self.tr("Export Error"), text=error_msg)
         except Exception as e:
@@ -1992,13 +2254,19 @@ class MainContent(QObject):
         )
         if answer == QMessageBox.StandardButton.Yes:
             logger.info("Resetting SteamCMD ACF data file")
-            steamcmd_appworkshop_acf_path = self.steamcmd_wrapper.steamcmd_appworkshop_acf_path
+            steamcmd_appworkshop_acf_path = (
+                self.steamcmd_wrapper.steamcmd_appworkshop_acf_path
+            )
             if os.path.exists(steamcmd_appworkshop_acf_path):
-                logger.debug(f"Deleting SteamCMD ACF data file: {steamcmd_appworkshop_acf_path}")
+                logger.debug(
+                    f"Deleting SteamCMD ACF data file: {steamcmd_appworkshop_acf_path}"
+                )
                 os.remove(steamcmd_appworkshop_acf_path)
                 dialogue.show_information(
                     title=self.tr("Reset SteamCMD ACF data file"),
-                    text=self.tr(f"Successfully deleted SteamCMD ACF data file: {steamcmd_appworkshop_acf_path}"),
+                    text=self.tr(
+                        f"Successfully deleted SteamCMD ACF data file: {steamcmd_appworkshop_acf_path}"
+                    ),
                     information=self.tr(
                         "ACF data file will be recreated when you download mods using steamcmd next time."
                     ),
@@ -2009,7 +2277,9 @@ class MainContent(QObject):
                 logger.debug("SteamCMD ACF data does not exist. Skipping deletion.")
                 dialogue.show_warning(
                     title=self.tr("SteamCMD ACF data file does not exist"),
-                    text=self.tr("ACf file does not exist. It will be created when you download mods using steamcmd."),
+                    text=self.tr(
+                        "ACf file does not exist. It will be created when you download mods using steamcmd."
+                    ),
                 )
         else:
             logger.debug("user cancelled reset of SteamCMD ACF data file")
@@ -2020,15 +2290,17 @@ class MainContent(QObject):
         if self.steam_browser:
             self.steam_browser.close()
             self.steam_browser.deleteLater()
-        
+
         self.steam_browser = SteamBrowser(
             "https://steamcommunity.com/app/294100/workshop/",
             self.metadata_manager,
             self.settings_controller,
         )
-        
+
         # Automatically null the reference when browser is destroyed
-        self.steam_browser.destroyed.connect(lambda: setattr(self, 'steam_browser', None))
+        self.steam_browser.destroyed.connect(
+            lambda: setattr(self, "steam_browser", None)
+        )
         self.steam_browser.show()
 
     def _do_check_for_workshop_updates(self) -> None:
@@ -2037,7 +2309,9 @@ class MainContent(QObject):
             return
         # Query Workshop for update data
         updates_checked = self.do_threaded_loading_animation(
-            gif_path=str(AppInfo().theme_data_folder / "default-icons" / "steam_api.gif"),
+            gif_path=str(
+                AppInfo().theme_data_folder / "default-icons" / "steam_api.gif"
+            ),
             target=partial(
                 metadata.query_workshop_update_data,
                 mods=self.metadata_manager.internal_local_metadata,
@@ -2048,7 +2322,9 @@ class MainContent(QObject):
         if updates_checked == "failed":
             dialogue.show_warning(
                 title=self.tr("Unable to check for updates"),
-                text=self.tr("RimSort was unable to query Steam WebAPI for update information!\n"),
+                text=self.tr(
+                    "RimSort was unable to query Steam WebAPI for update information!\n"
+                ),
                 information=self.tr("Are you connected to the Internet?"),
             )
             return
@@ -2057,7 +2333,9 @@ class MainContent(QObject):
             logger.debug("Displaying potential Workshop mod updates")
             workshop_mod_updater.show()
         else:
-            self.status_signal.emit(self.tr("All Workshop mods appear to be up to date!"))
+            self.status_signal.emit(
+                self.tr("All Workshop mods appear to be up to date!")
+            )
 
     def do_steam_verify_game_files(self) -> None:
         """Verify RimWorld game files through Steam."""
@@ -2069,7 +2347,9 @@ class MainContent(QObject):
         # Check if Steam Client Integration is enabled
         if not steam_client_integration_enabled:
             # Inform user that feature requires Steam Client Integration
-            logger.warning("Steam Client Integration is disabled. Cannot verify game files.")
+            logger.warning(
+                "Steam Client Integration is disabled. Cannot verify game files."
+            )
             dialogue.show_warning(
                 title=self.tr("Steam Client Integration is disabled"),
                 text=self.tr(
@@ -2099,7 +2379,8 @@ class MainContent(QObject):
                 title=self.tr("RimSort - SteamCMD setup"),
                 text=self.tr("Unable to create SteamCMD runner!"),
                 information=self.tr("There is an active process already running!"),
-                details=f"PID {self.steamcmd_runner.process.processId()} : " + self.steamcmd_runner.process.program(),
+                details=f"PID {self.steamcmd_runner.process.processId()} : "
+                + self.steamcmd_runner.process.program(),
             )
             return
         local_mods_path = self.settings_controller.settings.instances[
@@ -2119,12 +2400,18 @@ class MainContent(QObject):
         else:
             dialogue.show_warning(
                 title=self.tr("RimSort - SteamCMD setup"),
-                text=self.tr("Unable to initiate SteamCMD installation. Local mods path not set!"),
-                information=self.tr("Please configure local mods path in Settings before attempting to install."),
+                text=self.tr(
+                    "Unable to initiate SteamCMD installation. Local mods path not set!"
+                ),
+                information=self.tr(
+                    "Please configure local mods path in Settings before attempting to install."
+                ),
             )
 
     def _do_download_mods_with_steamcmd(self, publishedfileids: list[str]) -> None:
-        logger.debug(f"Attempting to download {len(publishedfileids)} mods with SteamCMD")
+        logger.debug(
+            f"Attempting to download {len(publishedfileids)} mods with SteamCMD"
+        )
         # Check for blacklisted mods
         if self.metadata_manager.external_steam_metadata is not None:
             publishedfileids = metadata.check_if_pfids_blacklisted(
@@ -2136,7 +2423,9 @@ class MainContent(QObject):
             dialogue.show_warning(
                 title=self.tr("RimSort"),
                 text=self.tr("No PublishedFileIds were supplied in operation."),
-                information=self.tr("Please add mods to list before attempting to download."),
+                information=self.tr(
+                    "Please add mods to list before attempting to download."
+                ),
             )
             return
         # Check for existing steamcmd_runner process
@@ -2149,11 +2438,14 @@ class MainContent(QObject):
                 title=self.tr("RimSort"),
                 text=self.tr("Unable to create SteamCMD runner!"),
                 information=self.tr("There is an active process already running!"),
-                details=f"PID {self.steamcmd_runner.process.processId()} : " + self.steamcmd_runner.process.program(),
+                details=f"PID {self.steamcmd_runner.process.processId()} : "
+                + self.steamcmd_runner.process.program(),
             )
             return
         # Check for SteamCMD executable
-        if self.steamcmd_wrapper.steamcmd and os.path.exists(self.steamcmd_wrapper.steamcmd):
+        if self.steamcmd_wrapper.steamcmd and os.path.exists(
+            self.steamcmd_wrapper.steamcmd
+        ):
             if self.steam_browser:
                 self.steam_browser.close()
             steam_db = self.metadata_manager.external_steam_metadata
@@ -2166,7 +2458,9 @@ class MainContent(QObject):
             )
             self.steamcmd_runner.setWindowTitle("RimSort - SteamCMD downloader")
             self.steamcmd_runner.show()
-            self.steamcmd_runner.message(f"Downloading {len(publishedfileids)} mods with SteamCMD...")
+            self.steamcmd_runner.message(
+                f"Downloading {len(publishedfileids)} mods with SteamCMD..."
+            )
             self.steamcmd_wrapper.download_mods(
                 publishedfileids=publishedfileids,
                 runner=self.steamcmd_runner,
@@ -2233,17 +2527,25 @@ class MainContent(QObject):
                     )
                     # Start the Steamworks API Process
                     steamworks_api_process.start()
-                    logger.info(f"Steamworks API process wrapper started with PID: {steamworks_api_process.pid}")
+                    logger.info(
+                        f"Steamworks API process wrapper started with PID: {steamworks_api_process.pid}"
+                    )
                     steamworks_api_process.join()
-                    logger.info(f"Steamworks API process wrapper completed for PID: {steamworks_api_process.pid}")
+                    logger.info(
+                        f"Steamworks API process wrapper completed for PID: {steamworks_api_process.pid}"
+                    )
                     self.steamworks_in_use = False
                 elif (
                     instruction[0] in subscription_actions and len(instruction[1]) >= 1
                 ):  # ISteamUGC/{SubscribeItem/UnsubscribeItem}
-                    logger.info(f"Creating Steamworks API process with instruction {instruction}")
+                    logger.info(
+                        f"Creating Steamworks API process with instruction {instruction}"
+                    )
                     self.steamworks_in_use = True
                     # Process all mods in a single handler to ensure proper sequencing and avoid parallel processing issues
-                    logger.debug(f"Processing {instruction[0]} sequentially for {len(instruction[1])} mod(s)")
+                    logger.debug(
+                        f"Processing {instruction[0]} sequentially for {len(instruction[1])} mod(s)"
+                    )
                     handler = SteamworksSubscriptionHandler(
                         action=instruction[0],
                         pfid_or_pfids=instruction[1],
@@ -2265,7 +2567,9 @@ class MainContent(QObject):
                 "Steamworks API is already initialized! We do NOT want multiple interactions. Skipping instruction..."
             )
 
-    def _do_steamworks_api_call_animated(self, instruction: list[list[str] | str]) -> None:
+    def _do_steamworks_api_call_animated(
+        self, instruction: list[list[str] | str]
+    ) -> None:
         publishedfileids = instruction[1]
         logger.debug(f"Attempting to download {len(publishedfileids)} mods with Steam")
         steamdb = self.metadata_manager.external_steam_metadata
@@ -2283,7 +2587,9 @@ class MainContent(QObject):
             dialogue.show_warning(
                 title=self.tr("RimSort"),
                 text=self.tr("No PublishedFileIds were supplied in operation."),
-                information=self.tr("Please add mods to list before attempting to download."),
+                information=self.tr(
+                    "Please add mods to list before attempting to download."
+                ),
             )
             return
         # Close browser if open
@@ -2293,7 +2599,9 @@ class MainContent(QObject):
         self.do_threaded_loading_animation(
             gif_path=str(AppInfo().theme_data_folder / "default-icons" / "steam.gif"),
             target=partial(self._do_steamworks_api_call, instruction=instruction),
-            text=self.tr("Processing Steam subscription action(s) via Steamworks API..."),
+            text=self.tr(
+                "Processing Steam subscription action(s) via Steamworks API..."
+            ),
         )
         # Do a full refresh of metadata and UI
         # self._do_refresh()
@@ -2316,7 +2624,9 @@ class MainContent(QObject):
         # download or select from local
         answer = dialogue.show_dialogue_conditional(
             title=self.tr("Download or select from local"),
-            text=self.tr("Please select a ZIP file to add to the local mods directory."),
+            text=self.tr(
+                "Please select a ZIP file to add to the local mods directory."
+            ),
             information=self.tr(
                 "You can download a ZIP file from the internet, or select a file from your local machine."
             ),
@@ -2419,7 +2729,9 @@ class MainContent(QObject):
                     dialogue.show_warning(
                         title=self.tr("Failed to download zip file"),
                         text=self.tr("The zip file could not be downloaded."),
-                        information=self.tr("File: {file_path}\nError: {e}").format(file_path=temp_path, e=e),
+                        information=self.tr("File: {file_path}\nError: {e}").format(
+                            file_path=temp_path, e=e
+                        ),
                     )
                     # Clean up on error
                     if os.path.exists(temp_path):
@@ -2454,7 +2766,9 @@ class MainContent(QObject):
             return
 
         base_path = str(
-            self.settings_controller.settings.instances[self.settings_controller.settings.current_instance].local_folder
+            self.settings_controller.settings.instances[
+                self.settings_controller.settings.current_instance
+            ].local_folder
         )
 
         try:
@@ -2463,18 +2777,26 @@ class MainContent(QObject):
             logger.error(f"Unsupported compression method: {e}")
             dialogue.show_warning(
                 title=self.tr("Unsupported Compression Method"),
-                text=self.tr("This ZIP file uses a compression method that is not supported by this version."),
-                information=self.tr("File: {file_path}\nError: {e}").format(file_path=file_path, e=e),
+                text=self.tr(
+                    "This ZIP file uses a compression method that is not supported by this version."
+                ),
+                information=self.tr("File: {file_path}\nError: {e}").format(
+                    file_path=file_path, e=e
+                ),
             )
         except (BadZipFile, ValueError, PermissionError, OSError) as e:
             logger.error(f"Failed to extract zip file: {e}")
             dialogue.show_warning(
                 title=self.tr("Failed to extract zip file"),
                 text=self.tr("The zip file could not be extracted."),
-                information=self.tr("File: {file_path}\nError: {e}").format(file_path=file_path, e=e),
+                information=self.tr("File: {file_path}\nError: {e}").format(
+                    file_path=file_path, e=e
+                ),
             )
 
-    def _do_extract_zip_to_path(self, base_path: str, file_path: str, delete: bool = False) -> None:
+    def _do_extract_zip_to_path(
+        self, base_path: str, file_path: str, delete: bool = False
+    ) -> None:
         zip_contents = get_zip_contents(file_path)
         conflicts = []
         non_conflicts = []
@@ -2500,7 +2822,9 @@ class MainContent(QObject):
         if conflicts and not non_conflicts:
             answer = dialogue.show_dialogue_conditional(
                 title=self.tr("Existing files or directories found"),
-                text=self.tr("All files in the archive already exist in the target path."),
+                text=self.tr(
+                    "All files in the archive already exist in the target path."
+                ),
                 information=self.tr(
                     "How would you like to proceed?\n\n"
                     "1) Overwrite All — Replace all existing files and directories.\n"
@@ -2514,14 +2838,19 @@ class MainContent(QObject):
         elif conflicts:
             answer = dialogue.show_dialogue_conditional(
                 title=self.tr("Existing files or directories found"),
-                text=self.tr("The following files or directories already exist in the target path:"),
+                text=self.tr(
+                    "The following files or directories already exist in the target path:"
+                ),
                 information=self.tr(
                     "{conflicts_list}\n\n"
                     "How would you like to proceed?\n\n"
                     "1) Overwrite All — Replace all existing files and directories.\n"
                     "2) Skip Existing — Extract only new files and leave existing ones untouched.\n"
                     "3) Cancel — Abort the extraction."
-                ).format(conflicts_list="<br/>".join(conflicts[:5]) + ("<br/>...<br/>" if len(conflicts) > 5 else "")),
+                ).format(
+                    conflicts_list="<br/>".join(conflicts[:5])
+                    + ("<br/>...<br/>" if len(conflicts) > 5 else "")
+                ),
                 button_text_override=["Overwrite All", "Skip Existing"],
             )
             if answer == QMessageBox.StandardButton.Cancel:
@@ -2543,7 +2872,9 @@ class MainContent(QObject):
         # Store reference for signal connections
         self._extract_progress_widget = progress_widget
 
-        self._extract_thread = ZipExtractThread(file_path, base_path, overwrite_all=overwrite, delete=delete)
+        self._extract_thread = ZipExtractThread(
+            file_path, base_path, overwrite_all=overwrite, delete=delete
+        )
         self._extract_thread.progress.connect(self._on_extract_progress)
         self._extract_thread.finished.connect(self._on_extract_finished)
         progress_widget.cancel_requested.connect(self._extract_thread.stop)
@@ -2559,7 +2890,10 @@ class MainContent(QObject):
         """Handle extraction completion."""
         try:
             # Clean up progress widget
-            if hasattr(self, "_extract_progress_widget") and self._extract_progress_widget:
+            if (
+                hasattr(self, "_extract_progress_widget")
+                and self._extract_progress_widget
+            ):
                 self.mod_info_panel.panel.removeWidget(self._extract_progress_widget)
                 self._extract_progress_widget.close()
                 self._extract_progress_widget = None
@@ -2597,7 +2931,9 @@ class MainContent(QObject):
         if answer == QMessageBox.StandardButton.Yes:
             open_url_browser("https://git-scm.com/downloads")
 
-    def _do_open_rule_editor(self, compact: bool, initial_mode: str, packageid: str | None = None) -> None:
+    def _do_open_rule_editor(
+        self, compact: bool, initial_mode: str, packageid: str | None = None
+    ) -> None:
         self.rule_editor = RuleEditor(
             # Initialization options
             compact=compact,
@@ -2626,7 +2962,9 @@ class MainContent(QObject):
         )
         logger.info(f"Selected path: {input_path}")
         if input_path and os.path.exists(input_path):
-            self.settings_controller.settings.external_steam_metadata_file_path = input_path
+            self.settings_controller.settings.external_steam_metadata_file_path = (
+                input_path
+            )
             self.settings_controller.settings.save()
         else:
             logger.debug("USER ACTION: cancelled selection!")
@@ -2643,7 +2981,9 @@ class MainContent(QObject):
         )
         logger.info(f"Selected path: {input_path}")
         if input_path and os.path.exists(input_path):
-            self.settings_controller.settings.external_community_rules_file_path = input_path
+            self.settings_controller.settings.external_community_rules_file_path = (
+                input_path
+            )
             self.settings_controller.settings.save()
         else:
             logger.debug("USER ACTION: cancelled selection!")
@@ -2730,7 +3070,9 @@ class MainContent(QObject):
             self.query_runner.progress_bar.show()
             self.query_runner.show()
             # Connect message signal
-            self.db_builder.db_builder_message_output_signal.connect(self.query_runner.message)
+            self.db_builder.db_builder_message_output_signal.connect(
+                self.query_runner.message
+            )
             # Start DB builder
             self.db_builder.start()
         else:
@@ -2752,15 +3094,21 @@ class MainContent(QObject):
                 comment = None
             # Check if our DB has an entry for the mod we are editing
             if not self.metadata_manager.external_steam_metadata.get(publishedfileid):
-                self.metadata_manager.external_steam_metadata.setdefault(publishedfileid, {})
+                self.metadata_manager.external_steam_metadata.setdefault(
+                    publishedfileid, {}
+                )
             # Edit our metadata
             if blacklist and comment:
-                self.metadata_manager.external_steam_metadata[publishedfileid]["blacklist"] = {
+                self.metadata_manager.external_steam_metadata[publishedfileid][
+                    "blacklist"
+                ] = {
                     "value": blacklist,
                     "comment": comment,
                 }
             else:
-                self.metadata_manager.external_steam_metadata[publishedfileid].pop("blacklist", None)
+                self.metadata_manager.external_steam_metadata[publishedfileid].pop(
+                    "blacklist", None
+                )
             logger.debug("Updating previous database with new metadata...\n")
             with open(
                 self.metadata_manager.external_steam_metadata_path,
@@ -2769,7 +3117,10 @@ class MainContent(QObject):
             ) as output:
                 json.dump(
                     {
-                        "version": int(time.time() + self.settings_controller.settings.database_expiry),
+                        "version": int(
+                            time.time()
+                            + self.settings_controller.settings.database_expiry
+                        ),
                         "database": self.metadata_manager.external_steam_metadata,
                     },
                     output,
@@ -2794,7 +3145,9 @@ class MainContent(QObject):
         self.query_runner.progress_bar.show()
         self.query_runner.show()
         # Connect message signal
-        self.db_builder.db_builder_message_output_signal.connect(self.query_runner.message)
+        self.db_builder.db_builder_message_output_signal.connect(
+            self.query_runner.message
+        )
         # Start DB builder
         self.db_builder.start()
         loop = QEventLoop()
@@ -2815,11 +3168,15 @@ class MainContent(QObject):
             if "steamcmd" in action:
                 # Filter out existing SteamCMD mods
                 mod_pfid = None
-                for metadata_values in self.metadata_manager.internal_local_metadata.values():
+                for (
+                    metadata_values
+                ) in self.metadata_manager.internal_local_metadata.values():
                     if metadata_values.get("steamcmd"):
                         mod_pfid = metadata_values.get("publishedfileid")
                     if mod_pfid and mod_pfid in self.db_builder.publishedfileids:
-                        logger.debug(f"Skipping download of existing SteamCMD mod: {mod_pfid}")
+                        logger.debug(
+                            f"Skipping download of existing SteamCMD mod: {mod_pfid}"
+                        )
                         self.db_builder.publishedfileids.remove(mod_pfid)
                 self._do_download_mods_with_steamcmd(self.db_builder.publishedfileids)
             elif "steamworks" in action:
@@ -2835,19 +3192,26 @@ class MainContent(QObject):
                     ),
                 )
                 if answer == QMessageBox.StandardButton.Yes:
-                    for metadata_values in self.metadata_manager.internal_local_metadata.values():
+                    for (
+                        metadata_values
+                    ) in self.metadata_manager.internal_local_metadata.values():
                         mod_pfid = metadata_values.get("publishedfileid")
                         if (
                             metadata_values["data_source"] == "workshop"
                             and mod_pfid
                             and mod_pfid in self.db_builder.publishedfileids
                         ):
-                            logger.warning(f"Skipping download of existing Steam mod: {mod_pfid}")
+                            logger.warning(
+                                f"Skipping download of existing Steam mod: {mod_pfid}"
+                            )
                             self.db_builder.publishedfileids.remove(mod_pfid)
                     self._do_steamworks_api_call_animated(
                         [
                             "subscribe",
-                            [eval(str_pfid) for str_pfid in self.db_builder.publishedfileids],
+                            [
+                                eval(str_pfid)
+                                for str_pfid in self.db_builder.publishedfileids
+                            ],
                         ]
                     )
 
@@ -2972,12 +3336,20 @@ class MainContent(QObject):
                             report += f"\n\nDISCREPANCY FOUND for {k}:"
                             report += f"\nhttps://steamcommunity.com/sharedfiles/filedetails/?id={k}"
                             report += f"\nMod name: {mod_name}"
-                            report += f"\n\nDatabase A:\n{v_total} dependencies found:\n{v}"
-                            report += f"\n\nDatabase B:\n{pp_total} dependencies found:\n{pp}"
-        logger.debug(f"Comparison skipped for {len(comparison_skipped)} unpublished mods: {comparison_skipped}")
+                            report += (
+                                f"\n\nDatabase A:\n{v_total} dependencies found:\n{v}"
+                            )
+                            report += (
+                                f"\n\nDatabase B:\n{pp_total} dependencies found:\n{pp}"
+                            )
+        logger.debug(
+            f"Comparison skipped for {len(comparison_skipped)} unpublished mods: {comparison_skipped}"
+        )
         dialogue.show_information(
             title=self.tr("Steam DB Builder"),
-            text=self.tr("Steam DB comparison report: {len} found").format(len=len(discrepancies)),
+            text=self.tr("Steam DB comparison report: {len} found").format(
+                len=len(discrepancies)
+            ),
             information=self.tr("Click 'Show Details' to see the full report!"),
             details=report,
         )
@@ -2998,7 +3370,9 @@ class MainContent(QObject):
                 + "\n\t1) Select input A (db to-be-updated)"
                 + "\n\t2) Select input B (update source)"
                 + "\n\t3) Select output C (resultant db)"
-            ).format(DB_BUILDER_RECURSE_EXCEPTIONS=app_constants.DB_BUILDER_RECURSE_EXCEPTIONS),
+            ).format(
+                DB_BUILDER_RECURSE_EXCEPTIONS=app_constants.DB_BUILDER_RECURSE_EXCEPTIONS
+            ),
         )
         # Input A
         logger.info("Opening file dialog to specify input file A")
@@ -3067,12 +3441,19 @@ class MainContent(QObject):
         rules_source = instruction[0]
         rules_data = instruction[1]
         # Get path based on rules source
-        if rules_source == "Community Rules" and self.metadata_manager.external_community_rules_path:
+        if (
+            rules_source == "Community Rules"
+            and self.metadata_manager.external_community_rules_path
+        ):
             path = self.metadata_manager.external_community_rules_path
-        elif rules_source == "User Rules" and str(AppInfo().databases_folder / "userRules.json"):
+        elif rules_source == "User Rules" and str(
+            AppInfo().databases_folder / "userRules.json"
+        ):
             path = str(AppInfo().databases_folder / "userRules.json")
         else:
-            logger.warning(f"No {rules_source} file path is set. There is no configured database to update!")
+            logger.warning(
+                f"No {rules_source} file path is set. There is no configured database to update!"
+            )
             return
         # Retrieve original database
         try:
@@ -3080,7 +3461,9 @@ class MainContent(QObject):
                 json_string = f.read()
                 logger.debug("Reading info...")
                 db_input_a = json.loads(json_string)
-                logger.debug(f"Retrieved copy of existing {rules_source} database to update.")
+                logger.debug(
+                    f"Retrieved copy of existing {rules_source} database to update."
+                )
         except Exception:
             logger.error("Failed to read info from existing database")
             dialogue.show_warning(
@@ -3122,7 +3505,9 @@ class MainContent(QObject):
         args, ok = QInputDialog.getText(
             None,
             self.tr("Edit SteamDB expiry:"),
-            self.tr("Enter your preferred expiry duration in seconds (default 1 week/604800 sec):"),
+            self.tr(
+                "Enter your preferred expiry duration in seconds (default 1 week/604800 sec):"
+            ),
             text=str(self.settings_controller.settings.database_expiry),
         )
         if ok:
@@ -3131,7 +3516,9 @@ class MainContent(QObject):
                 self.settings_controller.settings.save()
             except ValueError:
                 dialogue.show_warning(
-                    self.tr("Tried configuring Dynamic Query with a value that is not an integer."),
+                    self.tr(
+                        "Tried configuring Dynamic Query with a value that is not an integer."
+                    ),
                     self.tr(
                         "Please reconfigure the expiry value with an integer in terms of the seconds from epoch you would like your query to expire."
                     ),
@@ -3139,7 +3526,9 @@ class MainContent(QObject):
 
     @Slot()
     def _on_settings_have_changed(self) -> None:
-        instance = self.settings_controller.settings.instances.get(self.settings_controller.settings.current_instance)
+        instance = self.settings_controller.settings.instances.get(
+            self.settings_controller.settings.current_instance
+        )
         if not instance:
             logger.warning(
                 f"Tried to access instance {self.settings_controller.settings.current_instance} that does not exist!"
@@ -3153,7 +3542,9 @@ class MainContent(QObject):
                 steamcmd_prefix=str(steamcmd_prefix),
                 validate=self.settings_controller.settings.steamcmd_validate_downloads,
             )
-        self.steamcmd_wrapper.validate_downloads = self.settings_controller.settings.steamcmd_validate_downloads
+        self.steamcmd_wrapper.validate_downloads = (
+            self.settings_controller.settings.steamcmd_validate_downloads
+        )
 
     @Slot()
     def _on_do_download_all_mods_via_steamcmd(self) -> None:
@@ -3201,10 +3592,14 @@ class MainContent(QObject):
                 button_text_override=[self.tr("Save and Run"), self.tr("Run Anyway")],
             )
             if answer == self.tr("Save and Run"):
-                logger.info("User chose to save before proceeding with running the game.")
+                logger.info(
+                    "User chose to save before proceeding with running the game."
+                )
                 self._do_save()
             elif answer == self.tr("Run Anyway"):
-                logger.info("User chose to ignore unsaved changes and proceed with running the game anyway.")
+                logger.info(
+                    "User chose to ignore unsaved changes and proceed with running the game anyway."
+                )
                 pass
             elif answer == QMessageBox.StandardButton.Cancel:
                 logger.info("User chose to cancel.")
@@ -3229,9 +3624,13 @@ class MainContent(QObject):
 
         # Retrieve instance configuration
         current_instance = self.settings_controller.settings.current_instance
-        game_install_path = Path(self.settings_controller.settings.instances[current_instance].game_folder)
+        game_install_path = Path(
+            self.settings_controller.settings.instances[current_instance].game_folder
+        )
         # Run args is inconsistent and is sometimes a string and sometimes a list
-        run_args: list[str] | str = self.settings_controller.settings.instances[current_instance].run_args
+        run_args: list[str] | str = self.settings_controller.settings.instances[
+            current_instance
+        ].run_args
 
         run_args = [run_args] if isinstance(run_args, str) else run_args
 
@@ -3264,10 +3663,14 @@ class MainContent(QObject):
         if launch_via_steam_protocol:
             # Validate Steam Client Integration is enabled before using Steam protocol
             if not steam_client_integration:
-                logger.warning("Steam protocol launch requested but Steam Client Integration is disabled.")
+                logger.warning(
+                    "Steam protocol launch requested but Steam Client Integration is disabled."
+                )
                 dialogue.show_warning(
                     title=self.tr("Steam Client Integration is disabled"),
-                    text=self.tr("Steam protocol launch requires Steam Client Integration to be enabled."),
+                    text=self.tr(
+                        "Steam protocol launch requires Steam Client Integration to be enabled."
+                    ),
                     information=self.tr(
                         "Please enable Steam Client Integration in Settings → Steam to use this feature."
                     ),
@@ -3277,7 +3680,9 @@ class MainContent(QObject):
             # Launch via Steam protocol URI
             # This allows Steam to manage the game launch and enables the Steam overlay
             # Custom run arguments are ignored when using this method
-            logger.info("Launching game via Steam protocol URI (steam://rungameid/294100)...")
+            logger.info(
+                "Launching game via Steam protocol URI (steam://rungameid/294100)..."
+            )
             platform_specific_open("steam://rungameid/294100")
         else:
             # Launch game executable directly
@@ -3290,16 +3695,25 @@ class MainContent(QObject):
         """
         When clicked, opens the Use This Instead panel.
         """
-        if self.settings_controller.settings.external_use_this_instead_metadata_source == "None":
+        if (
+            self.settings_controller.settings.external_use_this_instead_metadata_source
+            == "None"
+        ):
             dialogue.show_warning(
                 title=self.tr("Use This Instead"),
-                text=self.tr('Please configure "Use This Instead" database in settings.'),
+                text=self.tr(
+                    'Please configure "Use This Instead" database in settings.'
+                ),
             )
             return
 
-        self.use_this_instead_dialog = UseThisInsteadPanel(mod_metadata=self.metadata_manager.internal_local_metadata)
+        self.use_this_instead_dialog = UseThisInsteadPanel(
+            mod_metadata=self.metadata_manager.internal_local_metadata
+        )
         if not self.use_this_instead_dialog.show_if_has_alternatives():
             dialogue.show_information(
                 title=self.tr("Use This Instead"),
-                text=self.tr('No suggestions were found in the "Use This Instead" database.'),
+                text=self.tr(
+                    'No suggestions were found in the "Use This Instead" database.'
+                ),
             )

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -67,7 +67,9 @@ class MainWindow(QMainWindow):
     Subclass QMainWindow to customize the main application window.
     """
 
-    def __init__(self, settings_controller: SettingsController, debug_mode: bool = False) -> None:
+    def __init__(
+        self, settings_controller: SettingsController, debug_mode: bool = False
+    ) -> None:
         """
         Initialize the main application window. Construct the layout,
         add the three main views, and set up relevant signals and slots.
@@ -103,8 +105,12 @@ class MainWindow(QMainWindow):
         app_layout.addWidget(self.tab_widget)
 
         # Create various panels on the application GUI
-        self.main_content_panel: MainContent = MainContent(settings_controller=self.settings_controller)
-        self.main_content_panel.disable_enable_widgets_signal.connect(self.__disable_enable_widgets)
+        self.main_content_panel: MainContent = MainContent(
+            settings_controller=self.settings_controller
+        )
+        self.main_content_panel.disable_enable_widgets_signal.connect(
+            self.__disable_enable_widgets
+        )
         self.bottom_panel = Status()
 
         # Create and add the Main Content panel tab
@@ -216,7 +222,9 @@ class MainWindow(QMainWindow):
             settings_controller=self.settings_controller,
         )
 
-        self.menu_bar = MenuBar(menu_bar=self.menuBar(), settings_controller=self.settings_controller)
+        self.menu_bar = MenuBar(
+            menu_bar=self.menuBar(), settings_controller=self.settings_controller
+        )
         self.menu_bar_controller = MenuBarController(
             view=self.menu_bar,
             settings_controller=self.settings_controller,
@@ -233,7 +241,9 @@ class MainWindow(QMainWindow):
         EventBus().do_clone_existing_instance.connect(self.__clone_existing_instance)
         EventBus().do_create_new_instance.connect(self.__create_new_instance)
         EventBus().do_delete_current_instance.connect(self.__delete_current_instance)
-        EventBus().do_restore_instance_from_archive.connect(self.__restore_instance_from_archive)
+        EventBus().do_restore_instance_from_archive.connect(
+            self.__restore_instance_from_archive
+        )
 
         # launch the main window
         self._launch_main_window()
@@ -243,12 +253,18 @@ class MainWindow(QMainWindow):
         """Apply main window launch state from settings"""
         from app.utils.window_launch_state import apply_window_launch_state
 
-        main_window_launch_state = self.settings_controller.settings.main_window_launch_state
+        main_window_launch_state = (
+            self.settings_controller.settings.main_window_launch_state
+        )
         custom_width = self.settings_controller.settings.main_window_custom_width
         custom_height = self.settings_controller.settings.main_window_custom_height
 
-        apply_window_launch_state(self, main_window_launch_state, custom_width, custom_height)
-        logger.info(f"Main window started with launch state: {main_window_launch_state}")
+        apply_window_launch_state(
+            self, main_window_launch_state, custom_width, custom_height
+        )
+        logger.info(
+            f"Main window started with launch state: {main_window_launch_state}"
+        )
 
     def __disable_enable_widgets(self, enable: bool) -> None:
         # Disable widgets
@@ -269,11 +285,15 @@ class MainWindow(QMainWindow):
         self.menu_bar_controller._on_instances_submenu_population(
             instance_names=list(self.settings_controller.settings.instances.keys())
         )
-        self.menu_bar_controller._on_set_current_instance(self.settings_controller.settings.current_instance)
+        self.menu_bar_controller._on_set_current_instance(
+            self.settings_controller.settings.current_instance
+        )
         # REFRESH CONFIGURED METADATA
         self.main_content_panel._do_refresh(is_initial=is_initial)
         # CHECK FOR STEAMCMD SETUP
-        if not os.path.exists(self.steamcmd_wrapper.steamcmd_prefix) or not self.steamcmd_wrapper.check_for_steamcmd(
+        if not os.path.exists(
+            self.steamcmd_wrapper.steamcmd_prefix
+        ) or not self.steamcmd_wrapper.check_for_steamcmd(
             prefix=self.steamcmd_wrapper.steamcmd_prefix
         ):
             if not self.settings_controller.active_instance.steamcmd_ignore:
@@ -312,7 +332,9 @@ class MainWindow(QMainWindow):
         if instance.initial_setup and not instance.steam_client_integration:
             diag = BinaryChoiceDialog(
                 title=self.tr("Steam Client Integration"),
-                text=self.tr("<h3>Would you like to enable Steam Client Integration for this instance?</h3>"),
+                text=self.tr(
+                    "<h3>Would you like to enable Steam Client Integration for this instance?</h3>"
+                ),
                 information=self.tr("""This will allow you to use RimSort features that require the Steam Client. This includes, among other things, unsubscribing from workshop mods and opening workshop links via the Steam Client. 
                 <br><br>
                 You can change this in the settings under the Advanced tab."""),
@@ -337,21 +359,27 @@ class MainWindow(QMainWindow):
             instance_name, ok = QInputDialog.getText(
                 self,
                 self.tr("Provide instance name"),
-                self.tr('Input a unique name for the backed up instance that is not "{name}"').format(
-                    name=DEFAULT_INSTANCE_NAME
-                ),
+                self.tr(
+                    'Input a unique name for the backed up instance that is not "{name}"'
+                ).format(name=DEFAULT_INSTANCE_NAME),
             )
             if ok and instance_name.lower() != DEFAULT_INSTANCE_NAME.lower():
                 return instance_name
             else:
                 return None
 
-    def __ask_how_to_workshop_mods(self, existing_instance_name: str, existing_instance_workshop_folder: str) -> str:
+    def __ask_how_to_workshop_mods(
+        self, existing_instance_name: str, existing_instance_workshop_folder: str
+    ) -> str:
         answer = show_dialogue_conditional(
             title=self.tr("Clone instance [{existing_instance_name}]").format(
                 existing_instance_name=existing_instance_name
             ),
-            text=(self.tr("What would you like to do with the configured Workshop mods folder?")),
+            text=(
+                self.tr(
+                    "What would you like to do with the configured Workshop mods folder?"
+                )
+            ),
             information=(
                 self.tr(
                     "Workshop folder: {existing_instance_workshop_folder}\n\n"
@@ -360,7 +388,9 @@ class MainWindow(QMainWindow):
                     + "Option 2: Keep Workshop Folder\n"
                     + "The new instance will use the same Workshop folder as the original instance. You can change this later in the settings if needed.\n\n"
                     + "How would you like to proceed?"
-                ).format(existing_instance_workshop_folder=existing_instance_workshop_folder)
+                ).format(
+                    existing_instance_workshop_folder=existing_instance_workshop_folder
+                )
             ),
             button_text_override=[
                 self.tr("Convert to SteamCMD"),
@@ -406,14 +436,16 @@ class MainWindow(QMainWindow):
                         instance_controller.compress_to_archive,
                         output_path,
                     ),
-                    self.tr("Compressing [{instance_name}] instance folder to archive...").format(
-                        instance_name=instance_name
-                    ),
+                    self.tr(
+                        "Compressing [{instance_name}] instance folder to archive..."
+                    ).format(instance_name=instance_name),
                 )
             except Exception as e:
                 show_fatal_error(
                     title=self.tr("Error compressing instance"),
-                    text=self.tr("An error occurred while compressing instance folder: {e}").format(e=e),
+                    text=self.tr(
+                        "An error occurred while compressing instance folder: {e}"
+                    ).format(e=e),
                     information=self.tr("Please check the logs for more information."),
                     details=format_exc(),
                 )
@@ -440,7 +472,9 @@ class MainWindow(QMainWindow):
             logger.error(f"Archive not found at path: {input_path}")
             show_warning(
                 title=self.tr("Error restoring instance"),
-                text=self.tr("Archive not found at path: {input_path}").format(input_path=input_path),
+                text=self.tr("Archive not found at path: {input_path}").format(
+                    input_path=input_path
+                ),
             )
             return
 
@@ -462,10 +496,12 @@ class MainWindow(QMainWindow):
         if os.path.exists(instance_controller.instance_folder_path):
             answer = show_dialogue_conditional(
                 title=self.tr("Instance folder exists"),
-                text=self.tr("Instance folder already exists: {instance_folder_path}").format(
-                    instance_folder_path=instance_controller.instance_folder_path
+                text=self.tr(
+                    "Instance folder already exists: {instance_folder_path}"
+                ).format(instance_folder_path=instance_controller.instance_folder_path),
+                information=self.tr(
+                    "Do you want to continue and replace the existing instance folder?"
                 ),
-                information=self.tr("Do you want to continue and replace the existing instance folder?"),
                 button_text_override=[
                     self.tr("Replace"),
                 ],
@@ -481,21 +517,27 @@ class MainWindow(QMainWindow):
                 instance_controller.extract_from_archive,
                 input_path,
             ),
-            self.tr("Restoring instance [{name}] from archive...").format(name=instance_controller.instance.name),
+            self.tr("Restoring instance [{name}] from archive...").format(
+                name=instance_controller.instance.name
+            ),
         )
 
         # Check that the instance folder exists. If it does, update Settings with the instance data
         if os.path.exists(instance_controller.instance_folder_path):
             cleared_paths = instance_controller.validate_paths()
             if cleared_paths:
-                logger.warning(f"Instance folder paths not found: {', '.join(cleared_paths)}")
+                logger.warning(
+                    f"Instance folder paths not found: {', '.join(cleared_paths)}"
+                )
                 show_warning(
                     title=self.tr("Invalid instance folder paths"),
                     text=self.tr("Invalid instance folder paths"),
                     information=self.tr(
                         "Some folder paths from the restored instance are invalid and were cleared. Please reconfigure them in the settings"
                     ),
-                    details=self.tr("Invalid paths: {path}").format(path=", ".join(cleared_paths)),
+                    details=self.tr("Invalid paths: {path}").format(
+                        path=", ".join(cleared_paths)
+                    ),
                 )
 
             steamcmd_link_path = str(
@@ -507,7 +549,10 @@ class MainWindow(QMainWindow):
                 / "294100"
             )
 
-            if os.path.exists(steamcmd_link_path) and instance_controller.instance.local_folder != "":
+            if (
+                os.path.exists(steamcmd_link_path)
+                and instance_controller.instance.local_folder != ""
+            ):
                 logger.info("Restoring steamcmd symlink...")
                 self.steamcmd_wrapper.create_symlink(
                     instance_controller.instance.local_folder,
@@ -534,43 +579,63 @@ class MainWindow(QMainWindow):
         else:
             show_warning(
                 title=self.tr("Error restoring instance"),
-                text=self.tr("An error occurred while restoring instance [{name}].").format(
-                    name=instance_controller.instance.name
-                ),
+                text=self.tr(
+                    "An error occurred while restoring instance [{name}]."
+                ).format(name=instance_controller.instance.name),
                 information=self.tr(
                     "The instance folder was not found after extracting the archive. Perhaps the archive is corrupt or the instance name is invalid."
                 ),
             )
 
-            logger.warning("Restore cancelled: Instance folder not found after extraction...")
+            logger.warning(
+                "Restore cancelled: Instance folder not found after extraction..."
+            )
 
     def __clone_existing_instance(self, existing_instance_name: str) -> None:
         """Clone an existing instance to create a new one with copied data."""
 
-        def copy_game_folder(existing_instance_game_folder: str, target_game_folder: str) -> None:
+        def copy_game_folder(
+            existing_instance_game_folder: str, target_game_folder: str
+        ) -> None:
             try:
-                if os.path.exists(target_game_folder) and os.path.isdir(target_game_folder):
-                    logger.info(f"Replacing existing game folder at {target_game_folder}")
+                if os.path.exists(target_game_folder) and os.path.isdir(
+                    target_game_folder
+                ):
+                    logger.info(
+                        f"Replacing existing game folder at {target_game_folder}"
+                    )
                     rmtree(
                         target_game_folder,
                         ignore_errors=False,
                         onerror=handle_remove_read_only,
                     )
-                logger.info(f"Copying game folder from {existing_instance_game_folder} to {target_game_folder}")
-                copytree(existing_instance_game_folder, target_game_folder, symlinks=True)
+                logger.info(
+                    f"Copying game folder from {existing_instance_game_folder} to {target_game_folder}"
+                )
+                copytree(
+                    existing_instance_game_folder, target_game_folder, symlinks=True
+                )
             except Exception as e:
                 logger.error(f"An error occurred while copying game folder: {e}")
 
-        def copy_config_folder(existing_instance_config_folder: str, target_config_folder: str) -> None:
+        def copy_config_folder(
+            existing_instance_config_folder: str, target_config_folder: str
+        ) -> None:
             try:
-                if os.path.exists(target_config_folder) and os.path.isdir(target_config_folder):
-                    logger.info(f"Replacing existing config folder at {target_config_folder}")
+                if os.path.exists(target_config_folder) and os.path.isdir(
+                    target_config_folder
+                ):
+                    logger.info(
+                        f"Replacing existing config folder at {target_config_folder}"
+                    )
                     rmtree(
                         target_config_folder,
                         ignore_errors=False,
                         onerror=handle_remove_read_only,
                     )
-                logger.info(f"Copying config folder from {existing_instance_config_folder} to {target_config_folder}")
+                logger.info(
+                    f"Copying config folder from {existing_instance_config_folder} to {target_config_folder}"
+                )
                 copytree(
                     existing_instance_config_folder,
                     target_config_folder,
@@ -579,16 +644,24 @@ class MainWindow(QMainWindow):
             except Exception as e:
                 logger.error(f"An error occurred while copying config folder: {e}")
 
-        def copy_local_folder(existing_instance_local_folder: str, target_local_folder: str) -> None:
+        def copy_local_folder(
+            existing_instance_local_folder: str, target_local_folder: str
+        ) -> None:
             try:
-                if os.path.exists(target_local_folder) and os.path.isdir(target_local_folder):
-                    logger.info(f"Replacing existing local folder at {target_local_folder}")
+                if os.path.exists(target_local_folder) and os.path.isdir(
+                    target_local_folder
+                ):
+                    logger.info(
+                        f"Replacing existing local folder at {target_local_folder}"
+                    )
                     rmtree(
                         target_local_folder,
                         ignore_errors=False,
                         onerror=handle_remove_read_only,
                     )
-                logger.info(f"Copying local folder from {existing_instance_local_folder} to {target_local_folder}")
+                logger.info(
+                    f"Copying local folder from {existing_instance_local_folder} to {target_local_folder}"
+                )
                 copytree(
                     existing_instance_local_folder,
                     target_local_folder,
@@ -597,14 +670,20 @@ class MainWindow(QMainWindow):
             except Exception as e:
                 logger.error(f"An error occurred while copying local folder: {e}")
 
-        def copy_workshop_mods_to_local(existing_instance_workshop_folder: str, target_local_folder: str) -> None:
+        def copy_workshop_mods_to_local(
+            existing_instance_workshop_folder: str, target_local_folder: str
+        ) -> None:
             try:
                 if not os.path.exists(target_local_folder):
                     os.mkdir(target_local_folder)
-                logger.info(f"Cloning Workshop mods from {existing_instance_workshop_folder} to {target_local_folder}")
+                logger.info(
+                    f"Cloning Workshop mods from {existing_instance_workshop_folder} to {target_local_folder}"
+                )
                 # Copy each subdirectory of the existing Workshop folder to the new local mods folder
                 for subdir in os.listdir(existing_instance_workshop_folder):
-                    if os.path.isdir(os.path.join(existing_instance_workshop_folder, subdir)):
+                    if os.path.isdir(
+                        os.path.join(existing_instance_workshop_folder, subdir)
+                    ):
                         logger.debug(f"Cloning Workshop mod: {subdir}")
                         copytree(
                             os.path.join(existing_instance_workshop_folder, subdir),
@@ -621,18 +700,26 @@ class MainWindow(QMainWindow):
             target_config_folder: str,
         ) -> None:
             # Clone the existing game_folder to the new instance
-            if os.path.exists(existing_instance_game_folder) and os.path.isdir(existing_instance_game_folder):
+            if os.path.exists(existing_instance_game_folder) and os.path.isdir(
+                existing_instance_game_folder
+            ):
                 copy_game_folder(existing_instance_game_folder, target_game_folder)
             # Clone the existing config_folder to the new instance
-            if os.path.exists(existing_instance_config_folder) and os.path.isdir(existing_instance_config_folder):
-                copy_config_folder(existing_instance_config_folder, target_config_folder)
+            if os.path.exists(existing_instance_config_folder) and os.path.isdir(
+                existing_instance_config_folder
+            ):
+                copy_config_folder(
+                    existing_instance_config_folder, target_config_folder
+                )
 
         # Check if paths are set. We can't clone if they aren't set
         if not self.main_content_panel.check_if_essential_paths_are_set(prompt=True):
             return
         # Get instance data from Settings
         current_instances = list(self.settings_controller.settings.instances.keys())
-        existing_instance = self.settings_controller.settings.instances[existing_instance_name]
+        existing_instance = self.settings_controller.settings.instances[
+            existing_instance_name
+        ]
 
         existing_instance_game_folder = existing_instance.game_folder
         game_folder_name = os.path.split(existing_instance_game_folder)[1]
@@ -641,8 +728,12 @@ class MainWindow(QMainWindow):
         existing_instance_workshop_folder = existing_instance.workshop_folder
         existing_instance_config_folder = existing_instance.config_folder
         existing_instance_run_args = existing_instance.run_args
-        existing_instance_steamcmd_install_path = existing_instance.steamcmd_install_path
-        existing_instance_steam_client_integration = existing_instance.steam_client_integration
+        existing_instance_steamcmd_install_path = (
+            existing_instance.steamcmd_install_path
+        )
+        existing_instance_steam_client_integration = (
+            existing_instance.steam_client_integration
+        )
         existing_instance_folder_override = existing_instance.instance_folder_override
         # Sanitize the input so that it does not produce any KeyError down the road
         new_instance_name = self.__ask_for_new_instance_name()
@@ -652,7 +743,9 @@ class MainWindow(QMainWindow):
             and new_instance_name not in current_instances
         ):
             new_instance_path = str(
-                InstanceController.get_instance_folder_path(new_instance_name, existing_instance_folder_override)
+                InstanceController.get_instance_folder_path(
+                    new_instance_name, existing_instance_folder_override
+                )
             )
             # Prompt user with the existing instance configuration and confirm that they would like to clone it
             answer = BinaryChoiceDialog(
@@ -671,9 +764,13 @@ class MainWindow(QMainWindow):
             if answer.exec_is_positive():
                 # Clone the RimWorld game_folder to the new instance
                 target_game_folder = str(Path(new_instance_path) / game_folder_name)
-                target_local_folder = str(Path(new_instance_path) / game_folder_name / local_folder_name)
+                target_local_folder = str(
+                    Path(new_instance_path) / game_folder_name / local_folder_name
+                )
                 target_workshop_folder = ""
-                target_config_folder = str(Path(new_instance_path) / "InstanceData" / "Config")
+                target_config_folder = str(
+                    Path(new_instance_path) / "InstanceData" / "Config"
+                )
                 EventBus().do_threaded_loading_animation.emit(
                     str(AppInfo().theme_data_folder / "default-icons" / "rimworld.gif"),
                     partial(
@@ -688,12 +785,19 @@ class MainWindow(QMainWindow):
                 # Clone the existing local_folder to the new instance
                 # Skip if local folder is already included within the game folder (prevents redundant cloning)
                 local_folder_in_game = (
-                    str(Path(existing_instance_game_folder) / local_folder_name) == existing_instance_local_folder
+                    str(Path(existing_instance_game_folder) / local_folder_name)
+                    == existing_instance_local_folder
                 )
                 if existing_instance_local_folder and not local_folder_in_game:
-                    if os.path.exists(existing_instance_local_folder) and os.path.isdir(existing_instance_local_folder):
+                    if os.path.exists(existing_instance_local_folder) and os.path.isdir(
+                        existing_instance_local_folder
+                    ):
                         EventBus().do_threaded_loading_animation.emit(
-                            str(AppInfo().theme_data_folder / "default-icons" / "rimworld.gif"),
+                            str(
+                                AppInfo().theme_data_folder
+                                / "default-icons"
+                                / "rimworld.gif"
+                            ),
                             partial(
                                 copy_local_folder,
                                 existing_instance_local_folder,
@@ -709,11 +813,15 @@ class MainWindow(QMainWindow):
                         existing_instance_workshop_folder=existing_instance_workshop_folder,
                     )
                     if answer_workshop_mods == self.tr("Convert to SteamCMD"):
-                        if os.path.exists(existing_instance_workshop_folder) and os.path.isdir(
+                        if os.path.exists(
                             existing_instance_workshop_folder
-                        ):
+                        ) and os.path.isdir(existing_instance_workshop_folder):
                             EventBus().do_threaded_loading_animation.emit(
-                                str(AppInfo().theme_data_folder / "default-icons" / "steam_api.gif"),
+                                str(
+                                    AppInfo().theme_data_folder
+                                    / "default-icons"
+                                    / "steam_api.gif"
+                                ),
                                 partial(
                                     copy_workshop_mods_to_local,
                                     existing_instance_workshop_folder,
@@ -726,16 +834,28 @@ class MainWindow(QMainWindow):
                                 title=self.tr("Workshop mods not found"),
                                 text=self.tr(
                                     "Workshop mods folder at [{existing_instance_workshop_folder}] not found."
-                                ).format(existing_instance_workshop_folder=existing_instance_workshop_folder),
+                                ).format(
+                                    existing_instance_workshop_folder=existing_instance_workshop_folder
+                                ),
                             )
                     elif answer_workshop_mods == self.tr("Keep Workshop Folder"):
                         target_workshop_folder = str(existing_instance_workshop_folder)
                 # If the instance has a 'steamcmd' folder, clone it to the new instance
-                steamcmd_install_path = str(Path(existing_instance_steamcmd_install_path) / STEAMCMD_FOLDER_NAME)
-                if os.path.exists(steamcmd_install_path) and os.path.isdir(steamcmd_install_path):
-                    target_steamcmd_install_path = str(Path(new_instance_path) / STEAMCMD_FOLDER_NAME)
-                    if os.path.exists(target_steamcmd_install_path) and os.path.isdir(target_steamcmd_install_path):
-                        logger.info(f"Replacing existing steamcmd folder at {target_steamcmd_install_path}")
+                steamcmd_install_path = str(
+                    Path(existing_instance_steamcmd_install_path) / STEAMCMD_FOLDER_NAME
+                )
+                if os.path.exists(steamcmd_install_path) and os.path.isdir(
+                    steamcmd_install_path
+                ):
+                    target_steamcmd_install_path = str(
+                        Path(new_instance_path) / STEAMCMD_FOLDER_NAME
+                    )
+                    if os.path.exists(target_steamcmd_install_path) and os.path.isdir(
+                        target_steamcmd_install_path
+                    ):
+                        logger.info(
+                            f"Replacing existing steamcmd folder at {target_steamcmd_install_path}"
+                        )
                         rmtree(
                             target_steamcmd_install_path,
                             ignore_errors=False,
@@ -750,28 +870,48 @@ class MainWindow(QMainWindow):
                         symlinks=True,
                     )
                 # If the instance has a 'steam' folder, clone it to the new instance
-                steam_install_path = str(Path(existing_instance_steamcmd_install_path) / STEAM_FOLDER_NAME)
-                if os.path.exists(steam_install_path) and os.path.isdir(steam_install_path):
-                    target_steam_install_path = str(Path(new_instance_path) / STEAM_FOLDER_NAME)
-                    if os.path.exists(target_steam_install_path) and os.path.isdir(target_steam_install_path):
-                        logger.info(f"Replacing existing steam folder at {target_steam_install_path}")
+                steam_install_path = str(
+                    Path(existing_instance_steamcmd_install_path) / STEAM_FOLDER_NAME
+                )
+                if os.path.exists(steam_install_path) and os.path.isdir(
+                    steam_install_path
+                ):
+                    target_steam_install_path = str(
+                        Path(new_instance_path) / STEAM_FOLDER_NAME
+                    )
+                    if os.path.exists(target_steam_install_path) and os.path.isdir(
+                        target_steam_install_path
+                    ):
+                        logger.info(
+                            f"Replacing existing steam folder at {target_steam_install_path}"
+                        )
                         rmtree(
                             target_steam_install_path,
                             ignore_errors=False,
                             onerror=handle_remove_read_only,
                         )
-                    logger.info(f"Copying steam folder from {steam_install_path} to {target_steam_install_path}")
+                    logger.info(
+                        f"Copying steam folder from {steam_install_path} to {target_steam_install_path}"
+                    )
                     # Copy the directory, but omit the symlink path
                     copytree(
                         steam_install_path,
                         target_steam_install_path,
                         symlinks=True,
                         ignore=lambda d, names: (
-                            ["steamapps/workshop/content/294100"] if d == steam_install_path else []
+                            ["steamapps/workshop/content/294100"]
+                            if d == steam_install_path
+                            else []
                         ),
                     )
                     # Unlink steam/workshop/content/294100 symlink if it exists, and relink it to our new target local mods folder
-                    link_path = str(Path(target_steam_install_path) / "steamapps" / "workshop" / "content" / "294100")
+                    link_path = str(
+                        Path(target_steam_install_path)
+                        / "steamapps"
+                        / "workshop"
+                        / "content"
+                        / "294100"
+                    )
                     self.steamcmd_wrapper.create_symlink(
                         target_local_folder, link_path, show_dialogues=False, force=True
                     )
@@ -785,7 +925,9 @@ class MainWindow(QMainWindow):
                         "config_folder": target_config_folder,
                         "run_args": existing_instance_run_args or [],
                         "steamcmd_install_path": str(
-                            AppInfo().app_storage_folder / INSTANCE_FOLDER_NAME / new_instance_name
+                            AppInfo().app_storage_folder
+                            / INSTANCE_FOLDER_NAME
+                            / new_instance_name
                         ),
                         "steam_client_integration": existing_instance_steam_client_integration,
                         "instance_folder_override": existing_instance_folder_override,
@@ -802,7 +944,9 @@ class MainWindow(QMainWindow):
         else:
             logger.debug("User cancelled clone operation")
 
-    def __create_new_instance(self, instance_name: str = "", instance_data: dict[str, Any] | None = None) -> None:
+    def __create_new_instance(
+        self, instance_name: str = "", instance_data: dict[str, Any] | None = None
+    ) -> None:
         """Create a new instance with the provided name and data."""
         if instance_data is None:
             instance_data = {}
@@ -814,7 +958,11 @@ class MainWindow(QMainWindow):
                 return
             instance_name = new_instance_name
         current_instances = list(self.settings_controller.settings.instances.keys())
-        if instance_name and instance_name != DEFAULT_INSTANCE_NAME and instance_name not in current_instances:
+        if (
+            instance_name
+            and instance_name != DEFAULT_INSTANCE_NAME
+            and instance_name not in current_instances
+        ):
             # Get instance folder override if provided
             # First check if override was passed in instance_data (e.g., from cloning)
             instance_folder_override = instance_data.get("instance_folder_override", "")
@@ -826,7 +974,9 @@ class MainWindow(QMainWindow):
                 ]
                 instance_folder_override = current_instance.instance_folder_override
             # Create new instance folder if it does not exist
-            instance_path = InstanceController.get_instance_folder_path(instance_name, instance_folder_override)
+            instance_path = InstanceController.get_instance_folder_path(
+                instance_name, instance_folder_override
+            )
             if not instance_path.exists():
                 instance_path.mkdir(parents=True, exist_ok=True)
             # Get run args from instance data, autogenerate additional config items if desired
@@ -843,7 +993,9 @@ class MainWindow(QMainWindow):
                 # Prompt the user if they would like to automatically generate run args for the instance
                 answer = show_dialogue_conditional(
                     title=self.tr("Create new instance [{instance_name}]"),
-                    text=self.tr("Would you like to automatically generate run args for the new instance?"),
+                    text=self.tr(
+                        "Would you like to automatically generate run args for the new instance?"
+                    ),
                     information=self.tr(
                         "This will try to generate run args for the new instance based on the configured Game/Config folders.\n\n"
                         + "Generated run arguments preview:\n{preview}"
@@ -863,7 +1015,9 @@ class MainWindow(QMainWindow):
                 config_folder=instance_data.get("config_folder", ""),
                 run_args=run_args,
                 steamcmd_install_path=str(instance_path),
-                steam_client_integration=instance_data.get("steam_client_integration", False),
+                steam_client_integration=instance_data.get(
+                    "steam_client_integration", False
+                ),
                 instance_folder_override=instance_folder_override,
             )
 
@@ -891,7 +1045,9 @@ class MainWindow(QMainWindow):
                 information=self.tr("The default instance cannot be deleted."),
             )
             return
-        elif not self.settings_controller.settings.instances.get(self.settings_controller.settings.current_instance):
+        elif not self.settings_controller.settings.instances.get(
+            self.settings_controller.settings.current_instance
+        ):
             show_fatal_error(
                 title=self.tr("Error deleting instance"),
                 text=self.tr("Unable to delete instance {current_instance}.").format(
@@ -905,12 +1061,16 @@ class MainWindow(QMainWindow):
                 title=self.tr("Delete instance {current_instance}").format(
                     current_instance=self.settings_controller.settings.current_instance
                 ),
-                text=self.tr("Are you sure you want to delete the selected instance and all of its data?"),
+                text=self.tr(
+                    "Are you sure you want to delete the selected instance and all of its data?"
+                ),
                 information=self.tr("This action cannot be undone."),
             )
             if answer.exec_is_positive():
-                aux_metadata_controller = AuxMetadataController.get_or_create_cached_instance(
-                    self.settings_controller.settings.aux_db_path
+                aux_metadata_controller = (
+                    AuxMetadataController.get_or_create_cached_instance(
+                        self.settings_controller.settings.aux_db_path
+                    )
                 )
                 aux_metadata_controller.engine.dispose()
                 try:
@@ -928,7 +1088,9 @@ class MainWindow(QMainWindow):
                 except Exception as e:
                     logger.error(f"Error deleting instance: {e}")
                 # Remove instance from settings and reset to Default
-                self.settings_controller.settings.instances.pop(self.settings_controller.settings.current_instance)
+                self.settings_controller.settings.instances.pop(
+                    self.settings_controller.settings.current_instance
+                )
                 self.__switch_to_instance(DEFAULT_INSTANCE_NAME)
 
     def __switch_to_instance(self, instance: str) -> None:
@@ -964,18 +1126,35 @@ class MainWindow(QMainWindow):
         self.watchdog_event_handler = WatchdogHandler(
             settings_controller=self.settings_controller,
             targets=[
-                str(Path(self.settings_controller.settings.instances[current_instance].game_folder) / "Data"),
-                self.settings_controller.settings.instances[current_instance].local_folder,
-                self.settings_controller.settings.instances[current_instance].workshop_folder,
+                str(
+                    Path(
+                        self.settings_controller.settings.instances[
+                            current_instance
+                        ].game_folder
+                    )
+                    / "Data"
+                ),
+                self.settings_controller.settings.instances[
+                    current_instance
+                ].local_folder,
+                self.settings_controller.settings.instances[
+                    current_instance
+                ].workshop_folder,
             ],
         )
         # Connect watchdog to MetadataManager for ACF changes
         self.watchdog_event_handler.acf_changed.connect(
             partial(refresh_acf_metadata, self.main_content_panel.metadata_manager)
         )
-        self.watchdog_event_handler.mod_created.connect(self.main_content_panel.metadata_manager.process_creation)
-        self.watchdog_event_handler.mod_deleted.connect(self.main_content_panel.metadata_manager.process_deletion)
-        self.watchdog_event_handler.mod_updated.connect(self.main_content_panel.metadata_manager.process_update)
+        self.watchdog_event_handler.mod_created.connect(
+            self.main_content_panel.metadata_manager.process_creation
+        )
+        self.watchdog_event_handler.mod_deleted.connect(
+            self.main_content_panel.metadata_manager.process_deletion
+        )
+        self.watchdog_event_handler.mod_updated.connect(
+            self.main_content_panel.metadata_manager.process_update
+        )
         # Connect main content signal so it can stop watchdog
         self.main_content_panel.stop_watchdog_signal.connect(self.shutdown_watchdog)
         # Start watchdog
@@ -989,7 +1168,9 @@ class MainWindow(QMainWindow):
             else:
                 logger.warning("Watchdog Mods Observer is None. Unable to start.")
         except Exception as e:
-            logger.warning(f"Unable to initialize Watchdog Observer(s) due to exception: {str(e)}")
+            logger.warning(
+                f"Unable to initialize Watchdog Observer(s) due to exception: {str(e)}"
+            )
 
     def stop_watchdog_if_running(self) -> None:
         # STOP WATCHDOG IF IT IS ALREADY RUNNING

--- a/app/views/menu_bar.py
+++ b/app/views/menu_bar.py
@@ -13,7 +13,9 @@ from app.utils.system_info import SystemInfo
 
 
 class MenuBar(QObject):
-    def __init__(self, menu_bar: QMenuBar, settings_controller: SettingsController) -> None:
+    def __init__(
+        self, menu_bar: QMenuBar, settings_controller: SettingsController
+    ) -> None:
         """
         Initialize the MenuBar object.
 
@@ -122,24 +124,38 @@ class MenuBar(QObject):
             QMenu: The created "File" menu.
         """
         file_menu = self.menu_bar.addMenu(self.tr("File"))
-        self.open_mod_list_action = self._add_action(file_menu, self.tr("Open Mod List…"), "Ctrl+O")
+        self.open_mod_list_action = self._add_action(
+            file_menu, self.tr("Open Mod List…"), "Ctrl+O"
+        )
         file_menu.addSeparator()
-        self.save_mod_list_action = self._add_action(file_menu, self.tr("Save Mod List As…"), "Ctrl+Shift+S")
+        self.save_mod_list_action = self._add_action(
+            file_menu, self.tr("Save Mod List As…"), "Ctrl+Shift+S"
+        )
         file_menu.addSeparator()
         self.import_submenu = QMenu(self.tr("Import"))
         file_menu.addMenu(self.import_submenu)
-        self.import_from_rentry_action = self._add_action(self.import_submenu, self.tr("From Rentry.co"))
+        self.import_from_rentry_action = self._add_action(
+            self.import_submenu, self.tr("From Rentry.co")
+        )
         self.import_from_workshop_collection_action = self._add_action(
             self.import_submenu, self.tr("From Workshop collection")
         )
-        self.import_from_save_file_action = self._add_action(self.import_submenu, self.tr("From Save file…"))
+        self.import_from_save_file_action = self._add_action(
+            self.import_submenu, self.tr("From Save file…")
+        )
         self.export_submenu = QMenu(self.tr("Export"))
         file_menu.addMenu(self.export_submenu)
-        self.export_to_clipboard_action = self._add_action(self.export_submenu, self.tr("To Clipboard…"))
-        self.export_to_rentry_action = self._add_action(self.export_submenu, self.tr("To Rentry.co…"))
+        self.export_to_clipboard_action = self._add_action(
+            self.export_submenu, self.tr("To Clipboard…")
+        )
+        self.export_to_rentry_action = self._add_action(
+            self.export_submenu, self.tr("To Rentry.co…")
+        )
         file_menu.addSeparator()
 
-        self.upload_submenu = self._create_logfile_submenu("Upload Log", self.upload_log_actions)
+        self.upload_submenu = self._create_logfile_submenu(
+            "Upload Log", self.upload_log_actions
+        )
         file_menu.addMenu(self.upload_submenu)
 
         if self.settings_controller.settings.text_editor_location:
@@ -158,7 +174,9 @@ class MenuBar(QObject):
         self.rimworld_shortcuts_submenu = QMenu(self.tr("RimWorld"))
         self.shortcuts_submenu.addMenu(self.rimworld_shortcuts_submenu)
         # Add actions to RimSort submenu
-        self.open_app_directory_action = self._add_action(self.rimsort_shortcuts_submenu, self.tr("Root Directory"))
+        self.open_app_directory_action = self._add_action(
+            self.rimsort_shortcuts_submenu, self.tr("Root Directory")
+        )
         self.open_settings_directory_action = self._add_action(
             self.rimsort_shortcuts_submenu, self.tr("Config Directory")
         )
@@ -184,7 +202,9 @@ class MenuBar(QObject):
 
         if SystemInfo().operating_system != SystemInfo.OperatingSystem.MACOS:
             file_menu.addSeparator()
-            self.settings_action = self._add_action(file_menu, self.tr("Settings…"), "Ctrl+,")
+            self.settings_action = self._add_action(
+                file_menu, self.tr("Settings…"), "Ctrl+,"
+            )
             file_menu.addSeparator()
             self.quit_action = self._add_action(file_menu, self.tr("Exit"), "Ctrl+Q")
         return file_menu
@@ -194,7 +214,9 @@ class MenuBar(QObject):
         menu_name: str,
         action_list: list[QAction],
     ) -> QMenu:
-        def create_entry(name: str, path_accessor: Callable[[], Path | None]) -> QAction:
+        def create_entry(
+            name: str, path_accessor: Callable[[], Path | None]
+        ) -> QAction:
             action = self._add_action(logfile_submenu, name)
             action.setData(path_accessor)
             action_list.append(action)
@@ -210,7 +232,9 @@ class MenuBar(QObject):
 
         logfile_submenu = QMenu(self.tr(menu_name))
         create_entry("RimSort.log", lambda: AppInfo().user_log_folder / "RimSort.log")
-        create_entry("RimSort.old.log", lambda: AppInfo().user_log_folder / "RimSort.old.log")
+        create_entry(
+            "RimSort.old.log", lambda: AppInfo().user_log_folder / "RimSort.old.log"
+        )
         create_entry(
             "RimWorld Player.log",
             partial(rimworld_log_path, "Player.log"),
@@ -235,11 +259,19 @@ class MenuBar(QObject):
         self.paste_action = self._add_action(edit_menu, self.tr("Paste"), "Ctrl+V")
         edit_menu.addSeparator()
         self.rule_editor_action = self._add_action(edit_menu, self.tr("Rule Editor…"))
-        self.ignore_json_editor_action = self._add_action(edit_menu, self.tr("Ignore JSON Editor…"))
-        self.reset_all_warnings_action = self._add_action(edit_menu, self.tr("Reset Warning Toggles"))
-        self.reset_all_mod_colors_action = self._add_action(edit_menu, self.tr("Reset Mod Colors"))
+        self.ignore_json_editor_action = self._add_action(
+            edit_menu, self.tr("Ignore JSON Editor…")
+        )
+        self.reset_all_warnings_action = self._add_action(
+            edit_menu, self.tr("Reset Warning Toggles")
+        )
+        self.reset_all_mod_colors_action = self._add_action(
+            edit_menu, self.tr("Reset Mod Colors")
+        )
         edit_menu.addSeparator()
-        self.auto_add_translations_action = self._add_action(edit_menu, self.tr("Auto-add Translations"))
+        self.auto_add_translations_action = self._add_action(
+            edit_menu, self.tr("Auto-add Translations")
+        )
         return edit_menu
 
     def _create_view_menu(self) -> QMenu:
@@ -263,13 +295,23 @@ class MenuBar(QObject):
             QMenu: The created "Download" menu.
         """
         download_menu = self.menu_bar.addMenu(self.tr("Download"))
-        self.add_git_mod_action = self._add_action(download_menu, self.tr("Add Git Mod"))
-        self.add_zip_mod_action = self._add_action(download_menu, self.tr("Add Zip Mod"))
+        self.add_git_mod_action = self._add_action(
+            download_menu, self.tr("Add Git Mod")
+        )
+        self.add_zip_mod_action = self._add_action(
+            download_menu, self.tr("Add Zip Mod")
+        )
         download_menu.addSeparator()
-        self.browse_workshop_action = self._add_action(download_menu, self.tr("Browse Workshop"))
-        self.update_workshop_mods_action = self._add_action(download_menu, self.tr("Update Workshop Mods"))
+        self.browse_workshop_action = self._add_action(
+            download_menu, self.tr("Browse Workshop")
+        )
+        self.update_workshop_mods_action = self._add_action(
+            download_menu, self.tr("Update Workshop Mods")
+        )
         download_menu.addSeparator()
-        self.steam_verify_game_files_action = self._add_action(download_menu, self.tr("Verify Game Files"))
+        self.steam_verify_game_files_action = self._add_action(
+            download_menu, self.tr("Verify Game Files")
+        )
         return download_menu
 
     def _create_instances_menu(self) -> QMenu:
@@ -283,12 +325,22 @@ class MenuBar(QObject):
         self.instances_submenu = QMenu(self.tr('Current: "Default"'))
         instances_menu.addMenu(self.instances_submenu)
         instances_menu.addSeparator()
-        self.backup_instance_action = self._add_action(instances_menu, self.tr("Backup Instance…"))
-        self.restore_instance_action = self._add_action(instances_menu, self.tr("Restore Instance…"))
+        self.backup_instance_action = self._add_action(
+            instances_menu, self.tr("Backup Instance…")
+        )
+        self.restore_instance_action = self._add_action(
+            instances_menu, self.tr("Restore Instance…")
+        )
         instances_menu.addSeparator()
-        self.clone_instance_action = self._add_action(instances_menu, self.tr("Clone Instance…"))
-        self.create_instance_action = self._add_action(instances_menu, self.tr("Create Instance…"))
-        self.delete_instance_action = self._add_action(instances_menu, self.tr("Delete Instance…"))
+        self.clone_instance_action = self._add_action(
+            instances_menu, self.tr("Clone Instance…")
+        )
+        self.create_instance_action = self._add_action(
+            instances_menu, self.tr("Create Instance…")
+        )
+        self.delete_instance_action = self._add_action(
+            instances_menu, self.tr("Delete Instance…")
+        )
         return instances_menu
 
     def _create_texture_menu(self) -> QMenu:
@@ -299,14 +351,20 @@ class MenuBar(QObject):
             QMenu: The created "Textures" menu.
         """
         texture_menu = self.menu_bar.addMenu(self.tr("Textures"))
-        self.optimize_textures_action = self._add_action(texture_menu, self.tr("Optimize Textures"))
+        self.optimize_textures_action = self._add_action(
+            texture_menu, self.tr("Optimize Textures")
+        )
         texture_menu.addSeparator()
-        self.delete_dds_textures_action = self._add_action(texture_menu, self.tr("Delete .dds Textures"))
+        self.delete_dds_textures_action = self._add_action(
+            texture_menu, self.tr("Delete .dds Textures")
+        )
         return texture_menu
 
     def _create_update_menu(self) -> QMenu:
         update_menu = self.menu_bar.addMenu(self.tr("Update"))
-        self.check_for_updates_action = self._add_action(update_menu, self.tr("Check for Updates…"))
+        self.check_for_updates_action = self._add_action(
+            update_menu, self.tr("Check for Updates…")
+        )
         self.check_for_updates_on_startup_action = self._add_action(
             update_menu, self.tr("Check for Updates on Startup"), checkable=True
         )

--- a/app/views/mod_info_panel.py
+++ b/app/views/mod_info_panel.py
@@ -139,45 +139,67 @@ class ModInfoPanel:
         self.panel.addWidget(self.info_panel_frame)
 
         # Create widgets
-        self.missing_image_path = str(AppInfo().theme_data_folder / "default-icons" / "missing.png")
-        self.rimsort_image_a_path = str(AppInfo().theme_data_folder / "default-icons" / "AppIcon_a.png")
-        self.rimsort_image_b_path = str(AppInfo().theme_data_folder / "default-icons" / "AppIcon_b.png")
-        self.scenario_image_path = str(AppInfo().theme_data_folder / "default-icons" / "rimworld.png")
+        self.missing_image_path = str(
+            AppInfo().theme_data_folder / "default-icons" / "missing.png"
+        )
+        self.rimsort_image_a_path = str(
+            AppInfo().theme_data_folder / "default-icons" / "AppIcon_a.png"
+        )
+        self.rimsort_image_b_path = str(
+            AppInfo().theme_data_folder / "default-icons" / "AppIcon_b.png"
+        )
+        self.scenario_image_path = str(
+            AppInfo().theme_data_folder / "default-icons" / "rimworld.png"
+        )
         self.preview_picture = ImageLabel()
         self.preview_picture.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.preview_picture.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+        self.preview_picture.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding
+        )
         self.preview_picture.setMinimumSize(1, 1)
         self.preview_picture.setPixmap(
-            QPixmap(self.rimsort_image_a_path).scaled(self.preview_picture.size(), Qt.AspectRatioMode.KeepAspectRatio)
+            QPixmap(self.rimsort_image_a_path).scaled(
+                self.preview_picture.size(), Qt.AspectRatioMode.KeepAspectRatio
+            )
         )
         self.mod_info_name_label = QLabel(self.tr("Name:"))
         self.mod_info_name_label.setObjectName("summaryLabel")
         self.mod_info_name_value = QLabel()
         self.mod_info_name_value.setObjectName("summaryValue")
-        self.mod_info_name_value.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
+        self.mod_info_name_value.setTextInteractionFlags(
+            Qt.TextInteractionFlag.TextSelectableByMouse
+        )
         self.mod_info_name_value.setWordWrap(True)
         self.scenario_info_summary_label = QLabel(self.tr("Summary:"))
         self.scenario_info_summary_label.setObjectName("summaryLabel")
         self.scenario_info_summary_value = QLabel()
-        self.scenario_info_summary_value.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
+        self.scenario_info_summary_value.setTextInteractionFlags(
+            Qt.TextInteractionFlag.TextSelectableByMouse
+        )
         self.scenario_info_summary_value.setWordWrap(True)
         self.mod_info_package_id_label = QLabel(self.tr("PackageID:"))
         self.mod_info_package_id_label.setObjectName("summaryLabel")
         self.mod_info_package_id_value = QLabel()
         self.mod_info_package_id_value.setObjectName("summaryValue")
-        self.mod_info_package_id_value.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
+        self.mod_info_package_id_value.setTextInteractionFlags(
+            Qt.TextInteractionFlag.TextSelectableByMouse
+        )
         self.mod_info_package_id_value.setWordWrap(True)
         self.mod_info_author_label = QLabel(self.tr("Authors:"))
         self.mod_info_author_label.setObjectName("summaryLabel")
         self.mod_info_author_value = QLabel()
         self.mod_info_author_value.setObjectName("summaryValue")
-        self.mod_info_author_value.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
+        self.mod_info_author_value.setTextInteractionFlags(
+            Qt.TextInteractionFlag.TextSelectableByMouse
+        )
         self.mod_info_author_value.setWordWrap(True)
         self.mod_info_mod_version_label = QLabel(self.tr("Mod Version:"))
         self.mod_info_mod_version_label.setObjectName("summaryLabel")
         self.mod_info_mod_version_value = QLabel()
         self.mod_info_mod_version_value.setObjectName("summaryValue")
-        self.mod_info_mod_version_value.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
+        self.mod_info_mod_version_value.setTextInteractionFlags(
+            Qt.TextInteractionFlag.TextSelectableByMouse
+        )
         self.mod_info_mod_version_value.setWordWrap(True)
         self.mod_info_supported_versions_label = QLabel(self.tr("Supported Version:"))
         self.mod_info_supported_versions_label.setObjectName("summaryLabel")
@@ -191,25 +213,33 @@ class ModInfoPanel:
         self.mod_info_path_label.setObjectName("summaryLabel")
         self.mod_info_path_value = ClickablePathLabel()
         self.mod_info_path_value.setObjectName("summaryValue")
-        self.mod_info_path_value.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
+        self.mod_info_path_value.setTextInteractionFlags(
+            Qt.TextInteractionFlag.TextSelectableByMouse
+        )
         self.mod_info_path_value.setWordWrap(True)
         self.mod_info_last_touched_label = QLabel(self.tr("Last Touched:"))
         self.mod_info_last_touched_label.setObjectName("summaryLabel")
         self.mod_info_last_touched_value = QLabel()
         self.mod_info_last_touched_value.setObjectName("summaryValue")
-        self.mod_info_last_touched_value.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
+        self.mod_info_last_touched_value.setTextInteractionFlags(
+            Qt.TextInteractionFlag.TextSelectableByMouse
+        )
         self.mod_info_last_touched_value.setWordWrap(True)
         self.mod_info_filesystem_time_label = QLabel(self.tr("Filesystem Modified:"))
         self.mod_info_filesystem_time_label.setObjectName("summaryLabel")
         self.mod_info_filesystem_time_value = QLabel()
         self.mod_info_filesystem_time_value.setObjectName("summaryValue")
-        self.mod_info_filesystem_time_value.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
+        self.mod_info_filesystem_time_value.setTextInteractionFlags(
+            Qt.TextInteractionFlag.TextSelectableByMouse
+        )
         self.mod_info_filesystem_time_value.setWordWrap(True)
         self.mod_info_external_times_label = QLabel(self.tr("Workshop Times:"))
         self.mod_info_external_times_label.setObjectName("summaryLabel")
         self.mod_info_external_times_value = QLabel()
         self.mod_info_external_times_value.setObjectName("summaryValue")
-        self.mod_info_external_times_value.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
+        self.mod_info_external_times_value.setTextInteractionFlags(
+            Qt.TextInteractionFlag.TextSelectableByMouse
+        )
         self.mod_info_external_times_value.setWordWrap(True)
         self.description = DescriptionWidget()
         self.description_text = self.tr("Welcome to RimSort!")
@@ -217,9 +247,7 @@ class ModInfoPanel:
             f"<br><br><br><center>{self.description_text}<h3></h3></center>",
             convert=False,
         )
-        self.notes = (
-            QTextEdit()
-        )  # TODO: Custom QTextEdit to allow markdown and clickable hyperlinks? Also make collapsible?
+        self.notes = QTextEdit()  # TODO: Custom QTextEdit to allow markdown and clickable hyperlinks? Also make collapsible?
         self.notes.setObjectName("userModNotes")
         self.notes.setPlaceholderText(self.tr("Put your personal mod notes here!"))
         self.notes.textChanged.connect(self.update_user_mod_notes)
@@ -230,24 +258,56 @@ class ModInfoPanel:
         self.mod_info_name.addWidget(self.mod_info_name_value, NAME_VALUE_RATIO)
         self.mod_info_path.addWidget(self.mod_info_path_label, NAME_LABEL_RATIO)
         self.mod_info_path.addWidget(self.mod_info_path_value, NAME_VALUE_RATIO)
-        self.scenario_info_summary.addWidget(self.scenario_info_summary_label, NAME_LABEL_RATIO)
-        self.scenario_info_summary.addWidget(self.scenario_info_summary_value, NAME_VALUE_RATIO)
-        self.mod_info_package_id.addWidget(self.mod_info_package_id_label, NAME_LABEL_RATIO)
-        self.mod_info_package_id.addWidget(self.mod_info_package_id_value, NAME_VALUE_RATIO)
+        self.scenario_info_summary.addWidget(
+            self.scenario_info_summary_label, NAME_LABEL_RATIO
+        )
+        self.scenario_info_summary.addWidget(
+            self.scenario_info_summary_value, NAME_VALUE_RATIO
+        )
+        self.mod_info_package_id.addWidget(
+            self.mod_info_package_id_label, NAME_LABEL_RATIO
+        )
+        self.mod_info_package_id.addWidget(
+            self.mod_info_package_id_value, NAME_VALUE_RATIO
+        )
         self.mod_info_authors.addWidget(self.mod_info_author_label, NAME_LABEL_RATIO)
         self.mod_info_authors.addWidget(self.mod_info_author_value, NAME_VALUE_RATIO)
-        self.mod_info_mod_version.addWidget(self.mod_info_mod_version_label, NAME_LABEL_RATIO)
-        self.mod_info_mod_version.addWidget(self.mod_info_mod_version_value, NAME_VALUE_RATIO)
-        self.mod_info_supported_versions.addWidget(self.mod_info_supported_versions_label, NAME_LABEL_RATIO)
-        self.mod_info_supported_versions.addWidget(self.mod_info_supported_versions_value, NAME_VALUE_RATIO)
-        self.mod_info_folder_size.addWidget(self.mod_info_folder_size_label, NAME_LABEL_RATIO)
-        self.mod_info_folder_size.addWidget(self.mod_info_folder_size_value, NAME_VALUE_RATIO)
-        self.mod_info_last_touched.addWidget(self.mod_info_last_touched_label, NAME_LABEL_RATIO)
-        self.mod_info_last_touched.addWidget(self.mod_info_last_touched_value, NAME_VALUE_RATIO)
-        self.mod_info_filesystem_time.addWidget(self.mod_info_filesystem_time_label, NAME_LABEL_RATIO)
-        self.mod_info_filesystem_time.addWidget(self.mod_info_filesystem_time_value, NAME_VALUE_RATIO)
-        self.mod_info_external_times.addWidget(self.mod_info_external_times_label, NAME_LABEL_RATIO)
-        self.mod_info_external_times.addWidget(self.mod_info_external_times_value, NAME_VALUE_RATIO)
+        self.mod_info_mod_version.addWidget(
+            self.mod_info_mod_version_label, NAME_LABEL_RATIO
+        )
+        self.mod_info_mod_version.addWidget(
+            self.mod_info_mod_version_value, NAME_VALUE_RATIO
+        )
+        self.mod_info_supported_versions.addWidget(
+            self.mod_info_supported_versions_label, NAME_LABEL_RATIO
+        )
+        self.mod_info_supported_versions.addWidget(
+            self.mod_info_supported_versions_value, NAME_VALUE_RATIO
+        )
+        self.mod_info_folder_size.addWidget(
+            self.mod_info_folder_size_label, NAME_LABEL_RATIO
+        )
+        self.mod_info_folder_size.addWidget(
+            self.mod_info_folder_size_value, NAME_VALUE_RATIO
+        )
+        self.mod_info_last_touched.addWidget(
+            self.mod_info_last_touched_label, NAME_LABEL_RATIO
+        )
+        self.mod_info_last_touched.addWidget(
+            self.mod_info_last_touched_value, NAME_VALUE_RATIO
+        )
+        self.mod_info_filesystem_time.addWidget(
+            self.mod_info_filesystem_time_label, NAME_LABEL_RATIO
+        )
+        self.mod_info_filesystem_time.addWidget(
+            self.mod_info_filesystem_time_value, NAME_VALUE_RATIO
+        )
+        self.mod_info_external_times.addWidget(
+            self.mod_info_external_times_label, NAME_LABEL_RATIO
+        )
+        self.mod_info_external_times.addWidget(
+            self.mod_info_external_times_value, NAME_VALUE_RATIO
+        )
         self.mod_info_layout.addLayout(self.mod_info_name)
         self.mod_info_layout.addLayout(self.scenario_info_summary)
         self.mod_info_layout.addLayout(self.mod_info_package_id)
@@ -295,7 +355,11 @@ class ModInfoPanel:
         ]
 
         # Hide all widgets by default
-        for widget in self.essential_info_widgets + self.base_mod_info_widgets + self.scenario_info_widgets:
+        for widget in (
+            self.essential_info_widgets
+            + self.base_mod_info_widgets
+            + self.scenario_info_widgets
+        ):
             widget.hide()
 
         logger.debug("Finished ModInfo initialization")
@@ -334,7 +398,9 @@ class ModInfoPanel:
         self.notes.blockSignals(False)
         logger.debug(f"Finished setting notes for UUID: {mod_data['uuid']}")
 
-    def _add_label_value_to_layout(self, layout: QHBoxLayout, label: QLabel, value: QLabel) -> None:
+    def _add_label_value_to_layout(
+        self, layout: QHBoxLayout, label: QLabel, value: QLabel
+    ) -> None:
         """Helper method to add label-value pairs to layouts with consistent ratios."""
         layout.addWidget(label, NAME_LABEL_RATIO)
         layout.addWidget(value, NAME_VALUE_RATIO)
@@ -356,7 +422,9 @@ class ModInfoPanel:
                 widget.style().unpolish(widget)
                 widget.style().polish(widget)
             # Set invalid path style (red color, no clickable styling)
-            self.mod_info_path_value.setStyleSheet("color: #cc0000; text-decoration: none;")
+            self.mod_info_path_value.setStyleSheet(
+                "color: #cc0000; text-decoration: none;"
+            )
             self.mod_info_path_value.setClickable(False)
         else:
             # Set valid value style
@@ -378,7 +446,9 @@ class ModInfoPanel:
         if isinstance(mod_version, dict):
             self.mod_info_mod_version_value.setText(mod_version.get("#text", UNKNOWN))
         else:
-            self.mod_info_mod_version_value.setText(mod_version if mod_version else UNKNOWN)
+            self.mod_info_mod_version_value.setText(
+                mod_version if mod_version else UNKNOWN
+            )
 
     def _set_folder_size_info(self, uuid: str) -> None:
         """Set folder size information using optimized calculation."""
@@ -392,7 +462,9 @@ class ModInfoPanel:
             logger.error(f"Error calculating folder size for UUID {uuid}: {e}")
             self.mod_info_folder_size_value.setText("Not available")
 
-    def _set_timestamp_info(self, timestamp: int | None, label: QLabel, field_name: str) -> None:
+    def _set_timestamp_info(
+        self, timestamp: int | None, label: QLabel, field_name: str
+    ) -> None:
         """Set timestamp information with consistent error handling."""
         if timestamp and timestamp != 0:
             try:
@@ -407,10 +479,16 @@ class ModInfoPanel:
 
     def _set_filesystem_time_info(self, mod_path: str | None) -> None:
         """Set filesystem modification time information."""
-        if self.settings_controller.settings.inactive_mods_sorting and mod_path and os.path.exists(mod_path):
+        if (
+            self.settings_controller.settings.inactive_mods_sorting
+            and mod_path
+            and os.path.exists(mod_path)
+        ):
             try:
                 fs_time = int(os.path.getmtime(mod_path))
-                self._set_timestamp_info(fs_time, self.mod_info_filesystem_time_value, "filesystem time")
+                self._set_timestamp_info(
+                    fs_time, self.mod_info_filesystem_time_value, "filesystem time"
+                )
             except (ValueError, OSError, OverflowError) as e:
                 logger.error(f"Error formatting filesystem time: {e}")
                 self.mod_info_filesystem_time_value.setText("Invalid timestamp")
@@ -427,21 +505,27 @@ class ModInfoPanel:
         if external_time_created:
             try:
                 dt_created = datetime.fromtimestamp(int(external_time_created))
-                external_times.append(f"Created: {dt_created.strftime('%Y-%m-%d %H:%M:%S')}")
+                external_times.append(
+                    f"Created: {dt_created.strftime('%Y-%m-%d %H:%M:%S')}"
+                )
             except (ValueError, OSError, OverflowError):
                 external_times.append("Created: Invalid")
 
         if external_time_updated:
             try:
                 dt_updated = datetime.fromtimestamp(int(external_time_updated))
-                external_times.append(f"Updated: {dt_updated.strftime('%Y-%m-%d %H:%M:%S')}")
+                external_times.append(
+                    f"Updated: {dt_updated.strftime('%Y-%m-%d %H:%M:%S')}"
+                )
             except (ValueError, OSError, OverflowError):
                 external_times.append("Updated: Invalid")
 
         if internal_time_updated:
             try:
                 dt_int_updated = datetime.fromtimestamp(int(internal_time_updated))
-                external_times.append(f"Steam Updated: {dt_int_updated.strftime('%Y-%m-%d %H:%M:%S')}")
+                external_times.append(
+                    f"Steam Updated: {dt_int_updated.strftime('%Y-%m-%d %H:%M:%S')}"
+                )
             except (ValueError, OSError, OverflowError):
                 external_times.append("Steam Updated: Invalid")
 
@@ -450,7 +534,9 @@ class ModInfoPanel:
         else:
             self.mod_info_external_times_value.setText("Not available")
 
-    def _set_mod_info_fields(self, mod_metadata: dict[str, Any], mod_info: ModInfo, uuid: str) -> None:
+    def _set_mod_info_fields(
+        self, mod_metadata: dict[str, Any], mod_info: ModInfo, uuid: str
+    ) -> None:
         """Set information fields for valid mods."""
         # Show valid-mod-specific fields, hide scenario summary
         for widget in self.base_mod_info_widgets:
@@ -490,7 +576,9 @@ class ModInfoPanel:
         for widget in self.scenario_info_widgets:
             widget.show()
 
-        self.scenario_info_summary_value.setText(mod_metadata.get("summary", "Not specified"))
+        self.scenario_info_summary_value.setText(
+            mod_metadata.get("summary", "Not specified")
+        )
 
     def _set_invalid_info_fields(self) -> None:
         """Set information fields for invalid mods."""
@@ -498,21 +586,31 @@ class ModInfoPanel:
         for widget in self.base_mod_info_widgets + self.scenario_info_widgets:
             widget.hide()
 
-    def _set_description(self, mod_metadata: dict[str, Any], render_unity_rt: bool) -> None:
+    def _set_description(
+        self, mod_metadata: dict[str, Any], render_unity_rt: bool
+    ) -> None:
         """Set the mod description with version-specific handling."""
         self.description.setText("")
         if "description" in mod_metadata:
             if mod_metadata["description"] is not None:
                 if isinstance(mod_metadata["description"], str):
-                    self.description.setText(mod_metadata["description"], render_unity_rt)
+                    self.description.setText(
+                        mod_metadata["description"], render_unity_rt
+                    )
                 else:
-                    logger.error(f"[description] tag is not a string: {mod_metadata['description']}")
-        elif "descriptionsbyversion" in mod_metadata and isinstance(mod_metadata["descriptionsbyversion"], dict):
+                    logger.error(
+                        f"[description] tag is not a string: {mod_metadata['description']}"
+                    )
+        elif "descriptionsbyversion" in mod_metadata and isinstance(
+            mod_metadata["descriptionsbyversion"], dict
+        ):
             major, minor = self.metadata_manager.game_version.split(".")[
                 :2
             ]  # Split the version and take the first two parts
             version_regex = rf"v{major}\.{minor}"  # Construct the regex to match both major and minor versions
-            for version, description_by_ver in mod_metadata["descriptionsbyversion"].items():
+            for version, description_by_ver in mod_metadata[
+                "descriptionsbyversion"
+            ].items():
                 if match(version_regex, version):
                     if isinstance(description_by_ver, str):
                         self.description.setText(description_by_ver, render_unity_rt)
@@ -521,33 +619,49 @@ class ModInfoPanel:
                             f"[descriptionbyversion] value for {version} is not a string: {description_by_ver}"
                         )
 
-    def _load_preview_image(self, mod_metadata: dict[str, Any], is_scenario: bool) -> None:
+    def _load_preview_image(
+        self, mod_metadata: dict[str, Any], is_scenario: bool
+    ) -> None:
         """Load and set the preview image for the mod."""
         if is_scenario:
             pixmap = QPixmap(self.scenario_image_path)
             self.preview_picture.setPixmap(
-                pixmap.scaled(self.preview_picture.size(), Qt.AspectRatioMode.KeepAspectRatio)
+                pixmap.scaled(
+                    self.preview_picture.size(), Qt.AspectRatioMode.KeepAspectRatio
+                )
             )
         else:
             # Get Preview.png
             workshop_folder_path = mod_metadata.get("path", "")
-            logger.debug(f"Retrieved mod path to parse preview image: {workshop_folder_path}")
+            logger.debug(
+                f"Retrieved mod path to parse preview image: {workshop_folder_path}"
+            )
             if os.path.exists(workshop_folder_path):
                 about_folder_name = "About"
-                about_folder_target_path = str((Path(workshop_folder_path) / about_folder_name))
+                about_folder_target_path = str(
+                    (Path(workshop_folder_path) / about_folder_name)
+                )
                 if os.path.exists(about_folder_target_path):
                     # Look for a case-insensitive About folder
                     invalid_folder_path_found = True
                     for temp_file in scanpath(workshop_folder_path):
-                        if temp_file.name.lower() == about_folder_name.lower() and temp_file.is_dir():
+                        if (
+                            temp_file.name.lower() == about_folder_name.lower()
+                            and temp_file.is_dir()
+                        ):
                             about_folder_name = temp_file.name
                             invalid_folder_path_found = False
                             break
                     # Look for a case-insensitive "Preview.png" file
                     invalid_file_path_found = True
                     preview_file_name = "Preview.png"
-                    for temp_file in scanpath(str((Path(workshop_folder_path) / about_folder_name))):
-                        if temp_file.name.lower() == preview_file_name.lower() and temp_file.is_file():
+                    for temp_file in scanpath(
+                        str((Path(workshop_folder_path) / about_folder_name))
+                    ):
+                        if (
+                            temp_file.name.lower() == preview_file_name.lower()
+                            and temp_file.is_file()
+                        ):
                             preview_file_name = temp_file.name
                             invalid_file_path_found = False
                             break
@@ -563,7 +677,13 @@ class ModInfoPanel:
                         )
                     else:
                         logger.debug("Preview image found")
-                        image_path = str((Path(workshop_folder_path) / about_folder_name / preview_file_name))
+                        image_path = str(
+                            (
+                                Path(workshop_folder_path)
+                                / about_folder_name
+                                / preview_file_name
+                            )
+                        )
                         pixmap = QPixmap(image_path)
                         self.preview_picture.setPixmap(
                             pixmap.scaled(

--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -172,7 +172,9 @@ class ModListItemInner(QWidget):
         # in this variable. This is exactly equal to the dict value of a
         # single all_mods key-value
         self.uuid = uuid
-        name_value = self.metadata_manager.internal_local_metadata.get(self.uuid, {}).get("name")
+        name_value = self.metadata_manager.internal_local_metadata.get(
+            self.uuid, {}
+        ).get("name")
         if not isinstance(name_value, str):
             name_value = "name error in mod about.xml"
         self.list_item_name = name_value
@@ -189,34 +191,57 @@ class ModListItemInner(QWidget):
         self.csharp_icon = None
         self.xml_icon = None
         if self.settings_controller.settings.mod_type_filter:
-            if (self.metadata_manager.internal_local_metadata.get(self.uuid, {}).get("csharp")) is not None:
+            if (
+                self.metadata_manager.internal_local_metadata.get(self.uuid, {}).get(
+                    "csharp"
+                )
+            ) is not None:
                 self.csharp_icon = QLabel()
-                self.csharp_icon.setPixmap(ModListIcons.csharp_icon().pixmap(QSize(20, 20)))
-                self.csharp_icon.setToolTip(self.tr("Contains custom C# assemblies (custom code)"))
+                self.csharp_icon.setPixmap(
+                    ModListIcons.csharp_icon().pixmap(QSize(20, 20))
+                )
+                self.csharp_icon.setToolTip(
+                    self.tr("Contains custom C# assemblies (custom code)")
+                )
             else:
                 self.xml_icon = QLabel()
                 self.xml_icon.setPixmap(ModListIcons.xml_icon().pixmap(QSize(20, 20)))
-                self.xml_icon.setToolTip(self.tr("Contains custom content (textures / XML)"))
+                self.xml_icon.setToolTip(
+                    self.tr("Contains custom content (textures / XML)")
+                )
         self.git_icon = None
         if (
-            self.metadata_manager.internal_local_metadata[self.uuid]["data_source"] == "local"
+            self.metadata_manager.internal_local_metadata[self.uuid]["data_source"]
+            == "local"
             and self.metadata_manager.internal_local_metadata[self.uuid].get("git_repo")
-            and not self.metadata_manager.internal_local_metadata[self.uuid].get("steamcmd")
+            and not self.metadata_manager.internal_local_metadata[self.uuid].get(
+                "steamcmd"
+            )
         ):
             self.git_icon = QLabel()
             self.git_icon.setPixmap(ModListIcons.git_icon().pixmap(QSize(20, 20)))
-            self.git_icon.setToolTip(self.tr("Local mod that contains a git repository"))
+            self.git_icon.setToolTip(
+                self.tr("Local mod that contains a git repository")
+            )
         self.steamcmd_icon = None
         if self.metadata_manager.internal_local_metadata[self.uuid][
             "data_source"
-        ] == "local" and self.metadata_manager.internal_local_metadata[self.uuid].get("steamcmd"):
+        ] == "local" and self.metadata_manager.internal_local_metadata[self.uuid].get(
+            "steamcmd"
+        ):
             self.steamcmd_icon = QLabel()
-            self.steamcmd_icon.setPixmap(ModListIcons.steamcmd_icon().pixmap(QSize(20, 20)))
-            self.steamcmd_icon.setToolTip(self.tr("Local mod that can be used with SteamCMD"))
+            self.steamcmd_icon.setPixmap(
+                ModListIcons.steamcmd_icon().pixmap(QSize(20, 20))
+            )
+            self.steamcmd_icon.setToolTip(
+                self.tr("Local mod that can be used with SteamCMD")
+            )
         # Warning icon hidden by default
         self.warning_icon_label = ClickableQLabel()
         self.warning_icon_label.clicked.connect(self.__on_warning_icon_clicked)
-        self.warning_icon_label.setPixmap(ModListIcons.warning_icon().pixmap(QSize(20, 20)))
+        self.warning_icon_label.setPixmap(
+            ModListIcons.warning_icon().pixmap(QSize(20, 20))
+        )
         # Default to hidden to avoid showing early
         self.warning_icon_label.setHidden(True)
         # New icon hidden by default
@@ -227,7 +252,9 @@ class ModListItemInner(QWidget):
         self.new_icon_label.setHidden(True)
         # In-save icon (for inactive list items): hidden by default
         self.in_save_icon_label = QLabel()
-        self.in_save_icon_label.setPixmap(ModListIcons.clear_icon().pixmap(QSize(20, 20)))
+        self.in_save_icon_label.setPixmap(
+            ModListIcons.clear_icon().pixmap(QSize(20, 20))
+        )
         self.in_save_icon_label.setToolTip(self.tr("In latest save"))
         self.in_save_icon_label.setHidden(True)
         # Error icon hidden by default
@@ -245,14 +272,22 @@ class ModListItemInner(QWidget):
             self.mod_source_icon = QLabel()
             self.mod_source_icon.setPixmap(self.get_icon().pixmap(QSize(20, 20)))
             # Set tooltip based on mod source
-            data_source = self.metadata_manager.internal_local_metadata[self.uuid].get("data_source")
+            data_source = self.metadata_manager.internal_local_metadata[self.uuid].get(
+                "data_source"
+            )
             if data_source == "expansion":
                 self.mod_source_icon.setObjectName("expansion")
-                self.mod_source_icon.setToolTip(self.tr("Official RimWorld content by Ludeon Studios"))
+                self.mod_source_icon.setToolTip(
+                    self.tr("Official RimWorld content by Ludeon Studios")
+                )
             elif data_source == "local":
-                if self.metadata_manager.internal_local_metadata[self.uuid].get("git_repo"):
+                if self.metadata_manager.internal_local_metadata[self.uuid].get(
+                    "git_repo"
+                ):
                     self.mod_source_icon.setObjectName("git_repo")
-                elif self.metadata_manager.internal_local_metadata[self.uuid].get("steamcmd"):
+                elif self.metadata_manager.internal_local_metadata[self.uuid].get(
+                    "steamcmd"
+                ):
                     self.mod_source_icon.setObjectName("steamcmd")
                 else:
                     self.mod_source_icon.setObjectName("local")
@@ -274,22 +309,38 @@ class ModListItemInner(QWidget):
         if self.git_icon:
             self.main_item_layout.addWidget(self.git_icon, Qt.AlignmentFlag.AlignRight)
         if self.steamcmd_icon:
-            self.main_item_layout.addWidget(self.steamcmd_icon, Qt.AlignmentFlag.AlignRight)
+            self.main_item_layout.addWidget(
+                self.steamcmd_icon, Qt.AlignmentFlag.AlignRight
+            )
         if self.mod_source_icon:
-            self.main_item_layout.addWidget(self.mod_source_icon, Qt.AlignmentFlag.AlignRight)
+            self.main_item_layout.addWidget(
+                self.mod_source_icon, Qt.AlignmentFlag.AlignRight
+            )
         if self.csharp_icon:
-            self.main_item_layout.addWidget(self.csharp_icon, Qt.AlignmentFlag.AlignRight)
+            self.main_item_layout.addWidget(
+                self.csharp_icon, Qt.AlignmentFlag.AlignRight
+            )
         if self.xml_icon:
             self.main_item_layout.addWidget(self.xml_icon, Qt.AlignmentFlag.AlignRight)
         # Compose the layout of our widget and set it to the main layout
         self.main_item_layout.addWidget(self.main_label, Qt.AlignmentFlag.AlignCenter)
         if self.settings_controller.settings.show_save_comparison_indicators:
-            self.main_item_layout.addWidget(self.in_save_icon_label, Qt.AlignmentFlag.AlignRight)
-            self.main_item_layout.addWidget(self.new_icon_label, Qt.AlignmentFlag.AlignRight)
+            self.main_item_layout.addWidget(
+                self.in_save_icon_label, Qt.AlignmentFlag.AlignRight
+            )
+            self.main_item_layout.addWidget(
+                self.new_icon_label, Qt.AlignmentFlag.AlignRight
+            )
 
-        self.main_item_layout.addWidget(self.translation_status_label, Qt.AlignmentFlag.AlignRight)
-        self.main_item_layout.addWidget(self.warning_icon_label, Qt.AlignmentFlag.AlignRight)
-        self.main_item_layout.addWidget(self.error_icon_label, Qt.AlignmentFlag.AlignRight)
+        self.main_item_layout.addWidget(
+            self.translation_status_label, Qt.AlignmentFlag.AlignRight
+        )
+        self.main_item_layout.addWidget(
+            self.warning_icon_label, Qt.AlignmentFlag.AlignRight
+        )
+        self.main_item_layout.addWidget(
+            self.error_icon_label, Qt.AlignmentFlag.AlignRight
+        )
         self.main_item_layout.addStretch()
         self.setLayout(self.main_item_layout)
 
@@ -323,12 +374,16 @@ class ModListItemInner(QWidget):
         if is_translated:
             self.translation_status_label.setText("🟢")
             self.translation_status_label.setToolTip(
-                self.tr("Translation available - This mod has a translation or is already localized")
+                self.tr(
+                    "Translation available - This mod has a translation or is already localized"
+                )
             )
         else:
             self.translation_status_label.setText("🔴")
             self.translation_status_label.setToolTip(
-                self.tr("No translation found - This mod does not have a translation installed")
+                self.tr(
+                    "No translation found - This mod does not have a translation installed"
+                )
             )
         self.translation_status_label.setHidden(False)
         self._resize_text_after_icon_toggle()
@@ -463,11 +518,20 @@ class ModListItemInner(QWidget):
 
         :return: QIcon object set to the path of the corresponding icon image
         """
-        if self.metadata_manager.internal_local_metadata[self.uuid].get("data_source") == "expansion":
+        if (
+            self.metadata_manager.internal_local_metadata[self.uuid].get("data_source")
+            == "expansion"
+        ):
             return ModListIcons.ludeon_icon()
-        elif self.metadata_manager.internal_local_metadata[self.uuid].get("data_source") == "local":
+        elif (
+            self.metadata_manager.internal_local_metadata[self.uuid].get("data_source")
+            == "local"
+        ):
             return ModListIcons.local_icon()
-        elif self.metadata_manager.internal_local_metadata[self.uuid].get("data_source") == "workshop":
+        elif (
+            self.metadata_manager.internal_local_metadata[self.uuid].get("data_source")
+            == "workshop"
+        ):
             return ModListIcons.steam_icon()
         else:
             logger.error(
@@ -489,13 +553,17 @@ class ModListItemInner(QWidget):
         icon_width = icon_count * 20
         if not self.translation_status_label.isHidden():
             icon_width += (
-                self.translation_status_label.fontMetrics().boundingRect(self.translation_status_label.text()).width()
+                self.translation_status_label.fontMetrics()
+                .boundingRect(self.translation_status_label.text())
+                .width()
                 + 6
             )
         # If only 2 icons (On the left, eg. c#/xml/steam/local etc.) No need for padding.
         padding = 6 if icon_count > 2 else 0
         self.item_width = super().width()
-        text_width_needed = QRectF(self.font_metrics.boundingRect(self.list_item_name)).width()
+        text_width_needed = QRectF(
+            self.font_metrics.boundingRect(self.list_item_name)
+        ).width()
         if text_width_needed > self.item_width - icon_width - padding:
             available_width = max(0, int(self.item_width - icon_width - padding))
             shortened_text = self.font_metrics.elidedText(
@@ -533,7 +601,9 @@ class ModListItemInner(QWidget):
         # Read list_type from persisted item metadata instead of Qt widget to satisfy static typing
         list_type = cast(str | None, item_data.__dict__.get("list_type"))
         # Respect setting toggle
-        show_indicators = self.settings_controller.settings.show_save_comparison_indicators
+        show_indicators = (
+            self.settings_controller.settings.show_save_comparison_indicators
+        )
         if not show_indicators:
             self.new_icon_label.setHidden(True)
             self.in_save_icon_label.setHidden(True)
@@ -571,7 +641,9 @@ class ModListItemInner(QWidget):
             self._resize_text_after_icon_toggle(icon_count=new_icon_count)
             self._last_icon_count = new_icon_count
 
-    def handle_mod_color_change(self, item: CustomListWidgetItem | None = None, init: bool = False) -> None:
+    def handle_mod_color_change(
+        self, item: CustomListWidgetItem | None = None, init: bool = False
+    ) -> None:
         """
         Handle mod color change (Background or Text) for *ModListItemInner*.
 
@@ -590,7 +662,9 @@ class ModListItemInner(QWidget):
             elif item:
                 item_data = item.data(Qt.ItemDataRole.UserRole)
                 new_mod_color_name = item_data["mod_color"].name()
-                self.mod_color = item_data["mod_color"]  # Update mod color in ModListItemInner
+                self.mod_color = item_data[
+                    "mod_color"
+                ]  # Update mod color in ModListItemInner
                 self.setStyleSheet(f"background: {new_mod_color_name};")
         else:
             # Color text
@@ -601,7 +675,9 @@ class ModListItemInner(QWidget):
             elif item:
                 item_data = item.data(Qt.ItemDataRole.UserRole)
                 new_mod_color_name = item_data["mod_color"].name()
-                self.mod_color = item_data["mod_color"]  # Update mod color in ModListItemInner
+                self.mod_color = item_data[
+                    "mod_color"
+                ]  # Update mod color in ModListItemInner
                 self.setStyleSheet(f"color: {new_mod_color_name};")
 
     def handle_mod_color_reset(self) -> None:
@@ -798,10 +874,14 @@ class ModListWidget(QListWidget):
         self.itemChanged.connect(self.handle_item_data_changed)
 
         # Allow inserting custom list items
-        self.model().rowsInserted.connect(self.handle_rows_inserted, Qt.ConnectionType.QueuedConnection)
+        self.model().rowsInserted.connect(
+            self.handle_rows_inserted, Qt.ConnectionType.QueuedConnection
+        )
 
         # Handle removing items to update count
-        self.model().rowsAboutToBeRemoved.connect(self.handle_rows_removed, Qt.ConnectionType.QueuedConnection)
+        self.model().rowsAboutToBeRemoved.connect(
+            self.handle_rows_removed, Qt.ConnectionType.QueuedConnection
+        )
 
         # Lazy load ModListItemInner
         self.verticalScrollBar().valueChanged.connect(self.check_widgets_visible)
@@ -824,7 +904,9 @@ class ModListWidget(QListWidget):
         )  # TODO: should we enable items conditionally? For now use all
         logger.debug("Finished ModListWidget initialization")
 
-    def on_selection_changed(self, selected: QItemSelection, deselected: QItemSelection) -> None:
+    def on_selection_changed(
+        self, selected: QItemSelection, deselected: QItemSelection
+    ) -> None:
         """
         Used to indicate when the custom widget is selected/not selected.
         """
@@ -863,7 +945,10 @@ class ModListWidget(QListWidget):
             # Get the new indexes of the dropped items
             new_indexes = [index.row() for index in self.selectedIndexes()]
             # Get the UUIDs of the dropped items
-            uuids = [item.data(Qt.ItemDataRole.UserRole)["uuid"] for item in self.selectedItems()]
+            uuids = [
+                item.data(Qt.ItemDataRole.UserRole)["uuid"]
+                for item in self.selectedItems()
+            ]
             # Insert the UUIDs at the respective new indexes
             for idx, uuid in zip(new_indexes, uuids):
                 if uuid in self.uuids:  # Remove the uuid if it exists in the list
@@ -871,7 +956,9 @@ class ModListWidget(QListWidget):
                 # Reinsert uuid at it's new index
                 self.uuids.insert(idx, uuid)
         # Update list signal
-        logger.debug(f"Emitting {self.list_type} list update signal after rows dropped [{self.count()}]")
+        logger.debug(
+            f"Emitting {self.list_type} list update signal after rows dropped [{self.count()}]"
+        )
         # Only emit "drop" signal if a mod was dragged and dropped within the same modlist
         if source_widget == self:
             self.list_update_signal.emit("drop")
@@ -882,10 +969,14 @@ class ModListWidget(QListWidget):
         for source_item in selected_items:
             if type(source_item) is CustomListWidgetItem:
                 item_data = source_item.data(Qt.ItemDataRole.UserRole)
-                metadata.append(self.metadata_manager.internal_local_metadata[item_data["uuid"]])
+                metadata.append(
+                    self.metadata_manager.internal_local_metadata[item_data["uuid"]]
+                )
         return metadata
 
-    def _calculate_translation_similarity(self, mod_name: str, trans_name: str) -> float:
+    def _calculate_translation_similarity(
+        self, mod_name: str, trans_name: str
+    ) -> float:
         """
         Calculate similarity score between original mod name and translation mod name.
 
@@ -938,7 +1029,9 @@ class ModListWidget(QListWidget):
             "翻译",
         ]
 
-        has_translation_keyword = any(keyword in trans_lower for keyword in translation_keywords)
+        has_translation_keyword = any(
+            keyword in trans_lower for keyword in translation_keywords
+        )
 
         # Bonus if translation keywords are present
         keyword_bonus = 0.2 if has_translation_keyword else 0.0
@@ -948,21 +1041,37 @@ class ModListWidget(QListWidget):
             substring_score = 0.8
         else:
             # Try removing common prefixes/suffixes and check again
-            cleaned_mod = mod_lower.replace("[", "").replace("]", "").replace("(", "").replace(")", "").strip()
-            cleaned_trans = trans_lower.replace("[", "").replace("]", "").replace("(", "").replace(")", "").strip()
+            cleaned_mod = (
+                mod_lower.replace("[", "")
+                .replace("]", "")
+                .replace("(", "")
+                .replace(")", "")
+                .strip()
+            )
+            cleaned_trans = (
+                trans_lower.replace("[", "")
+                .replace("]", "")
+                .replace("(", "")
+                .replace(")", "")
+                .strip()
+            )
 
             if cleaned_mod in cleaned_trans:
                 substring_score = 0.7
             else:
                 # Use sequence matcher for partial matching
-                substring_score = SequenceMatcher(None, mod_lower, trans_lower).ratio() * 0.6
+                substring_score = (
+                    SequenceMatcher(None, mod_lower, trans_lower).ratio() * 0.6
+                )
 
         # Combine scores
         final_score = min(1.0, substring_score + keyword_bonus)
 
         return final_score
 
-    def _find_and_open_translations(self, package_id: str, mod_metadata: dict[str, Any]) -> None:
+    def _find_and_open_translations(
+        self, package_id: str, mod_metadata: dict[str, Any]
+    ) -> None:
         """
         Find and open translation mods for the specified mod.
 
@@ -1002,7 +1111,9 @@ class ModListWidget(QListWidget):
                 if tag and tag.replace(".", "").isdigit():
                     mod_version_tags.add(tag)
 
-        logger.info(f"Searching for translations of mod with packageId: {package_id}, version tags: {mod_version_tags}")
+        logger.info(
+            f"Searching for translations of mod with packageId: {package_id}, version tags: {mod_version_tags}"
+        )
 
         # Search for translation mods
         translation_mods = []
@@ -1066,7 +1177,9 @@ class ModListWidget(QListWidget):
             logger.info(f"No translations found for mod: {package_id}")
             show_warning(
                 title=self.tr("No translations found"),
-                text=self.tr("No translation mods were found for this mod in the Steam Workshop database."),
+                text=self.tr(
+                    "No translation mods were found for this mod in the Steam Workshop database."
+                ),
             )
             return
 
@@ -1076,7 +1189,9 @@ class ModListWidget(QListWidget):
         # Filter out translations with very low similarity (likely false positives)
         # Keep at least one result even if similarity is low
         SIMILARITY_THRESHOLD = 0.3
-        filtered_mods = [m for m in translation_mods if m["similarity"] >= SIMILARITY_THRESHOLD]
+        filtered_mods = [
+            m for m in translation_mods if m["similarity"] >= SIMILARITY_THRESHOLD
+        ]
         if not filtered_mods and translation_mods:
             # If all mods filtered out, keep the best match
             filtered_mods = [translation_mods[0]]
@@ -1091,7 +1206,9 @@ class ModListWidget(QListWidget):
         # If only one translation, open it directly
         if len(translation_mods) == 1:
             trans_mod = translation_mods[0]
-            logger.info(f"Opening translation: {trans_mod['name']} - {trans_mod['url']}")
+            logger.info(
+                f"Opening translation: {trans_mod['name']} - {trans_mod['url']}"
+            )
             open_url_browser(trans_mod["url"])
             return
 
@@ -1104,7 +1221,11 @@ class ModListWidget(QListWidget):
         layout = QVBoxLayout()
 
         # Add label
-        label = QLabel(self.tr(f"Found {len(translation_mods)} translation(s). Select one to open:"))
+        label = QLabel(
+            self.tr(
+                f"Found {len(translation_mods)} translation(s). Select one to open:"
+            )
+        )
         layout.addWidget(label)
 
         # Add list widget
@@ -1265,7 +1386,9 @@ class ModListWidget(QListWidget):
                     # Open folder in text editor text
                     if self.settings_controller.settings.text_editor_location:
                         open_folder_text_editor_action = QAction()
-                        open_folder_text_editor_action.setText(self.tr("Open folder in text editor"))
+                        open_folder_text_editor_action.setText(
+                            self.tr("Open folder in text editor")
+                        )
                     # Change mod color action
                     change_mod_color_action = QAction()
                     change_mod_color_action.setText(self.tr("Change mod color"))
@@ -1276,7 +1399,9 @@ class ModListWidget(QListWidget):
                         open_url_browser_action = QAction()
                         open_url_browser_action.setText(self.tr("Open URL in browser"))
                         copy_url_to_clipboard_action = QAction()
-                        copy_url_to_clipboard_action.setText(self.tr("Copy URL to clipboard"))
+                        copy_url_to_clipboard_action.setText(
+                            self.tr("Copy URL to clipboard")
+                        )
                     # If we have a "steam_uri"
                     if (
                         mod_metadata.get("steam_uri")
@@ -1293,34 +1418,49 @@ class ModListWidget(QListWidget):
                         mod_folder_path = mod_metadata["path"]
                         publishedfileid = mod_metadata.get("publishedfileid", "")
                         if not isinstance(publishedfileid, str):
-                            logger.error(f"Invalid publishedfileid type: {publishedfileid} for {mod_name}")
+                            logger.error(
+                                f"Invalid publishedfileid type: {publishedfileid} for {mod_name}"
+                            )
                             publishedfileid = ""
 
                         if not mod_metadata.get("steamcmd") and (
                             self.metadata_manager.external_steam_metadata
                             and publishedfileid
-                            and publishedfileid in self.metadata_manager.external_steam_metadata.keys()
+                            and publishedfileid
+                            in self.metadata_manager.external_steam_metadata.keys()
                         ):
-                            local_steamcmd_name_to_publishedfileid[mod_folder_name] = publishedfileid
+                            local_steamcmd_name_to_publishedfileid[mod_folder_name] = (
+                                publishedfileid
+                            )
                             # Convert local mods -> steamcmd
                             convert_local_steamcmd_action = QAction()
-                            convert_local_steamcmd_action.setText(self.tr("Convert local mod to SteamCMD"))
+                            convert_local_steamcmd_action.setText(
+                                self.tr("Convert local mod to SteamCMD")
+                            )
                         if mod_metadata.get("steamcmd"):
                             steamcmd_mod_paths.append(mod_folder_path)
                             steamcmd_publishedfileid_to_name[publishedfileid] = mod_name
                             # Convert steamcmd mods -> local
                             convert_steamcmd_local_action = QAction()
-                            convert_steamcmd_local_action.setText(self.tr("Convert SteamCMD mod to local"))
+                            convert_steamcmd_local_action.setText(
+                                self.tr("Convert SteamCMD mod to local")
+                            )
                             # Re-download steamcmd mods
                             re_steamcmd_action = QAction()
-                            re_steamcmd_action.setText(self.tr("Re-download mod with SteamCMD"))
+                            re_steamcmd_action.setText(
+                                self.tr("Re-download mod with SteamCMD")
+                            )
                         # Update local mods that contain git repos that are not steamcmd mods
-                        if not mod_metadata.get("steamcmd") and mod_metadata.get("git_repo"):
+                        if not mod_metadata.get("steamcmd") and mod_metadata.get(
+                            "git_repo"
+                        ):
                             git_paths.append(mod_folder_path)
                             re_git_action = QAction()
                             re_git_action.setText(self.tr("Update mod with git"))
                     # If Workshop, and pfid, allow Steam actions
-                    if mod_data_source == "workshop" and mod_metadata.get("publishedfileid"):
+                    if mod_data_source == "workshop" and mod_metadata.get(
+                        "publishedfileid"
+                    ):
                         mod_name = mod_metadata.get("name")
                         mod_folder_path = mod_metadata["path"]
                         publishedfileid = mod_metadata["publishedfileid"]
@@ -1328,31 +1468,48 @@ class ModListWidget(QListWidget):
                         steam_publishedfileid_to_name[publishedfileid] = mod_name
                         # Convert steam mods -> local
                         convert_workshop_local_action = QAction()
-                        convert_workshop_local_action.setText(self.tr("Convert Steam mod to local"))
+                        convert_workshop_local_action.setText(
+                            self.tr("Convert Steam mod to local")
+                        )
                         # Only enable subscription actions if user has enabled Steam client integration
                         if self.settings_controller.settings.instances[
                             self.settings_controller.settings.current_instance
                         ].steam_client_integration:
                             # Re-subscribe steam mods
                             re_steam_action = QAction()
-                            re_steam_action.setText(self.tr("Re-subscribe mod with Steam"))
+                            re_steam_action.setText(
+                                self.tr("Re-subscribe mod with Steam")
+                            )
                             # Unsubscribe steam mods
                             unsubscribe_mod_steam_action = QAction()
-                            unsubscribe_mod_steam_action.setText(self.tr("Unsubscribe mod with Steam"))
+                            unsubscribe_mod_steam_action.setText(
+                                self.tr("Unsubscribe mod with Steam")
+                            )
                     # SteamDB blacklist options
-                    if self.metadata_manager.external_steam_metadata and mod_metadata.get("publishedfileid"):
+                    if (
+                        self.metadata_manager.external_steam_metadata
+                        and mod_metadata.get("publishedfileid")
+                    ):
                         publishedfileid = mod_metadata["publishedfileid"]
-                        if self.metadata_manager.external_steam_metadata.get(publishedfileid, {}).get("blacklist"):
+                        if self.metadata_manager.external_steam_metadata.get(
+                            publishedfileid, {}
+                        ).get("blacklist"):
                             steamdb_remove_blacklist = publishedfileid
                             remove_from_steamdb_blacklist_action = QAction()
-                            remove_from_steamdb_blacklist_action.setText(self.tr("Remove mod from SteamDB blacklist"))
+                            remove_from_steamdb_blacklist_action.setText(
+                                self.tr("Remove mod from SteamDB blacklist")
+                            )
                         else:
                             steamdb_add_blacklist = publishedfileid
                             add_to_steamdb_blacklist_action = QAction()
-                            add_to_steamdb_blacklist_action.setText(self.tr("Add mod to SteamDB blacklist"))
+                            add_to_steamdb_blacklist_action.setText(
+                                self.tr("Add mod to SteamDB blacklist")
+                            )
                     # Copy packageId to clipboard
                     copy_packageid_to_clipboard_action = QAction()
-                    copy_packageid_to_clipboard_action.setText(self.tr("Copy packageId to clipboard"))
+                    copy_packageid_to_clipboard_action.setText(
+                        self.tr("Copy packageId to clipboard")
+                    )
                     # Edit mod rules with Rule Editor (only for individual mods)
                     edit_mod_rules_action = QAction()
                     edit_mod_rules_action.setText(self.tr("Edit mod with Rule Editor"))
@@ -1376,10 +1533,15 @@ class ModListWidget(QListWidget):
                         uuid = item_data["uuid"]
                         all_selected_uuids[item_idx] = uuid
                         # Retrieve metadata
-                        mod_metadata = self.metadata_manager.internal_local_metadata[uuid]
+                        mod_metadata = self.metadata_manager.internal_local_metadata[
+                            uuid
+                        ]
                         if all_warnings_toggled:
                             package_id = mod_metadata.get("packageid")
-                            if package_id and package_id not in self.ignore_warning_list:
+                            if (
+                                package_id
+                                and package_id not in self.ignore_warning_list
+                            ):
                                 all_warnings_toggled = False
                         mod_data_source = mod_metadata.get("data_source")
                         # Open folder action text
@@ -1387,7 +1549,9 @@ class ModListWidget(QListWidget):
                         open_folder_action.setText(self.tr("Open folder(s)"))
                         if self.settings_controller.settings.text_editor_location:
                             open_folder_text_editor_action = QAction()
-                            open_folder_text_editor_action.setText(self.tr("Open folder(s) in text editor"))
+                            open_folder_text_editor_action.setText(
+                                self.tr("Open folder(s) in text editor")
+                            )
                         # Change mod color action
                         change_mod_color_action = QAction()
                         change_mod_color_action.setText("Change mod colors")
@@ -1396,7 +1560,9 @@ class ModListWidget(QListWidget):
                         # If we have a "url" or "steam_url"
                         if mod_metadata.get("url") or mod_metadata.get("steam_url"):
                             open_url_browser_action = QAction()
-                            open_url_browser_action.setText(self.tr("Open URL(s) in browser"))
+                            open_url_browser_action.setText(
+                                self.tr("Open URL(s) in browser")
+                            )
                         # Conversion options (local <-> SteamCMD)
                         if mod_data_source == "local":
                             mod_name = mod_metadata.get("name")
@@ -1406,30 +1572,45 @@ class ModListWidget(QListWidget):
                             if not mod_metadata.get("steamcmd") and (
                                 self.metadata_manager.external_steam_metadata
                                 and publishedfileid
-                                and publishedfileid in self.metadata_manager.external_steam_metadata.keys()
+                                and publishedfileid
+                                in self.metadata_manager.external_steam_metadata.keys()
                             ):
-                                local_steamcmd_name_to_publishedfileid[mod_folder_name] = publishedfileid
+                                local_steamcmd_name_to_publishedfileid[
+                                    mod_folder_name
+                                ] = publishedfileid
                                 # Convert local mods -> steamcmd
                                 if not convert_local_steamcmd_action:
                                     convert_local_steamcmd_action = QAction()
-                                    convert_local_steamcmd_action.setText(self.tr("Convert local mod(s) to SteamCMD"))
+                                    convert_local_steamcmd_action.setText(
+                                        self.tr("Convert local mod(s) to SteamCMD")
+                                    )
                             if mod_metadata.get("steamcmd"):
                                 steamcmd_mod_paths.append(mod_folder_path)
-                                steamcmd_publishedfileid_to_name[publishedfileid] = mod_name
+                                steamcmd_publishedfileid_to_name[publishedfileid] = (
+                                    mod_name
+                                )
                                 # Convert steamcmd mods -> local
                                 if not convert_steamcmd_local_action:
                                     convert_steamcmd_local_action = QAction()
-                                    convert_steamcmd_local_action.setText(self.tr("Convert SteamCMD mod(s) to local"))
+                                    convert_steamcmd_local_action.setText(
+                                        self.tr("Convert SteamCMD mod(s) to local")
+                                    )
                                 # Re-download steamcmd mods
                                 if not re_steamcmd_action:
                                     re_steamcmd_action = QAction()
-                                    re_steamcmd_action.setText(self.tr("Re-download mod(s) with SteamCMD"))
+                                    re_steamcmd_action.setText(
+                                        self.tr("Re-download mod(s) with SteamCMD")
+                                    )
                             # Update git mods if local mod with git repo, but not steamcmd
-                            if not mod_metadata.get("steamcmd") and mod_metadata.get("git_repo"):
+                            if not mod_metadata.get("steamcmd") and mod_metadata.get(
+                                "git_repo"
+                            ):
                                 git_paths.append(mod_folder_path)
                                 if not re_git_action:
                                     re_git_action = QAction()
-                                    re_git_action.setText(self.tr("Update mod(s) with git"))
+                                    re_git_action.setText(
+                                        self.tr("Update mod(s) with git")
+                                    )
                         # No "Edit mod rules" when multiple selected
                         # Toggle warning
                         if item_idx == len(selected_items) - 1:
@@ -1438,7 +1619,9 @@ class ModListWidget(QListWidget):
                             toggle_warning_action.setCheckable(True)
                             toggle_warning_action.setChecked(all_warnings_toggled)
                         # If Workshop, and pfid, allow Steam actions
-                        if mod_data_source == "workshop" and mod_metadata.get("publishedfileid"):
+                        if mod_data_source == "workshop" and mod_metadata.get(
+                            "publishedfileid"
+                        ):
                             mod_name = mod_metadata.get("name")
                             mod_folder_path = mod_metadata["path"]
                             publishedfileid = mod_metadata["publishedfileid"]
@@ -1447,7 +1630,9 @@ class ModListWidget(QListWidget):
                             # Convert steam mods -> local
                             if not convert_workshop_local_action:
                                 convert_workshop_local_action = QAction()
-                                convert_workshop_local_action.setText(self.tr("Convert Steam mod(s) to local"))
+                                convert_workshop_local_action.setText(
+                                    self.tr("Convert Steam mod(s) to local")
+                                )
                             # Only enable subscription actions if user has enabled Steam client integration
                             if self.settings_controller.settings.instances[
                                 self.settings_controller.settings.current_instance
@@ -1455,11 +1640,15 @@ class ModListWidget(QListWidget):
                                 # Re-subscribe steam mods
                                 if not re_steam_action:
                                     re_steam_action = QAction()
-                                    re_steam_action.setText(self.tr("Re-subscribe mod(s) with Steam"))
+                                    re_steam_action.setText(
+                                        self.tr("Re-subscribe mod(s) with Steam")
+                                    )
                                 # Unsubscribe steam mods
                                 if not unsubscribe_mod_steam_action:
                                     unsubscribe_mod_steam_action = QAction()
-                                    unsubscribe_mod_steam_action.setText(self.tr("Unsubscribe mod(s) with Steam"))
+                                    unsubscribe_mod_steam_action.setText(
+                                        self.tr("Unsubscribe mod(s) with Steam")
+                                    )
                         # No SteamDB blacklist options when multiple selected
             # Put together our contextMenu
             if open_folder_action:
@@ -1525,12 +1714,17 @@ class ModListWidget(QListWidget):
                     workshop_actions_menu.addAction(re_steam_action)
                 if unsubscribe_mod_steam_action:
                     workshop_actions_menu.addAction(unsubscribe_mod_steam_action)
-                if add_to_steamdb_blacklist_action or remove_from_steamdb_blacklist_action:
+                if (
+                    add_to_steamdb_blacklist_action
+                    or remove_from_steamdb_blacklist_action
+                ):
                     workshop_actions_menu.addSeparator()
                 if add_to_steamdb_blacklist_action:
                     workshop_actions_menu.addAction(add_to_steamdb_blacklist_action)
                 if remove_from_steamdb_blacklist_action:
-                    workshop_actions_menu.addAction(remove_from_steamdb_blacklist_action)
+                    workshop_actions_menu.addAction(
+                        remove_from_steamdb_blacklist_action
+                    )
                 context_menu.addMenu(workshop_actions_menu)
             # Execute QMenu and return it's ACTION
             action = context_menu.exec_(self.mapToGlobal(pos_local))
@@ -1541,7 +1735,9 @@ class ModListWidget(QListWidget):
                     # Prompt user
                     answer = show_dialogue_conditional(
                         title=self.tr("Are you sure?"),
-                        text=self.tr("You have selected {len} git mods to be updated.").format(len=len(git_paths)),
+                        text=self.tr(
+                            "You have selected {len} git mods to be updated."
+                        ).format(len=len(git_paths)),
                         information=self.tr("Do you want to proceed?"),
                     )
                     if answer == QMessageBox.StandardButton.Yes:
@@ -1549,7 +1745,8 @@ class ModListWidget(QListWidget):
                         self.update_git_mods_signal.emit(git_paths)
                     return True
                 elif (  # ACTION: Convert local mod(s) -> SteamCMD
-                    action == convert_local_steamcmd_action and len(local_steamcmd_name_to_publishedfileid) > 0
+                    action == convert_local_steamcmd_action
+                    and len(local_steamcmd_name_to_publishedfileid) > 0
                 ):
                     local_folder = self.settings_controller.settings.instances[
                         self.settings_controller.settings.current_instance
@@ -1569,14 +1766,19 @@ class ModListWidget(QListWidget):
                                     )
                                 except Exception as e:
                                     stacktrace = format_exc()
-                                    logger.error(f"Failed to convert mod: {original_mod_path} - {e}")
+                                    logger.error(
+                                        f"Failed to convert mod: {original_mod_path} - {e}"
+                                    )
                                     logger.error(stacktrace)
                             else:
-                                logger.warning(f"Failed to convert mod! Destination already exists: {renamed_mod_path}")
+                                logger.warning(
+                                    f"Failed to convert mod! Destination already exists: {renamed_mod_path}"
+                                )
                     self.refresh_signal.emit()
                     return True
                 elif (  # ACTION: Convert SteamCMD mod(s) -> local
-                    action == convert_steamcmd_local_action and len(steamcmd_publishedfileid_to_name) > 0
+                    action == convert_steamcmd_local_action
+                    and len(steamcmd_publishedfileid_to_name) > 0
                 ):
                     local_folder = self.settings_controller.settings.instances[
                         self.settings_controller.settings.current_instance
@@ -1585,7 +1787,11 @@ class ModListWidget(QListWidget):
                         publishedfileid,
                         mod_name,
                     ) in steamcmd_publishedfileid_to_name.items():
-                        mod_name = sanitize_filename(mod_name) if mod_name else f"{publishedfileid}_local"
+                        mod_name = (
+                            sanitize_filename(mod_name)
+                            if mod_name
+                            else f"{publishedfileid}_local"
+                        )
                         original_mod_path = str((Path(local_folder) / publishedfileid))
                         renamed_mod_path = str((Path(local_folder) / mod_name))
                         if os.path.exists(original_mod_path):
@@ -1597,26 +1803,35 @@ class ModListWidget(QListWidget):
                                     )
                                 except Exception as e:
                                     stacktrace = format_exc()
-                                    logger.error(f"Failed to convert mod: {original_mod_path} - {e}")
+                                    logger.error(
+                                        f"Failed to convert mod: {original_mod_path} - {e}"
+                                    )
                                     logger.error(stacktrace)
                             else:
-                                logger.warning(f"Failed to convert mod! Destination already exists: {renamed_mod_path}")
+                                logger.warning(
+                                    f"Failed to convert mod! Destination already exists: {renamed_mod_path}"
+                                )
                     self.refresh_signal.emit()
                     return True
                 elif (  # ACTION: Re-download SteamCMD mod(s)
-                    action == re_steamcmd_action and len(steamcmd_publishedfileid_to_name.keys()) > 0
+                    action == re_steamcmd_action
+                    and len(steamcmd_publishedfileid_to_name.keys()) > 0
                 ):
-                    logger.debug(f"Selected mods for deleting + redownloading: {steamcmd_publishedfileid_to_name}")
-                    steamcmd_publishedfileid_to_redownload = steamcmd_publishedfileid_to_name.keys()
+                    logger.debug(
+                        f"Selected mods for deleting + redownloading: {steamcmd_publishedfileid_to_name}"
+                    )
+                    steamcmd_publishedfileid_to_redownload = (
+                        steamcmd_publishedfileid_to_name.keys()
+                    )
                     logger.debug(
                         f"Selected publishedfileid for deleting + redownloading: {steamcmd_publishedfileid_to_redownload}"
                     )
                     # Prompt user
                     answer = show_dialogue_conditional(
                         title=self.tr("Are you sure?"),
-                        text=self.tr("You have selected {len} mods for deletion + re-download.").format(
-                            len=len(steamcmd_publishedfileid_to_redownload)
-                        ),
+                        text=self.tr(
+                            "You have selected {len} mods for deletion + re-download."
+                        ).format(len=len(steamcmd_publishedfileid_to_redownload)),
                         information=self.tr(
                             "\nThis operation will recursively delete all mod files, except for .dds textures found, "
                             + "and attempt to re-download the mods via SteamCMD. Do you want to proceed?"
@@ -1628,9 +1843,13 @@ class ModListWidget(QListWidget):
                         )
                         for path in steamcmd_mod_paths:
                             # Delete all files except .dds
-                            delete_files_except_extension(directory=path, extension=".dds")
+                            delete_files_except_extension(
+                                directory=path, extension=".dds"
+                            )
                             # Calculate SteamCMD mod publishedfileids to purge from acf metadata
-                            steamcmd_acf_pfid_purge = set(steamcmd_publishedfileid_to_redownload)
+                            steamcmd_acf_pfid_purge = set(
+                                steamcmd_publishedfileid_to_redownload
+                            )
                         # Purge any deleted SteamCMD mods from acf metadata (only if auto-clear depot cache is enabled)
                         if steamcmd_acf_pfid_purge:
                             steamcmd_purge_mods(
@@ -1644,7 +1863,9 @@ class ModListWidget(QListWidget):
                         logger.debug(
                             f"Emitting do_steamcmd_download for {list(steamcmd_publishedfileid_to_redownload)}"
                         )
-                        EventBus().do_steamcmd_download.emit(list(steamcmd_publishedfileid_to_redownload))
+                        EventBus().do_steamcmd_download.emit(
+                            list(steamcmd_publishedfileid_to_redownload)
+                        )
                     return True
                 elif (  # ACTION: Convert Steam mod(s) -> local
                     action == convert_workshop_local_action
@@ -1653,7 +1874,9 @@ class ModListWidget(QListWidget):
                 ):
                     for path in steam_mod_paths:
                         publishedfileid_from_folder_name = os.path.split(path)[1]
-                        mod_name = steam_publishedfileid_to_name.get(publishedfileid_from_folder_name)
+                        mod_name = steam_publishedfileid_to_name.get(
+                            publishedfileid_from_folder_name
+                        )
                         if mod_name:
                             mod_name = sanitize_filename(mod_name)
                         renamed_mod_path = str(
@@ -1663,7 +1886,11 @@ class ModListWidget(QListWidget):
                                         self.settings_controller.settings.current_instance
                                     ].local_folder
                                 )
-                                / (mod_name if mod_name else publishedfileid_from_folder_name)
+                                / (
+                                    mod_name
+                                    if mod_name
+                                    else publishedfileid_from_folder_name
+                                )
                             )
                         )
                         if os.path.exists(path):
@@ -1672,7 +1899,9 @@ class ModListWidget(QListWidget):
                                     logger.warning(
                                         "Destination exists. Removing all files except for .dds textures first..."
                                     )
-                                    delete_files_except_extension(directory=renamed_mod_path, extension=".dds")
+                                    delete_files_except_extension(
+                                        directory=renamed_mod_path, extension=".dds"
+                                    )
                                 try:
                                     copytree(path, renamed_mod_path)
                                 except FileExistsError:
@@ -1700,9 +1929,9 @@ class ModListWidget(QListWidget):
                     # Prompt user
                     answer = show_dialogue_conditional(
                         title=self.tr("Are you sure?"),
-                        text=self.tr("You have selected {len} mods for resubscribe:(unsubscribe + subscribe).").format(
-                            len=len(publishedfileids)
-                        ),
+                        text=self.tr(
+                            "You have selected {len} mods for resubscribe:(unsubscribe + subscribe)."
+                        ).format(len=len(publishedfileids)),
                         information=self.tr(
                             "\nThis operation will potentially delete .dds textures leftover. Steam is unreliable for this. Do you want to proceed?"
                         ),
@@ -1712,7 +1941,9 @@ class ModListWidget(QListWidget):
                             f"re-subscribing: (Unsubscribing + subscribing) to {len(publishedfileids)} mod(s)"
                         )
                         for path in steam_mod_paths:
-                            delete_files_except_extension(directory=path, extension=".dds")
+                            delete_files_except_extension(
+                                directory=path, extension=".dds"
+                            )
                         EventBus().do_steamworks_api_call.emit(
                             [
                                 "resubscribe",
@@ -1721,17 +1952,22 @@ class ModListWidget(QListWidget):
                         )
                     return True
                 elif (  # ACTION: Unsubscribe mod(s) with steam
-                    action == unsubscribe_mod_steam_action and len(steam_publishedfileid_to_name) > 0
+                    action == unsubscribe_mod_steam_action
+                    and len(steam_publishedfileid_to_name) > 0
                 ):
                     publishedfileids = steam_publishedfileid_to_name.keys()
                     # Prompt user
                     answer = show_dialogue_conditional(
                         title=self.tr("Are you sure?"),
-                        text=self.tr("You have selected {len} mods for unsubscribe.").format(len=len(publishedfileids)),
+                        text=self.tr(
+                            "You have selected {len} mods for unsubscribe."
+                        ).format(len=len(publishedfileids)),
                         information=self.tr("\nDo you want to proceed?"),
                     )
                     if answer == QMessageBox.StandardButton.Yes:
-                        logger.debug(f"Unsubscribing from {len(publishedfileids)} mod(s)")
+                        logger.debug(
+                            f"Unsubscribing from {len(publishedfileids)} mod(s)"
+                        )
                         EventBus().do_steamworks_api_call.emit(
                             [
                                 "unsubscribe",
@@ -1739,9 +1975,16 @@ class ModListWidget(QListWidget):
                             ]
                         )
                     return True
-                elif action == add_to_steamdb_blacklist_action:  # ACTION: Blacklist workshop mod in SteamDB
-                    if self.metadata_manager.external_steam_metadata is None or steamdb_add_blacklist is None:
-                        logger.error(f"Unable to add mod to SteamDB blacklist: {steamdb_remove_blacklist}")
+                elif (
+                    action == add_to_steamdb_blacklist_action
+                ):  # ACTION: Blacklist workshop mod in SteamDB
+                    if (
+                        self.metadata_manager.external_steam_metadata is None
+                        or steamdb_add_blacklist is None
+                    ):
+                        logger.error(
+                            f"Unable to add mod to SteamDB blacklist: {steamdb_remove_blacklist}"
+                        )
                         show_warning(
                             "Warning",
                             "Unable to add mod to SteamDB blacklist",
@@ -1753,11 +1996,15 @@ class ModListWidget(QListWidget):
                     args, ok = QInputDialog.getText(
                         self,
                         self.tr("Add comment"),
-                        self.tr("Enter a comment providing your reasoning for wanting to blacklist this mod: ")
+                        self.tr(
+                            "Enter a comment providing your reasoning for wanting to blacklist this mod: "
+                        )
                         + f"{self.metadata_manager.external_steam_metadata.get(steamdb_add_blacklist, {}).get('steamName', steamdb_add_blacklist)}",
                     )
                     if ok:
-                        self.steamdb_blacklist_signal.emit([steamdb_add_blacklist, True, args])
+                        self.steamdb_blacklist_signal.emit(
+                            [steamdb_add_blacklist, True, args]
+                        )
                     else:
                         show_warning(
                             title=self.tr("Unable to add to blacklist"),
@@ -1766,9 +2013,16 @@ class ModListWidget(QListWidget):
                             ),
                         )
                     return True
-                elif action == remove_from_steamdb_blacklist_action:  # ACTION: Blacklist workshop mod in SteamDB
-                    if self.metadata_manager.external_steam_metadata is None or steamdb_remove_blacklist is None:
-                        logger.error(f"Unable to remove mod from SteamDB blacklist: {steamdb_remove_blacklist}")
+                elif (
+                    action == remove_from_steamdb_blacklist_action
+                ):  # ACTION: Blacklist workshop mod in SteamDB
+                    if (
+                        self.metadata_manager.external_steam_metadata is None
+                        or steamdb_remove_blacklist is None
+                    ):
+                        logger.error(
+                            f"Unable to remove mod from SteamDB blacklist: {steamdb_remove_blacklist}"
+                        )
                         show_warning(
                             "Warning",
                             "Unable to remove mod from SteamDB blacklist",
@@ -1785,13 +2039,17 @@ class ModListWidget(QListWidget):
                         + "\nDo you want to proceed?",
                     )
                     if answer == QMessageBox.StandardButton.Yes:
-                        self.steamdb_blacklist_signal.emit([steamdb_remove_blacklist, False])
+                        self.steamdb_blacklist_signal.emit(
+                            [steamdb_remove_blacklist, False]
+                        )
                     return True
                 # If user is changing mod color, display color picker once no matter how many mods are selected
                 invalid_color = True
                 new_color = QColor()
                 if action == change_mod_color_action:
-                    color_dlg = QColorDialog(options=QColorDialog.ColorDialogOption.DontUseNativeDialog)
+                    color_dlg = QColorDialog(
+                        options=QColorDialog.ColorDialogOption.DontUseNativeDialog
+                    )
                     self.SetUserCustomColors(color_dlg)
                     new_color = color_dlg.getColor()
                     self.SaveUserCustomColors(color_dlg)
@@ -1805,7 +2063,9 @@ class ModListWidget(QListWidget):
                         item_data = source_item.data(Qt.ItemDataRole.UserRole)
                         uuid = all_selected_uuids[item_idx]
                         # Retrieve metadata
-                        mod_metadata = self.metadata_manager.internal_local_metadata[uuid]
+                        mod_metadata = self.metadata_manager.internal_local_metadata[
+                            uuid
+                        ]
                         mod_data_source = mod_metadata.get("data_source")
                         mod_path = mod_metadata["path"]
                         # Toggle warning action
@@ -1817,17 +2077,29 @@ class ModListWidget(QListWidget):
                                     self.toggle_warning(mod_metadata["packageid"], uuid)
                                 else:
                                     if not item_data["warning_toggled"]:
-                                        self.toggle_warning(mod_metadata["packageid"], uuid)
+                                        self.toggle_warning(
+                                            mod_metadata["packageid"], uuid
+                                        )
                             else:
                                 self.toggle_warning(mod_metadata["packageid"], uuid)
                         elif action == change_mod_color_action and not invalid_color:
-                            if len(selected_items) > 1 and item_idx == len(selected_items) - 1:
-                                self.change_all_mod_colors(list(all_selected_uuids.values()), new_color)
+                            if (
+                                len(selected_items) > 1
+                                and item_idx == len(selected_items) - 1
+                            ):
+                                self.change_all_mod_colors(
+                                    list(all_selected_uuids.values()), new_color
+                                )
                             elif len(selected_items) == 1:
                                 self.change_mod_color(uuid, new_color)
                         elif action == reset_mod_color_action:
-                            if len(selected_items) > 1 and item_idx == len(selected_items) - 1:
-                                self.reset_all_mod_colors(list(all_selected_uuids.values()))
+                            if (
+                                len(selected_items) > 1
+                                and item_idx == len(selected_items) - 1
+                            ):
+                                self.reset_all_mod_colors(
+                                    list(all_selected_uuids.values())
+                                )
                             elif len(selected_items) == 1:
                                 self.reset_mod_color(uuid)
                         # Open folder action
@@ -1835,17 +2107,26 @@ class ModListWidget(QListWidget):
                             if os.path.exists(mod_path):  # If the path actually exists
                                 logger.info(f"Opening folder: {mod_path}")
                                 platform_specific_open(mod_path)
-                        elif action == open_folder_text_editor_action:  # ACTION: Open folder in text editor
+                        elif (
+                            action == open_folder_text_editor_action
+                        ):  # ACTION: Open folder in text editor
                             if os.path.exists(mod_path):
-                                logger.info(f"Opening folder in text editor: {mod_path}")
+                                logger.info(
+                                    f"Opening folder in text editor: {mod_path}"
+                                )
                                 launch_process(
                                     self.settings_controller.settings.text_editor_location,
-                                    self.settings_controller.settings.text_editor_folder_arg.split(" ") + [mod_path],
+                                    self.settings_controller.settings.text_editor_folder_arg.split(
+                                        " "
+                                    )
+                                    + [mod_path],
                                     str(AppInfo().application_folder),
                                 )
 
                         # Open url action
-                        elif action == open_url_browser_action:  # ACTION: Open URL in browser
+                        elif (
+                            action == open_url_browser_action
+                        ):  # ACTION: Open URL in browser
                             if mod_metadata.get("url") or mod_metadata.get(
                                 "steam_url"
                             ):  # If we have some form of "url" to work with...
@@ -1855,25 +2136,42 @@ class ModListWidget(QListWidget):
                                     or mod_metadata.get("steamcmd")
                                     or mod_data_source == "workshop"
                                 ):
-                                    url = mod_metadata.get("steam_url", mod_metadata.get("url"))
-                                elif mod_data_source == "local" and not mod_metadata.get("steamcmd"):
-                                    url = mod_metadata.get("url", mod_metadata.get("steam_url"))
+                                    url = mod_metadata.get(
+                                        "steam_url", mod_metadata.get("url")
+                                    )
+                                elif (
+                                    mod_data_source == "local"
+                                    and not mod_metadata.get("steamcmd")
+                                ):
+                                    url = mod_metadata.get(
+                                        "url", mod_metadata.get("steam_url")
+                                    )
                                 if url:
                                     logger.info(f"Opening url in browser: {url}")
                                     open_url_browser(url)
                         # Open Steam URI with Steam action
-                        elif action == open_mod_steam_action:  # ACTION: Open steam:// uri in Steam
+                        elif (
+                            action == open_mod_steam_action
+                        ):  # ACTION: Open steam:// uri in Steam
                             if mod_metadata.get("steam_uri"):  # If we have steam_uri
                                 platform_specific_open(mod_metadata["steam_uri"])
                         # Find translation mods action
-                        elif action == find_translation_action:  # ACTION: Find translation mods
+                        elif (
+                            action == find_translation_action
+                        ):  # ACTION: Find translation mods
                             package_id = mod_metadata.get("packageid")
                             if package_id:
-                                self._find_and_open_translations(package_id, mod_metadata)
+                                self._find_and_open_translations(
+                                    package_id, mod_metadata
+                                )
                         # Copy to clipboard actions
-                        elif action == copy_packageid_to_clipboard_action:  # ACTION: Copy packageId to clipboard
+                        elif (
+                            action == copy_packageid_to_clipboard_action
+                        ):  # ACTION: Copy packageId to clipboard
                             copy_to_clipboard_safely(mod_metadata["packageid"])
-                        elif action == copy_url_to_clipboard_action:  # ACTION: Copy URL to clipboard
+                        elif (
+                            action == copy_url_to_clipboard_action
+                        ):  # ACTION: Copy URL to clipboard
                             if mod_metadata.get("url") or mod_metadata.get(
                                 "steam_url"
                             ):  # If we have some form of "url" to work with...
@@ -1883,14 +2181,23 @@ class ModListWidget(QListWidget):
                                     or mod_metadata.get("steamcmd")
                                     or mod_data_source == "workshop"
                                 ):
-                                    url = mod_metadata.get("steam_url", mod_metadata.get("url"))
-                                elif mod_data_source == "local" and not mod_metadata.get("steamcmd"):
-                                    url = mod_metadata.get("url", mod_metadata.get("steam_url"))
+                                    url = mod_metadata.get(
+                                        "steam_url", mod_metadata.get("url")
+                                    )
+                                elif (
+                                    mod_data_source == "local"
+                                    and not mod_metadata.get("steamcmd")
+                                ):
+                                    url = mod_metadata.get(
+                                        "url", mod_metadata.get("steam_url")
+                                    )
                                 if url:
                                     copy_to_clipboard_safely(url)
                         # Edit mod rules action
                         elif action == edit_mod_rules_action:
-                            self.edit_rules_signal.emit(True, "user_rules", mod_metadata["packageid"])
+                            self.edit_rules_signal.emit(
+                                True, "user_rules", mod_metadata["packageid"]
+                            )
             return True
         return super().eventFilter(object, event)
 
@@ -1915,11 +2222,19 @@ class ModListWidget(QListWidget):
                     menu.addAction(action)
                 self.deletion_sub_menu._refresh_actions()
                 menu.exec_(QCursor.pos())
-        elif event.modifiers() & Qt.KeyboardModifier.ControlModifier and event.key() == Qt.Key.Key_Return:
+        elif (
+            event.modifiers() & Qt.KeyboardModifier.ControlModifier
+            and event.key() == Qt.Key.Key_Return
+        ):
             self.key_press_signal.emit("Ctrl+Return")
         else:
             key_pressed = QKeySequence(event.key()).toString()
-            if key_pressed == "Left" or key_pressed == "Right" or key_pressed == "Return" or key_pressed == "Space":
+            if (
+                key_pressed == "Left"
+                or key_pressed == "Right"
+                or key_pressed == "Return"
+                or key_pressed == "Space"
+            ):
                 self.key_press_signal.emit(key_pressed)
             else:
                 return super().keyPressEvent(event)
@@ -1968,7 +2283,9 @@ class ModListWidget(QListWidget):
         )
         with aux_metadata_controller.Session() as aux_metadata_session:
             aux_metadata_controller.get_or_create(aux_metadata_session, mod_path)
-            aux_metadata_controller.update(aux_metadata_session, mod_path, outdated=False)
+            aux_metadata_controller.update(
+                aux_metadata_session, mod_path, outdated=False
+            )
             data = CustomListWidgetItemMetadata(
                 uuid=uuid,
                 list_type=self.list_type,
@@ -2080,7 +2397,9 @@ class ModListWidget(QListWidget):
 
             # Apply translation status if enabled
             if self.show_translation_status:
-                pkg_id = self.metadata_manager.internal_local_metadata[uuid].get("packageid")
+                pkg_id = self.metadata_manager.internal_local_metadata[uuid].get(
+                    "packageid"
+                )
                 has_translation = pkg_id in self.translation_lookup
                 widget.update_translation_status(has_translation)
 
@@ -2196,7 +2515,9 @@ class ModListWidget(QListWidget):
         # Update list signal if all items are loaded
         if len(self.uuids) == self.count():
             # Update list with the number of items
-            logger.debug(f"Emitting {self.list_type} list update signal after rows inserted [{self.count()}]")
+            logger.debug(
+                f"Emitting {self.list_type} list update signal after rows inserted [{self.count()}]"
+            )
             self.list_update_signal.emit(str(self.count()))
 
     def handle_rows_removed(self, parent: QModelIndex, first: int, last: int) -> None:
@@ -2219,7 +2540,9 @@ class ModListWidget(QListWidget):
         # Update list signal if all items are loaded
         if len(self.uuids) == self.count():
             # Update list with the number of items
-            logger.debug(f"Emitting {self.list_type} list update signal after rows removed [{self.count()}]")
+            logger.debug(
+                f"Emitting {self.list_type} list update signal after rows removed [{self.count()}]"
+            )
             self.list_update_signal.emit(str(self.count()))
 
     def get_item_widget_at_index(self, idx: int) -> QWidget | None:
@@ -2228,7 +2551,9 @@ class ModListWidget(QListWidget):
             return self.itemWidget(item)
         return None
 
-    def mod_changed_to(self, current: CustomListWidgetItem, previous: CustomListWidgetItem) -> None:
+    def mod_changed_to(
+        self, current: CustomListWidgetItem, previous: CustomListWidgetItem
+    ) -> None:
         """
         Method to handle clicking on a row or navigating between rows with
         the keyboard. Look up the mod's data by uuid
@@ -2251,7 +2576,9 @@ class ModListWidget(QListWidget):
             mod_info = self.metadata_manager.internal_local_metadata[data["uuid"]]
             mod_info = flatten_to_list(mod_info)
             mod_info_pretty = json.dumps(mod_info, indent=4)
-            logger.debug(f"USER ACTION: mod was clicked: [{data['uuid']}] {mod_info_pretty}")
+            logger.debug(
+                f"USER ACTION: mod was clicked: [{data['uuid']}] {mod_info_pretty}"
+            )
 
     def mod_double_clicked(self, item: CustomListWidgetItem) -> None:
         """
@@ -2281,9 +2608,7 @@ class ModListWidget(QListWidget):
         """Check for missing dependencies and alternative dependencies."""
         missing_deps: set[str] = set()
         alternative_deps: set[str] = set()
-        consider_alternatives = (
-            self.metadata_manager.settings_controller.settings.use_alternative_package_ids_as_satisfying_dependencies
-        )
+        consider_alternatives = self.metadata_manager.settings_controller.settings.use_alternative_package_ids_as_satisfying_dependencies
         for dep_entry in mod_data.get("dependencies", []):
             alt_ids: set[str] = set()
             if isinstance(dep_entry, tuple):
@@ -2300,19 +2625,29 @@ class ModListWidget(QListWidget):
             satisfied = dep_id in package_ids_set
             if not satisfied and consider_alternatives:
                 satisfied = any(alt in package_ids_set for alt in alt_ids)
-            if not satisfied and self._has_replacement(mod_data["packageid"], dep_id, package_ids_set):
+            if not satisfied and self._has_replacement(
+                mod_data["packageid"], dep_id, package_ids_set
+            ):
                 satisfied = True
 
             if not satisfied:
                 missing_deps.add(dep_id)
                 if consider_alternatives:
                     alt_candidates = {a for a in alt_ids if a not in package_ids_set}
-                    alternative_deps.update(alt_candidates if alt_candidates else alt_ids)
+                    alternative_deps.update(
+                        alt_candidates if alt_candidates else alt_ids
+                    )
         return missing_deps, alternative_deps
 
-    def _check_incompatibilities(self, mod_data: ModMetadata, package_ids_set: set[str]) -> set[str]:
+    def _check_incompatibilities(
+        self, mod_data: ModMetadata, package_ids_set: set[str]
+    ) -> set[str]:
         """Check for conflicting incompatibilities."""
-        return {incomp for incomp in mod_data.get("incompatibilities", []) if incomp in package_ids_set}
+        return {
+            incomp
+            for incomp in mod_data.get("incompatibilities", [])
+            if incomp in package_ids_set
+        }
 
     def _check_load_order_violations(
         self,
@@ -2327,14 +2662,16 @@ class ModListWidget(QListWidget):
             if (
                 load_this_before[1]
                 and load_this_before[0] in packageid_to_uuid
-                and current_mod_index <= self.uuids.index(packageid_to_uuid[load_this_before[0]])
+                and current_mod_index
+                <= self.uuids.index(packageid_to_uuid[load_this_before[0]])
             ):
                 load_before_violations.add(load_this_before[0])
         for load_this_after in mod_data.get("loadTheseAfter", []):
             if (
                 load_this_after[1]
                 and load_this_after[0] in packageid_to_uuid
-                and current_mod_index >= self.uuids.index(packageid_to_uuid[load_this_after[0]])
+                and current_mod_index
+                >= self.uuids.index(packageid_to_uuid[load_this_after[0]])
             ):
                 load_after_violations.add(load_this_after[0])
         return load_before_violations, load_after_violations
@@ -2357,19 +2694,26 @@ class ModListWidget(QListWidget):
 
         internal_local_metadata = self.metadata_manager.internal_local_metadata
 
-        packageid_to_uuid = {internal_local_metadata[uuid]["packageid"]: uuid for uuid in self.uuids}
+        packageid_to_uuid = {
+            internal_local_metadata[uuid]["packageid"]: uuid for uuid in self.uuids
+        }
         package_ids_set = set(packageid_to_uuid.keys())
 
         package_id_to_errors: dict[str, dict[str, None | set[str] | bool]] = {
             uuid: {
                 "missing_dependencies": set() if self.list_type == "Active" else None,
-                "alternative_dependencies": set() if self.list_type == "Active" else None,
-                "conflicting_incompatibilities": (set() if self.list_type == "Active" else None),
+                "alternative_dependencies": set()
+                if self.list_type == "Active"
+                else None,
+                "conflicting_incompatibilities": (
+                    set() if self.list_type == "Active" else None
+                ),
                 "load_before_violations": set() if self.list_type == "Active" else None,
                 "load_after_violations": set() if self.list_type == "Active" else None,
                 "version_mismatch": True,
                 "use_this_instead": set()
-                if self.settings_controller.settings.external_use_this_instead_metadata_source != "None"
+                if self.settings_controller.settings.external_use_this_instead_metadata_source
+                != "None"
                 else None,
             }
             for uuid in self.uuids
@@ -2381,7 +2725,9 @@ class ModListWidget(QListWidget):
         total_error_text = ""
 
         # Load latest save package ids once for this run, only if feature enabled
-        save_compare_enabled: bool = self.settings_controller.settings.show_save_comparison_indicators
+        save_compare_enabled: bool = (
+            self.settings_controller.settings.show_save_comparison_indicators
+        )
         if save_compare_enabled:
             latest_save_ids = self._get_latest_save_package_ids()
         else:
@@ -2400,7 +2746,11 @@ class ModListWidget(QListWidget):
             if save_compare_enabled:
                 try:
                     pkg_id = internal_local_metadata[uuid]["packageid"]
-                    is_in_save = pkg_id in latest_save_ids if latest_save_ids is not None else False
+                    is_in_save = (
+                        pkg_id in latest_save_ids
+                        if latest_save_ids is not None
+                        else False
+                    )
                     if self.list_type == "Active":
                         current_item_data.__dict__["is_new"] = not is_in_save
                         current_item_data.__dict__["in_save"] = False
@@ -2417,7 +2767,10 @@ class ModListWidget(QListWidget):
             # Check mod supportedversions against currently loaded version of game
             mod_errors["version_mismatch"] = self._check_version_mismatch(uuid)
             # Set an item's validity dynamically based on the version mismatch value
-            if mod_data["packageid"] not in self.ignore_warning_list and not current_item_data["warning_toggled"]:
+            if (
+                mod_data["packageid"] not in self.ignore_warning_list
+                and not current_item_data["warning_toggled"]
+            ):
                 current_item_data["mismatch"] = mod_errors["version_mismatch"]
             else:
                 # If a mod has been moved for eg. inactive -> active. We keep ignoring the warnings.
@@ -2440,11 +2793,15 @@ class ModListWidget(QListWidget):
                     mod_errors["missing_dependencies"],
                     mod_errors["alternative_dependencies"],
                 ) = self._check_missing_dependencies(mod_data, package_ids_set)
-                mod_errors["conflicting_incompatibilities"] = self._check_incompatibilities(mod_data, package_ids_set)
+                mod_errors["conflicting_incompatibilities"] = (
+                    self._check_incompatibilities(mod_data, package_ids_set)
+                )
                 (
                     mod_errors["load_before_violations"],
                     mod_errors["load_after_violations"],
-                ) = self._check_load_order_violations(mod_data, packageid_to_uuid, current_mod_index)
+                ) = self._check_load_order_violations(
+                    mod_data, packageid_to_uuid, current_mod_index
+                )
             # Calculate any needed string for errors
             tool_tip_text = ""
             # Build tooltip sections, conditionally include alternatives
@@ -2467,9 +2824,13 @@ class ModListWidget(QListWidget):
                     errors = mod_errors[error_type]
                     assert isinstance(errors, set)
                     for key in errors:
-                        name = internal_local_metadata.get(packageid_to_uuid.get(key, ""), {}).get(
+                        name = internal_local_metadata.get(
+                            packageid_to_uuid.get(key, ""), {}
+                        ).get(
                             "name",
-                            self.metadata_manager.steamdb_packageid_to_name.get(key, key),
+                            self.metadata_manager.steamdb_packageid_to_name.get(
+                                key, key
+                            ),
                         )
                         tool_tip_text += f"\n  * {name}"
             # If missing dependency and/or incompatibility, add tooltip to errors
@@ -2484,13 +2845,20 @@ class ModListWidget(QListWidget):
                     errors = mod_errors[error_type]
                     assert isinstance(errors, set)
                     for key in errors:
-                        name = internal_local_metadata.get(packageid_to_uuid.get(key, ""), {}).get(
+                        name = internal_local_metadata.get(
+                            packageid_to_uuid.get(key, ""), {}
+                        ).get(
                             "name",
-                            self.metadata_manager.steamdb_packageid_to_name.get(key, key),
+                            self.metadata_manager.steamdb_packageid_to_name.get(
+                                key, key
+                            ),
                         )
                         tool_tip_text += f"\n  * {name}"
             # Handle version mismatch behavior
-            if mod_errors["version_mismatch"] and mod_data["packageid"] not in self.ignore_warning_list:
+            if (
+                mod_errors["version_mismatch"]
+                and mod_data["packageid"] not in self.ignore_warning_list
+            ):
                 # Add tool tip to indicate mod and game version mismatch
                 tool_tip_text += self.tr("\nMod and Game Version Mismatch")
             # Handle "use this instead" behavior
@@ -2499,9 +2867,9 @@ class ModListWidget(QListWidget):
                 and mod_data["packageid"] not in self.ignore_warning_list
             ):
                 mod_errors["use_this_instead"] = True
-                tool_tip_text += self.tr("\nAn alternative updated mod is recommended:\n{alternative}").format(
-                    alternative=current_item_data["alternative"]
-                )
+                tool_tip_text += self.tr(
+                    "\nAn alternative updated mod is recommended:\n{alternative}"
+                ).format(alternative=current_item_data["alternative"])
             # Add to error summary if any missing dependencies or incompatibilities
             if self.list_type == "Active" and any(
                 [
@@ -2541,7 +2909,9 @@ class ModListWidget(QListWidget):
                 total_warning_text += tool_tip_text
             # Add tooltip to item data and set the data back to the item
             current_item_data["errors_warnings"] = tool_tip_text.strip()
-            current_item_data["warnings"] = tool_tip_text[len(current_item_data["errors"]) :].strip()
+            current_item_data["warnings"] = tool_tip_text[
+                len(current_item_data["errors"]) :
+            ].strip()
             current_item_data["errors"] = current_item_data["errors"].strip()
             current_item.setData(Qt.ItemDataRole.UserRole, current_item_data)
         logger.info(f"Finished recalculating {self.list_type} list errors and warnings")
@@ -2596,14 +2966,18 @@ class ModListWidget(QListWidget):
         except Exception:
             return None
 
-    def _has_replacement(self, package_id: str, dep: str, package_ids_set: set[str]) -> bool:
+    def _has_replacement(
+        self, package_id: str, dep: str, package_ids_set: set[str]
+    ) -> bool:
         # Get a list of mods that can replace this mod
         replacements = KNOWN_MOD_REPLACEMENTS.get(dep, set())
         # Return true if any of the above mods (replacements) are in the mod list
         # If no replacements exist for dep, returns false
         for replacement in replacements:
             if replacement in package_ids_set:
-                logger.debug(f"Missing dependency [{dep}] for [{package_id}] replaced with [{replacement}]")
+                logger.debug(
+                    f"Missing dependency [{dep}] for [{package_id}] replaced with [{replacement}]"
+                )
                 return True
         return False
 
@@ -2643,7 +3017,9 @@ class ModListWidget(QListWidget):
         else:
             self.recreate_mod_list(list_type, uuids)
 
-    def recreate_mod_list(self, list_type: str, uuids: list[str], filtering: bool = False) -> None:
+    def recreate_mod_list(
+        self, list_type: str, uuids: list[str], filtering: bool = False
+    ) -> None:
         """
         Clear all mod items and add new ones from a dict.
 
@@ -2659,8 +3035,12 @@ class ModListWidget(QListWidget):
                 and self.settings_controller.settings.save_inactive_mods_sort_state
                 and self.settings_controller.settings.inactive_mods_sorting
             ):
-                sort_key = ModsPanelSortKey[self.settings_controller.settings.inactive_mods_sort_key]
-                descending = self.settings_controller.settings.inactive_mods_sort_descending
+                sort_key = ModsPanelSortKey[
+                    self.settings_controller.settings.inactive_mods_sort_key
+                ]
+                descending = (
+                    self.settings_controller.settings.inactive_mods_sort_descending
+                )
                 uuids = sort_uuids(
                     uuids,
                     key=sort_key,
@@ -2691,13 +3071,21 @@ class ModListWidget(QListWidget):
         self.uuids = list()
         if uuids:  # Insert data...
             for uuid_key in uuids:
-                mod_path = self.metadata_manager.internal_local_metadata[uuid_key]["path"]
-                aux_metadata_controller = AuxMetadataController.get_or_create_cached_instance(
-                    self.settings_controller.settings.aux_db_path
+                mod_path = self.metadata_manager.internal_local_metadata[uuid_key][
+                    "path"
+                ]
+                aux_metadata_controller = (
+                    AuxMetadataController.get_or_create_cached_instance(
+                        self.settings_controller.settings.aux_db_path
+                    )
                 )
                 with aux_metadata_controller.Session() as aux_metadata_session:
-                    aux_metadata_controller.get_or_create(aux_metadata_session, mod_path)
-                    aux_metadata_controller.update(aux_metadata_session, mod_path, outdated=False)
+                    aux_metadata_controller.get_or_create(
+                        aux_metadata_session, mod_path
+                    )
+                    aux_metadata_controller.update(
+                        aux_metadata_session, mod_path, outdated=False
+                    )
                     list_item = CustomListWidgetItem(self)
                     data = CustomListWidgetItemMetadata(
                         uuid=uuid_key,
@@ -2715,13 +3103,21 @@ class ModListWidget(QListWidget):
         else:  # ...unless we don't have mods, at which point reenable updates and exit
             self.setUpdatesEnabled(True)
             # Reconnect model signals
-            self.model().rowsInserted.connect(self.handle_rows_inserted, Qt.ConnectionType.QueuedConnection)
-            self.model().rowsAboutToBeRemoved.connect(self.handle_rows_removed, Qt.ConnectionType.QueuedConnection)
+            self.model().rowsInserted.connect(
+                self.handle_rows_inserted, Qt.ConnectionType.QueuedConnection
+            )
+            self.model().rowsAboutToBeRemoved.connect(
+                self.handle_rows_removed, Qt.ConnectionType.QueuedConnection
+            )
             return
 
         # Reconnect model signals
-        self.model().rowsInserted.connect(self.handle_rows_inserted, Qt.ConnectionType.QueuedConnection)
-        self.model().rowsAboutToBeRemoved.connect(self.handle_rows_removed, Qt.ConnectionType.QueuedConnection)
+        self.model().rowsInserted.connect(
+            self.handle_rows_inserted, Qt.ConnectionType.QueuedConnection
+        )
+        self.model().rowsAboutToBeRemoved.connect(
+            self.handle_rows_removed, Qt.ConnectionType.QueuedConnection
+        )
         # Enable updates and repaint
         self.setUpdatesEnabled(True)
         self.repaint()
@@ -2747,7 +3143,9 @@ class ModListWidget(QListWidget):
         )
         uuid = item_data["uuid"]
         if not uuid:
-            logger.error("Unable to retrieve uuid when saving toggle_warning to Aux DB.")
+            logger.error(
+                "Unable to retrieve uuid when saving toggle_warning to Aux DB."
+            )
             return
         with aux_metadata_controller.Session() as aux_metadata_session:
             mod_path = self.metadata_manager.internal_local_metadata[uuid]["path"]
@@ -2829,8 +3227,12 @@ class ModListWidget(QListWidget):
             pass
 
         # Reconnect to ALL slots
-        self.model().rowsInserted.connect(self.handle_rows_inserted, Qt.ConnectionType.QueuedConnection)
-        self.model().rowsAboutToBeRemoved.connect(self.handle_rows_removed, Qt.ConnectionType.QueuedConnection)
+        self.model().rowsInserted.connect(
+            self.handle_rows_inserted, Qt.ConnectionType.QueuedConnection
+        )
+        self.model().rowsAboutToBeRemoved.connect(
+            self.handle_rows_removed, Qt.ConnectionType.QueuedConnection
+        )
 
 
 class ModsPanel(QWidget):
@@ -2861,8 +3263,12 @@ class ModsPanel(QWidget):
 
         Restores the saved sort key and direction to the UI combobox and button.
         """
-        self.inactive_mods_sort_key = self.settings_controller.settings.inactive_mods_sort_key
-        self.inactive_mods_sort_descending = self.settings_controller.settings.inactive_mods_sort_descending
+        self.inactive_mods_sort_key = (
+            self.settings_controller.settings.inactive_mods_sort_key
+        )
+        self.inactive_mods_sort_descending = (
+            self.settings_controller.settings.inactive_mods_sort_descending
+        )
         # Map enum names to translated text for setting combo box selection
         key_to_text = {
             "MODNAME": self.tr("Name"),
@@ -2900,8 +3306,12 @@ class ModsPanel(QWidget):
             self.settings_controller.settings.inactive_mods_sorting
             and self.settings_controller.settings.save_inactive_mods_sort_state
         ):
-            self.inactive_mods_sort_key = self.settings_controller.settings.inactive_mods_sort_key
-            self.inactive_mods_sort_descending = self.settings_controller.settings.inactive_mods_sort_descending
+            self.inactive_mods_sort_key = (
+                self.settings_controller.settings.inactive_mods_sort_key
+            )
+            self.inactive_mods_sort_descending = (
+                self.settings_controller.settings.inactive_mods_sort_descending
+            )
         else:
             self.inactive_mods_sort_key = "FILESYSTEM_MODIFIED_TIME"
             self.inactive_mods_sort_descending = True
@@ -2916,7 +3326,9 @@ class ModsPanel(QWidget):
         self._sort_debounce_timer = QTimer()
         self._sort_debounce_timer.setSingleShot(True)
         self._sort_debounce_timer.timeout.connect(self._execute_pending_sort)
-        self._pending_sort_params: Optional[tuple[str, list[str], ModsPanelSortKey, bool]] = None
+        self._pending_sort_params: Optional[
+            tuple[str, list[str], ModsPanelSortKey, bool]
+        ] = None
 
         # Base layout with a splitter for resizable mod lists
         self.panel = QVBoxLayout()
@@ -2942,16 +3354,24 @@ class ModsPanel(QWidget):
         self.button_panel_frame.setObjectName("MainWindowButtons")
 
         # Create and add Use This Instead button
-        self.use_this_instead_button = QPushButton(self.tr('Check "Use This Instead" Database'))
+        self.use_this_instead_button = QPushButton(
+            self.tr('Check "Use This Instead" Database')
+        )
         self.use_this_instead_button.setObjectName("UseThisInsteadButton")
-        self.use_this_instead_button.clicked.connect(EventBus().use_this_instead_clicked.emit)
+        self.use_this_instead_button.clicked.connect(
+            EventBus().use_this_instead_clicked.emit
+        )
         self.button_panel.addWidget(self.use_this_instead_button)
 
         # Create and add Check Dependencies button
-        self.check_dependencies_button: QPushButton = QPushButton(self.tr("Check Dependencies"))
+        self.check_dependencies_button: QPushButton = QPushButton(
+            self.tr("Check Dependencies")
+        )
         self.check_dependencies_button.setObjectName("CheckDependenciesButton")
         self.button_panel.addWidget(self.check_dependencies_button)
-        self.check_dependencies_button.clicked.connect(self.check_dependencies_signal.emit)
+        self.check_dependencies_button.clicked.connect(
+            self.check_dependencies_signal.emit
+        )
         self.button_panel_frame.setLayout(self.button_panel)
 
         # Add the buttons frame below the lists panel
@@ -2985,9 +3405,13 @@ class ModsPanel(QWidget):
             self.tr("Showing XML Mods"),
         ]
 
-        self.mode_filter_icon = QIcon(str(AppInfo().theme_data_folder / "default-icons" / "filter.png"))
+        self.mode_filter_icon = QIcon(
+            str(AppInfo().theme_data_folder / "default-icons" / "filter.png")
+        )
         self.mode_filter_tooltip = self.tr("Hide Filter Disabled")
-        self.mode_nofilter_icon = QIcon(str(AppInfo().theme_data_folder / "default-icons" / "nofilter.png"))
+        self.mode_nofilter_icon = QIcon(
+            str(AppInfo().theme_data_folder / "default-icons" / "nofilter.png")
+        )
         self.mode_nofilter_tooltip = self.tr("Hide Filter Enabled")
 
         # ACTIVE mod list widget
@@ -3052,35 +3476,49 @@ class ModsPanel(QWidget):
         self.active_mods_filter_data_source_button.setToolTip(
             self.data_source_filter_tooltips[self.active_mods_filter_data_source_index]
         )
-        self.active_mods_filter_data_source_button.clicked.connect(self.on_active_mods_search_data_source_filter)
+        self.active_mods_filter_data_source_button.clicked.connect(
+            self.on_active_mods_search_data_source_filter
+        )
         self.active_data_source_filter_type_index = 0
         self.active_mods_data_source_filter_type = SEARCH_DATA_SOURCE_FILTER_INDEXES[
             self.active_data_source_filter_type_index
         ]
         self.active_data_source_filter_type_button = QToolButton()
         self.active_data_source_filter_type_button.setIcon(
-            self.data_source_filter_type_icons[self.active_data_source_filter_type_index]
+            self.data_source_filter_type_icons[
+                self.active_data_source_filter_type_index
+            ]
         )
         self.active_data_source_filter_type_button.setToolTip(
-            self.data_source_filter_type_tooltips[self.active_data_source_filter_type_index]
+            self.data_source_filter_type_tooltips[
+                self.active_data_source_filter_type_index
+            ]
         )
-        self.active_data_source_filter_type_button.clicked.connect(self.on_active_mods_search_data_source_filter_type)
+        self.active_data_source_filter_type_button.clicked.connect(
+            self.on_active_mods_search_data_source_filter_type
+        )
         self.active_mods_search_filter_state = True
         self.active_mods_search_mode_filter_button = QToolButton()
         self.active_mods_search_mode_filter_button.setIcon(self.mode_filter_icon)
         self.active_mods_search_mode_filter_button.setToolTip(self.mode_filter_tooltip)
-        self.active_mods_search_mode_filter_button.clicked.connect(self.on_active_mods_mode_filter_toggle)
+        self.active_mods_search_mode_filter_button.clicked.connect(
+            self.on_active_mods_mode_filter_toggle
+        )
         self.active_mods_search = QLineEdit()
         self.active_mods_search.setClearButtonEnabled(True)
         self.active_mods_search.textChanged.connect(self.on_active_mods_search)
         self.active_mods_search.inputRejected.connect(self.on_active_mods_search_clear)
         self.active_mods_search.setPlaceholderText(self.tr("Search by..."))
         # Add explicit type annotation to help mypy
-        self.active_mods_search_clear_button = cast(QToolButton, self.active_mods_search.findChild(QToolButton))
+        self.active_mods_search_clear_button = cast(
+            QToolButton, self.active_mods_search.findChild(QToolButton)
+        )
         if not isinstance(self.active_mods_search_clear_button, QToolButton):
             raise TypeError("Could not find QToolButton in QLineEdit")
         self.active_mods_search_clear_button.setEnabled(True)
-        self.active_mods_search_clear_button.clicked.connect(self.on_active_mods_search_clear)
+        self.active_mods_search_clear_button.clicked.connect(
+            self.on_active_mods_search_clear
+        )
         self.active_mods_search_filter: QComboBox = QComboBox()
         self.active_mods_search_filter.setObjectName("MainUI")
         self.active_mods_search_filter.setMaximumWidth(125)
@@ -3095,10 +3533,16 @@ class ModsPanel(QWidget):
             ]
         )
         # Active mods search layouts
-        self.active_mods_search_layout.addWidget(self.active_mods_filter_data_source_button)
+        self.active_mods_search_layout.addWidget(
+            self.active_mods_filter_data_source_button
+        )
         if self.settings_controller.settings.mod_type_filter:
-            self.active_mods_search_layout.addWidget(self.active_data_source_filter_type_button)
-        self.active_mods_search_layout.addWidget(self.active_mods_search_mode_filter_button)
+            self.active_mods_search_layout.addWidget(
+                self.active_data_source_filter_type_button
+            )
+        self.active_mods_search_layout.addWidget(
+            self.active_mods_search_mode_filter_button
+        )
         self.active_mods_search_layout.addWidget(self.active_mods_search, 45)
         self.active_mods_search_layout.addWidget(self.active_mods_search_filter, 70)
         # Active mods list Errors/warnings widgets
@@ -3112,7 +3556,9 @@ class ModsPanel(QWidget):
         self.warnings_errors_layout.setSpacing(2)
         self.warnings_icon: QLabel = QLabel()
         self.warnings_icon.setPixmap(ModListIcons.warning_icon().pixmap(QSize(20, 20)))
-        self.warnings_text: AdvancedClickableQLabel = AdvancedClickableQLabel(self.tr("0 warnings"))
+        self.warnings_text: AdvancedClickableQLabel = AdvancedClickableQLabel(
+            self.tr("0 warnings")
+        )
         self.warnings_text.setObjectName("summaryValue")
         self.warnings_text.setToolTip(self.tr("Click to only show mods with warnings"))
         self.errors_icon: QLabel = QLabel()
@@ -3139,11 +3585,17 @@ class ModsPanel(QWidget):
         self.news_layout = QHBoxLayout()
         self.new_icon: QLabel = QLabel()
         self.new_icon.setPixmap(
-            QIcon(str(AppInfo().theme_data_folder / "default-icons" / "new.png")).pixmap(QSize(20, 20))
+            QIcon(
+                str(AppInfo().theme_data_folder / "default-icons" / "new.png")
+            ).pixmap(QSize(20, 20))
         )
-        self.new_text: AdvancedClickableQLabel = AdvancedClickableQLabel(self.tr("0 new"))
+        self.new_text: AdvancedClickableQLabel = AdvancedClickableQLabel(
+            self.tr("0 new")
+        )
         self.new_text.setObjectName("summaryValue")
-        self.new_text.setToolTip(self.tr("Click to only show active mods not in latest save"))
+        self.new_text.setToolTip(
+            self.tr("Click to only show active mods not in latest save")
+        )
         self.news_layout.addWidget(self.new_icon, 1)
         self.news_layout.addWidget(self.new_text, 99)
         self.warnings_errors_layout.addLayout(self.news_layout, 50)
@@ -3159,19 +3611,27 @@ class ModsPanel(QWidget):
             self.data_source_filter_icons[self.inactive_mods_filter_data_source_index]
         )
         self.inactive_mods_filter_data_source_button.setToolTip(
-            self.data_source_filter_tooltips[self.inactive_mods_filter_data_source_index]
+            self.data_source_filter_tooltips[
+                self.inactive_mods_filter_data_source_index
+            ]
         )
-        self.inactive_mods_filter_data_source_button.clicked.connect(self.on_inactive_mods_search_data_source_filter)
+        self.inactive_mods_filter_data_source_button.clicked.connect(
+            self.on_inactive_mods_search_data_source_filter
+        )
         self.inactive_data_source_filter_type_index = 0
         self.inactive_mods_data_source_filter_type = SEARCH_DATA_SOURCE_FILTER_INDEXES[
             self.inactive_data_source_filter_type_index
         ]
         self.inactive_data_source_filter_type_button = QToolButton()
         self.inactive_data_source_filter_type_button.setIcon(
-            self.data_source_filter_type_icons[self.inactive_data_source_filter_type_index]
+            self.data_source_filter_type_icons[
+                self.inactive_data_source_filter_type_index
+            ]
         )
         self.inactive_data_source_filter_type_button.setToolTip(
-            self.data_source_filter_type_tooltips[self.inactive_data_source_filter_type_index]
+            self.data_source_filter_type_tooltips[
+                self.inactive_data_source_filter_type_index
+            ]
         )
         self.inactive_data_source_filter_type_button.clicked.connect(
             self.on_inactive_mods_search_data_source_filter_type
@@ -3179,19 +3639,29 @@ class ModsPanel(QWidget):
         self.inactive_mods_search_filter_state = True
         self.inactive_mods_search_mode_filter_button = QToolButton()
         self.inactive_mods_search_mode_filter_button.setIcon(self.mode_filter_icon)
-        self.inactive_mods_search_mode_filter_button.setToolTip(self.mode_filter_tooltip)
-        self.inactive_mods_search_mode_filter_button.clicked.connect(self.on_inactive_mods_mode_filter_toggle)
+        self.inactive_mods_search_mode_filter_button.setToolTip(
+            self.mode_filter_tooltip
+        )
+        self.inactive_mods_search_mode_filter_button.clicked.connect(
+            self.on_inactive_mods_mode_filter_toggle
+        )
         self.inactive_mods_search = QLineEdit()
         self.inactive_mods_search.setClearButtonEnabled(True)
         self.inactive_mods_search.textChanged.connect(self.on_inactive_mods_search)
-        self.inactive_mods_search.inputRejected.connect(self.on_inactive_mods_search_clear)
+        self.inactive_mods_search.inputRejected.connect(
+            self.on_inactive_mods_search_clear
+        )
         self.inactive_mods_search.setPlaceholderText(self.tr("Search by..."))
         # Add explicit type annotation to help mypy
-        self.inactive_mods_search_clear_button = cast(QToolButton, self.inactive_mods_search.findChild(QToolButton))
+        self.inactive_mods_search_clear_button = cast(
+            QToolButton, self.inactive_mods_search.findChild(QToolButton)
+        )
         if not isinstance(self.inactive_mods_search_clear_button, QToolButton):
             raise TypeError("Could not find QToolButton in QLineEdit")
         self.inactive_mods_search_clear_button.setEnabled(True)
-        self.inactive_mods_search_clear_button.clicked.connect(self.on_inactive_mods_search_clear)
+        self.inactive_mods_search_clear_button.clicked.connect(
+            self.on_inactive_mods_search_clear
+        )
         self.inactive_mods_search_filter: QComboBox = QComboBox()
         self.inactive_mods_search_filter.setParent(self)
         self.inactive_mods_search_filter.setObjectName("MainUI")
@@ -3246,13 +3716,21 @@ class ModsPanel(QWidget):
         self.inactive_mods_sort_order_button.setText(
             self.tr("Desc") if self.inactive_mods_sort_descending else self.tr("Asc")
         )
-        self.inactive_mods_search_layout.addWidget(self.inactive_mods_filter_data_source_button)
+        self.inactive_mods_search_layout.addWidget(
+            self.inactive_mods_filter_data_source_button
+        )
         if self.settings_controller.settings.mod_type_filter:
-            self.inactive_mods_search_layout.addWidget(self.inactive_data_source_filter_type_button)
-        self.inactive_mods_search_layout.addWidget(self.inactive_mods_search_mode_filter_button)
+            self.inactive_mods_search_layout.addWidget(
+                self.inactive_data_source_filter_type_button
+            )
+        self.inactive_mods_search_layout.addWidget(
+            self.inactive_mods_search_mode_filter_button
+        )
         self.inactive_mods_search_layout.addWidget(self.inactive_mods_search, 45)
         self.inactive_mods_search_layout.addWidget(self.inactive_mods_search_filter, 70)
-        self.inactive_mods_search_layout.addWidget(self.inactive_mods_sort_combobox, 120)
+        self.inactive_mods_search_layout.addWidget(
+            self.inactive_mods_sort_combobox, 120
+        )
         self.inactive_mods_search_layout.addWidget(self.inactive_mods_sort_order_button)
 
         # Set initial visibility based on settings
@@ -3269,16 +3747,24 @@ class ModsPanel(QWidget):
         # Connect signals and slots
 
     def connect_signals(self) -> None:
-        self.active_mods_list.list_update_signal.connect(self.on_active_mods_list_updated)
-        self.inactive_mods_list.list_update_signal.connect(self.on_inactive_mods_list_updated)
+        self.active_mods_list.list_update_signal.connect(
+            self.on_active_mods_list_updated
+        )
+        self.inactive_mods_list.list_update_signal.connect(
+            self.on_inactive_mods_list_updated
+        )
         self.active_mods_list.recalculate_warnings_signal.connect(
             partial(self.recalculate_list_errors_warnings, list_type="Active")
         )
         self.inactive_mods_list.recalculate_warnings_signal.connect(
             partial(self.recalculate_list_errors_warnings, list_type="Inactive")
         )
-        self.inactive_mods_sort_combobox.currentTextChanged.connect(self.on_inactive_mods_sort_changed)
-        self.inactive_mods_sort_order_button.clicked.connect(self.on_inactive_mods_sort_order_toggled)
+        self.inactive_mods_sort_combobox.currentTextChanged.connect(
+            self.on_inactive_mods_sort_changed
+        )
+        self.inactive_mods_sort_order_button.clicked.connect(
+            self.on_inactive_mods_sort_order_toggled
+        )
 
     def on_inactive_mods_sort_order_toggled(self) -> None:
         """
@@ -3298,7 +3784,9 @@ class ModsPanel(QWidget):
             self.settings_controller.settings.inactive_mods_sorting
             and self.settings_controller.settings.save_inactive_mods_sort_state
         ):
-            self.settings_controller.settings.inactive_mods_sort_descending = self.inactive_sort_descending
+            self.settings_controller.settings.inactive_mods_sort_descending = (
+                self.inactive_sort_descending
+            )
             self.settings_controller.settings.save()
 
         # Apply updated sort direction - re-sort with new descending flag
@@ -3364,8 +3852,10 @@ class ModsPanel(QWidget):
             lw.uuids = list()
 
             # Get aux controller once for performance
-            aux_metadata_controller = AuxMetadataController.get_or_create_cached_instance(
-                self.settings_controller.settings.aux_db_path
+            aux_metadata_controller = (
+                AuxMetadataController.get_or_create_cached_instance(
+                    self.settings_controller.settings.aux_db_path
+                )
             )
 
             # OPTIMIZATION 1: Single DB session for all mods instead of per-mod
@@ -3382,13 +3872,20 @@ class ModsPanel(QWidget):
                     )
                     list_item.setData(Qt.ItemDataRole.UserRole, data)
                     lw.addItem(list_item)
-                    if hasattr(self, "_size_progress_dialog") and self._size_progress_dialog:
+                    if (
+                        hasattr(self, "_size_progress_dialog")
+                        and self._size_progress_dialog
+                    ):
                         self._size_progress_dialog.setValue(idx)
             lw.uuids = sorted_uuids
 
             # Reconnect model signals
-            lw.model().rowsInserted.connect(lw.handle_rows_inserted, Qt.ConnectionType.QueuedConnection)
-            lw.model().rowsAboutToBeRemoved.connect(lw.handle_rows_removed, Qt.ConnectionType.QueuedConnection)
+            lw.model().rowsInserted.connect(
+                lw.handle_rows_inserted, Qt.ConnectionType.QueuedConnection
+            )
+            lw.model().rowsAboutToBeRemoved.connect(
+                lw.handle_rows_removed, Qt.ConnectionType.QueuedConnection
+            )
             lw.setUpdatesEnabled(True)
             lw.repaint()
             # Load visible widgets after rebuild completes
@@ -3425,7 +3922,11 @@ class ModsPanel(QWidget):
             list_type, uuids, key, descending = self._pending_sort_params
             self._pending_sort_params = None
             # Get the appropriate list widget and call recreate_mod_list_and_sort
-            mod_list = self.active_mods_list if list_type == "Active" else self.inactive_mods_list
+            mod_list = (
+                self.active_mods_list
+                if list_type == "Active"
+                else self.inactive_mods_list
+            )
             mod_list.recreate_mod_list_and_sort(list_type, uuids, key, descending)
 
     @staticmethod
@@ -3519,11 +4020,15 @@ class ModsPanel(QWidget):
                     self.settings_controller.settings.inactive_mods_sorting
                     and self.settings_controller.settings.save_inactive_mods_sort_state
                 ):
-                    self.settings_controller.settings.inactive_mods_sort_key = sort_key.name
+                    self.settings_controller.settings.inactive_mods_sort_key = (
+                        sort_key.name
+                    )
                     self.settings_controller.settings.save()
                 self.inactive_mods_sort_key = sort_key.name
 
-    def mod_list_updated(self, count: str, list_type: str, recalculate_list_errors_warnings: bool = True) -> None:
+    def mod_list_updated(
+        self, count: str, list_type: str, recalculate_list_errors_warnings: bool = True
+    ) -> None:
         # If count is 'drop', it indicates that the update was just a drag and drop within the list
         if count != "drop":
             logger.info(f"{list_type} mod count changed to: {count}")
@@ -3587,7 +4092,8 @@ class ModsPanel(QWidget):
         # Define the mod types
         mod_types = ["csharp", "xml"]
         source_filter_index: int = (
-            self.active_data_source_filter_type_index or self.inactive_data_source_filter_type_index
+            self.active_data_source_filter_type_index
+            or self.inactive_data_source_filter_type_index
         )
 
         if list_type == "Active":
@@ -3613,12 +4119,18 @@ class ModsPanel(QWidget):
         # Update the relevant index for the list type
         if list_type == "Active":
             self.active_data_source_filter_type_index = source_index
-            self.active_mods_data_source_filter_type = SEARCH_DATA_SOURCE_FILTER_INDEXES[source_index]
+            self.active_mods_data_source_filter_type = (
+                SEARCH_DATA_SOURCE_FILTER_INDEXES[source_index]
+            )
         elif list_type == "Inactive":
             self.inactive_data_source_filter_type_index = source_index
-            self.inactive_mods_data_source_filter_type = SEARCH_DATA_SOURCE_FILTER_INDEXES[source_index]
+            self.inactive_mods_data_source_filter_type = (
+                SEARCH_DATA_SOURCE_FILTER_INDEXES[source_index]
+            )
 
-        mod_list = self.active_mods_list if list_type == "Active" else self.inactive_mods_list
+        mod_list = (
+            self.active_mods_list if list_type == "Active" else self.inactive_mods_list
+        )
 
         # Apply filtering based on the selected type
         for uuid in mod_list.uuids:
@@ -3626,7 +4138,13 @@ class ModsPanel(QWidget):
             item_data = item.data(Qt.ItemDataRole.UserRole)
 
             # Determine the mod type
-            mod_type = "csharp" if self.metadata_manager.internal_local_metadata.get(uuid, {}).get("csharp") else "xml"
+            mod_type = (
+                "csharp"
+                if self.metadata_manager.internal_local_metadata.get(uuid, {}).get(
+                    "csharp"
+                )
+                else "xml"
+            )
             if mod_type and mod_types:
                 item.setData(Qt.ItemDataRole.UserRole, item_data)
 
@@ -3683,22 +4201,40 @@ class ModsPanel(QWidget):
             if self.settings_controller.settings.show_save_comparison_indicators:
                 try:
                     for item in self.active_mods_list.get_all_mod_list_items():
-                        if item.data(Qt.ItemDataRole.UserRole).__dict__.get("is_new", False):
+                        if item.data(Qt.ItemDataRole.UserRole).__dict__.get(
+                            "is_new", False
+                        ):
                             new_count += 1
                 except Exception:
                     pass
 
             padding = " "
-            has_errors_warnings = total_error_text or total_warning_text or num_errors or num_warnings
+            has_errors_warnings = (
+                total_error_text or total_warning_text or num_errors or num_warnings
+            )
 
             # Show summary frame only if there are errors, warnings, or new mods to display
-            self.errors_summary_frame.setHidden(not (has_errors_warnings or new_count > 0))
+            self.errors_summary_frame.setHidden(
+                not (has_errors_warnings or new_count > 0)
+            )
 
             # Update error and warning counts/tooltips (show 0 if none exist)
-            self.warnings_text.setText(self.tr("{padding}{num} warning(s)").format(padding=padding, num=num_warnings))
-            self.errors_text.setText(self.tr("{padding}{num} error(s)").format(padding=padding, num=num_errors))
-            self.errors_icon.setToolTip(total_error_text.lstrip() if total_error_text else "")
-            self.warnings_icon.setToolTip(total_warning_text.lstrip() if total_warning_text else "")
+            self.warnings_text.setText(
+                self.tr("{padding}{num} warning(s)").format(
+                    padding=padding, num=num_warnings
+                )
+            )
+            self.errors_text.setText(
+                self.tr("{padding}{num} error(s)").format(
+                    padding=padding, num=num_errors
+                )
+            )
+            self.errors_icon.setToolTip(
+                total_error_text.lstrip() if total_error_text else ""
+            )
+            self.warnings_icon.setToolTip(
+                total_warning_text.lstrip() if total_warning_text else ""
+            )
 
             # Update new mods display (icon and count)
             # Hide icon and text if no new mods, otherwise show with count
@@ -3826,11 +4362,18 @@ class ModsPanel(QWidget):
         num_unfiltered = 0
         if pattern.strip() and (
             search_filter == "notes"
-            or (search_filter == "name" and self.settings_controller.settings.include_mod_notes_in_mod_name_filter)
+            or (
+                search_filter == "name"
+                and self.settings_controller.settings.include_mod_notes_in_mod_name_filter
+            )
         ):
             matches = self.search_mod_notes(pattern)
         for idx, uuid in enumerate(uuids):
-            item = self.active_mods_list.item(idx) if list_type == "Active" else self.inactive_mods_list.item(idx)
+            item = (
+                self.active_mods_list.item(idx)
+                if list_type == "Active"
+                else self.inactive_mods_list.item(idx)
+            )
             if item is None:
                 continue
             # Check if UUID exists in metadata before accessing
@@ -3858,7 +4401,9 @@ class ModsPanel(QWidget):
                 versions = metadata.get("supportedversions", {}).get("li", [])
                 if isinstance(versions, str):
                     versions = [versions]
-                if not versions or not any(pattern.lower() in v.lower() for v in versions):
+                if not versions or not any(
+                    pattern.lower() in v.lower() for v in versions
+                ):
                     item_filtered = True
             elif search_filter == "notes":
                 if not pattern.strip():
@@ -3942,28 +4487,42 @@ class ModsPanel(QWidget):
     def signal_search_mode_filter(self, list_type: str) -> None:
         if list_type == "Active":
             # Toggle the mode filter state
-            self.active_mods_search_filter_state = not self.active_mods_search_filter_state
+            self.active_mods_search_filter_state = (
+                not self.active_mods_search_filter_state
+            )
             # Update the icon based on the current state
             if self.active_mods_search_filter_state:
-                self.active_mods_search_mode_filter_button.setIcon(self.mode_filter_icon)  # Active state icon
-                self.active_mods_search_mode_filter_button.setToolTip(self.mode_filter_tooltip)  # Active state tooltip
+                self.active_mods_search_mode_filter_button.setIcon(
+                    self.mode_filter_icon
+                )  # Active state icon
+                self.active_mods_search_mode_filter_button.setToolTip(
+                    self.mode_filter_tooltip
+                )  # Active state tooltip
             else:
-                self.active_mods_search_mode_filter_button.setIcon(self.mode_nofilter_icon)  # Inactive state icon
+                self.active_mods_search_mode_filter_button.setIcon(
+                    self.mode_nofilter_icon
+                )  # Inactive state icon
                 self.active_mods_search_mode_filter_button.setToolTip(
                     self.mode_nofilter_tooltip
                 )  # Inactive state tooltip
             pattern = self.active_mods_search.text()
         elif list_type == "Inactive":
             # Toggle the mode filter state
-            self.inactive_mods_search_filter_state = not self.inactive_mods_search_filter_state
+            self.inactive_mods_search_filter_state = (
+                not self.inactive_mods_search_filter_state
+            )
             # Update the icon based on the current state
             if self.inactive_mods_search_filter_state:
-                self.inactive_mods_search_mode_filter_button.setIcon(self.mode_filter_icon)  # Active state icon
+                self.inactive_mods_search_mode_filter_button.setIcon(
+                    self.mode_filter_icon
+                )  # Active state icon
                 self.inactive_mods_search_mode_filter_button.setToolTip(
                     self.mode_filter_tooltip
                 )  # Active state tooltip
             else:
-                self.inactive_mods_search_mode_filter_button.setIcon(self.mode_nofilter_icon)  # Inactive state icon
+                self.inactive_mods_search_mode_filter_button.setIcon(
+                    self.mode_nofilter_icon
+                )  # Inactive state icon
                 self.inactive_mods_search_mode_filter_button.setToolTip(
                     self.mode_nofilter_tooltip
                 )  # Inactive state tooltip
@@ -3993,18 +4552,26 @@ class ModsPanel(QWidget):
         button.setToolTip(self.data_source_filter_tooltips[source_index])
         if list_type == "Active":
             self.active_mods_filter_data_source_index = source_index
-            self.active_mods_data_source_filter = SEARCH_DATA_SOURCE_FILTER_INDEXES[source_index]
+            self.active_mods_data_source_filter = SEARCH_DATA_SOURCE_FILTER_INDEXES[
+                source_index
+            ]
         elif list_type == "Inactive":
             self.inactive_mods_filter_data_source_index = source_index
-            self.inactive_mods_data_source_filter = SEARCH_DATA_SOURCE_FILTER_INDEXES[source_index]
+            self.inactive_mods_data_source_filter = SEARCH_DATA_SOURCE_FILTER_INDEXES[
+                source_index
+            ]
         if source_index == 0:
             filters_active = False
         else:
             filters_active = True
         # Filter widgets by data source, while preserving any active search pattern
-        self.signal_search_and_filters(list_type=list_type, pattern=search.text(), filters_active=filters_active)
+        self.signal_search_and_filters(
+            list_type=list_type, pattern=search.text(), filters_active=filters_active
+        )
 
-    def direct_update_count(self, list_type: str, filtered: int, unfiltered: int) -> None:
+    def direct_update_count(
+        self, list_type: str, filtered: int, unfiltered: int
+    ) -> None:
         """
         This version of update_count allows you to pass in direct values.
 
@@ -4012,24 +4579,54 @@ class ModsPanel(QWidget):
         """
         if filtered > 0:
             # If any filter is active, show how many mods are displayed out of total
-            list_type_label = self.tr("Active") if list_type == "Active" else self.tr("Inactive")
-            label = self.active_mods_label if list_type == "Active" else self.inactive_mods_label
+            list_type_label = (
+                self.tr("Active") if list_type == "Active" else self.tr("Inactive")
+            )
+            label = (
+                self.active_mods_label
+                if list_type == "Active"
+                else self.inactive_mods_label
+            )
             label.setText(f"{list_type_label} [{unfiltered}/{filtered + unfiltered}]")
         else:
-            list_type_label = self.tr("Active") if list_type == "Active" else self.tr("Inactive")
-            label = self.active_mods_label if list_type == "Active" else self.inactive_mods_label
+            list_type_label = (
+                self.tr("Active") if list_type == "Active" else self.tr("Inactive")
+            )
+            label = (
+                self.active_mods_label
+                if list_type == "Active"
+                else self.inactive_mods_label
+            )
             label.setText(f"{list_type_label} [{filtered + unfiltered}]")
 
     def update_count(self, list_type: str) -> None:
         # Calculate filtered items
-        list_type_label = self.tr("Active") if list_type == "Active" else self.tr("Inactive")
-        label = self.active_mods_label if list_type == "Active" else self.inactive_mods_label
-        search = self.active_mods_search if list_type == "Active" else self.inactive_mods_search
-        uuids = self.active_mods_list.uuids if list_type == "Active" else self.inactive_mods_list.uuids
+        list_type_label = (
+            self.tr("Active") if list_type == "Active" else self.tr("Inactive")
+        )
+        label = (
+            self.active_mods_label
+            if list_type == "Active"
+            else self.inactive_mods_label
+        )
+        search = (
+            self.active_mods_search
+            if list_type == "Active"
+            else self.inactive_mods_search
+        )
+        uuids = (
+            self.active_mods_list.uuids
+            if list_type == "Active"
+            else self.inactive_mods_list.uuids
+        )
         num_filtered = 0
         num_unfiltered = 0
         for idx in range(len(uuids)):
-            item = self.active_mods_list.item(idx) if list_type == "Active" else self.inactive_mods_list.item(idx)
+            item = (
+                self.active_mods_list.item(idx)
+                if list_type == "Active"
+                else self.inactive_mods_list.item(idx)
+            )
             if item is None:
                 continue
             item_data = item.data(Qt.ItemDataRole.UserRole)
@@ -4040,10 +4637,14 @@ class ModsPanel(QWidget):
             else:
                 num_unfiltered += 1
         if search.text():
-            label.setText(f"{list_type_label} [{num_unfiltered}/{num_filtered + num_unfiltered}]")
+            label.setText(
+                f"{list_type_label} [{num_unfiltered}/{num_filtered + num_unfiltered}]"
+            )
         elif num_filtered > 0:
             # If any filter is active, show how many mods are displayed out of total
-            label.setText(f"{list_type_label} [{num_unfiltered}/{num_filtered + num_unfiltered}]")
+            label.setText(
+                f"{list_type_label} [{num_unfiltered}/{num_filtered + num_unfiltered}]"
+            )
         else:
             label.setText(f"{list_type_label} [{num_filtered + num_unfiltered}]")
 
@@ -4089,9 +4690,15 @@ class ModsPanel(QWidget):
                         is_translation_mod = False
                         pfid = meta.get("publishedfileid")
                         if pfid and self.metadata_manager.external_steam_metadata:
-                            steam_data = self.metadata_manager.external_steam_metadata.get(pfid, {})
+                            steam_data = (
+                                self.metadata_manager.external_steam_metadata.get(
+                                    pfid, {}
+                                )
+                            )
                             tags = steam_data.get("tags", [])
-                            tag_set = {tag_item.get("tag", "").lower() for tag_item in tags}
+                            tag_set = {
+                                tag_item.get("tag", "").lower() for tag_item in tags
+                            }
                             is_translation_mod = "translation" in tag_set
 
                         # Mark as localized if:
@@ -4123,7 +4730,9 @@ class ModsPanel(QWidget):
 
         # Check if Steam metadata is available
         if not self.metadata_manager.external_steam_metadata:
-            logger.warning("Steam Workshop metadata database is not loaded for translation lookup")
+            logger.warning(
+                "Steam Workshop metadata database is not loaded for translation lookup"
+            )
             return translated_pkg_ids
 
         # Get all installed mods' publishedfileids
@@ -4168,7 +4777,9 @@ class ModsPanel(QWidget):
                 if dep_pfid in pfid_to_packageid:
                     target_packageid = pfid_to_packageid[dep_pfid]
                     translated_pkg_ids.add(target_packageid)
-                    logger.debug(f"Found translation {meta.get('name')} for mod with packageId {target_packageid}")
+                    logger.debug(
+                        f"Found translation {meta.get('name')} for mod with packageId {target_packageid}"
+                    )
 
         return translated_pkg_ids
 
@@ -4181,7 +4792,9 @@ class ModsPanel(QWidget):
 
         # Check if Steam metadata is available
         if not self.metadata_manager.external_steam_metadata:
-            logger.warning("Steam Workshop metadata database is not loaded for auto-add translations")
+            logger.warning(
+                "Steam Workshop metadata database is not loaded for auto-add translations"
+            )
             show_warning(
                 self.tr("Database not available"),
                 self.tr(
@@ -4247,14 +4860,20 @@ class ModsPanel(QWidget):
                     # Get the target mod's name for similarity check
                     target_uuid = pfid_to_uuid.get(dep_pfid)
                     if target_uuid and target_uuid in all_local_metadata:
-                        target_mod_name = all_local_metadata[target_uuid].get("name", "")
-                    logger.debug(f"Found translation {meta.get('name')} for active mod with pfid {dep_pfid}")
+                        target_mod_name = all_local_metadata[target_uuid].get(
+                            "name", ""
+                        )
+                    logger.debug(
+                        f"Found translation {meta.get('name')} for active mod with pfid {dep_pfid}"
+                    )
                     break
 
             if targets_active_mod:
                 # Calculate similarity score to filter out false positives
                 trans_name = meta.get("name", "")
-                similarity = self.active_mods_list._calculate_translation_similarity(target_mod_name, trans_name)
+                similarity = self.active_mods_list._calculate_translation_similarity(
+                    target_mod_name, trans_name
+                )
 
                 SIMILARITY_THRESHOLD = 0.5
                 if similarity >= SIMILARITY_THRESHOLD:
@@ -4272,7 +4891,9 @@ class ModsPanel(QWidget):
         if not mods_to_add:
             show_warning(
                 self.tr("No Translations Found"),
-                self.tr("No applicable translation mods were found for your active mod list."),
+                self.tr(
+                    "No applicable translation mods were found for your active mod list."
+                ),
             )
             return
 
@@ -4284,7 +4905,9 @@ class ModsPanel(QWidget):
                 # Need to find the item in inactive list
                 if uuid in self.inactive_mods_list.uuids:
                     index = self.inactive_mods_list.uuids.index(uuid)
-                    item = self.inactive_mods_list.takeItem(index)  # This removes from list widget
+                    item = self.inactive_mods_list.takeItem(
+                        index
+                    )  # This removes from list widget
                     self.inactive_mods_list.uuids.pop(index)
 
                     self.active_mods_list.addItem(item)
@@ -4303,7 +4926,9 @@ class ModsPanel(QWidget):
             logger.info(f"Added {count} translation mods.")
             show_warning(
                 self.tr("Translations Added"),
-                self.tr(f"Successfully added {count} translation mods to the active list."),
+                self.tr(
+                    f"Successfully added {count} translation mods to the active list."
+                ),
             )
 
             # Also update translation status indicators if enabled

--- a/app/views/player_log_tab.py
+++ b/app/views/player_log_tab.py
@@ -50,12 +50,18 @@ class LogPatternManager:
 
     # Pre-compiled patterns for syntax highlighting
     TIMESTAMP_PATTERN = re.compile(r"\d{1,2}:\d{2}:\d{2} [AP]M")
-    INFO_PATTERN = re.compile(r"\b(info|initialized|loaded|start(ed)?|starting|done|success)\b", re.IGNORECASE)
+    INFO_PATTERN = re.compile(
+        r"\b(info|initialized|loaded|start(ed)?|starting|done|success)\b", re.IGNORECASE
+    )
     KEYBIND_PATTERN = re.compile(r"key binding conflict", re.IGNORECASE)
     MOD_ISSUE_PATTERN = re.compile(r"\[([^\]]+)\]")
-    WARNING_PATTERN = re.compile(r"\b(warning|warn|deprecat|deprecated)\b", re.IGNORECASE)
+    WARNING_PATTERN = re.compile(
+        r"\b(warning|warn|deprecat|deprecated)\b", re.IGNORECASE
+    )
     WARNING_SHORT_PATTERN = re.compile(r"\[W\]")
-    ERROR_PATTERN = re.compile(r"\b(error|failed|exception|fatal|critical)\b|\[E\]", re.IGNORECASE)
+    ERROR_PATTERN = re.compile(
+        r"\b(error|failed|exception|fatal|critical)\b|\[E\]", re.IGNORECASE
+    )
     ERROR_SHORT_PATTERN = re.compile(r"\[E\]")
     EXCEPTION_PATTERN = re.compile(r".*Exception.*:|.*Error.*:")
     STACK_TRACE_PATTERN = re.compile(r"^\s*at .*")
@@ -66,9 +72,15 @@ class LogPatternManager:
         re.IGNORECASE,
     )
     KEYBIND_FILTER_PATTERN = re.compile(r"key binding conflict", re.IGNORECASE)
-    MOD_ISSUE_FILTER_PATTERN = re.compile(r"(\[.*\].*(error|warning|exception))|(mod.*(conflict|issue))", re.IGNORECASE)
-    WARNING_FILTER_PATTERN = re.compile(r"\b(warning|warn|deprecat|deprecated)\b|\[W\]", re.IGNORECASE)
-    ERROR_FILTER_PATTERN = re.compile(r"\b(error|failed|fatal|critical)\b|\[E\]", re.IGNORECASE)
+    MOD_ISSUE_FILTER_PATTERN = re.compile(
+        r"(\[.*\].*(error|warning|exception))|(mod.*(conflict|issue))", re.IGNORECASE
+    )
+    WARNING_FILTER_PATTERN = re.compile(
+        r"\b(warning|warn|deprecat|deprecated)\b|\[W\]", re.IGNORECASE
+    )
+    ERROR_FILTER_PATTERN = re.compile(
+        r"\b(error|failed|fatal|critical)\b|\[E\]", re.IGNORECASE
+    )
     EXCEPTION_FILTER_PATTERN = re.compile(r"exception", re.IGNORECASE)
 
     PATHLIKE_PATTERN = re.compile(
@@ -135,7 +147,10 @@ class LogContentStorage:
             line_length = len(line)
 
             # If adding this line would exceed chunk size and we have existing content
-            if current_chunk_size + line_length > self.max_chunk_size and current_chunk_lines:
+            if (
+                current_chunk_size + line_length > self.max_chunk_size
+                and current_chunk_lines
+            ):
                 # Join the current chunk and add to deque
                 self.chunks.append("".join(current_chunk_lines))
                 current_chunk_lines = [line]
@@ -175,7 +190,9 @@ class LogContentStorage:
         """Get the full content as a string (use sparingly)."""
         return "".join(self.chunks)
 
-    def get_lines(self, start_line: int = 0, end_line: Optional[int] = None) -> List[str]:
+    def get_lines(
+        self, start_line: int = 0, end_line: Optional[int] = None
+    ) -> List[str]:
         """Get specific lines efficiently without loading entire content."""
         lines = []
         current_line = 0
@@ -286,10 +303,16 @@ class PlayerLogTab(QWidget):
     match_count_label: QLabel
     _file_change_debounce_timer: QTimer
     # Precompile regex patterns for filtering and analysis once at class level
-    _info_pattern = re.compile(r"\b(info|initialized|loaded|start(ed)?|done|success)\b", re.IGNORECASE)
+    _info_pattern = re.compile(
+        r"\b(info|initialized|loaded|start(ed)?|done|success)\b", re.IGNORECASE
+    )
     _keybind_pattern = re.compile(r"key binding conflict", re.IGNORECASE)
-    _mod_issue_pattern = re.compile(r"(\[.*\].*(error|warning|exception))|(mod.*(conflict|issue))", re.IGNORECASE)
-    _warning_pattern = re.compile(r"\b(warning|warn|deprecat|deprecated)\b|\[W\]", re.IGNORECASE)
+    _mod_issue_pattern = re.compile(
+        r"(\[.*\].*(error|warning|exception))|(mod.*(conflict|issue))", re.IGNORECASE
+    )
+    _warning_pattern = re.compile(
+        r"\b(warning|warn|deprecat|deprecated)\b|\[W\]", re.IGNORECASE
+    )
     _error_pattern = re.compile(r"\b(error|failed|fatal)\b|\[E\]", re.IGNORECASE)
     _exception_pattern = re.compile(r"exception", re.IGNORECASE)
 
@@ -407,7 +430,9 @@ class PlayerLogTab(QWidget):
     def _get_player_log_path(self) -> Optional[Path]:
         try:
             current_instance: str = self.settings_controller.settings.current_instance
-            config_folder: str = self.settings_controller.settings.instances[current_instance].config_folder
+            config_folder: str = self.settings_controller.settings.instances[
+                current_instance
+            ].config_folder
             player_log_path: Path = Path(config_folder).parent / "Player.log"
             if player_log_path.exists():
                 return player_log_path
@@ -435,7 +460,9 @@ class PlayerLogTab(QWidget):
         self.log_display.customContextMenuRequested.connect(self.show_context_menu)
 
         self.horizontal_splitter = QSplitter(Qt.Orientation.Horizontal)
-        self.horizontal_splitter.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+        self.horizontal_splitter.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding
+        )
         self.horizontal_splitter.addWidget(self.left_panel)
         self.horizontal_splitter.addWidget(self.middle_panel)
         self.horizontal_splitter.setSizes([400, 1250])
@@ -450,7 +477,9 @@ class PlayerLogTab(QWidget):
         self.left_panel = QWidget()
         self.left_panel.setMinimumWidth(350)
         self.left_panel.setMaximumWidth(500)
-        self.left_panel.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Expanding)
+        self.left_panel.setSizePolicy(
+            QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Expanding
+        )
         self.left_layout = QVBoxLayout(self.left_panel)
         self.left_layout.setSpacing(1)
         self.left_layout.setContentsMargins(1, 1, 1, 1)
@@ -465,7 +494,9 @@ class PlayerLogTab(QWidget):
     def _init_middle_panel(self) -> None:
         """Initialize the middle panel UI components."""
         self.middle_panel = QWidget()
-        self.middle_panel.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+        self.middle_panel.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding
+        )
         self.middle_layout = QVBoxLayout(self.middle_panel)
         self.middle_layout.setContentsMargins(8, 8, 8, 8)
 
@@ -473,7 +504,9 @@ class PlayerLogTab(QWidget):
         self.log_display.setReadOnly(True)
         self.log_display.setFont(QFont("Consolas", 10))
         self.log_display.setMinimumSize(400, 200)
-        self.log_display.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+        self.log_display.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding
+        )
         self.log_display.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self.log_display.customContextMenuRequested.connect(self.show_context_menu)
         self.middle_layout.addWidget(self.log_display)
@@ -488,7 +521,9 @@ class PlayerLogTab(QWidget):
         file_info_layout.setSpacing(1)
         file_info_layout.setContentsMargins(1, 1, 1, 1)
 
-        file_info_group.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Preferred)
+        file_info_group.setSizePolicy(
+            QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Preferred
+        )
 
         self.file_path_label = QLabel(self.tr("Path:"))
         self.file_path_label.setWordWrap(True)
@@ -512,7 +547,9 @@ class PlayerLogTab(QWidget):
                 widget = item.widget()
                 if widget:
                     widget.setContentsMargins(0, 0, 0, 0)
-                    widget.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Preferred)
+                    widget.setSizePolicy(
+                        QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Preferred
+                    )
 
     def _init_statistics_group(self) -> None:
         stats_group = QGroupBox(self.tr("Statistics"))
@@ -523,21 +560,39 @@ class PlayerLogTab(QWidget):
 
         def create_stat_button(text: str, color: str, filter_name: str) -> QPushButton:
             btn = QPushButton(text)
-            btn.setStyleSheet(f"color: {color}; background: transparent; border: none; text-align: left;")
+            btn.setStyleSheet(
+                f"color: {color}; background: transparent; border: none; text-align: left;"
+            )
             btn.setCursor(Qt.CursorShape.PointingHandCursor)
             btn.setFlat(True)
             btn.clicked.connect(lambda: self._on_stat_button_clicked(filter_name))
             btn.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
             return btn
 
-        self.total_lines_label = create_stat_button(self.tr("Total Lines: 0"), "#00FF00", self.tr("All Entries"))
-        self.info_label = create_stat_button(self.tr("Infos: 0"), "#00FF00", self.tr("Infos Only"))
-        self.keybind_label = create_stat_button(self.tr("Keybinds: 0"), "#EEFF00", self.tr("Keybinds Only"))
-        self.mod_issues_label = create_stat_button(self.tr("Mod Issues: 0"), "#FF8C00", self.tr("Mod Issues"))
-        self.warnings_label = create_stat_button(self.tr("Warnings: 0"), "#FF8C00", self.tr("Warnings Only"))
-        self.errors_label = create_stat_button(self.tr("Errors: 0"), "#FF0000", self.tr("Errors Only"))
-        self.exceptions_label = create_stat_button(self.tr("Exceptions: 0"), "#FF0000", self.tr("Exceptions Only"))
-        self.all_issues_label = create_stat_button(self.tr("All Issues: 0"), "#FF0000", self.tr("All Issues"))
+        self.total_lines_label = create_stat_button(
+            self.tr("Total Lines: 0"), "#00FF00", self.tr("All Entries")
+        )
+        self.info_label = create_stat_button(
+            self.tr("Infos: 0"), "#00FF00", self.tr("Infos Only")
+        )
+        self.keybind_label = create_stat_button(
+            self.tr("Keybinds: 0"), "#EEFF00", self.tr("Keybinds Only")
+        )
+        self.mod_issues_label = create_stat_button(
+            self.tr("Mod Issues: 0"), "#FF8C00", self.tr("Mod Issues")
+        )
+        self.warnings_label = create_stat_button(
+            self.tr("Warnings: 0"), "#FF8C00", self.tr("Warnings Only")
+        )
+        self.errors_label = create_stat_button(
+            self.tr("Errors: 0"), "#FF0000", self.tr("Errors Only")
+        )
+        self.exceptions_label = create_stat_button(
+            self.tr("Exceptions: 0"), "#FF0000", self.tr("Exceptions Only")
+        )
+        self.all_issues_label = create_stat_button(
+            self.tr("All Issues: 0"), "#FF0000", self.tr("All Issues")
+        )
 
         stats_layout.addWidget(self.total_lines_label)
         stats_layout.addWidget(self.info_label)
@@ -564,7 +619,9 @@ class PlayerLogTab(QWidget):
         controls_layout.setSpacing(1)
         controls_layout.setContentsMargins(1, 1, 1, 1)
 
-        self.auto_load_player_log_on_startup_checkbox = QCheckBox(self.tr("Auto Load Game Log on Startup"))
+        self.auto_load_player_log_on_startup_checkbox = QCheckBox(
+            self.tr("Auto Load Game Log on Startup")
+        )
         self.auto_load_player_log_on_startup_checkbox.setToolTip(
             self.tr("If checked, the Game log will be loaded automatically on startup.")
         )
@@ -572,11 +629,19 @@ class PlayerLogTab(QWidget):
         self.auto_load_player_log_on_startup_checkbox.setChecked(
             self.settings_controller.settings.auto_load_player_log_on_startup
         )
-        self.auto_load_player_log_on_startup_checkbox.toggled.connect(self._on_auto_load_player_log_on_startup_toggled)
+        self.auto_load_player_log_on_startup_checkbox.toggled.connect(
+            self._on_auto_load_player_log_on_startup_toggled
+        )
 
-        self.real_time_monitor_checkbox = QCheckBox(self.tr("Enable Real-Time Log Monitoring"))
-        self.real_time_monitor_checkbox.setToolTip(self.tr("Enable real-time monitoring of Player.log file changes."))
-        self.real_time_monitor_checkbox.toggled.connect(self.toggle_real_time_monitoring)
+        self.real_time_monitor_checkbox = QCheckBox(
+            self.tr("Enable Real-Time Log Monitoring")
+        )
+        self.real_time_monitor_checkbox.setToolTip(
+            self.tr("Enable real-time monitoring of Player.log file changes.")
+        )
+        self.real_time_monitor_checkbox.toggled.connect(
+            self.toggle_real_time_monitoring
+        )
         controls_layout.addWidget(self.real_time_monitor_checkbox)
 
         button_layout = QHBoxLayout()
@@ -595,12 +660,16 @@ class PlayerLogTab(QWidget):
         load_buttons_layout = QHBoxLayout()
         load_buttons_layout.setSpacing(1)
         self.load_default_button = QPushButton(self.tr("Load Game Log"))
-        self.load_default_button.setToolTip(self.tr("Loads the game's Player.log file."))
+        self.load_default_button.setToolTip(
+            self.tr("Loads the game's Player.log file.")
+        )
         self.load_default_button.clicked.connect(self.load_default_log)
         load_buttons_layout.addWidget(self.load_default_button)
 
         self.load_file_button = QPushButton(self.tr("Load Log from File"))
-        self.load_file_button.setToolTip(self.tr("Open a file dialog to select a log file"))
+        self.load_file_button.setToolTip(
+            self.tr("Open a file dialog to select a log file")
+        )
         self.load_file_button.clicked.connect(self.load_log_from_file)
         load_buttons_layout.addWidget(self.load_file_button)
 
@@ -660,12 +729,16 @@ class PlayerLogTab(QWidget):
                 self.tr("All Issues"),
             ]
         )
-        self.filter_combo.currentIndexChanged.connect(lambda _: self.apply_filter(clear_log=True, filter_type="Type"))
+        self.filter_combo.currentIndexChanged.connect(
+            lambda _: self.apply_filter(clear_log=True, filter_type="Type")
+        )
         filter_layout.addWidget(self.filter_combo)
 
         self.mod_filter_input = QLineEdit()
         self.mod_filter_input.setPlaceholderText(self.tr("Filter by mod name..."))
-        self.mod_filter_input.textChanged.connect(lambda _: self.apply_filter(clear_log=True, filter_type="Search"))
+        self.mod_filter_input.textChanged.connect(
+            lambda _: self.apply_filter(clear_log=True, filter_type="Search")
+        )
         filter_layout.addWidget(self.mod_filter_input)
         search_filter_layout.addLayout(filter_layout)
 
@@ -674,7 +747,9 @@ class PlayerLogTab(QWidget):
         highlight_nav_layout.setSpacing(1)
 
         self.color_picker_button = QPushButton(self.tr("Highlight Color"))
-        self.color_picker_button.setToolTip(self.tr("Pick color for search and navigation highlighting"))
+        self.color_picker_button.setToolTip(
+            self.tr("Pick color for search and navigation highlighting")
+        )
         self.color_picker_button.setMaximumHeight(24)
         self.color_picker_button.clicked.connect(self.pick_highlight_color)
 
@@ -701,7 +776,9 @@ class PlayerLogTab(QWidget):
         return lambda: self.goto_next_pattern(pattern)
 
     def _init_quick_navigation_group(self) -> None:
-        def create_nav_button(text: str, tooltip: str, callback: Callable[[], None]) -> QPushButton:
+        def create_nav_button(
+            text: str, tooltip: str, callback: Callable[[], None]
+        ) -> QPushButton:
             btn = QPushButton(text)
             btn.setToolTip(tooltip)
             btn.clicked.connect(callback)
@@ -730,7 +807,9 @@ class PlayerLogTab(QWidget):
         for row, (label_text, pattern) in enumerate(log_types):
             prev_btn = create_nav_button(
                 "<",
-                self.tr("Jump to previous {lower} entry").format(lower=label_text.lower()),
+                self.tr("Jump to previous {lower} entry").format(
+                    lower=label_text.lower()
+                ),
                 self._make_prev_callback(pattern),
             )
             next_btn = create_nav_button(
@@ -752,7 +831,9 @@ class PlayerLogTab(QWidget):
         scroll_to_end_btn.setToolTip(self.tr("Scroll to the end of the log display"))
         scroll_to_end_btn.clicked.connect(self.scroll_to_end)
         scroll_to_end_btn.setMaximumHeight(24)
-        scroll_to_end_btn.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        scroll_to_end_btn.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed
+        )
         nav_layout.addWidget(scroll_to_end_btn, len(log_types), 0, 1, 3)
 
         self.left_layout.addWidget(self.nav_group)
@@ -773,11 +854,17 @@ class PlayerLogTab(QWidget):
                 logger.debug("Player log path is None in _process_file_change.")
                 return
             current_size = self.player_log_path.stat().st_size
-            logger.debug(f"_process_file_change: current_size={current_size}, last_log_size={self.last_log_size}")
-            with open(self.player_log_path, "r", encoding="utf-8", errors="ignore") as f:
+            logger.debug(
+                f"_process_file_change: current_size={current_size}, last_log_size={self.last_log_size}"
+            )
+            with open(
+                self.player_log_path, "r", encoding="utf-8", errors="ignore"
+            ) as f:
                 while True:
                     if current_size < self.last_log_size:
-                        logger.debug("File size smaller than last log size, treating as reset.")
+                        logger.debug(
+                            "File size smaller than last log size, treating as reset."
+                        )
                         self.log_storage.clear()
                         self.last_log_size = 0
                         self.load_log()
@@ -789,7 +876,9 @@ class PlayerLogTab(QWidget):
                         f"Read {len(new_content)} new characters from log file: {new_content[:100]}..."  # Log first 100 characters
                     )
                     if new_content.startswith("Mono path"):
-                        logger.debug("New content starts with 'Mono path', reloading log.")
+                        logger.debug(
+                            "New content starts with 'Mono path', reloading log."
+                        )
                         self.log_storage.clear()
                         self.last_log_size = 0
                         self.load_log()
@@ -800,9 +889,13 @@ class PlayerLogTab(QWidget):
                         # Instead of breaking, restart the debounce timer to keep monitoring
                         self._file_change_debounce_timer.start()
                         return
-                    logger.debug(f"Appending {len(new_content)} new characters to log content.")
+                    logger.debug(
+                        f"Appending {len(new_content)} new characters to log content."
+                    )
                     self.log_storage.append(new_content)  # Use new storage method
-                    self.current_log_content = str(self.log_storage)  # Keep for backward compatibility
+                    self.current_log_content = str(
+                        self.log_storage
+                    )  # Keep for backward compatibility
                     self.last_log_size = current_size
                     break
             self._analyze_log_content(new_content)  # Analyze only the new content
@@ -830,7 +923,11 @@ class PlayerLogTab(QWidget):
 
         if enabled:
             self._observer = Observer()
-            if hasattr(self, "_observer") and self._observer is not None and self._observer.is_alive():
+            if (
+                hasattr(self, "_observer")
+                and self._observer is not None
+                and self._observer.is_alive()
+            ):
                 logger.debug("Real-time monitoring already running.")
                 return
             if self.player_log_path is None:
@@ -846,15 +943,23 @@ class PlayerLogTab(QWidget):
             event_handler = PlayerLogEventHandler(self)
             self.file_changed_signal.connect(self.on_file_changed)
             try:
-                self._observer.schedule(event_handler, str(self.player_log_path.parent), recursive=False)
+                self._observer.schedule(
+                    event_handler, str(self.player_log_path.parent), recursive=False
+                )
                 self._observer.start()
-                logger.info(f"Started real-time monitoring of Player.log at {self.player_log_path}")
+                logger.info(
+                    f"Started real-time monitoring of Player.log at {self.player_log_path}"
+                )
             except Exception as e:
                 logger.error(f"Failed to start observer: {e}")
                 show_warning(f"Failed to start real-time monitoring: {e}")
                 self.real_time_monitor_checkbox.setChecked(False)
         else:
-            if hasattr(self, "_observer") and self._observer is not None and self._observer.is_alive():
+            if (
+                hasattr(self, "_observer")
+                and self._observer is not None
+                and self._observer.is_alive()
+            ):
                 self._observer.stop()
                 self._observer.join()
                 logger.info("Stopped real-time monitoring of Player.log.")
@@ -906,10 +1011,13 @@ class PlayerLogTab(QWidget):
                 "errors": 0,
                 "exceptions": 0,
             }
-            with open(self.player_log_path, "r", encoding="utf-8", errors="ignore") as f:
+            with open(
+                self.player_log_path, "r", encoding="utf-8", errors="ignore"
+            ) as f:
                 total_chunks = max(
                     1,
-                    (self.player_log_path.stat().st_size + chunk_size - 1) // chunk_size,
+                    (self.player_log_path.stat().st_size + chunk_size - 1)
+                    // chunk_size,
                 )
                 chunk_cnt = 0
                 self.progress_bar.setTextVisible(True)
@@ -926,12 +1034,16 @@ class PlayerLogTab(QWidget):
                     QApplication.processEvents()
 
             self.last_log_size = len(self.log_storage)  # Update based on new storage
-            self.current_log_content = str(self.log_storage)  # Keep for backward compatibility
+            self.current_log_content = str(
+                self.log_storage
+            )  # Keep for backward compatibility
             self._update_file_info()
             self._update_statistics()
             self.apply_filter()
             self.enable_options()
-            logger.info("Loaded player log file in chunks using memory-efficient storage.")
+            logger.info(
+                "Loaded player log file in chunks using memory-efficient storage."
+            )
         except Exception as e:
             logger.error(f"Failed to load player log file: {e}")
             self.progress_bar.hide()
@@ -944,10 +1056,16 @@ class PlayerLogTab(QWidget):
             if self.current_log_content:
                 url = self.url
                 if url:
-                    self.file_path_label.setText(self.tr("Path: Loaded from URL: {url}").format(url=url))
+                    self.file_path_label.setText(
+                        self.tr("Path: Loaded from URL: {url}").format(url=url)
+                    )
                 else:
                     self.file_path_label.setText(self.tr("Path: Loaded from URL"))
-                self.file_size_label.setText(self.tr("Size: {size:,} bytes").format(size=len(self.current_log_content)))
+                self.file_size_label.setText(
+                    self.tr("Size: {size:,} bytes").format(
+                        size=len(self.current_log_content)
+                    )
+                )
                 self.last_modified_label.setText(self.tr("Modified: N/A"))
             else:
                 self.file_path_label.setText(self.tr("Path: N/A"))
@@ -973,18 +1091,28 @@ class PlayerLogTab(QWidget):
                 return f"{size:.1f} PB"
 
             size_str = format_size(size_bytes)
-            modified_str = datetime.fromtimestamp(modified_time).strftime("%Y-%m-%d %H:%M:%S")
+            modified_str = datetime.fromtimestamp(modified_time).strftime(
+                "%Y-%m-%d %H:%M:%S"
+            )
 
-            self.file_path_label.setText(self.tr("Path: {path_str}").format(path_str=path_str))
-            self.file_size_label.setText(self.tr("Size: {size_str}").format(size_str=size_str))
-            self.last_modified_label.setText(self.tr("Modified: {modified_str}").format(modified_str=modified_str))
+            self.file_path_label.setText(
+                self.tr("Path: {path_str}").format(path_str=path_str)
+            )
+            self.file_size_label.setText(
+                self.tr("Size: {size_str}").format(size_str=size_str)
+            )
+            self.last_modified_label.setText(
+                self.tr("Modified: {modified_str}").format(modified_str=modified_str)
+            )
         except Exception as e:
             logger.error(f"Failed to update file info: {e}")
 
     def _update_match_count(self) -> None:
         """Update the match count label based on current matches."""
         total_matches = len(self.matches)
-        current_index = self.current_match_index + 1 if self.current_match_index >= 0 else 0
+        current_index = (
+            self.current_match_index + 1 if self.current_match_index >= 0 else 0
+        )
         self.match_count_label.setText(f"{current_index}/{total_matches}")
 
     def _on_search_text_changed_debounced(self) -> None:
@@ -1002,7 +1130,9 @@ class PlayerLogTab(QWidget):
             return
         cursor = self.log_display.textCursor()
         document = self.log_display.document()
-        regex = QRegularExpression(text, QRegularExpression.PatternOption.CaseInsensitiveOption)
+        regex = QRegularExpression(
+            text, QRegularExpression.PatternOption.CaseInsensitiveOption
+        )
         pos = 0
         while True:
             match = regex.match(document.toPlainText(), pos)
@@ -1024,7 +1154,9 @@ class PlayerLogTab(QWidget):
             return
         self.current_match_index = (self.current_match_index - 1) % len(self.matches)
         if self.current_match_index < 0:
-            self.current_match_index = len(self.matches) - 1  # Wrap around to last match
+            self.current_match_index = (
+                len(self.matches) - 1
+            )  # Wrap around to last match
         self.log_display.setTextCursor(self.matches[self.current_match_index])
         self._update_match_count()
 
@@ -1057,7 +1189,9 @@ class PlayerLogTab(QWidget):
                 if match.hasMatch():
                     cursor = QTextCursor(document)
                     cursor.setPosition(match.capturedStart())
-                    cursor.setPosition(match.capturedEnd(), QTextCursor.MoveMode.KeepAnchor)
+                    cursor.setPosition(
+                        match.capturedEnd(), QTextCursor.MoveMode.KeepAnchor
+                    )
                     matches.append(QTextCursor(cursor))
 
             self._pattern_matches_cache[pattern] = matches
@@ -1146,7 +1280,9 @@ class PlayerLogTab(QWidget):
         cursor.mergeCharFormat(self.quick_nav_highlight_format)
 
         # Update status message (optional - could be shown in a status bar)
-        logger.debug(f"Navigated to pattern '{pattern}' - {total_matches} total matches")
+        logger.debug(
+            f"Navigated to pattern '{pattern}' - {total_matches} total matches"
+        )
 
     def load_default_log(self) -> None:
         self.player_log_path = self._get_player_log_path()
@@ -1156,7 +1292,9 @@ class PlayerLogTab(QWidget):
         self.load_log()
 
     def load_log_from_file(self) -> None:
-        file_path, _ = QFileDialog.getOpenFileName(self, "Open Log File", "", "Log Files (*.log *.txt);;All Files (*)")
+        file_path, _ = QFileDialog.getOpenFileName(
+            self, "Open Log File", "", "Log Files (*.log *.txt);;All Files (*)"
+        )
         if file_path:
             self.player_log_path = Path(file_path)
             self.load_log()
@@ -1189,7 +1327,9 @@ class PlayerLogTab(QWidget):
             self.current_log_content = b"".join(chunks).decode("utf-8", errors="ignore")
             self.progress_bar.setValue(100)
 
-        url, ok = QInputDialog.getText(self, self.tr("Load Log from Link"), self.tr("Enter URL:"))
+        url, ok = QInputDialog.getText(
+            self, self.tr("Load Log from Link"), self.tr("Enter URL:")
+        )
         if ok and url:
             try:
                 self.clear_log()
@@ -1215,7 +1355,9 @@ class PlayerLogTab(QWidget):
         self.load_log()
 
     def export_log(self) -> None:
-        file_path, _ = QFileDialog.getSaveFileName(self, "Export Log", "", "Text Files (*.txt);;All Files (*)")
+        file_path, _ = QFileDialog.getSaveFileName(
+            self, "Export Log", "", "Text Files (*.txt);;All Files (*)"
+        )
         if file_path:
             try:
                 with open(file_path, "w", encoding="utf-8") as f:
@@ -1230,7 +1372,11 @@ class PlayerLogTab(QWidget):
         menu = self.log_display.createStandardContextMenu()
         cursor = self.log_display.cursorForPosition(pos)
         line_number = cursor.blockNumber()
-        bookmark_action_text = "Remove Bookmark" if line_number in self.bookmarked_lines else "Add Bookmark"
+        bookmark_action_text = (
+            "Remove Bookmark"
+            if line_number in self.bookmarked_lines
+            else "Add Bookmark"
+        )
         bookmark_action = menu.addAction(bookmark_action_text)
         bookmark_action.triggered.connect(lambda: self.toggle_bookmark(line_number))
         pathmatch = LogPatternManager.PATHLIKE_PATTERN.findall(cursor.block().text())
@@ -1241,7 +1387,9 @@ class PlayerLogTab(QWidget):
                     path[:-1],
                 ):  # error messages frequently tag on a ] or other terminator character
                     if os.path.exists(candidate):
-                        menu.addAction(f"Open '{candidate}'", lambda p=candidate: self.open_file(p))
+                        menu.addAction(
+                            f"Open '{candidate}'", lambda p=candidate: self.open_file(p)
+                        )
                         break
         menu.exec(self.log_display.mapToGlobal(pos))
 
@@ -1249,7 +1397,8 @@ class PlayerLogTab(QWidget):
         if self.settings_controller.settings.text_editor_location:
             launch_process(
                 self.settings_controller.settings.text_editor_location,
-                self.settings_controller.settings.text_editor_file_arg.split(" ") + [file_path],
+                self.settings_controller.settings.text_editor_file_arg.split(" ")
+                + [file_path],
                 str(AppInfo().application_folder),
             )
 
@@ -1310,7 +1459,9 @@ class PlayerLogTab(QWidget):
             self.clear_log()
         self.progress_bar.setFormat(self.tr("Loading file... %p%"))
         self.progress_bar.show()
-        filter_text = self.filter_combo.currentText() if self.filter_combo else "All Entries"
+        filter_text = (
+            self.filter_combo.currentText() if self.filter_combo else "All Entries"
+        )
         mod_filter = self.mod_filter_input.text() if self.mod_filter_input else ""
         lines = new_content.splitlines() or self.current_log_content.splitlines()
 
@@ -1332,17 +1483,27 @@ class PlayerLogTab(QWidget):
                 continue
             if filter_text == self.tr("All Entries"):
                 filtered_lines.append(line)
-            elif filter_text == self.tr("Infos Only") and self._info_pattern.search(line):
+            elif filter_text == self.tr("Infos Only") and self._info_pattern.search(
+                line
+            ):
                 filtered_lines.append(line)
-            elif filter_text == self.tr("Keybinds Only") and keybind_pattern.search(line):
+            elif filter_text == self.tr("Keybinds Only") and keybind_pattern.search(
+                line
+            ):
                 filtered_lines.append(line)
-            elif filter_text == self.tr("Mod Issues") and mod_issue_pattern.search(line):
+            elif filter_text == self.tr("Mod Issues") and mod_issue_pattern.search(
+                line
+            ):
                 filtered_lines.append(line)
-            elif filter_text == self.tr("Warnings Only") and warning_pattern.search(line):
+            elif filter_text == self.tr("Warnings Only") and warning_pattern.search(
+                line
+            ):
                 filtered_lines.append(line)
             elif filter_text == self.tr("Errors Only") and error_pattern.search(line):
                 filtered_lines.append(line)
-            elif filter_text == self.tr("Exceptions Only") and exception_pattern.search(line):
+            elif filter_text == self.tr("Exceptions Only") and exception_pattern.search(
+                line
+            ):
                 filtered_lines.append(line)
             elif filter_text == self.tr("All Issues") and (
                 keybind_pattern.search(line)
@@ -1356,7 +1517,9 @@ class PlayerLogTab(QWidget):
         collapsed_lines = self._collapse_repeated_lines(filtered_lines)
         self.filtered_content = "\n".join(collapsed_lines)
         scroll_bar = self.log_display.verticalScrollBar()
-        total_chunks = max(1, (len(self.filtered_content) + chunk_size - 1) // chunk_size)
+        total_chunks = max(
+            1, (len(self.filtered_content) + chunk_size - 1) // chunk_size
+        )
         chunk_cnt = 0
         for i in range(0, len(self.filtered_content), chunk_size):
             old_value = scroll_bar.value()
@@ -1383,17 +1546,31 @@ class PlayerLogTab(QWidget):
         """Update the statistics labels in the UI (consolidated)."""
         # Update button texts for clickable stats
         self.total_lines_label.setText(
-            self.tr("Total Lines: {total_lines}").format(total_lines=self.log_stats["total_lines"])
+            self.tr("Total Lines: {total_lines}").format(
+                total_lines=self.log_stats["total_lines"]
+            )
         )
-        self.info_label.setText(self.tr("Infos: {infos}").format(infos=self.log_stats["infos"]))
-        self.keybind_label.setText(self.tr("Keybinds: {keybinds}").format(keybinds=self.log_stats["keybinds"]))
+        self.info_label.setText(
+            self.tr("Infos: {infos}").format(infos=self.log_stats["infos"])
+        )
+        self.keybind_label.setText(
+            self.tr("Keybinds: {keybinds}").format(keybinds=self.log_stats["keybinds"])
+        )
         self.mod_issues_label.setText(
-            self.tr("Mod Issues: {mod_issues}").format(mod_issues=self.log_stats["mod_issues"])
+            self.tr("Mod Issues: {mod_issues}").format(
+                mod_issues=self.log_stats["mod_issues"]
+            )
         )
-        self.warnings_label.setText(self.tr("Warnings: {warnings}").format(warnings=self.log_stats["warnings"]))
-        self.errors_label.setText(self.tr("Errors: {errors}").format(errors=self.log_stats["errors"]))
+        self.warnings_label.setText(
+            self.tr("Warnings: {warnings}").format(warnings=self.log_stats["warnings"])
+        )
+        self.errors_label.setText(
+            self.tr("Errors: {errors}").format(errors=self.log_stats["errors"])
+        )
         self.exceptions_label.setText(
-            self.tr("Exceptions: {exceptions}").format(exceptions=self.log_stats["exceptions"])
+            self.tr("Exceptions: {exceptions}").format(
+                exceptions=self.log_stats["exceptions"]
+            )
         )
         self.all_issues_label.setText(
             self.tr("All Issues: {all_issues}").format(

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -52,7 +52,9 @@ class SettingsDialog(QDialog):
         main_layout.addLayout(button_layout)
 
         # Reset to defaults button
-        self.global_reset_to_defaults_button = QPushButton(self.tr("Reset to Defaults"), self)
+        self.global_reset_to_defaults_button = QPushButton(
+            self.tr("Reset to Defaults"), self
+        )
         button_layout.addWidget(self.global_reset_to_defaults_button)
 
         button_layout.addStretch()
@@ -100,7 +102,9 @@ class SettingsDialog(QDialog):
         # "Game location" → "Config location" → "Steam mods location" → "Local mods location"
         self.setTabOrder(self.game_location, self.config_folder_location)
         self.setTabOrder(self.config_folder_location, self.steam_mods_folder_location)
-        self.setTabOrder(self.steam_mods_folder_location, self.local_mods_folder_location)
+        self.setTabOrder(
+            self.steam_mods_folder_location, self.local_mods_folder_location
+        )
 
         # Push the buttons to the bottom
         tab_layout.addStretch()
@@ -147,7 +151,9 @@ class SettingsDialog(QDialog):
 
         self.game_location = QLineEdit()
         self.game_location.setPlaceholderText(
-            self.tr(r"Should be like: C:\Program Files (x86)\Steam\steamapps\common\RimWorld")
+            self.tr(
+                r"Should be like: C:\Program Files (x86)\Steam\steamapps\common\RimWorld"
+            )
         )
         self.game_location.setTextMargins(GUIInfo().text_field_margins)
         self.game_location.setFixedHeight(GUIInfo().default_font_line_height * 2)
@@ -185,7 +191,9 @@ class SettingsDialog(QDialog):
             )
         )
         self.config_folder_location.setTextMargins(GUIInfo().text_field_margins)
-        self.config_folder_location.setFixedHeight(GUIInfo().default_font_line_height * 2)
+        self.config_folder_location.setFixedHeight(
+            GUIInfo().default_font_line_height * 2
+        )
         group_layout.addWidget(self.config_folder_location)
 
     def _do_steam_mods_folder_location_area(self, tab_layout: QVBoxLayout) -> None:
@@ -197,10 +205,14 @@ class SettingsDialog(QDialog):
         header_layout = QHBoxLayout()
         group_layout.addLayout(header_layout)
 
-        self.steam_client_integration_checkbox = QCheckBox(self.tr("Enable Steam client integration"))
+        self.steam_client_integration_checkbox = QCheckBox(
+            self.tr("Enable Steam client integration")
+        )
         group_layout.addWidget(self.steam_client_integration_checkbox)
 
-        self.steam_client_integration_checkbox.stateChanged.connect(self._on_steam_integration_toggled)
+        self.steam_client_integration_checkbox.stateChanged.connect(
+            self._on_steam_integration_toggled
+        )
 
         section_label = QLabel(self.tr("Steam mods location"))
         section_label.setFont(GUIInfo().emphasis_font)
@@ -225,7 +237,9 @@ class SettingsDialog(QDialog):
             )
         )
         self.steam_mods_folder_location.setTextMargins(GUIInfo().text_field_margins)
-        self.steam_mods_folder_location.setFixedHeight(GUIInfo().default_font_line_height * 2)
+        self.steam_mods_folder_location.setFixedHeight(
+            GUIInfo().default_font_line_height * 2
+        )
         group_layout.addWidget(self.steam_mods_folder_location)
 
     def _do_local_mods_folder_location_area(self, tab_layout: QVBoxLayout) -> None:
@@ -255,10 +269,14 @@ class SettingsDialog(QDialog):
 
         self.local_mods_folder_location = QLineEdit()
         self.local_mods_folder_location.setPlaceholderText(
-            self.tr(r"should be like: C:\Program Files (x86)\Steam\steamapps\common\Rimworld\Mods")
+            self.tr(
+                r"should be like: C:\Program Files (x86)\Steam\steamapps\common\Rimworld\Mods"
+            )
         )
         self.local_mods_folder_location.setTextMargins(GUIInfo().text_field_margins)
-        self.local_mods_folder_location.setFixedHeight(GUIInfo().default_font_line_height * 2)
+        self.local_mods_folder_location.setFixedHeight(
+            GUIInfo().default_font_line_height * 2
+        )
         group_layout.addWidget(self.local_mods_folder_location)
 
     def _do_instance_folder_location_area(self, tab_layout: QVBoxLayout) -> None:
@@ -285,9 +303,13 @@ class SettingsDialog(QDialog):
 
         self.instance_folder_location = QLineEdit()
         self.instance_folder_location.setReadOnly(True)
-        self.instance_folder_location.setPlaceholderText(self.tr("Leave empty to use default location"))
+        self.instance_folder_location.setPlaceholderText(
+            self.tr("Leave empty to use default location")
+        )
         self.instance_folder_location.setTextMargins(GUIInfo().text_field_margins)
-        self.instance_folder_location.setFixedHeight(GUIInfo().default_font_line_height * 2)
+        self.instance_folder_location.setFixedHeight(
+            GUIInfo().default_font_line_height * 2
+        )
         group_layout.addWidget(self.instance_folder_location)
 
     def _do_game_launch_tab(self) -> None:
@@ -314,7 +336,9 @@ class SettingsDialog(QDialog):
             )
         )
         # Connect checkbox to disable/enable run_args group
-        self.launch_via_steam_protocol_checkbox.stateChanged.connect(self._on_steam_protocol_toggled)
+        self.launch_via_steam_protocol_checkbox.stateChanged.connect(
+            self._on_steam_protocol_toggled
+        )
         steam_protocol_layout.addWidget(self.launch_via_steam_protocol_checkbox)
 
         # Game arguments group
@@ -347,7 +371,9 @@ class SettingsDialog(QDialog):
         run_args_layout.addLayout(run_args_info_layout, 0, 0, 1, 2)
 
         run_args_label = QLabel(self.tr("Edit Game Run Arguments:"))
-        run_args_layout.addWidget(run_args_label, 1, 0, alignment=Qt.AlignmentFlag.AlignRight)
+        run_args_layout.addWidget(
+            run_args_label, 1, 0, alignment=Qt.AlignmentFlag.AlignRight
+        )
 
         self.run_args = QLineEdit()
         self.run_args.setTextMargins(GUIInfo().text_field_margins)
@@ -398,9 +424,13 @@ class SettingsDialog(QDialog):
         backup_group_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         tab_layout.addWidget(backup_group_label)
 
-        self.backup_saves_on_launch_checkbox = QCheckBox(self.tr("Automatically backup saves on first daily launch"))
+        self.backup_saves_on_launch_checkbox = QCheckBox(
+            self.tr("Automatically backup saves on first daily launch")
+        )
         self.backup_saves_on_launch_checkbox.setToolTip(
-            self.tr("If enabled, RimSort will automatically backup saves on the first daily launch.")
+            self.tr(
+                "If enabled, RimSort will automatically backup saves on the first daily launch."
+            )
         )
         tab_layout.addWidget(self.backup_saves_on_launch_checkbox)
 
@@ -408,13 +438,17 @@ class SettingsDialog(QDialog):
         retention_layout = QHBoxLayout()
         retention_label = QLabel(self.tr("Number of backups to keep:"))
         retention_label.setToolTip(
-            self.tr("The number of backups to keep. Set to -1 to keep all backups, 0 to delete all.")
+            self.tr(
+                "The number of backups to keep. Set to -1 to keep all backups, 0 to delete all."
+            )
         )
         retention_layout.addWidget(retention_label)
 
         self.auto_backup_retention_count_spinbox = QSpinBox()
         self.auto_backup_retention_count_spinbox.setRange(-1, 999)
-        self.auto_backup_retention_count_spinbox.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        self.auto_backup_retention_count_spinbox.setSizePolicy(
+            QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed
+        )
         retention_layout.addWidget(self.auto_backup_retention_count_spinbox)
         tab_layout.addLayout(retention_layout)
 
@@ -429,7 +463,9 @@ class SettingsDialog(QDialog):
         )
         self.auto_backup_compression_count_spinbox = QSpinBox()
         self.auto_backup_compression_count_spinbox.setRange(-1, 999)
-        self.auto_backup_compression_count_spinbox.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        self.auto_backup_compression_count_spinbox.setSizePolicy(
+            QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed
+        )
         compression_layout.addWidget(self.auto_backup_compression_count_spinbox)
         tab_layout.addLayout(compression_layout)
 
@@ -468,7 +504,9 @@ class SettingsDialog(QDialog):
 
         section_label = QLabel(section_lbl)
         section_label.setFont(GUIInfo().emphasis_font)
-        section_label.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
+        section_label.setSizePolicy(
+            QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed
+        )
         group_layout.addWidget(section_label)
 
         section_layout = QVBoxLayout()
@@ -537,7 +575,9 @@ class SettingsDialog(QDialog):
         local_file_choose_button = QToolButton()
         local_file_choose_button.setText(self.tr("Choose…"))
         local_file_choose_button.setEnabled(False)
-        local_file_choose_button.setFixedWidth(github_download_button.sizeHint().width())
+        local_file_choose_button.setFixedWidth(
+            github_download_button.sizeHint().width()
+        )
         row_layout.addWidget(local_file_choose_button)
 
         section_layout.addStretch(1)
@@ -593,7 +633,9 @@ class SettingsDialog(QDialog):
             self.steam_workshop_db_local_file_choose_button,
         ) = self.__create_db_group(section_lbl, none_lbl, tab_layout)
         database_expiry_label = QLabel(
-            self.tr("Database expiry in seconds for example, 604800 for 7 days. and 0 for no expiry.")
+            self.tr(
+                "Database expiry in seconds for example, 604800 for 7 days. and 0 for no expiry."
+            )
         )
         database_expiry_label.setFont(GUIInfo().emphasis_font)
         group_layout.addWidget(database_expiry_label)
@@ -635,7 +677,9 @@ class SettingsDialog(QDialog):
 
     def _do_aux_db_time_limit_group(self, tab_layout: QBoxLayout) -> None:
         self.aux_db_time_limit_label = QLabel(
-            self.tr("Auxiliary Metadata DB deletion time limit in seconds. (Delete instantly 0, Never Delete -1)")
+            self.tr(
+                "Auxiliary Metadata DB deletion time limit in seconds. (Delete instantly 0, Never Delete -1)"
+            )
         )
         aux_db_tooltip = self.tr("""To enable editing of this time limit, enable the checkbox (Enable editing) on the right.
 After a mod is deleted, this is the time we wait until this mod item is deleted from the Auxiliary Metadata DB. 
@@ -652,9 +696,13 @@ This basically preserves your mod coloring, user notes etc. for this many second
         self.aux_db_time_limit.setFixedHeight(GUIInfo().default_font_line_height * 2)
 
         self.enable_aux_db_behavior_editing = QCheckBox(self.tr("Enable editing"))
-        self.enable_aux_db_behavior_editing.stateChanged.connect(self.enable_aux_db_time_limit_line_edit)
+        self.enable_aux_db_behavior_editing.stateChanged.connect(
+            self.enable_aux_db_time_limit_line_edit
+        )
         self.enable_aux_db_behavior_editing.setToolTip(
-            self.tr("This enables the editing of the time limit for Aux Metadata DB data deletion.")
+            self.tr(
+                "This enables the editing of the time limit for Aux Metadata DB data deletion."
+            )
         )
 
         label_layout = QHBoxLayout()
@@ -701,7 +749,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         deps_group_box_layout.addWidget(deps_label)
 
         # Use dependencies for sorting checkbox
-        self.use_moddependencies_as_loadTheseBefore = QCheckBox(self.tr("Use dependency rules for sorting."))
+        self.use_moddependencies_as_loadTheseBefore = QCheckBox(
+            self.tr("Use dependency rules for sorting.")
+        )
         self.use_moddependencies_as_loadTheseBefore.setToolTip(
             self.tr(
                 "If enabled, also uses moddependencies as loadTheseBefore, and mods will be sorted such that dependencies are loaded before the dependent mod."
@@ -710,8 +760,8 @@ This basically preserves your mod coloring, user notes etc. for this many second
         deps_group_box_layout.addWidget(self.use_moddependencies_as_loadTheseBefore)
 
         # Use alternativePackageIds as satisfying dependencies
-        self.use_alternative_package_ids_as_satisfying_dependencies_checkbox = QCheckBox(
-            self.tr("Use alternativePackageIds as satisfying dependencies")
+        self.use_alternative_package_ids_as_satisfying_dependencies_checkbox = (
+            QCheckBox(self.tr("Use alternativePackageIds as satisfying dependencies"))
         )
         self.use_alternative_package_ids_as_satisfying_dependencies_checkbox.setToolTip(
             self.tr(
@@ -719,9 +769,13 @@ This basically preserves your mod coloring, user notes etc. for this many second
                 "E.g., 'oels.vehiclemapframework', alternatives: 'oels.vehiclemapframework.dev'"
             )
         )
-        deps_group_box_layout.addWidget(self.use_alternative_package_ids_as_satisfying_dependencies_checkbox)
+        deps_group_box_layout.addWidget(
+            self.use_alternative_package_ids_as_satisfying_dependencies_checkbox
+        )
 
-        self.check_deps_checkbox = QCheckBox(self.tr("Prompt user to download dependencies when click in Sort"))
+        self.check_deps_checkbox = QCheckBox(
+            self.tr("Prompt user to download dependencies when click in Sort")
+        )
         deps_group_box_layout.addWidget(self.check_deps_checkbox)
 
         # XML parsing behavior group
@@ -735,7 +789,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         xml_parsing_explanatory_label = QLabel(self.tr("XML Parsing Behavior"))
         xml_parsing_explanatory_label.setFont(GUIInfo().emphasis_font)
         xml_parsing_group_box_layout.addWidget(xml_parsing_explanatory_label)
-        self.prefer_versioned_about_tags_checkbox = QCheckBox(self.tr("Prefer versioned About.xml tags over base tags"))
+        self.prefer_versioned_about_tags_checkbox = QCheckBox(
+            self.tr("Prefer versioned About.xml tags over base tags")
+        )
         self.prefer_versioned_about_tags_checkbox.setToolTip(
             self.tr(
                 "When enabled, *ByVersion tags take precedence over the base tags, \n"
@@ -744,7 +800,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
             )
         )
 
-        xml_parsing_group_box_layout.addWidget(self.prefer_versioned_about_tags_checkbox)
+        xml_parsing_group_box_layout.addWidget(
+            self.prefer_versioned_about_tags_checkbox
+        )
 
         # Mod list options group
         modlist_option_group_box = QGroupBox()
@@ -758,56 +816,80 @@ This basically preserves your mod coloring, user notes etc. for this many second
         modlist_option_group_box_layout.addWidget(modlist_option_label)
 
         # Download missing mods checkbox
-        self.download_missing_mods_checkbox = QCheckBox(self.tr("Download missing mods automatically"))
+        self.download_missing_mods_checkbox = QCheckBox(
+            self.tr("Download missing mods automatically")
+        )
         self.download_missing_mods_checkbox.setToolTip(
-            self.tr("Notifies to download mods that may be missing in the active modlist")
+            self.tr(
+                "Notifies to download mods that may be missing in the active modlist"
+            )
         )
         modlist_option_group_box_layout.addWidget(self.download_missing_mods_checkbox)
 
         # Duplicate mod notification checkbox
-        self.show_duplicate_mods_warning_checkbox = QCheckBox(self.tr("Show duplicate mods warning"))
+        self.show_duplicate_mods_warning_checkbox = QCheckBox(
+            self.tr("Show duplicate mods warning")
+        )
         self.show_duplicate_mods_warning_checkbox.setToolTip(
             self.tr("Notifies and displays the mods that have the same packageid")
         )
-        modlist_option_group_box_layout.addWidget(self.show_duplicate_mods_warning_checkbox)
+        modlist_option_group_box_layout.addWidget(
+            self.show_duplicate_mods_warning_checkbox
+        )
 
         # Mod type filter checkbox
         self.mod_type_filter_checkbox = QCheckBox(self.tr("Enable mod type filter"))
         self.mod_type_filter_checkbox.setToolTip(
-            self.tr("Add icons and filtering options for easy mods identification and grouping")
+            self.tr(
+                "Add icons and filtering options for easy mods identification and grouping"
+            )
         )
         modlist_option_group_box_layout.addWidget(self.mod_type_filter_checkbox)
 
         # Hide invalid mod filtering checkbox
-        self.hide_invalid_mods_when_filtering_checkbox = QCheckBox(self.tr("Hide invalid mods when filtering"))
+        self.hide_invalid_mods_when_filtering_checkbox = QCheckBox(
+            self.tr("Hide invalid mods when filtering")
+        )
         self.hide_invalid_mods_when_filtering_checkbox.setToolTip(
             self.tr("Hides invalid mods, not recommended to enable")
         )
-        modlist_option_group_box_layout.addWidget(self.hide_invalid_mods_when_filtering_checkbox)
+        modlist_option_group_box_layout.addWidget(
+            self.hide_invalid_mods_when_filtering_checkbox
+        )
 
         # Inactive mods sorting group
         self.inactive_mods_sorting_group_box = QGroupBox()
         tab_layout.addWidget(self.inactive_mods_sorting_group_box)
 
         inactive_mods_sorting_group_box_layout = QVBoxLayout()
-        self.inactive_mods_sorting_group_box.setLayout(inactive_mods_sorting_group_box_layout)
+        self.inactive_mods_sorting_group_box.setLayout(
+            inactive_mods_sorting_group_box_layout
+        )
 
         inactive_mods_sorting_label = QLabel(self.tr("Inactive Mods Sorting"))
         inactive_mods_sorting_label.setFont(GUIInfo().emphasis_font)
         inactive_mods_sorting_group_box_layout.addWidget(inactive_mods_sorting_label)
 
         # Inactive mods sorting options checkbox
-        self.enable_inactive_mods_sorting_checkbox = QCheckBox(self.tr("Enable inactive mods sorting"))
+        self.enable_inactive_mods_sorting_checkbox = QCheckBox(
+            self.tr("Enable inactive mods sorting")
+        )
         self.enable_inactive_mods_sorting_checkbox.setToolTip(
             self.tr(
                 "Additional options like name, author, folder size, modified date will be available in the mods panel for sorting inactive mods \n"
                 "Disabling this can improve performance by avoiding heavy calculations."
             )
         )
-        inactive_mods_sorting_group_box_layout.addWidget(self.enable_inactive_mods_sorting_checkbox)
+        inactive_mods_sorting_group_box_layout.addWidget(
+            self.enable_inactive_mods_sorting_checkbox
+        )
 
-        self.save_inactive_mods_sort_state_checkbox = QCheckBox(self.tr("Save inactive mods sort state"))
-        inactive_mods_sorting_group_box_layout.addWidget(self.save_inactive_mods_sort_state_checkbox)
+        self.save_inactive_mods_sort_state_checkbox = QCheckBox(
+            self.tr("Save inactive mods sort state")
+        )
+        inactive_mods_sorting_group_box_layout.addWidget(
+            self.save_inactive_mods_sort_state_checkbox
+        )
 
         tab_layout.addStretch()
 
@@ -829,7 +911,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         when_building_database_label.setFont(GUIInfo().emphasis_font)
         group_layout.addWidget(when_building_database_label)
 
-        self.db_builder_include_all_radio = QRadioButton(self.tr("Get PublishedFileIDs from locally installed mods."))
+        self.db_builder_include_all_radio = QRadioButton(
+            self.tr("Get PublishedFileIDs from locally installed mods.")
+        )
         group_layout.addWidget(self.db_builder_include_all_radio)
 
         explanatory_label = QLabel(
@@ -840,7 +924,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         )
         group_layout.addWidget(explanatory_label)
 
-        self.db_builder_include_no_local_radio = QRadioButton(self.tr("Get PublishedFileIDs from the Steam Workshop."))
+        self.db_builder_include_no_local_radio = QRadioButton(
+            self.tr("Get PublishedFileIDs from the Steam Workshop.")
+        )
         group_layout.addWidget(self.db_builder_include_no_local_radio)
 
         explanatory_label = QLabel(
@@ -858,7 +944,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         group_layout = QVBoxLayout()
         group_box.setLayout(group_layout)
 
-        self.db_builder_query_dlc_checkbox = QCheckBox(self.tr("Query DLC dependency data with Steamworks API"))
+        self.db_builder_query_dlc_checkbox = QCheckBox(
+            self.tr("Query DLC dependency data with Steamworks API")
+        )
         group_layout.addWidget(self.db_builder_query_dlc_checkbox)
 
         self.db_builder_update_instead_of_overwriting_checkbox = QCheckBox(
@@ -879,7 +967,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         self.db_builder_steam_api_key = QLineEdit()
         self.db_builder_steam_api_key.setEchoMode(QLineEdit.EchoMode.Password)
         self.db_builder_steam_api_key.setTextMargins(GUIInfo().text_field_margins)
-        self.db_builder_steam_api_key.setFixedHeight(GUIInfo().default_font_line_height * 2)
+        self.db_builder_steam_api_key.setFixedHeight(
+            GUIInfo().default_font_line_height * 2
+        )
         grid_group_layout.addWidget(self.db_builder_steam_api_key, 1, 1)
 
         grid_group_layout.setColumnStretch(0, 0)
@@ -896,10 +986,14 @@ This basically preserves your mod coloring, user notes etc. for this many second
         item_label = QLabel(self.tr("Download all published Workshop mods via:"))
         item_layout.addWidget(item_label)
 
-        self.db_builder_download_all_mods_via_steamcmd_button = QPushButton(self.tr("SteamCMD"))
+        self.db_builder_download_all_mods_via_steamcmd_button = QPushButton(
+            self.tr("SteamCMD")
+        )
         item_layout.addWidget(self.db_builder_download_all_mods_via_steamcmd_button)
 
-        self.db_builder_download_all_mods_via_steam_button = QPushButton(self.tr("Steam"))
+        self.db_builder_download_all_mods_via_steam_button = QPushButton(
+            self.tr("Steam")
+        )
         self.db_builder_download_all_mods_via_steam_button.setFixedWidth(
             self.db_builder_download_all_mods_via_steamcmd_button.sizeHint().width()
         )
@@ -911,7 +1005,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
 
         item_layout.addStretch()
 
-        self.db_builder_compare_databases_button = QPushButton(self.tr("Compare Databases"))
+        self.db_builder_compare_databases_button = QPushButton(
+            self.tr("Compare Databases")
+        )
         item_layout.addWidget(self.db_builder_compare_databases_button)
 
         self.db_builder_merge_databases_button = QPushButton(self.tr("Merge Databases"))
@@ -921,7 +1017,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         item_layout.addWidget(self.db_builder_merge_databases_button)
 
         self.db_builder_build_database_button = QPushButton(self.tr("Build Database"))
-        self.db_builder_build_database_button.setFixedWidth(self.db_builder_compare_databases_button.sizeHint().width())
+        self.db_builder_build_database_button.setFixedWidth(
+            self.db_builder_compare_databases_button.sizeHint().width()
+        )
         item_layout.addWidget(self.db_builder_build_database_button)
 
     def _do_steamcmd_tab(self) -> None:
@@ -937,10 +1035,14 @@ This basically preserves your mod coloring, user notes etc. for this many second
         group_layout = QVBoxLayout()
         group_box.setLayout(group_layout)
 
-        self.steamcmd_validate_downloads_checkbox = QCheckBox(self.tr("Validate downloaded mods"))
+        self.steamcmd_validate_downloads_checkbox = QCheckBox(
+            self.tr("Validate downloaded mods")
+        )
         group_layout.addWidget(self.steamcmd_validate_downloads_checkbox)
 
-        self.steamcmd_auto_clear_depot_cache_checkbox = QCheckBox(self.tr("Automatically clear depot cache"))
+        self.steamcmd_auto_clear_depot_cache_checkbox = QCheckBox(
+            self.tr("Automatically clear depot cache")
+        )
         self.steamcmd_auto_clear_depot_cache_checkbox.setToolTip(
             (
                 self.tr(
@@ -951,7 +1053,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         )
         group_layout.addWidget(self.steamcmd_auto_clear_depot_cache_checkbox)
 
-        self.steamcmd_delete_before_update_checkbox = QCheckBox(self.tr("Delete before update"))
+        self.steamcmd_delete_before_update_checkbox = QCheckBox(
+            self.tr("Delete before update")
+        )
         self.steamcmd_delete_before_update_checkbox.setToolTip(
             self.tr("This is useful if you want to ensure clean mod updates.")
         )
@@ -976,7 +1080,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
 
         self.steamcmd_install_location = QLineEdit()
         self.steamcmd_install_location.setTextMargins(GUIInfo().text_field_margins)
-        self.steamcmd_install_location.setFixedHeight(GUIInfo().default_font_line_height * 2)
+        self.steamcmd_install_location.setFixedHeight(
+            GUIInfo().default_font_line_height * 2
+        )
         group_layout.addWidget(self.steamcmd_install_location)
 
         tab_layout.addStretch()
@@ -986,7 +1092,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
 
         button_layout.addStretch()
 
-        self.steamcmd_clear_depot_cache_button = QPushButton(self.tr("Clear depot cache"))
+        self.steamcmd_clear_depot_cache_button = QPushButton(
+            self.tr("Clear depot cache")
+        )
         self.steamcmd_clear_depot_cache_button.setToolTip(
             self.tr(
                 "Clear the depot cache manually. This may be useful if you encounter issues with downloading mods through SteamCMD."
@@ -1020,25 +1128,33 @@ This basically preserves your mod coloring, user notes etc. for this many second
         quality_preset_label.setFont(GUIInfo().emphasis_font)
         group_layout.addWidget(quality_preset_label)
 
-        self.todds_preset_optimized_radio = QRadioButton(self.tr("Optimized - Recommended for RimWorld"))
+        self.todds_preset_optimized_radio = QRadioButton(
+            self.tr("Optimized - Recommended for RimWorld")
+        )
         group_layout.addWidget(self.todds_preset_optimized_radio)
 
         self.todds_preset_custom_radio = QRadioButton(self.tr("Custom todds command"))
         group_layout.addWidget(self.todds_preset_custom_radio)
 
         custom_command_label = QLabel(
-            self.tr("If -p as in path is not specified, path from current active or all mods selection will be used.")
+            self.tr(
+                "If -p as in path is not specified, path from current active or all mods selection will be used."
+            )
         )
         custom_command_label.setFont(GUIInfo().emphasis_font)
         group_layout.addWidget(custom_command_label)
 
         self.todds_custom_command_lineedit = QLineEdit()
-        todds_example = '-f BC1 -af BC7 -on -vf -fs -r Textures -t -p "D:\\Games\\RimWorld\\Mods"'
+        todds_example = (
+            '-f BC1 -af BC7 -on -vf -fs -r Textures -t -p "D:\\Games\\RimWorld\\Mods"'
+        )
         self.todds_custom_command_lineedit.setPlaceholderText(
             self.tr("eg: {todds_example}").format(todds_example=todds_example)
         )
         self.todds_custom_command_lineedit.setTextMargins(GUIInfo().text_field_margins)
-        self.todds_custom_command_lineedit.setFixedHeight(GUIInfo().default_font_line_height * 2)
+        self.todds_custom_command_lineedit.setFixedHeight(
+            GUIInfo().default_font_line_height * 2
+        )
         group_layout.addWidget(self.todds_custom_command_lineedit)
 
         group_box = QGroupBox()
@@ -1051,7 +1167,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         when_optimizing_label.setFont(GUIInfo().emphasis_font)
         group_layout.addWidget(when_optimizing_label)
 
-        self.todds_active_mods_only_radio = QRadioButton(self.tr("Optimize active mods only"))
+        self.todds_active_mods_only_radio = QRadioButton(
+            self.tr("Optimize active mods only")
+        )
         group_layout.addWidget(self.todds_active_mods_only_radio)
 
         self.todds_all_mods_radio = QRadioButton(self.tr("Optimize all mods"))
@@ -1066,11 +1184,15 @@ This basically preserves your mod coloring, user notes etc. for this many second
         self.todds_dry_run_checkbox = QCheckBox(self.tr("Enable dry-run mode"))
         group_layout.addWidget(self.todds_dry_run_checkbox)
 
-        self.todds_overwrite_checkbox = QCheckBox(self.tr("Overwrite existing optimized textures"))
+        self.todds_overwrite_checkbox = QCheckBox(
+            self.tr("Overwrite existing optimized textures")
+        )
         group_layout.addWidget(self.todds_overwrite_checkbox)
 
         self.auto_delete_orphaned_dds_checkbox = QCheckBox(
-            self.tr("Automatically delete .dds files if no corresponding .png file exists")
+            self.tr(
+                "Automatically delete .dds files if no corresponding .png file exists"
+            )
         )
         self.auto_delete_orphaned_dds_checkbox.setToolTip(
             self.tr(
@@ -1122,7 +1244,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         group_layout.addWidget(folder_arg_label)
         self.text_editor_folder_arg = QLineEdit()
         self.text_editor_folder_arg.setTextMargins(GUIInfo().text_field_margins)
-        self.text_editor_folder_arg.setFixedHeight(GUIInfo().default_font_line_height * 2)
+        self.text_editor_folder_arg.setFixedHeight(
+            GUIInfo().default_font_line_height * 2
+        )
         group_layout.addWidget(self.text_editor_folder_arg)
 
         file_arg_label = QLabel(self.tr("Additional Arguments (Opening Single File)"))
@@ -1169,7 +1293,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         theme_layout = QHBoxLayout()
         theme_group_box.setLayout(theme_layout)
 
-        self.enable_themes_checkbox = QCheckBox(self.tr("Enable to use theme / stylesheet instead of system Theme"))
+        self.enable_themes_checkbox = QCheckBox(
+            self.tr("Enable to use theme / stylesheet instead of system Theme")
+        )
         self.enable_themes_checkbox.setToolTip(
             self.tr(
                 "To add your own theme / stylesheet \n\n"
@@ -1185,7 +1311,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         theme_layout.addWidget(self.enable_themes_checkbox)
 
         self.themes_combobox = QComboBox()
-        self.themes_combobox.setSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred)
+        self.themes_combobox.setSizePolicy(
+            QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred
+        )
         theme_layout.addWidget(self.themes_combobox)
 
         self.theme_location_open_button = QToolButton()
@@ -1209,7 +1337,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         font_family_layout.addWidget(font_family_label)
 
         self.font_family_combobox = QFontComboBox()
-        self.font_family_combobox.setSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred)
+        self.font_family_combobox.setSizePolicy(
+            QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred
+        )
         font_family_layout.addWidget(self.font_family_combobox)
 
         font_size_layout = QHBoxLayout()
@@ -1221,11 +1351,15 @@ This basically preserves your mod coloring, user notes etc. for this many second
         self.font_size_spinbox = QSpinBox()
         self.font_size_spinbox.setRange(8, 20)
         self.font_size_spinbox.setValue(12)
-        self.font_size_spinbox.setSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred)
+        self.font_size_spinbox.setSizePolicy(
+            QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred
+        )
         font_size_layout.addWidget(self.font_size_spinbox)
 
         reset_button = QPushButton(self.tr("Reset"))
-        reset_button.setSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred)
+        reset_button.setSizePolicy(
+            QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred
+        )
 
         reset_button_layout = QHBoxLayout()
         reset_button_layout.addStretch(1)
@@ -1234,7 +1368,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         reset_button.clicked.connect(self.reset_font_settings)
 
         if self.enable_themes_checkbox.isChecked():
-            self.enable_themes_checkbox.stateChanged.connect(self.connect_populate_themes_combobox)
+            self.enable_themes_checkbox.stateChanged.connect(
+                self.connect_populate_themes_combobox
+            )
         else:
             self.themes_combobox.clear()
 
@@ -1249,11 +1385,15 @@ This basically preserves your mod coloring, user notes etc. for this many second
         language_group_layout = QHBoxLayout()
         language_group_box.setLayout(language_group_layout)
 
-        language_label = QLabel(self.tr("Select Language (Restart required to apply changes)"))
+        language_label = QLabel(
+            self.tr("Select Language (Restart required to apply changes)")
+        )
         language_group_layout.addWidget(language_label)
 
         self.language_combobox = QComboBox()
-        self.language_combobox.setSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred)
+        self.language_combobox.setSizePolicy(
+            QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred
+        )
 
         language_group_layout.addWidget(self.language_combobox)
 
@@ -1316,9 +1456,15 @@ This basically preserves your mod coloring, user notes etc. for this many second
         group_layout.addWidget(self.main_window_group)
 
         # Connect main window radio buttons to enable/disable custom size spinboxes dynamically
-        self.main_launch_maximized_radio.toggled.connect(self.disable_main_custom_size_spinboxes)
-        self.main_launch_normal_radio.toggled.connect(self.disable_main_custom_size_spinboxes)
-        self.main_launch_custom_radio.toggled.connect(self.enable_main_custom_size_spinboxes)
+        self.main_launch_maximized_radio.toggled.connect(
+            self.disable_main_custom_size_spinboxes
+        )
+        self.main_launch_normal_radio.toggled.connect(
+            self.disable_main_custom_size_spinboxes
+        )
+        self.main_launch_custom_radio.toggled.connect(
+            self.enable_main_custom_size_spinboxes
+        )
 
         # Browser Window
         (
@@ -1344,9 +1490,15 @@ This basically preserves your mod coloring, user notes etc. for this many second
         group_layout.addWidget(self.browser_window_group)
 
         # Connect browser window radio buttons to enable/disable custom size spinboxes dynamically
-        self.browser_launch_maximized_radio.toggled.connect(self.disable_browser_custom_size_spinboxes)
-        self.browser_launch_normal_radio.toggled.connect(self.disable_browser_custom_size_spinboxes)
-        self.browser_launch_custom_radio.toggled.connect(self.enable_browser_custom_size_spinboxes)
+        self.browser_launch_maximized_radio.toggled.connect(
+            self.disable_browser_custom_size_spinboxes
+        )
+        self.browser_launch_normal_radio.toggled.connect(
+            self.disable_browser_custom_size_spinboxes
+        )
+        self.browser_launch_custom_radio.toggled.connect(
+            self.enable_browser_custom_size_spinboxes
+        )
 
         # Settings Window (only custom option)
         settings_window_title_label = QLabel(self.tr("Settings Window Launch State"))
@@ -1358,7 +1510,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         settings_window_group.setLayout(settings_window_layout)
 
         self.settings_custom_width_spinbox = QSpinBox()
-        self.settings_custom_width_spinbox.setRange(Settings.MIN_SIZE, Settings.MAX_SIZE)
+        self.settings_custom_width_spinbox.setRange(
+            Settings.MIN_SIZE, Settings.MAX_SIZE
+        )
         self.settings_custom_width_spinbox.setValue(Settings.DEFAULT_WIDTH)
         self.settings_custom_width_spinbox.setSuffix(" px")
         self.settings_custom_width_spinbox.setFixedWidth(100)
@@ -1368,7 +1522,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         settings_window_layout.addWidget(self.settings_custom_width_spinbox)
 
         self.settings_custom_height_spinbox = QSpinBox()
-        self.settings_custom_height_spinbox.setRange(Settings.MIN_SIZE, Settings.MAX_SIZE)
+        self.settings_custom_height_spinbox.setRange(
+            Settings.MIN_SIZE, Settings.MAX_SIZE
+        )
         self.settings_custom_height_spinbox.setValue(Settings.DEFAULT_HEIGHT)
         self.settings_custom_height_spinbox.setSuffix(" px")
         self.settings_custom_height_spinbox.setFixedWidth(100)
@@ -1439,12 +1595,16 @@ This basically preserves your mod coloring, user notes etc. for this many second
         auth_group.setLayout(auth_group_layout)
 
         rentry_auth_label = QLabel(self.tr("Rentry Auth:"))
-        auth_group_layout.addWidget(rentry_auth_label, 0, 0, alignment=Qt.AlignmentFlag.AlignRight)
+        auth_group_layout.addWidget(
+            rentry_auth_label, 0, 0, alignment=Qt.AlignmentFlag.AlignRight
+        )
 
         self.rentry_auth_code = QLineEdit()
         self.rentry_auth_code.setTextMargins(GUIInfo().text_field_margins)
         self.rentry_auth_code.setFixedHeight(GUIInfo().default_font_line_height * 2)
-        self.rentry_auth_code.setPlaceholderText(self.tr("Obtain rentry auth code by emailing: support@rentry.co"))
+        self.rentry_auth_code.setPlaceholderText(
+            self.tr("Obtain rentry auth code by emailing: support@rentry.co")
+        )
         # TODO: If we add a rentry auth code with builds, we should change placeholder to clarify this code will be used instead of the provided one
         auth_group_layout.addWidget(self.rentry_auth_code, 0, 1)
 
@@ -1455,7 +1615,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         github_identity_group.setLayout(github_identity_layout)
 
         github_username_label = QLabel(self.tr("GitHub username:"))
-        github_identity_layout.addWidget(github_username_label, 0, 0, alignment=Qt.AlignmentFlag.AlignRight)
+        github_identity_layout.addWidget(
+            github_username_label, 0, 0, alignment=Qt.AlignmentFlag.AlignRight
+        )
 
         self.github_username = QLineEdit()
         self.github_username.setTextMargins(GUIInfo().text_field_margins)
@@ -1463,7 +1625,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         github_identity_layout.addWidget(self.github_username, 0, 1)
 
         github_token_label = QLabel(self.tr("GitHub personal access token:"))
-        github_identity_layout.addWidget(github_token_label, 1, 0, alignment=Qt.AlignmentFlag.AlignRight)
+        github_identity_layout.addWidget(
+            github_token_label, 1, 0, alignment=Qt.AlignmentFlag.AlignRight
+        )
 
         self.github_token = QLineEdit()
         self.github_token.setEchoMode(QLineEdit.EchoMode.Password)
@@ -1499,27 +1663,37 @@ This basically preserves your mod coloring, user notes etc. for this many second
         self.debug_logging_checkbox = QCheckBox(self.tr("Enable debug logging"))
         group_layout.addWidget(self.debug_logging_checkbox)
 
-        self.watchdog_checkbox = QCheckBox(self.tr("Enable watchdog file monitor daemon"))
+        self.watchdog_checkbox = QCheckBox(
+            self.tr("Enable watchdog file monitor daemon")
+        )
         group_layout.addWidget(self.watchdog_checkbox)
 
         # Clear button behavior
         self.clear_moves_dlc_checkbox = QCheckBox(self.tr("Clear also moves DLC"))
         group_layout.addWidget(self.clear_moves_dlc_checkbox)
 
-        self.show_mod_updates_checkbox = QCheckBox(self.tr("Check for mod updates on refresh"))
+        self.show_mod_updates_checkbox = QCheckBox(
+            self.tr("Check for mod updates on refresh")
+        )
         group_layout.addWidget(self.show_mod_updates_checkbox)
 
-        self.render_unity_rich_text_checkbox = QCheckBox(self.tr("Render Unity Rich Text in mod descriptions"))
+        self.render_unity_rich_text_checkbox = QCheckBox(
+            self.tr("Render Unity Rich Text in mod descriptions")
+        )
         self.color_background_instead_of_text_checkbox = QCheckBox(
             self.tr("Apply mod coloring to background instead of text")
         )
         group_layout.addWidget(self.color_background_instead_of_text_checkbox)
         self.render_unity_rich_text_checkbox.setToolTip(
-            self.tr("Enable this option to render Unity Rich Text in mod descriptions. Images will not be displayed.")
+            self.tr(
+                "Enable this option to render Unity Rich Text in mod descriptions. Images will not be displayed."
+            )
         )
         group_layout.addWidget(self.render_unity_rich_text_checkbox)
 
-        self.update_databases_on_startup_checkbox = QCheckBox(self.tr("Update databases on startup"))
+        self.update_databases_on_startup_checkbox = QCheckBox(
+            self.tr("Update databases on startup")
+        )
         self.update_databases_on_startup_checkbox.setToolTip(
             self.tr(
                 "Enable this option to automatically update enabled databases when RimSort starts. "
@@ -1532,13 +1706,17 @@ This basically preserves your mod coloring, user notes etc. for this many second
             self.tr("Include mod notes in mod name search filter")
         )
         self.include_mod_notes_in_mod_name_filter_checkbox.setToolTip(
-            self.tr("This option will include searching mod notes when searching by mod name.")
+            self.tr(
+                "This option will include searching mod notes when searching by mod name."
+            )
         )
         group_layout.addWidget(self.include_mod_notes_in_mod_name_filter_checkbox)
 
         # Put checkbox, label and spinbox on the same horizontal line
         backup_layout = QHBoxLayout()
-        self.enable_backup_before_update_checkbox = QCheckBox(self.tr("Create backup before RimSort update"))
+        self.enable_backup_before_update_checkbox = QCheckBox(
+            self.tr("Create backup before RimSort update")
+        )
         self.enable_backup_before_update_checkbox.setToolTip(
             self.tr(
                 "Recommended to keep this enabled as it creates a backup before updating RimSort, "

--- a/app/views/status_panel.py
+++ b/app/views/status_panel.py
@@ -51,11 +51,15 @@ class Status:
             self.status_text.start_pause_fade("Checking for RimSort updates")
         # actions panel actions
         elif action == "refresh":
-            self.status_text.start_pause_fade("Refreshed local metadata and repopulating info from external metadata")
+            self.status_text.start_pause_fade(
+                "Refreshed local metadata and repopulating info from external metadata"
+            )
         elif action == "clear":
             self.status_text.start_pause_fade("Cleared active mods")
         elif action == "restore":
-            self.status_text.start_pause_fade("Restored mod list to last saved ModsConfig.xml state")
+            self.status_text.start_pause_fade(
+                "Restored mod list to last saved ModsConfig.xml state"
+            )
         elif action == "sort":
             self.status_text.start_pause_fade("Sorted active mods list")
         elif action == "optimize_textures":
@@ -69,7 +73,9 @@ class Status:
         elif action == "setup_steamcmd":
             self.status_text.start_pause_fade("SteamCMD setup completed")
         elif action == "import_steamcmd_acf_data":
-            self.status_text.start_pause_fade("Imported data from another SteamCMD instance")
+            self.status_text.start_pause_fade(
+                "Imported data from another SteamCMD instance"
+            )
         elif action == "reset_steamcmd_acf_data":
             self.status_text.start_pause_fade("Deleted SteamCMD ACF data")
         elif "import_list" in action:
@@ -77,7 +83,9 @@ class Status:
         elif "export_list" in action:
             self.status_text.start_pause_fade("Exported active mods list")
         elif action == "upload_list_rentry":
-            self.status_text.start_pause_fade("Copied mod report to clipboard; uploaded to http://rentry.co")
+            self.status_text.start_pause_fade(
+                "Copied mod report to clipboard; uploaded to http://rentry.co"
+            )
         elif action == "save":
             self.status_text.start_pause_fade("Active mods saved into ModsConfig.xml")
         elif action == "run":
@@ -90,19 +98,31 @@ class Status:
         elif action == "configure_steam_database_repo":
             self.status_text.start_pause_fade("Configured SteamDB repository")
         elif action == "download_steam_database":
-            self.status_text.start_pause_fade("Downloaded SteamDB from configured repository")
+            self.status_text.start_pause_fade(
+                "Downloaded SteamDB from configured repository"
+            )
         elif action == "upload_steam_database":
-            self.status_text.start_pause_fade("Uploaded SteamDB to configured repository")
+            self.status_text.start_pause_fade(
+                "Uploaded SteamDB to configured repository"
+            )
         elif action == "configure_community_rules_db_path":
             self.status_text.start_pause_fade("Configured Community Rules DB file path")
         elif action == "configure_community_rules_db_repo":
-            self.status_text.start_pause_fade("Configured Community Rules DB repository")
+            self.status_text.start_pause_fade(
+                "Configured Community Rules DB repository"
+            )
         elif action == "download_community_rules_database":
-            self.status_text.start_pause_fade("Downloaded Community Rules DB from configured repository")
+            self.status_text.start_pause_fade(
+                "Downloaded Community Rules DB from configured repository"
+            )
         elif action == "open_community_rules_with_rule_editor":
-            self.status_text.start_pause_fade("Opening Rule Editor with Community Rules DB context")
+            self.status_text.start_pause_fade(
+                "Opening Rule Editor with Community Rules DB context"
+            )
         elif action == "upload_community_rules_database":
-            self.status_text.start_pause_fade("Uploaded Community Rules DB to configured repository")
+            self.status_text.start_pause_fade(
+                "Uploaded Community Rules DB to configured repository"
+            )
         elif action == "build_steam_database_thread":
             self.status_text.start_pause_fade("Building SteamDB with DB Builder")
         elif action == "merge_databases":
@@ -115,8 +135,12 @@ class Status:
             self.status_text.start_pause_fade("Created SteamDB comparison report")
         elif "download_entire_workshop" in action:
             if "steamcmd" in action:
-                self.status_text.start_pause_fade("Attempting to download all Workshop mods with SteamCMD")
+                self.status_text.start_pause_fade(
+                    "Attempting to download all Workshop mods with SteamCMD"
+                )
             elif "steamworks" in action:
-                self.status_text.start_pause_fade("Attempting to subscribe to all Workshop mods with Steam")
+                self.status_text.start_pause_fade(
+                    "Attempting to subscribe to all Workshop mods with Steam"
+                )
         else:  # Otherwise, just display whatever text is passed
             self.status_text.start_pause_fade(action)

--- a/app/views/troubleshooting_dialog.py
+++ b/app/views/troubleshooting_dialog.py
@@ -126,8 +126,8 @@ class TroubleshootingDialog(QDialog):
 
     def _create_game_recovery_section(self, parent_layout: QVBoxLayout) -> None:
         """Create the game files recovery section"""
-        section_frame, section_layout, content_widget, content_layout = self._setup_section_base(
-            parent_layout, self.tr("Game Files Recovery")
+        section_frame, section_layout, content_widget, content_layout = (
+            self._setup_section_base(parent_layout, self.tr("Game Files Recovery"))
         )
 
         # Description
@@ -140,7 +140,9 @@ class TroubleshootingDialog(QDialog):
         description.setAlignment(Qt.AlignmentFlag.AlignCenter)
         content_layout.addWidget(description)
 
-        warning_label = QLabel(self.tr("Warning: These operations will delete selected files permanently!"))
+        warning_label = QLabel(
+            self.tr("Warning: These operations will delete selected files permanently!")
+        )
         warning_label.setObjectName("warningLabel")
         warning_label.setWordWrap(True)
         warning_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
@@ -169,19 +171,27 @@ class TroubleshootingDialog(QDialog):
         checkboxes_layout.addLayout(center_layout)
 
         self.integrity_delete_game_files = QCheckBox(
-            self.tr("Reset game files (Preserves local mods, deletes and redownloads game files)")
+            self.tr(
+                "Reset game files (Preserves local mods, deletes and redownloads game files)"
+            )
         )
         self.integrity_delete_game_files.setObjectName("styledCheckbox")
         self.integrity_delete_game_files.setToolTip(
-            self.tr("Deletes and redownloads game files but keeps your local mods intact.")
+            self.tr(
+                "Deletes and redownloads game files but keeps your local mods intact."
+            )
         )
         checkbox_items_layout.addWidget(self.integrity_delete_game_files)
 
         self.integrity_delete_steam_mods = QCheckBox(
-            self.tr("Reset Steam Workshop mods (Deletes and redownloads all Steam mods)")
+            self.tr(
+                "Reset Steam Workshop mods (Deletes and redownloads all Steam mods)"
+            )
         )
         self.integrity_delete_steam_mods.setObjectName("styledCheckbox")
-        self.integrity_delete_steam_mods.setToolTip(self.tr("Deletes all Steam Workshop mods and triggers redownload."))
+        self.integrity_delete_steam_mods.setToolTip(
+            self.tr("Deletes all Steam Workshop mods and triggers redownload.")
+        )
         checkbox_items_layout.addWidget(self.integrity_delete_steam_mods)
 
         self.integrity_delete_mod_configs = QCheckBox(
@@ -189,16 +199,22 @@ class TroubleshootingDialog(QDialog):
         )
         self.integrity_delete_mod_configs.setObjectName("styledCheckbox")
         self.integrity_delete_mod_configs.setToolTip(
-            self.tr("Deletes mod configuration files except ModsConfig.xml and Prefs.xml.")
+            self.tr(
+                "Deletes mod configuration files except ModsConfig.xml and Prefs.xml."
+            )
         )
         checkbox_items_layout.addWidget(self.integrity_delete_mod_configs)
 
         self.integrity_delete_game_configs = QCheckBox(
-            self.tr("Reset game configurations (ModsConfig.xml, Prefs.xml, KeyPrefs.xml)*")
+            self.tr(
+                "Reset game configurations (ModsConfig.xml, Prefs.xml, KeyPrefs.xml)*"
+            )
         )
         self.integrity_delete_game_configs.setObjectName("styledCheckbox")
         self.integrity_delete_game_configs.setToolTip(
-            self.tr("Deletes game configuration files including ModsConfig.xml, Prefs.xml, and KeyPrefs.xml.")
+            self.tr(
+                "Deletes game configuration files including ModsConfig.xml, Prefs.xml, and KeyPrefs.xml."
+            )
         )
         checkbox_items_layout.addWidget(self.integrity_delete_game_configs)
 
@@ -236,8 +252,10 @@ class TroubleshootingDialog(QDialog):
 
     def _create_mod_configuration_section(self, parent_layout: QVBoxLayout) -> None:
         """Create the mod configuration section"""
-        section_frame, section_layout, content_widget, content_layout = self._setup_section_base(
-            parent_layout, self.tr("Mod Configuration Options")
+        section_frame, section_layout, content_widget, content_layout = (
+            self._setup_section_base(
+                parent_layout, self.tr("Mod Configuration Options")
+            )
         )
 
         # Set specific spacing for this section
@@ -268,7 +286,9 @@ class TroubleshootingDialog(QDialog):
         export_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         export_layout.addWidget(export_label)
 
-        export_desc = QLabel(self.tr("Save your current mod list to a .xml file to share with others."))
+        export_desc = QLabel(
+            self.tr("Save your current mod list to a .xml file to share with others.")
+        )
         export_desc.setObjectName("sectionDescription")
         export_desc.setWordWrap(True)
         export_desc.setAlignment(Qt.AlignmentFlag.AlignCenter)
@@ -276,7 +296,9 @@ class TroubleshootingDialog(QDialog):
 
         self.mod_export_list_button = QPushButton(self.tr("Export List"))
         self.mod_export_list_button.setObjectName("actionButton")
-        self.mod_export_list_button.setToolTip(self.tr("Export your current mod list to a file"))
+        self.mod_export_list_button.setToolTip(
+            self.tr("Export your current mod list to a file")
+        )
         export_layout.addWidget(self.mod_export_list_button)
 
         # Import section
@@ -289,7 +311,9 @@ class TroubleshootingDialog(QDialog):
         import_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         import_layout.addWidget(import_label)
 
-        import_desc = QLabel(self.tr("Import a mod list in .xml format from another player"))
+        import_desc = QLabel(
+            self.tr("Import a mod list in .xml format from another player")
+        )
         import_desc.setObjectName("sectionDescription")
         import_desc.setWordWrap(True)
         import_desc.setAlignment(Qt.AlignmentFlag.AlignCenter)
@@ -317,7 +341,11 @@ class TroubleshootingDialog(QDialog):
         clear_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         clear_layout.addWidget(clear_label)
 
-        clear_warning = QLabel(self.tr("This will delete all mods in your Mods folder and reset to vanilla state"))
+        clear_warning = QLabel(
+            self.tr(
+                "This will delete all mods in your Mods folder and reset to vanilla state"
+            )
+        )
         clear_warning.setObjectName("warningLabel")
         clear_warning.setWordWrap(True)
         clear_warning.setAlignment(Qt.AlignmentFlag.AlignCenter)
@@ -329,7 +357,9 @@ class TroubleshootingDialog(QDialog):
 
         self.clear_mods_button = QPushButton(self.tr("Clear All Mods"))
         self.clear_mods_button.setObjectName("dangerButton")
-        self.clear_mods_button.setToolTip(self.tr("Delete all mods and reset to vanilla state"))
+        self.clear_mods_button.setToolTip(
+            self.tr("Delete all mods and reset to vanilla state")
+        )
         clear_button_layout.addStretch()
         clear_button_layout.addWidget(self.clear_mods_button)
         clear_button_layout.addStretch()
@@ -338,13 +368,15 @@ class TroubleshootingDialog(QDialog):
 
     def _create_steam_utilities_section(self, parent_layout: QVBoxLayout) -> None:
         """Create the Steam utilities section"""
-        section_frame, section_layout, content_widget, content_layout = self._setup_section_base(
-            parent_layout, self.tr("Steam Utilities")
+        section_frame, section_layout, content_widget, content_layout = (
+            self._setup_section_base(parent_layout, self.tr("Steam Utilities"))
         )
 
         # Description
         content_description = self._create_description_label(
-            self.tr("Steam-specific utilities to help resolve download and game file issues.")
+            self.tr(
+                "Steam-specific utilities to help resolve download and game file issues."
+            )
         )
         content_description.setAlignment(Qt.AlignmentFlag.AlignCenter)
         content_layout.addWidget(content_description)
@@ -373,10 +405,12 @@ class TroubleshootingDialog(QDialog):
         utilities_layout.addLayout(verify_layout)
         utilities_layout.addStretch()
 
-        self.steam_repair_library_button, repair_layout = self._create_button_with_layout(
-            self.tr("Repair Steam Library"),
-            self.tr("Verify integrity of all installed Steam games"),
-            "primaryButton",
+        self.steam_repair_library_button, repair_layout = (
+            self._create_button_with_layout(
+                self.tr("Repair Steam Library"),
+                self.tr("Verify integrity of all installed Steam games"),
+                "primaryButton",
+            )
         )
         utilities_layout.addLayout(repair_layout)
         utilities_layout.addStretch()

--- a/app/windows/base_mods_panel.py
+++ b/app/windows/base_mods_panel.py
@@ -204,20 +204,30 @@ class BaseModsPanel(QWidget):
         """
         # Set up model with header labels
         self.editor_model = QStandardItemModel(0, len(additional_columns) + 1)
-        editor_header_labels = ["✔"] + [col[0] if isinstance(col, tuple) else col for col in additional_columns]
+        editor_header_labels = ["✔"] + [
+            col[0] if isinstance(col, tuple) else col for col in additional_columns
+        ]
         self.editor_model.setHorizontalHeaderLabels(editor_header_labels)
 
         # Set up table view
         self.editor_table_view = QTableView()
         self.editor_table_view.setModel(self.editor_model)
         self.editor_table_view.setSortingEnabled(sorting_enabled)
-        self.editor_table_view.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
-        self.editor_table_view.setSelectionMode(QAbstractItemView.SelectionMode.NoSelection)
-        self.editor_table_view.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+        self.editor_table_view.setEditTriggers(
+            QAbstractItemView.EditTrigger.NoEditTriggers
+        )
+        self.editor_table_view.setSelectionMode(
+            QAbstractItemView.SelectionMode.NoSelection
+        )
+        self.editor_table_view.setHorizontalScrollBarPolicy(
+            Qt.ScrollBarPolicy.ScrollBarAsNeeded
+        )
 
         # Set up headers - checkbox column resizes to contents
         header = self.editor_table_view.horizontalHeader()
-        header.setSectionResizeMode(ColumnIndex.CHECKBOX.value, QHeaderView.ResizeMode.ResizeToContents)
+        header.setSectionResizeMode(
+            ColumnIndex.CHECKBOX.value, QHeaderView.ResizeMode.ResizeToContents
+        )
 
         # Additional columns: use specified ResizeMode or default to Stretch
         for column_index, column in enumerate(additional_columns):
@@ -225,27 +235,47 @@ class BaseModsPanel(QWidget):
                 resize_mode = column[1]
             else:
                 resize_mode = QHeaderView.ResizeMode.Stretch
-            header.setSectionResizeMode(ColumnIndex.CHECKBOX.value + column_index + 1, resize_mode)
+            header.setSectionResizeMode(
+                ColumnIndex.CHECKBOX.value + column_index + 1, resize_mode
+            )
 
         # Set vertical header to resize to contents
-        self.editor_table_view.verticalHeader().setSectionResizeMode(QHeaderView.ResizeMode.ResizeToContents)
+        self.editor_table_view.verticalHeader().setSectionResizeMode(
+            QHeaderView.ResizeMode.ResizeToContents
+        )
 
     def _setup_action_buttons(self) -> None:
         """Set up the action buttons layout."""
-        self.layouts.editor_actions_layout.addLayout(self.layouts.editor_checkbox_actions_layout)
+        self.layouts.editor_actions_layout.addLayout(
+            self.layouts.editor_checkbox_actions_layout
+        )
         self.layouts.editor_actions_layout.addStretch(25)
-        self.layouts.editor_actions_layout.addLayout(self.layouts.editor_main_actions_layout)
+        self.layouts.editor_actions_layout.addLayout(
+            self.layouts.editor_main_actions_layout
+        )
         self.layouts.editor_actions_layout.addStretch(25)
-        self.layouts.editor_actions_layout.addLayout(self.layouts.editor_exit_actions_layout)
+        self.layouts.editor_actions_layout.addLayout(
+            self.layouts.editor_exit_actions_layout
+        )
 
-        self.ui_elements.editor_deselect_all_button.clicked.connect(partial(self._set_all_checkbox_rows, False))
-        self.layouts.editor_checkbox_actions_layout.addWidget(self.ui_elements.editor_deselect_all_button)
+        self.ui_elements.editor_deselect_all_button.clicked.connect(
+            partial(self._set_all_checkbox_rows, False)
+        )
+        self.layouts.editor_checkbox_actions_layout.addWidget(
+            self.ui_elements.editor_deselect_all_button
+        )
 
-        self.ui_elements.editor_select_all_button.clicked.connect(partial(self._set_all_checkbox_rows, True))
-        self.layouts.editor_checkbox_actions_layout.addWidget(self.ui_elements.editor_select_all_button)
+        self.ui_elements.editor_select_all_button.clicked.connect(
+            partial(self._set_all_checkbox_rows, True)
+        )
+        self.layouts.editor_checkbox_actions_layout.addWidget(
+            self.ui_elements.editor_select_all_button
+        )
 
         self.ui_elements.editor_cancel_button.clicked.connect(self.close)
-        self.layouts.editor_exit_actions_layout.addWidget(self.ui_elements.editor_cancel_button)
+        self.layouts.editor_exit_actions_layout.addWidget(
+            self.ui_elements.editor_cancel_button
+        )
 
         self.layouts.editor_layout.addWidget(self.editor_table_view)
         self.layouts.editor_layout.addLayout(self.layouts.editor_actions_layout)
@@ -326,7 +356,9 @@ class BaseModsPanel(QWidget):
         self._initialize_ui_elements()
         self._initialize_layouts()
         self._initialize_components()
-        self._setup_components(object_name, window_title, title_text, details_text, additional_columns)
+        self._setup_components(
+            object_name, window_title, title_text, details_text, additional_columns
+        )
 
     def eventFilter(self, watched: QObject, event: QEvent) -> bool:
         if event.type() == QEvent.Type.KeyPress:
@@ -359,7 +391,9 @@ class BaseModsPanel(QWidget):
         # Iterate through the editor's rows
         for row in range(self.editor_model.rowCount()):
             # If an existing row is found, setChecked the value
-            checkbox = self.editor_table_view.indexWidget(self.editor_model.item(row, 0).index())
+            checkbox = self.editor_table_view.indexWidget(
+                self.editor_model.item(row, 0).index()
+            )
             if isinstance(checkbox, QCheckBox):
                 checkbox.setChecked(value)
 
@@ -413,7 +447,9 @@ class BaseModsPanel(QWidget):
         if self.__class__.__name__ != "AcfLogReader":
             self.close()
 
-    def _collect_pfids_by_mode(self, pfid_column: int, mode: OperationMode) -> tuple[list[str], list[str]]:
+    def _collect_pfids_by_mode(
+        self, pfid_column: int, mode: OperationMode
+    ) -> tuple[list[str], list[str]]:
         pfid_fn = self._get_selected_text_by_column(pfid_column)
         pfids = [(pfid, mode) for pfid in self._run_for_selected_rows(pfid_fn)]
 
@@ -453,7 +489,9 @@ class BaseModsPanel(QWidget):
         if not filtered_pfids:
             return
 
-        logger.warning(f"Queuing '{command}' action for {len(filtered_pfids)} mods via Steamworks API")
+        logger.warning(
+            f"Queuing '{command}' action for {len(filtered_pfids)} mods via Steamworks API"
+        )
         EventBus().do_steamworks_api_call.emit([command, filtered_pfids])
 
     def _create_update_callback(
@@ -496,7 +534,9 @@ class BaseModsPanel(QWidget):
                 widget.deleteLater()
 
     def _row_is_checked(self, row: int) -> bool:
-        checkbox = self.editor_table_view.indexWidget(self.editor_model.item(row, 0).index())
+        checkbox = self.editor_table_view.indexWidget(
+            self.editor_model.item(row, 0).index()
+        )
         return isinstance(checkbox, QCheckBox) and checkbox.isChecked()
 
     def _get_selected_row_indices(self) -> set[int]:
@@ -506,7 +546,11 @@ class BaseModsPanel(QWidget):
         Returns:
             Set of row indices that are checked.
         """
-        return {row for row in range(self.editor_model.rowCount()) if self._row_is_checked(row)}
+        return {
+            row
+            for row in range(self.editor_model.rowCount())
+            if self._row_is_checked(row)
+        }
 
     T = TypeVar("T")
 
@@ -526,7 +570,9 @@ class BaseModsPanel(QWidget):
 
         return __selected_text_by_column
 
-    def _resolve_mode_getter(self, mode: OperationMode | str | int) -> Callable[[int], str]:
+    def _resolve_mode_getter(
+        self, mode: OperationMode | str | int
+    ) -> Callable[[int], str]:
         """
         Resolve a mode value getter function for the given mode parameter.
 
@@ -550,13 +596,19 @@ class BaseModsPanel(QWidget):
             # Return constant function for string mode
             return lambda _: mode
 
-    def _delete_selected_mods(self, pfid_column: int, mode: OperationMode | str | int) -> None:
-        delete_before_update_state = self.settings_controller.settings.steamcmd_delete_before_update
+    def _delete_selected_mods(
+        self, pfid_column: int, mode: OperationMode | str | int
+    ) -> None:
+        delete_before_update_state = (
+            self.settings_controller.settings.steamcmd_delete_before_update
+        )
         if delete_before_update_state:
             pfid_fn = self._get_selected_text_by_column(pfid_column)
             get_mode = self._resolve_mode_getter(mode)
 
-            pfid_mode_pairs = self._run_for_selected_rows(lambda row: (pfid_fn(row), get_mode(row)))
+            pfid_mode_pairs = self._run_for_selected_rows(
+                lambda row: (pfid_fn(row), get_mode(row))
+            )
             for pfid, mod_mode in pfid_mode_pairs:
                 if mod_mode == OperationMode.STEAMCMD.value:
                     mod_path = get_mod_path_from_pfid(pfid)
@@ -587,7 +639,9 @@ class BaseModsPanel(QWidget):
         if callback is not None:
             button.clicked.connect(callback)
 
-    def _create_workshop_button(self, url: str, object_name: str = "workshopButton") -> QPushButton:
+    def _create_workshop_button(
+        self, url: str, object_name: str = "workshopButton"
+    ) -> QPushButton:
         """
         Create a standardized workshop button that opens the Steam Workshop page.
 
@@ -705,13 +759,19 @@ class BaseModsPanel(QWidget):
         # Fallback
         return self._create_button(text or "Button", custom_callback)
 
-    def _create_refresh_button(self, callback: Callable[[], None] | None) -> QPushButton:
+    def _create_refresh_button(
+        self, callback: Callable[[], None] | None
+    ) -> QPushButton:
         """Create a standardized refresh button."""
-        return self._create_standardized_button(ButtonType.REFRESH, custom_callback=callback)
+        return self._create_standardized_button(
+            ButtonType.REFRESH, custom_callback=callback
+        )
 
     def _create_steamcmd_button(self, pfid_column: int) -> QPushButton:
         """Create a standardized SteamCMD button."""
-        return self._create_standardized_button(ButtonType.STEAMCMD, pfid_column=pfid_column)
+        return self._create_standardized_button(
+            ButtonType.STEAMCMD, pfid_column=pfid_column
+        )
 
     def _create_subscribe_button(
         self, pfid_column: int, completion_callback: Callable[[], None] | None = None
@@ -781,7 +841,9 @@ class BaseModsPanel(QWidget):
             enable_delete_and_resubscribe=steam_client_integration_enabled,
         )
         button.setMenu(deletion_menu)
-        button.clicked.connect(lambda: deletion_menu.exec(button.mapToGlobal(button.rect().bottomLeft())))
+        button.clicked.connect(
+            lambda: deletion_menu.exec(button.mapToGlobal(button.rect().bottomLeft()))
+        )
         return button
 
     def _setup_buttons_from_config(self, button_configs: list[ButtonConfig]) -> None:
@@ -810,7 +872,9 @@ class BaseModsPanel(QWidget):
         factory = self.get_button_factory()
         return self._create_button_from_config_with_factory(config, factory)
 
-    def _create_button_from_config_with_factory(self, config: ButtonConfig, factory: ButtonFactory) -> QWidget | None:
+    def _create_button_from_config_with_factory(
+        self, config: ButtonConfig, factory: ButtonFactory
+    ) -> QWidget | None:
         """
         Create a button from a single button configuration using a factory.
 
@@ -837,29 +901,43 @@ class BaseModsPanel(QWidget):
             return self._create_select_button_from_config(config, factory)
         return None
 
-    def _create_refresh_button_from_config(self, config: ButtonConfig, factory: ButtonFactory) -> QWidget | None:
+    def _create_refresh_button_from_config(
+        self, config: ButtonConfig, factory: ButtonFactory
+    ) -> QWidget | None:
         """Create a refresh button from config."""
         return factory.create_refresh_button(config.custom_callback)
 
-    def _create_steamcmd_button_from_config(self, config: ButtonConfig, factory: ButtonFactory) -> QWidget | None:
+    def _create_steamcmd_button_from_config(
+        self, config: ButtonConfig, factory: ButtonFactory
+    ) -> QWidget | None:
         """Create a SteamCMD button from config."""
         if config.pfid_column is not None:
             return factory.create_steamcmd_button(config.pfid_column)
         return None
 
-    def _create_subscribe_button_from_config(self, config: ButtonConfig, factory: ButtonFactory) -> QWidget | None:
+    def _create_subscribe_button_from_config(
+        self, config: ButtonConfig, factory: ButtonFactory
+    ) -> QWidget | None:
         """Create a subscribe button from config."""
         if config.pfid_column is not None:
-            return factory.create_subscribe_button(config.pfid_column, config.completion_callback)
+            return factory.create_subscribe_button(
+                config.pfid_column, config.completion_callback
+            )
         return None
 
-    def _create_unsubscribe_button_from_config(self, config: ButtonConfig, factory: ButtonFactory) -> QWidget | None:
+    def _create_unsubscribe_button_from_config(
+        self, config: ButtonConfig, factory: ButtonFactory
+    ) -> QWidget | None:
         """Create an unsubscribe button from config."""
         if config.pfid_column is not None:
-            return factory.create_unsubscribe_button(config.pfid_column, config.completion_callback)
+            return factory.create_unsubscribe_button(
+                config.pfid_column, config.completion_callback
+            )
         return None
 
-    def _create_delete_button_from_config(self, config: ButtonConfig, factory: ButtonFactory) -> QWidget | None:
+    def _create_delete_button_from_config(
+        self, config: ButtonConfig, factory: ButtonFactory
+    ) -> QWidget | None:
         """Create a delete button from config."""
         if config.menu_title is not None:
             return factory.create_delete_button(
@@ -873,19 +951,25 @@ class BaseModsPanel(QWidget):
             )
         return None
 
-    def _create_custom_button_from_config(self, config: ButtonConfig, factory: ButtonFactory) -> QWidget | None:
+    def _create_custom_button_from_config(
+        self, config: ButtonConfig, factory: ButtonFactory
+    ) -> QWidget | None:
         """Create a custom button from config."""
         if config.custom_callback is not None:
             return factory.create_custom_button(config.text, config.custom_callback)
         return None
 
-    def _create_select_button_from_config(self, config: ButtonConfig, factory: ButtonFactory) -> QWidget | None:
+    def _create_select_button_from_config(
+        self, config: ButtonConfig, factory: ButtonFactory
+    ) -> QWidget | None:
         """Create a select button from config."""
         if config.menu_items:
             return factory.create_select_button(config.text, config.menu_items)
         return None
 
-    def _create_custom_button(self, text: str, callback: Callable[[], None]) -> QPushButton:
+    def _create_custom_button(
+        self, text: str, callback: Callable[[], None]
+    ) -> QPushButton:
         """
         Create a custom button with text and callback.
 
@@ -900,7 +984,9 @@ class BaseModsPanel(QWidget):
         button.clicked.connect(callback)
         return button
 
-    def _create_select_button(self, text: str, menu_items: list[MenuItem]) -> QToolButton:
+    def _create_select_button(
+        self, text: str, menu_items: list[MenuItem]
+    ) -> QToolButton:
         """
         Create a select button with dropdown menu.
 
@@ -961,7 +1047,9 @@ class BaseModsPanel(QWidget):
                 if self._row_is_checked(row):
                     uuid = self._get_uuid_from_row(row)
                     if uuid and uuid in self.metadata_manager.internal_local_metadata:
-                        selected_mods.append(self.metadata_manager.internal_local_metadata[uuid])
+                        selected_mods.append(
+                            self.metadata_manager.internal_local_metadata[uuid]
+                        )
         except Exception as e:
             logger.warning(f"Error getting selected mod metadata: {e}")
         return selected_mods
@@ -1083,8 +1171,12 @@ class BaseModsPanel(QWidget):
 
         # Add workshop button to the workshop column only if published_file_id exists
         if mod_info.published_file_id and mod_info.published_file_id.strip():
-            workshop_button = self._create_workshop_button(mod_info.workshop_url, "workshopButton")
-            self.editor_table_view.setIndexWidget(workshop_item.index(), workshop_button)
+            workshop_button = self._create_workshop_button(
+                mod_info.workshop_url, "workshopButton"
+            )
+            self.editor_table_view.setIndexWidget(
+                workshop_item.index(), workshop_button
+            )
 
     def _add_group_header_row(self, header_text: str) -> None:
         """
@@ -1097,12 +1189,16 @@ class BaseModsPanel(QWidget):
         header_item.setData(None, Qt.ItemDataRole.UserRole)
 
         # Create empty items for other columns
-        empty_items = [QStandardItem("") for _ in range(self.editor_model.columnCount() - 1)]
+        empty_items = [
+            QStandardItem("") for _ in range(self.editor_model.columnCount() - 1)
+        ]
         items = [header_item] + empty_items
 
         self.editor_model.appendRow(items)
 
-    def _extract_mod_info_from_metadata(self, uuid: str | None, metadata: dict[str, Any]) -> ModInfo:
+    def _extract_mod_info_from_metadata(
+        self, uuid: str | None, metadata: dict[str, Any]
+    ) -> ModInfo:
         """
         Extract ModInfo from metadata dictionary.
 
@@ -1202,7 +1298,9 @@ class BaseModsPanel(QWidget):
             ),
         ]
 
-    def _extend_button_configs_with_steam_actions(self, button_configs: list[ButtonConfig]) -> list[ButtonConfig]:
+    def _extend_button_configs_with_steam_actions(
+        self, button_configs: list[ButtonConfig]
+    ) -> list[ButtonConfig]:
         """
         Extend button configurations with Steam client actions if integration is enabled.
 
@@ -1228,7 +1326,9 @@ class BaseModsPanel(QWidget):
             )
         return button_configs
 
-    def _create_delete_button_config(self, menu_title: str, enable_delete_and_unsubscribe: bool = True) -> ButtonConfig:
+    def _create_delete_button_config(
+        self, menu_title: str, enable_delete_and_unsubscribe: bool = True
+    ) -> ButtonConfig:
         """
         Create a delete button configuration with standard settings.
 
@@ -1250,8 +1350,10 @@ class BaseModsPanel(QWidget):
             enable_delete_mod=True,
             enable_delete_keep_dds=False,
             enable_delete_dds_only=False,
-            enable_delete_and_unsubscribe=enable_delete_and_unsubscribe and steam_client_integration_enabled,
-            enable_delete_and_resubscribe=enable_delete_and_unsubscribe and steam_client_integration_enabled,
+            enable_delete_and_unsubscribe=enable_delete_and_unsubscribe
+            and steam_client_integration_enabled,
+            enable_delete_and_resubscribe=enable_delete_and_unsubscribe
+            and steam_client_integration_enabled,
         )
 
     def _check_missing_publish_field_id_notification(self) -> None:
@@ -1270,7 +1372,9 @@ class BaseModsPanel(QWidget):
         missing_pfid_mods = [
             self.editor_model.item(row, 1).text()
             for row in selected_indices
-            if self._row_has_missing_pfid(row, missing_publishfieldid_mods, use_explicit_mode)
+            if self._row_has_missing_pfid(
+                row, missing_publishfieldid_mods, use_explicit_mode
+            )
             and self.editor_model.item(row, 1) is not None
         ]
 
@@ -1286,7 +1390,11 @@ class BaseModsPanel(QWidget):
         """Check if a mod at given row has missing Publish Field ID."""
         if use_explicit_mode:
             uuid = self._get_uuid_from_row(row)
-            return bool(uuid and missing_publishfieldid_mods and uuid in missing_publishfieldid_mods)
+            return bool(
+                uuid
+                and missing_publishfieldid_mods
+                and uuid in missing_publishfieldid_mods
+            )
         else:
             pfid_item = self.editor_model.item(row, ColumnIndex.PUBLISHED_FILE_ID.value)
             return bool(pfid_item and not pfid_item.text().strip())

--- a/app/windows/duplicate_mods_panel.py
+++ b/app/windows/duplicate_mods_panel.py
@@ -52,7 +52,9 @@ class DuplicateModsPanel(BaseModsPanel):
 
         button_configs = self._get_base_button_configs()
         self._extend_button_configs_with_steam_actions(button_configs)
-        button_configs.append(self._create_delete_button_config(self.tr("Delete Selected Mods")))
+        button_configs.append(
+            self._create_delete_button_config(self.tr("Delete Selected Mods"))
+        )
         self._setup_buttons_from_config(button_configs)
 
         # Populate the table with duplicate mod data
@@ -76,7 +78,9 @@ class DuplicateModsPanel(BaseModsPanel):
                     if metadata:
                         mod_list.append((uuid, metadata))
                     else:
-                        logger.warning(f"Metadata not found for UUID: {uuid} in package group {packageid}")
+                        logger.warning(
+                            f"Metadata not found for UUID: {uuid} in package group {packageid}"
+                        )
                 if mod_list:  # Only add groups that have mods
                     groups[packageid] = mod_list
 

--- a/app/windows/ignore_json_editor.py
+++ b/app/windows/ignore_json_editor.py
@@ -45,7 +45,9 @@ class IgnoreJsonEditor(QDialog):
         main_layout = QVBoxLayout(self)
 
         # Add description label
-        description_label = QLabel(self.tr("Mods checked below will be removed from the ignore list."))
+        description_label = QLabel(
+            self.tr("Mods checked below will be removed from the ignore list.")
+        )
         main_layout.addWidget(description_label)
 
         # Create list widget
@@ -90,7 +92,8 @@ class IgnoreJsonEditor(QDialog):
         indices_to_remove = [
             i
             for i in range(self.list_widget.count())
-            if (item := self.list_widget.item(i)) and item.checkState() == Qt.CheckState.Checked
+            if (item := self.list_widget.item(i))
+            and item.checkState() == Qt.CheckState.Checked
         ]
 
         # Remove in reverse order to maintain correct indices

--- a/app/windows/missing_dependencies_dialog.py
+++ b/app/windows/missing_dependencies_dialog.py
@@ -191,11 +191,15 @@ class MissingDependenciesDialog(QDialog):
         dep_name = self.metadata_manager.get_mod_name_from_package_id(dep_id)
         checkbox = QCheckBox(dep_name)
         checkbox.setToolTip(self.tr("Package ID: {dep_id}").format(dep_id=dep_id))
-        checkbox.stateChanged.connect(partial(self._toggle_mod_selection, mod_id=dep_id))
+        checkbox.stateChanged.connect(
+            partial(self._toggle_mod_selection, mod_id=dep_id)
+        )
         group_layout.addWidget(checkbox)
         self.checkboxes[dep_id] = checkbox
 
-        requiring_label = QLabel(self.tr("Required by:\n  • ") + "\n  • ".join(requiring_mods))
+        requiring_label = QLabel(
+            self.tr("Required by:\n  • ") + "\n  • ".join(requiring_mods)
+        )
         requiring_label.setStyleSheet("color: gray; margin-left: 20px;")
         requiring_label.setWordWrap(True)
         group_layout.addWidget(requiring_label)

--- a/app/windows/missing_mod_properties_panel.py
+++ b/app/windows/missing_mod_properties_panel.py
@@ -130,7 +130,9 @@ class MissingModPropertiesPanel(BaseModsPanel):
             True if addition was successful, False otherwise
         """
         # Extract package IDs and categorize by validity
-        packageids_to_add, skipped_mods = self._extract_and_validate_packageids(selected_indices)
+        packageids_to_add, skipped_mods = self._extract_and_validate_packageids(
+            selected_indices
+        )
 
         if not packageids_to_add:
             self._show_no_valid_packageids_warning(skipped_mods)
@@ -178,7 +180,9 @@ class MissingModPropertiesPanel(BaseModsPanel):
             logger.warning(f"Failed to extract mod info for UUID {uuid}: {e}")
             return None
 
-    def _extract_and_validate_packageids(self, row_indices: Iterable[int]) -> tuple[list[str], list[str]]:
+    def _extract_and_validate_packageids(
+        self, row_indices: Iterable[int]
+    ) -> tuple[list[str], list[str]]:
         """
         Extract and validate package IDs from selected rows.
 
@@ -234,7 +238,9 @@ class MissingModPropertiesPanel(BaseModsPanel):
                 "warning",
             )
 
-    def _show_message(self, title: str, message: str, message_type: str = "information") -> None:
+    def _show_message(
+        self, title: str, message: str, message_type: str = "information"
+    ) -> None:
         """
         Show a message dialog with configurable type.
 

--- a/app/windows/missing_mods_panel.py
+++ b/app/windows/missing_mods_panel.py
@@ -84,7 +84,9 @@ class MissingModsPrompt(BaseModsPanel):
                 ButtonConfig(
                     button_type=ButtonType.CUSTOM,
                     text=self.tr("Download with Steam client"),
-                    custom_callback=self._create_update_callback(5, OperationMode.STEAM, "subscribe"),
+                    custom_callback=self._create_update_callback(
+                        5, OperationMode.STEAM, "subscribe"
+                    ),
                 )
             )
         self._setup_buttons_from_config(button_configs)
@@ -139,7 +141,9 @@ class MissingModsPrompt(BaseModsPanel):
             return  # Return here to exit function
 
         # If we're still here, we need to actually create a new row
-        self._create_new_missing_mod_row(name, packageid, game_versions, mod_variants, published_file_id)
+        self._create_new_missing_mod_row(
+            name, packageid, game_versions, mod_variants, published_file_id
+        )
 
     def _filter_eligible_mods(self) -> list[str]:
         """
@@ -162,14 +166,20 @@ class MissingModsPrompt(BaseModsPanel):
 
         steam_metadata = self._cached_steam_metadata
         if steam_metadata and len(steam_metadata) > 500:
-            logger.info(f"Processing large Steam metadata set with {len(steam_metadata)} items")
+            logger.info(
+                f"Processing large Steam metadata set with {len(steam_metadata)} items"
+            )
 
         variants_by_packageid: dict[str, dict[str, Any]] = {}
         if steam_metadata:
             for published_file_id, metadata in steam_metadata.items():
-                name = metadata.get("steamName", metadata.get("name", "Not found in steam database"))
+                name = metadata.get(
+                    "steamName", metadata.get("name", "Not found in steam database")
+                )
                 packageid = metadata.get("packageId", "").lower()
-                game_versions = metadata.get("gameVersions", ["Not found in steam database"])
+                game_versions = metadata.get(
+                    "gameVersions", ["Not found in steam database"]
+                )
 
                 # Remove AppId dependencies from this dict. They cannot be subscribed like mods.
                 dependencies = {
@@ -188,7 +198,9 @@ class MissingModsPrompt(BaseModsPanel):
                     }
         return variants_by_packageid
 
-    def _add_default_entries_for_missing_packageids(self, variants_by_packageid: dict[str, dict[str, Any]]) -> None:
+    def _add_default_entries_for_missing_packageids(
+        self, variants_by_packageid: dict[str, dict[str, Any]]
+    ) -> None:
         """
         Add default entries for package IDs not found in Steam metadata.
 
@@ -204,7 +216,9 @@ class MissingModsPrompt(BaseModsPanel):
                     }
                 }
 
-    def _populate_table_from_variants(self, variants_by_packageid: dict[str, dict[str, Any]]) -> None:
+    def _populate_table_from_variants(
+        self, variants_by_packageid: dict[str, dict[str, Any]]
+    ) -> None:
         """
         Populate the table with mod variants.
 
@@ -248,7 +262,9 @@ class MissingModsPrompt(BaseModsPanel):
 
         combo_box = self.editor_table_view.indexWidget(existing_item.index())
         if not isinstance(combo_box, QComboBox):
-            logger.error(f"Expected QComboBox at row {row}, column 5, but found {type(combo_box)}")
+            logger.error(
+                f"Expected QComboBox at row {row}, column 5, but found {type(combo_box)}"
+            )
             return
 
         combo_box.addItem(published_file_id)
@@ -295,7 +311,9 @@ class MissingModsPrompt(BaseModsPanel):
         # Track the row index for this packageid
         self.packageid_to_row[packageid] = self.editor_model.rowCount() - 1
 
-    def _setup_variant_combo_box(self, items: list[QStandardItem], published_file_id: str) -> None:
+    def _setup_variant_combo_box(
+        self, items: list[QStandardItem], published_file_id: str
+    ) -> None:
         """
         Set up the combo box for variant selection.
 
@@ -319,7 +337,10 @@ class MissingModsPrompt(BaseModsPanel):
         try:
             # Cache Steam metadata to avoid repeated access
             self._cached_steam_metadata = self.metadata_manager.external_steam_metadata
-            if self._cached_steam_metadata and len(self._cached_steam_metadata.keys()) > 0:
+            if (
+                self._cached_steam_metadata
+                and len(self._cached_steam_metadata.keys()) > 0
+            ):
                 # Group mods by package ID from Steam metadata
                 variants_by_packageid = self._build_variant_data_from_steam_metadata()
 
@@ -348,6 +369,12 @@ class MissingModsPrompt(BaseModsPanel):
         if index.isValid():
             row = index.row()
             packageid = self.editor_model.item(row, 1).text()
-            variant_data = self.data_by_variants.get(packageid, {}).get(published_file_id, {})
-            self.editor_model.item(row, 0).setText(variant_data.get("name", self.DEFAULT_NOT_FOUND))
-            self.editor_model.item(row, 2).setText(str(variant_data.get("gameVersions", self.DEFAULT_NOT_FOUND)))
+            variant_data = self.data_by_variants.get(packageid, {}).get(
+                published_file_id, {}
+            )
+            self.editor_model.item(row, 0).setText(
+                variant_data.get("name", self.DEFAULT_NOT_FOUND)
+            )
+            self.editor_model.item(row, 2).setText(
+                str(variant_data.get("gameVersions", self.DEFAULT_NOT_FOUND))
+            )

--- a/app/windows/rule_editor_panel.py
+++ b/app/windows/rule_editor_panel.py
@@ -36,7 +36,9 @@ from app.views.dialogue import show_warning
 
 
 class EditableDelegate(QItemDelegate):
-    comment_edited_signal = Signal(list)  # signal connects to _do_update_rules_database in main_content_panel.py
+    comment_edited_signal = Signal(
+        list
+    )  # signal connects to _do_update_rules_database in main_content_panel.py
 
     def createEditor(
         self,
@@ -46,10 +48,14 @@ class EditableDelegate(QItemDelegate):
     ) -> QWidget:
         if index.column() == 4:  # Check if it's the 5th column
             model = index.model()
-            column3_value = model.index(index.row(), 2).data()  # Get the value of the 3rd column
+            column3_value = model.index(
+                index.row(), 2
+            ).data()  # Get the value of the 3rd column
 
             # Add detailed logging for debugging
-            logger.debug(f"Attempting to create editor for row {index.row()}, column {index.column()}")
+            logger.debug(
+                f"Attempting to create editor for row {index.row()}, column {index.column()}"
+            )
             logger.debug(f"Column 3 value: {column3_value}")
 
             if column3_value in [
@@ -61,13 +67,17 @@ class EditableDelegate(QItemDelegate):
 
             # Provide more informative error message if editor creation fails
             if column3_value not in ["About.xml"]:
-                error_msg = f"Editor creation failed! for Column 3 value '{column3_value}' "
+                error_msg = (
+                    f"Editor creation failed! for Column 3 value '{column3_value}' "
+                )
                 logger.error(error_msg)
 
         # Handle case where wrong column is being edited
         return QLineEdit(parent, readOnly=True)  # Return a basic editor as fallback
 
-    def setEditorData(self, editor: QWidget, index: QModelIndex | QPersistentModelIndex) -> None:
+    def setEditorData(
+        self, editor: QWidget, index: QModelIndex | QPersistentModelIndex
+    ) -> None:
         if index.column() == 4:  # Only set data for the 5th column
             super().setEditorData(editor, index)
 
@@ -82,11 +92,15 @@ class EditableDelegate(QItemDelegate):
             # Send the column data back to the editor so we can update the metadata
             # edited_data = model.data(index, Qt.DisplayRole)  # Get the edited data
             column_values = [
-                model.data(model.index(index.row(), column), Qt.ItemDataRole.DisplayRole)
+                model.data(
+                    model.index(index.row(), column), Qt.ItemDataRole.DisplayRole
+                )
                 for column in range(model.columnCount())
             ]  # Get the values of all columns in the edited row
 
-            self.comment_edited_signal.emit(column_values)  # Emit the signal with column values and edited data
+            self.comment_edited_signal.emit(
+                column_values
+            )  # Emit the signal with column values and edited data
 
 
 class RuleEditor(QWidget):
@@ -118,7 +132,9 @@ class RuleEditor(QWidget):
         self.setObjectName("RuleEditor")
 
         # LAUNCH OPTIONS
-        self.block_comment_prompt = False  # Used to block comment prompt when metadata is being populated
+        self.block_comment_prompt = (
+            False  # Used to block comment prompt when metadata is being populated
+        )
         self.compact = compact
         self.edit_packageid = edit_packageid
         self.initial_mode = initial_mode
@@ -131,7 +147,9 @@ class RuleEditor(QWidget):
         )
         self.community_rules_hidden: bool = False
         self.user_rules = (
-            self.metadata_manager.external_user_rules.copy() if self.metadata_manager.external_user_rules else {}
+            self.metadata_manager.external_user_rules.copy()
+            if self.metadata_manager.external_user_rules
+            else {}
         )
         self.user_rules_hidden: bool = False
         # Can be used to get proper names for mods found in list
@@ -142,7 +160,9 @@ class RuleEditor(QWidget):
             for metadata in external_steam_metadata.values():
                 package_id = metadata.get("packageId") or metadata.get("packageid")
                 if package_id:
-                    self.steam_workshop_metadata_packageids_to_name[package_id] = metadata["name"]
+                    self.steam_workshop_metadata_packageids_to_name[package_id] = (
+                        metadata["name"]
+                    )
 
         # MOD LABEL
         self.mod_label = QLabel(self.tr("No mod currently being edited"))
@@ -169,19 +189,27 @@ class RuleEditor(QWidget):
         # local metadata
         self.local_metadata_loadAfter_label = QLabel(self.tr("About.xml (loadAfter)"))
         self.local_metadata_loadBefore_label = QLabel(self.tr("About.xml (loadBefore)"))
-        self.local_metadata_incompatibilities_label = QLabel(self.tr("About.xml (incompatibilitiesWith)"))
+        self.local_metadata_incompatibilities_label = QLabel(
+            self.tr("About.xml (incompatibilitiesWith)")
+        )
         self.local_metadata_loadAfter_list = QListWidget()
         self.local_metadata_loadBefore_list = QListWidget()
         self.local_metadata_incompatibilities_list = QListWidget()
 
         # community rules
-        self.external_community_rules_loadAfter_label = QLabel(self.tr("Community Rules (loadAfter)"))
-        self.external_community_rules_loadBefore_label = QLabel(self.tr("Community Rules (loadBefore)"))
+        self.external_community_rules_loadAfter_label = QLabel(
+            self.tr("Community Rules (loadAfter)")
+        )
+        self.external_community_rules_loadBefore_label = QLabel(
+            self.tr("Community Rules (loadBefore)")
+        )
         self.external_community_rules_incompatibilities_label = QLabel(
             self.tr("Community Rules (incompatibilitiesWith)")
         )
         self.external_community_rules_loadAfter_list = QListWidget()
-        self.external_community_rules_loadAfter_list.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self.external_community_rules_loadAfter_list.setContextMenuPolicy(
+            Qt.ContextMenuPolicy.CustomContextMenu
+        )
         self.external_community_rules_loadAfter_list.customContextMenuRequested.connect(
             partial(
                 self.ruleItemContextMenuEvent,
@@ -189,12 +217,16 @@ class RuleEditor(QWidget):
             )
         )
         self.external_community_rules_loadAfter_list.setAcceptDrops(True)
-        self.external_community_rules_loadAfter_list.setDragDropMode(QListWidget.DragDropMode.DropOnly)
+        self.external_community_rules_loadAfter_list.setDragDropMode(
+            QListWidget.DragDropMode.DropOnly
+        )
         self.external_community_rules_loadAfter_list.dropEvent = self.createDropEvent(  # type: ignore
             self.external_community_rules_loadAfter_list
         )
         self.external_community_rules_loadBefore_list = QListWidget()
-        self.external_community_rules_loadBefore_list.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self.external_community_rules_loadBefore_list.setContextMenuPolicy(
+            Qt.ContextMenuPolicy.CustomContextMenu
+        )
         self.external_community_rules_loadBefore_list.customContextMenuRequested.connect(
             partial(
                 self.ruleItemContextMenuEvent,
@@ -202,13 +234,19 @@ class RuleEditor(QWidget):
             )
         )
         self.external_community_rules_loadBefore_list.setAcceptDrops(True)
-        self.external_community_rules_loadBefore_list.setDragDropMode(QListWidget.DragDropMode.DropOnly)
+        self.external_community_rules_loadBefore_list.setDragDropMode(
+            QListWidget.DragDropMode.DropOnly
+        )
         self.external_community_rules_loadBefore_list.dropEvent = self.createDropEvent(  # type: ignore
             self.external_community_rules_loadBefore_list
         )
-        self.external_community_rules_loadTop_checkbox = QCheckBox(self.tr("Force load at top of list"))
+        self.external_community_rules_loadTop_checkbox = QCheckBox(
+            self.tr("Force load at top of list")
+        )
         self.external_community_rules_loadTop_checkbox.setObjectName("summaryValue")
-        self.external_community_rules_loadBottom_checkbox = QCheckBox(self.tr("Force load at bottom of list"))
+        self.external_community_rules_loadBottom_checkbox = QCheckBox(
+            self.tr("Force load at bottom of list")
+        )
         self.external_community_rules_loadBottom_checkbox.setObjectName("summaryValue")
         self.external_community_rules_incompatibilities_list = QListWidget()
         self.external_community_rules_incompatibilities_list.setContextMenuPolicy(
@@ -221,16 +259,26 @@ class RuleEditor(QWidget):
             )
         )
         self.external_community_rules_incompatibilities_list.setAcceptDrops(True)
-        self.external_community_rules_incompatibilities_list.setDragDropMode(QListWidget.DragDropMode.DropOnly)
+        self.external_community_rules_incompatibilities_list.setDragDropMode(
+            QListWidget.DragDropMode.DropOnly
+        )
         self.external_community_rules_incompatibilities_list.dropEvent = (  # type: ignore
             self.createDropEvent(self.external_community_rules_incompatibilities_list)
         )
         # user rules
-        self.external_user_rules_loadAfter_label = QLabel(self.tr("User Rules (loadAfter)"))
-        self.external_user_rules_loadBefore_label = QLabel(self.tr("User Rules (loadBefore)"))
-        self.external_user_rules_incompatibilities_label = QLabel(self.tr("User Rules (incompatibilitiesWith)"))
+        self.external_user_rules_loadAfter_label = QLabel(
+            self.tr("User Rules (loadAfter)")
+        )
+        self.external_user_rules_loadBefore_label = QLabel(
+            self.tr("User Rules (loadBefore)")
+        )
+        self.external_user_rules_incompatibilities_label = QLabel(
+            self.tr("User Rules (incompatibilitiesWith)")
+        )
         self.external_user_rules_loadAfter_list = QListWidget()
-        self.external_user_rules_loadAfter_list.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self.external_user_rules_loadAfter_list.setContextMenuPolicy(
+            Qt.ContextMenuPolicy.CustomContextMenu
+        )
         self.external_user_rules_loadAfter_list.customContextMenuRequested.connect(
             partial(
                 self.ruleItemContextMenuEvent,
@@ -238,12 +286,16 @@ class RuleEditor(QWidget):
             )
         )
         self.external_user_rules_loadAfter_list.setAcceptDrops(True)
-        self.external_user_rules_loadAfter_list.setDragDropMode(QListWidget.DragDropMode.DropOnly)
+        self.external_user_rules_loadAfter_list.setDragDropMode(
+            QListWidget.DragDropMode.DropOnly
+        )
         self.external_user_rules_loadAfter_list.dropEvent = self.createDropEvent(  # type: ignore
             self.external_user_rules_loadAfter_list
         )
         self.external_user_rules_loadBefore_list = QListWidget()
-        self.external_user_rules_loadBefore_list.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self.external_user_rules_loadBefore_list.setContextMenuPolicy(
+            Qt.ContextMenuPolicy.CustomContextMenu
+        )
         self.external_user_rules_loadBefore_list.customContextMenuRequested.connect(
             partial(
                 self.ruleItemContextMenuEvent,
@@ -251,16 +303,24 @@ class RuleEditor(QWidget):
             )
         )
         self.external_user_rules_loadBefore_list.setAcceptDrops(True)
-        self.external_user_rules_loadBefore_list.setDragDropMode(QListWidget.DragDropMode.DropOnly)
+        self.external_user_rules_loadBefore_list.setDragDropMode(
+            QListWidget.DragDropMode.DropOnly
+        )
         self.external_user_rules_loadBefore_list.dropEvent = self.createDropEvent(  # type: ignore
             self.external_user_rules_loadBefore_list
         )
-        self.external_user_rules_loadTop_checkbox = QCheckBox(self.tr("Force load at top of list"))
+        self.external_user_rules_loadTop_checkbox = QCheckBox(
+            self.tr("Force load at top of list")
+        )
         self.external_user_rules_loadTop_checkbox.setObjectName("summaryValue")
-        self.external_user_rules_loadBottom_checkbox = QCheckBox(self.tr("Force load at bottom of list"))
+        self.external_user_rules_loadBottom_checkbox = QCheckBox(
+            self.tr("Force load at bottom of list")
+        )
         self.external_user_rules_loadBottom_checkbox.setObjectName("summaryValue")
         self.external_user_rules_incompatibilities_list = QListWidget()
-        self.external_user_rules_incompatibilities_list.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self.external_user_rules_incompatibilities_list.setContextMenuPolicy(
+            Qt.ContextMenuPolicy.CustomContextMenu
+        )
         self.external_user_rules_incompatibilities_list.customContextMenuRequested.connect(
             partial(
                 self.ruleItemContextMenuEvent,
@@ -268,7 +328,9 @@ class RuleEditor(QWidget):
             )
         )
         self.external_user_rules_incompatibilities_list.setAcceptDrops(True)
-        self.external_user_rules_incompatibilities_list.setDragDropMode(QListWidget.DragDropMode.DropOnly)
+        self.external_user_rules_incompatibilities_list.setDragDropMode(
+            QListWidget.DragDropMode.DropOnly
+        )
         self.external_user_rules_incompatibilities_list.dropEvent = (  # type: ignore
             self.createDropEvent(self.external_user_rules_incompatibilities_list)
         )
@@ -286,29 +348,51 @@ class RuleEditor(QWidget):
         )
         # Create the table view and set the model
         self.editor_delegate = EditableDelegate()
-        self.editor_delegate.comment_edited_signal.connect(self._comment_edited)  # Connect the signal to the slot
+        self.editor_delegate.comment_edited_signal.connect(
+            self._comment_edited
+        )  # Connect the signal to the slot
         self.editor_table_view = QTableView()
         self.editor_table_view.setCornerButtonEnabled(False)
         self.editor_table_view.setModel(self.editor_model)
         self.editor_table_view.setSortingEnabled(True)  # Enable sorting on the columns
-        self.editor_table_view.setItemDelegate(self.editor_delegate)  # Set the delegate for editing
+        self.editor_table_view.setItemDelegate(
+            self.editor_delegate
+        )  # Set the delegate for editing
         self.editor_table_view.setEditTriggers(
             QTableView.EditTrigger.DoubleClicked | QTableView.EditTrigger.EditKeyPressed
         )  # Enable editing
         # Set default stretch for each column
-        self.editor_table_view.horizontalHeader().setSectionResizeMode(0, QHeaderView.ResizeMode.Stretch)
-        self.editor_table_view.horizontalHeader().setSectionResizeMode(1, QHeaderView.ResizeMode.ResizeToContents)
-        self.editor_table_view.horizontalHeader().setSectionResizeMode(2, QHeaderView.ResizeMode.ResizeToContents)
-        self.editor_table_view.horizontalHeader().setSectionResizeMode(3, QHeaderView.ResizeMode.ResizeToContents)
-        self.editor_table_view.horizontalHeader().setSectionResizeMode(4, QHeaderView.ResizeMode.Stretch)
+        self.editor_table_view.horizontalHeader().setSectionResizeMode(
+            0, QHeaderView.ResizeMode.Stretch
+        )
+        self.editor_table_view.horizontalHeader().setSectionResizeMode(
+            1, QHeaderView.ResizeMode.ResizeToContents
+        )
+        self.editor_table_view.horizontalHeader().setSectionResizeMode(
+            2, QHeaderView.ResizeMode.ResizeToContents
+        )
+        self.editor_table_view.horizontalHeader().setSectionResizeMode(
+            3, QHeaderView.ResizeMode.ResizeToContents
+        )
+        self.editor_table_view.horizontalHeader().setSectionResizeMode(
+            4, QHeaderView.ResizeMode.Stretch
+        )
         # Editor actions
         # community rules
         self.editor_save_community_rules_icon = QIcon(
-            str(AppInfo().theme_data_folder / "default-icons" / "save_community_rules.png")
+            str(
+                AppInfo().theme_data_folder
+                / "default-icons"
+                / "save_community_rules.png"
+            )
         )
         self.editor_save_community_rules_button = QToolButton()
-        self.editor_save_community_rules_button.setToolTip(self.tr("Save rules to communityRules.json"))
-        self.editor_save_community_rules_button.setIcon(self.editor_save_community_rules_icon)
+        self.editor_save_community_rules_button.setToolTip(
+            self.tr("Save rules to communityRules.json")
+        )
+        self.editor_save_community_rules_button.setIcon(
+            self.editor_save_community_rules_icon
+        )
         self.editor_save_community_rules_button.clicked.connect(
             partial(self._save_editor_rules, rules_source="Community Rules")
         )
@@ -317,16 +401,22 @@ class RuleEditor(QWidget):
             str(AppInfo().theme_data_folder / "default-icons" / "save_user_rules.png")
         )
         self.editor_save_user_rules_button = QToolButton()
-        self.editor_save_user_rules_button.setToolTip(self.tr("Save rules to userRules.json"))
+        self.editor_save_user_rules_button.setToolTip(
+            self.tr("Save rules to userRules.json")
+        )
         self.editor_save_user_rules_button.setIcon(self.editor_save_user_rules_icon)
-        self.editor_save_user_rules_button.clicked.connect(partial(self._save_editor_rules, rules_source="User Rules"))
+        self.editor_save_user_rules_button.clicked.connect(
+            partial(self._save_editor_rules, rules_source="User Rules")
+        )
         # MODS WIDGETS
         # Mods search
         self.mods_search = QLineEdit()
         self.mods_search.setClearButtonEnabled(True)
         self.mods_search.textChanged.connect(self.signal_mods_search)
         self.mods_search.setPlaceholderText(self.tr("Search mods by name"))
-        self.mods_search_clear_button: object | QToolButton | None = self.mods_search.findChild(QToolButton)
+        self.mods_search_clear_button: object | QToolButton | None = (
+            self.mods_search.findChild(QToolButton)
+        )
         if type(self.mods_search_clear_button) is not QToolButton:
             raise Exception("Failed to find clear button in QLineEdit")
         if self.mods_search_clear_button is not None:
@@ -361,28 +451,72 @@ class RuleEditor(QWidget):
             )
         )
         # Build the details layout
-        self.internal_local_metadata_layout.addWidget(self.local_metadata_loadAfter_label)
-        self.internal_local_metadata_layout.addWidget(self.local_metadata_loadAfter_list)
-        self.internal_local_metadata_layout.addWidget(self.local_metadata_loadBefore_label)
-        self.internal_local_metadata_layout.addWidget(self.local_metadata_loadBefore_list)
-        self.internal_local_metadata_layout.addWidget(self.local_metadata_incompatibilities_label)
-        self.internal_local_metadata_layout.addWidget(self.local_metadata_incompatibilities_list)
-        self.external_community_rules_layout.addWidget(self.external_community_rules_loadAfter_label)
-        self.external_community_rules_layout.addWidget(self.external_community_rules_loadAfter_list)
-        self.external_community_rules_layout.addWidget(self.external_community_rules_loadBefore_label)
-        self.external_community_rules_layout.addWidget(self.external_community_rules_loadBefore_list)
-        self.external_community_rules_layout.addWidget(self.external_community_rules_loadTop_checkbox)
-        self.external_community_rules_layout.addWidget(self.external_community_rules_loadBottom_checkbox)
-        self.external_community_rules_layout.addWidget(self.external_community_rules_incompatibilities_label)
-        self.external_community_rules_layout.addWidget(self.external_community_rules_incompatibilities_list)
-        self.external_user_rules_layout.addWidget(self.external_user_rules_loadAfter_label)
-        self.external_user_rules_layout.addWidget(self.external_user_rules_loadAfter_list)
-        self.external_user_rules_layout.addWidget(self.external_user_rules_loadBefore_label)
-        self.external_user_rules_layout.addWidget(self.external_user_rules_loadBefore_list)
-        self.external_user_rules_layout.addWidget(self.external_user_rules_loadTop_checkbox)
-        self.external_user_rules_layout.addWidget(self.external_user_rules_loadBottom_checkbox)
-        self.external_user_rules_layout.addWidget(self.external_user_rules_incompatibilities_label)
-        self.external_user_rules_layout.addWidget(self.external_user_rules_incompatibilities_list)
+        self.internal_local_metadata_layout.addWidget(
+            self.local_metadata_loadAfter_label
+        )
+        self.internal_local_metadata_layout.addWidget(
+            self.local_metadata_loadAfter_list
+        )
+        self.internal_local_metadata_layout.addWidget(
+            self.local_metadata_loadBefore_label
+        )
+        self.internal_local_metadata_layout.addWidget(
+            self.local_metadata_loadBefore_list
+        )
+        self.internal_local_metadata_layout.addWidget(
+            self.local_metadata_incompatibilities_label
+        )
+        self.internal_local_metadata_layout.addWidget(
+            self.local_metadata_incompatibilities_list
+        )
+        self.external_community_rules_layout.addWidget(
+            self.external_community_rules_loadAfter_label
+        )
+        self.external_community_rules_layout.addWidget(
+            self.external_community_rules_loadAfter_list
+        )
+        self.external_community_rules_layout.addWidget(
+            self.external_community_rules_loadBefore_label
+        )
+        self.external_community_rules_layout.addWidget(
+            self.external_community_rules_loadBefore_list
+        )
+        self.external_community_rules_layout.addWidget(
+            self.external_community_rules_loadTop_checkbox
+        )
+        self.external_community_rules_layout.addWidget(
+            self.external_community_rules_loadBottom_checkbox
+        )
+        self.external_community_rules_layout.addWidget(
+            self.external_community_rules_incompatibilities_label
+        )
+        self.external_community_rules_layout.addWidget(
+            self.external_community_rules_incompatibilities_list
+        )
+        self.external_user_rules_layout.addWidget(
+            self.external_user_rules_loadAfter_label
+        )
+        self.external_user_rules_layout.addWidget(
+            self.external_user_rules_loadAfter_list
+        )
+        self.external_user_rules_layout.addWidget(
+            self.external_user_rules_loadBefore_label
+        )
+        self.external_user_rules_layout.addWidget(
+            self.external_user_rules_loadBefore_list
+        )
+        self.external_user_rules_layout.addWidget(
+            self.external_user_rules_loadTop_checkbox
+        )
+        self.external_user_rules_layout.addWidget(
+            self.external_user_rules_loadBottom_checkbox
+        )
+        self.external_user_rules_layout.addWidget(
+            self.external_user_rules_incompatibilities_label
+        )
+        self.external_user_rules_layout.addWidget(
+            self.external_user_rules_incompatibilities_list
+        )
         self.details_layout.addLayout(self.internal_local_metadata_layout)
         self.details_layout.addLayout(self.external_community_rules_layout)
         self.details_layout.addLayout(self.external_user_rules_layout)
@@ -413,9 +547,13 @@ class RuleEditor(QWidget):
 
         # Allow toggle layouts based on context
         if self.compact:
-            self._toggle_details_layout_widgets(layout=self.internal_local_metadata_layout, override=True)
+            self._toggle_details_layout_widgets(
+                layout=self.internal_local_metadata_layout, override=True
+            )
         else:
-            self._toggle_details_layout_widgets(layout=self.internal_local_metadata_layout, override=False)
+            self._toggle_details_layout_widgets(
+                layout=self.internal_local_metadata_layout, override=False
+            )
         # If no initial packageid supplied, lock checkboxes
         if not self.edit_packageid:
             self.external_community_rules_loadTop_checkbox.setCheckable(False)
@@ -424,11 +562,19 @@ class RuleEditor(QWidget):
             self.external_user_rules_loadBottom_checkbox.setCheckable(False)
         # Initial mode
         if self.initial_mode == "community_rules":
-            self._toggle_details_layout_widgets(layout=self.external_community_rules_layout, override=False)
-            self._toggle_details_layout_widgets(layout=self.external_user_rules_layout, override=False)
+            self._toggle_details_layout_widgets(
+                layout=self.external_community_rules_layout, override=False
+            )
+            self._toggle_details_layout_widgets(
+                layout=self.external_user_rules_layout, override=False
+            )
         elif self.initial_mode == "user_rules":
-            self._toggle_details_layout_widgets(layout=self.external_community_rules_layout, override=False)
-            self._toggle_details_layout_widgets(layout=self.external_user_rules_layout, override=False)
+            self._toggle_details_layout_widgets(
+                layout=self.external_community_rules_layout, override=False
+            )
+            self._toggle_details_layout_widgets(
+                layout=self.external_user_rules_layout, override=False
+            )
         # Connect these after metadata population
         self.external_community_rules_loadTop_checkbox.stateChanged.connect(
             partial(self._toggle_loadTop_rule, "Community Rules")
@@ -436,7 +582,9 @@ class RuleEditor(QWidget):
         self.external_community_rules_loadBottom_checkbox.stateChanged.connect(
             partial(self._toggle_loadBottom_rule, "Community Rules")
         )
-        self.external_user_rules_loadTop_checkbox.stateChanged.connect(partial(self._toggle_loadTop_rule, "User Rules"))
+        self.external_user_rules_loadTop_checkbox.stateChanged.connect(
+            partial(self._toggle_loadTop_rule, "User Rules")
+        )
         self.external_user_rules_loadBottom_checkbox.stateChanged.connect(
             partial(self._toggle_loadBottom_rule, "User Rules")
         )
@@ -446,7 +594,9 @@ class RuleEditor(QWidget):
         # Set the window size
         self.resize(900, 600)
 
-    def createDropEvent(self, destination_list: QListWidget) -> Callable[[QDropEvent], None]:
+    def createDropEvent(
+        self, destination_list: QListWidget
+    ) -> Callable[[QDropEvent], None]:
         def dropEvent(event: QDropEvent) -> None:
             # If the item was sourced from mods list
             if event.source() == self.mods_list and self.edit_packageid:
@@ -470,7 +620,10 @@ class RuleEditor(QWidget):
                 elif destination_list is self.external_community_rules_loadBefore_list:
                     mode = ["Community Rules", "loadBefore"]
 
-                elif destination_list is self.external_community_rules_incompatibilities_list:
+                elif (
+                    destination_list
+                    is self.external_community_rules_incompatibilities_list
+                ):
                     mode = ["Community Rules", "incompatibleWith"]
 
                 elif destination_list is self.external_user_rules_loadAfter_list:
@@ -479,7 +632,9 @@ class RuleEditor(QWidget):
                 elif destination_list is self.external_user_rules_loadBefore_list:
                     mode = ["User Rules", "loadBefore"]
 
-                elif destination_list is self.external_user_rules_incompatibilities_list:
+                elif (
+                    destination_list is self.external_user_rules_incompatibilities_list
+                ):
                     mode = ["User Rules", "incompatibleWith"]
 
                 else:
@@ -490,9 +645,15 @@ class RuleEditor(QWidget):
                 # Search for & remove the rule's row entry from the editor table
                 for row in range(self.editor_model.rowCount()):
                     # Define criteria
-                    packageid_value = self.editor_model.item(row, 1)  # Get the item in column 2 (index 1)
-                    rule_source_value = self.editor_model.item(row, 2)  # Get the item in column 3 (index 2)
-                    rule_type_value = self.editor_model.item(row, 3)  # Get the item in column 4 (index 3)
+                    packageid_value = self.editor_model.item(
+                        row, 1
+                    )  # Get the item in column 2 (index 1)
+                    rule_source_value = self.editor_model.item(
+                        row, 2
+                    )  # Get the item in column 3 (index 2)
+                    rule_type_value = self.editor_model.item(
+                        row, 3
+                    )  # Get the item in column 4 (index 3)
                     # Search table for rows that match.
                     if (
                         (packageid_value and rule_data == packageid_value.text())
@@ -545,7 +706,9 @@ class RuleEditor(QWidget):
                     metadata[self.edit_packageid][mode[1]] = {}
                 if not metadata[self.edit_packageid][mode[1]].get(rule_data):
                     metadata[self.edit_packageid][mode[1]][rule_data] = {}
-                metadata[self.edit_packageid][mode[1]][rule_data]["name"] = item_label_text
+                metadata[self.edit_packageid][mode[1]][rule_data]["name"] = (
+                    item_label_text
+                )
                 metadata[self.edit_packageid][mode[1]][rule_data]["comment"] = comment
             else:
                 event.ignore()
@@ -565,7 +728,9 @@ class RuleEditor(QWidget):
     ) -> None:
         if not self.edit_packageid:
             return
-        logger.debug(f"Adding {rule_source} {rule_type} rule to mod {self.edit_packageid} with comment: {comment}")
+        logger.debug(
+            f"Adding {rule_source} {rule_type} rule to mod {self.edit_packageid} with comment: {comment}"
+        )
         # Create the standard items for each column
         items = [
             QStandardItem(name),
@@ -625,14 +790,26 @@ class RuleEditor(QWidget):
                 logger.error(f"Invalid rule source!: {instruction[2]}")
                 return
             # Edit based on type of rule
-            if instruction[3] == "loadAfter" or instruction[3] == "loadBefore" or instruction[3] == "incompatibleWith":
-                metadata[self.edit_packageid][instruction[3]][instruction[1]]["comment"] = instruction[4]
+            if (
+                instruction[3] == "loadAfter"
+                or instruction[3] == "loadBefore"
+                or instruction[3] == "incompatibleWith"
+            ):
+                metadata[self.edit_packageid][instruction[3]][instruction[1]][
+                    "comment"
+                ] = instruction[4]
             elif instruction[3] == "loadTop":
-                metadata[self.edit_packageid][instruction[3]]["comment"] = instruction[4]
+                metadata[self.edit_packageid][instruction[3]]["comment"] = instruction[
+                    4
+                ]
             elif instruction[3] == "loadBottom":
-                metadata[self.edit_packageid][instruction[3]]["comment"] = instruction[4]
+                metadata[self.edit_packageid][instruction[3]]["comment"] = instruction[
+                    4
+                ]
 
-    def _create_list_item(self, _list: QListWidget, title: str, metadata: str | None = None) -> None:
+    def _create_list_item(
+        self, _list: QListWidget, title: str, metadata: str | None = None
+    ) -> None:
         # Create our list item
         item = QListWidgetItem()
         if metadata:
@@ -678,7 +855,9 @@ class RuleEditor(QWidget):
                     and metadata["packageid"].lower() == self.edit_packageid.lower()
                 ):
                     self.edit_name = metadata["name"]
-                    self.mod_label.setText(self.tr("Editing rules for: {name}").format(name=self.edit_name))
+                    self.mod_label.setText(
+                        self.tr("Editing rules for: {name}").format(name=self.edit_name)
+                    )
                     # All Lowercase!!!
                     # cSpell:enableCompoundWords
                     rule_types = {
@@ -694,7 +873,9 @@ class RuleEditor(QWidget):
                                 rules = [rules]
                             if isinstance(rules, list):
                                 for rule in rules:
-                                    name = self.steam_workshop_metadata_packageids_to_name.get(rule.lower(), rule)
+                                    name = self.steam_workshop_metadata_packageids_to_name.get(
+                                        rule.lower(), rule
+                                    )
                                     # Ensure name is a string
                                     name_str = str(name) if name is not None else rule
                                     self._create_list_item(_list=_list, title=name_str)
@@ -757,7 +938,9 @@ class RuleEditor(QWidget):
                         continue
                     for rule_id, rule_data in metadata[rule_type].items():
                         rule_name = _get_first_item_or_value(rule_data.get("name", ""))
-                        rule_comment = _get_first_item_or_value(rule_data.get("comment", ""))
+                        rule_comment = _get_first_item_or_value(
+                            rule_data.get("comment", "")
+                        )
 
                         if not rule_name:
                             # Set rule name to the packageid if it's empty
@@ -798,7 +981,9 @@ class RuleEditor(QWidget):
                             packageid=self.edit_packageid,
                             rule_source=rule_source,
                             rule_type="loadTop",
-                            comment=_get_first_item_or_value(rule_data.get("comment", "")),
+                            comment=_get_first_item_or_value(
+                                rule_data.get("comment", "")
+                            ),
                             hidden=hidden,
                         )
 
@@ -813,7 +998,9 @@ class RuleEditor(QWidget):
                             packageid=self.edit_packageid,
                             rule_source=rule_source,
                             rule_type="loadBottom",
-                            comment=_get_first_item_or_value(rule_data.get("comment", "")),
+                            comment=_get_first_item_or_value(
+                                rule_data.get("comment", "")
+                            ),
                             hidden=hidden,
                         )
 
@@ -881,9 +1068,15 @@ class RuleEditor(QWidget):
         # Search for & remove the rule's row entry from the editor table
         for row in range(self.editor_model.rowCount()):
             # Define criteria
-            packageid_value = self.editor_model.item(row, 1)  # Get the item in column 2 (index 1)
-            rule_source_value = self.editor_model.item(row, 2)  # Get the item in column 3 (index 2)
-            rule_type_value = self.editor_model.item(row, 3)  # Get the item in column 4 (index 3)
+            packageid_value = self.editor_model.item(
+                row, 1
+            )  # Get the item in column 2 (index 1)
+            rule_source_value = self.editor_model.item(
+                row, 2
+            )  # Get the item in column 3 (index 2)
+            rule_type_value = self.editor_model.item(
+                row, 3
+            )  # Get the item in column 4 (index 3)
             # Search table for rows that match
             if (
                 (packageid_value and rule_data in packageid_value.text())
@@ -892,7 +1085,9 @@ class RuleEditor(QWidget):
             ):  # Remove row if criteria matches search
                 self.editor_model.removeRow(row)
         # Remove rule from the database
-        if self.edit_packageid is not None and metadata.get(self.edit_packageid, {}).get(mode[1], {}).get(rule_data):
+        if self.edit_packageid is not None and metadata.get(
+            self.edit_packageid, {}
+        ).get(mode[1], {}).get(rule_data):
             metadata[self.edit_packageid][mode[1]].pop(rule_data)
 
     def _save_editor_rules(self, rules_source: str) -> None:
@@ -910,7 +1105,9 @@ class RuleEditor(QWidget):
         self._clear_widget()
         self._populate_from_metadata()
 
-    def _toggle_details_layout_widgets(self, layout: QVBoxLayout, override: bool = False) -> None:
+    def _toggle_details_layout_widgets(
+        self, layout: QVBoxLayout, override: bool = False
+    ) -> None:
         visibility = None
         # Iterate through all widgets in layout
         for i in range(layout.count()):
@@ -936,33 +1133,47 @@ class RuleEditor(QWidget):
             if layout is self.internal_local_metadata_layout:
                 self.local_rules_hidden = True
                 self.local_metadata_button.setText(self.tr("Show About.xml rules"))
-                self._toggle_editor_table_rows(rule_type="About.xml", visibility=visibility)
+                self._toggle_editor_table_rows(
+                    rule_type="About.xml", visibility=visibility
+                )
             elif layout is self.external_community_rules_layout:
                 self.community_rules_hidden = True
                 self.community_rules_button.setText(self.tr("Edit Community Rules"))
-                self._toggle_editor_table_rows(rule_type="Community Rules", visibility=visibility)
+                self._toggle_editor_table_rows(
+                    rule_type="Community Rules", visibility=visibility
+                )
             elif layout is self.external_user_rules_layout:
                 self.user_rules_hidden = True
                 self.user_rules_button.setText(self.tr("Edit User Rules"))
-                self._toggle_editor_table_rows(rule_type="User Rules", visibility=visibility)
+                self._toggle_editor_table_rows(
+                    rule_type="User Rules", visibility=visibility
+                )
         else:
             if layout is self.internal_local_metadata_layout:
                 self.local_rules_hidden = False
                 self.local_metadata_button.setText(self.tr("Hide About.xml rules"))
-                self._toggle_editor_table_rows(rule_type="About.xml", visibility=visibility)
+                self._toggle_editor_table_rows(
+                    rule_type="About.xml", visibility=visibility
+                )
             elif layout is self.external_community_rules_layout:
                 self.community_rules_hidden = False
                 self.community_rules_button.setText(self.tr("Lock Community Rules"))
-                self._toggle_editor_table_rows(rule_type="Community Rules", visibility=visibility)
+                self._toggle_editor_table_rows(
+                    rule_type="Community Rules", visibility=visibility
+                )
             elif layout is self.external_user_rules_layout:
                 self.user_rules_hidden = False
                 self.user_rules_button.setText(self.tr("Lock User Rules"))
-                self._toggle_editor_table_rows(rule_type="User Rules", visibility=visibility)
+                self._toggle_editor_table_rows(
+                    rule_type="User Rules", visibility=visibility
+                )
 
     def _toggle_editor_table_rows(self, rule_type: str, visibility: bool) -> None:
         for row in range(self.editor_model.rowCount()):
             item = self.editor_model.item(row, 2)  # Get the item in column 3 (index 2)
-            if item and item.text() == rule_type:  # Toggle row visibility based on the value
+            if (
+                item and item.text() == rule_type
+            ):  # Toggle row visibility based on the value
                 self.editor_table_view.setRowHidden(row, visibility)
 
     def _toggle_loadTop_rule(self, rule_source: str, state: int) -> None:
@@ -1010,18 +1221,34 @@ class RuleEditor(QWidget):
                 # Search for & remove the rule's row entry from the editor table
                 for row in range(self.editor_model.rowCount()):
                     # Define criteria
-                    packageid_value = self.editor_model.item(row, 1)  # Get the item in column 2 (index 1)
-                    rule_source_value = self.editor_model.item(row, 2)  # Get the item in column 3 (index 2)
-                    rule_type_value = self.editor_model.item(row, 3)  # Get the item in column 4 (index 3)
+                    packageid_value = self.editor_model.item(
+                        row, 1
+                    )  # Get the item in column 2 (index 1)
+                    rule_source_value = self.editor_model.item(
+                        row, 2
+                    )  # Get the item in column 3 (index 2)
+                    rule_type_value = self.editor_model.item(
+                        row, 3
+                    )  # Get the item in column 4 (index 3)
                     # Search table for rows that match
                     if (
-                        (packageid_value and self.edit_packageid in packageid_value.text())
-                        and (rule_source_value and rule_source in rule_source_value.text())
+                        (
+                            packageid_value
+                            and self.edit_packageid in packageid_value.text()
+                        )
+                        and (
+                            rule_source_value
+                            and rule_source in rule_source_value.text()
+                        )
                         and (rule_type_value and "loadTop" in rule_type_value.text())
                     ):  # Remove row if criteria matches search
                         self.editor_model.removeRow(row)
                 # Remove rule from the database
-                if metadata.get(self.edit_packageid, {}).get("loadTop", {}).get("value"):
+                if (
+                    metadata.get(self.edit_packageid, {})
+                    .get("loadTop", {})
+                    .get("value")
+                ):
                     metadata[self.edit_packageid].pop("loadTop")
 
     def _toggle_loadBottom_rule(self, rule_source: str, state: int) -> None:
@@ -1069,18 +1296,34 @@ class RuleEditor(QWidget):
                 # Search for & remove the rule's row entry from the editor table
                 for row in range(self.editor_model.rowCount()):
                     # Define criteria
-                    packageid_value = self.editor_model.item(row, 1)  # Get the item in column 2 (index 1)
-                    rule_source_value = self.editor_model.item(row, 2)  # Get the item in column 3 (index 2)
-                    rule_type_value = self.editor_model.item(row, 3)  # Get the item in column 4 (index 3)
+                    packageid_value = self.editor_model.item(
+                        row, 1
+                    )  # Get the item in column 2 (index 1)
+                    rule_source_value = self.editor_model.item(
+                        row, 2
+                    )  # Get the item in column 3 (index 2)
+                    rule_type_value = self.editor_model.item(
+                        row, 3
+                    )  # Get the item in column 4 (index 3)
                     # Search table for rows that match
                     if (
-                        (packageid_value and self.edit_packageid in packageid_value.text())
-                        and (rule_source_value and rule_source in rule_source_value.text())
+                        (
+                            packageid_value
+                            and self.edit_packageid in packageid_value.text()
+                        )
+                        and (
+                            rule_source_value
+                            and rule_source in rule_source_value.text()
+                        )
                         and (rule_type_value and "loadBottom" in rule_type_value.text())
                     ):  # Remove row if criteria matches search
                         self.editor_model.removeRow(row)
                 # Remove rule from the database
-                if metadata.get(self.edit_packageid, {}).get("loadBottom", {}).get("value"):
+                if (
+                    metadata.get(self.edit_packageid, {})
+                    .get("loadBottom", {})
+                    .get("value")
+                ):
                     metadata[self.edit_packageid].pop("loadBottom")
 
     def _show_comment_input(self) -> str:
@@ -1107,8 +1350,12 @@ class RuleEditor(QWidget):
         context_item = self.mods_list.itemAt(point)
         if context_item is None:
             return
-        open_mod = context_menu.addAction(self.tr("Open this mod in the editor"))  # open mod in editor
-        open_mod.triggered.connect(partial(self._open_mod_in_editor, context_item=context_item))
+        open_mod = context_menu.addAction(
+            self.tr("Open this mod in the editor")
+        )  # open mod in editor
+        open_mod.triggered.connect(
+            partial(self._open_mod_in_editor, context_item=context_item)
+        )
         _ = context_menu.exec_(self.mods_list.mapToGlobal(point))
 
     def ruleItemContextMenuEvent(self, point: QPoint, _list: QListWidget) -> None:
@@ -1116,7 +1363,9 @@ class RuleEditor(QWidget):
         if context_item is None:
             return
         context_menu = QMenu(self)  # Rule item context menu event
-        remove_rule = context_menu.addAction(self.tr("Remove this rule"))  # remove this rule
+        remove_rule = context_menu.addAction(
+            self.tr("Remove this rule")
+        )  # remove this rule
         remove_rule.triggered.connect(
             partial(
                 self._remove_rule,

--- a/app/windows/runner_panel.py
+++ b/app/windows/runner_panel.py
@@ -541,8 +541,7 @@ class RunnerPanel(QWidget):
         total_batches = self._steamcmd_batch_index + len(self._pending_steamcmd_batches)
 
         self.message(
-            f"\nBatch {self._steamcmd_batch_index}/{total_batches}: "
-            f"downloading {len(next_batch)} mod(s)..."
+            f"\nBatch {self._steamcmd_batch_index}/{total_batches}: downloading {len(next_batch)} mod(s)..."
         )
 
         # _steamcmd_wrapper is the SteamcmdInterface instance set by download_mods()

--- a/app/windows/use_this_instead_panel.py
+++ b/app/windows/use_this_instead_panel.py
@@ -206,7 +206,9 @@ class UseThisInsteadPanel(BaseModsPanel):
             # Graceful degradation: clear table if error occurs
             self._clear_table_model()
 
-    def _track_row_indices_during_population(self, groups: dict[str, list[ModGroupItem]]) -> None:
+    def _track_row_indices_during_population(
+        self, groups: dict[str, list[ModGroupItem]]
+    ) -> None:
         """
         Track row indices for originals and replacements during population.
 
@@ -243,7 +245,9 @@ class UseThisInsteadPanel(BaseModsPanel):
             formatted_groups[package_id] = mod_list
         return formatted_groups
 
-    def _prepare_mod_list_for_group(self, originals: list[ModGroupItem]) -> list[tuple[str | None, dict[str, Any]]]:
+    def _prepare_mod_list_for_group(
+        self, originals: list[ModGroupItem]
+    ) -> list[tuple[str | None, dict[str, Any]]]:
         """
         Prepare mod list for a group, including originals and replacement.
 
@@ -281,7 +285,9 @@ class UseThisInsteadPanel(BaseModsPanel):
         metadata_copy["type"] = "Original"
         return metadata_copy
 
-    def _create_replacement_metadata(self, mod_replacement: ReplacementInfo) -> tuple[str | None, dict[str, Any]]:
+    def _create_replacement_metadata(
+        self, mod_replacement: ReplacementInfo
+    ) -> tuple[str | None, dict[str, Any]]:
         """
         Create metadata for a replacement mod.
 
@@ -292,9 +298,13 @@ class UseThisInsteadPanel(BaseModsPanel):
             Tuple of (uuid, metadata).
         """
         # Check if the replacement mod already exists locally
-        exists_locally, uuid = self._check_replacement_exists_locally(mod_replacement.pfid)
+        exists_locally, uuid = self._check_replacement_exists_locally(
+            mod_replacement.pfid
+        )
 
-        fake_metadata = self._build_replacement_metadata(mod_replacement, exists_locally, uuid)
+        fake_metadata = self._build_replacement_metadata(
+            mod_replacement, exists_locally, uuid
+        )
         return uuid, fake_metadata
 
     def _check_replacement_exists_locally(self, pfid: str) -> tuple[bool, str | None]:
@@ -308,7 +318,8 @@ class UseThisInsteadPanel(BaseModsPanel):
             Tuple of (exists_locally, uuid).
         """
         exists_locally = any(
-            mod.get("publishedfileid") == pfid for mod in self.metadata_manager.internal_local_metadata.values()
+            mod.get("publishedfileid") == pfid
+            for mod in self.metadata_manager.internal_local_metadata.values()
         )
         uuid = None
         if exists_locally:
@@ -321,7 +332,9 @@ class UseThisInsteadPanel(BaseModsPanel):
                     break
         return exists_locally, uuid
 
-    def _get_local_metadata_for_replacement(self, uuid: str | None) -> dict[str, Any] | None:
+    def _get_local_metadata_for_replacement(
+        self, uuid: str | None
+    ) -> dict[str, Any] | None:
         """
         Retrieve local metadata for a replacement mod if it exists.
 
@@ -355,8 +368,12 @@ class UseThisInsteadPanel(BaseModsPanel):
                         "supportedversions", external_metadata["supportedversions"]
                     ),
                     "path": local_metadata.get("path", ""),
-                    "internal_time_touched": local_metadata.get("internal_time_touched"),
-                    "external_time_updated": local_metadata.get("external_time_updated"),
+                    "internal_time_touched": local_metadata.get(
+                        "internal_time_touched"
+                    ),
+                    "external_time_updated": local_metadata.get(
+                        "external_time_updated"
+                    ),
                     "data_source": local_metadata.get("source"),
                 }
             )
@@ -386,7 +403,9 @@ class UseThisInsteadPanel(BaseModsPanel):
             "data_source": mod_replacement.source,
             "path": None,
             "type": "Replacement",
-            "installed_status": (self.tr("Installed") if exists_locally else self.tr("Not Installed")),
+            "installed_status": (
+                self.tr("Installed") if exists_locally else self.tr("Not Installed")
+            ),
         }
 
     def _build_replacement_metadata(
@@ -403,7 +422,9 @@ class UseThisInsteadPanel(BaseModsPanel):
         Returns:
             Metadata dictionary.
         """
-        fake_metadata = self._create_base_replacement_metadata(mod_replacement, exists_locally)
+        fake_metadata = self._create_base_replacement_metadata(
+            mod_replacement, exists_locally
+        )
         local_metadata = self._get_local_metadata_for_replacement(uuid)
         return self._merge_local_and_external_metadata(fake_metadata, local_metadata)
 
@@ -426,7 +447,9 @@ class UseThisInsteadPanel(BaseModsPanel):
         Args:
             groups: Dictionary of groups by package ID.
         """
-        for group_counter, package_id, originals, current_row in self._process_groups(groups):
+        for group_counter, package_id, originals, current_row in self._process_groups(
+            groups
+        ):
             self._add_group_to_table(group_counter, package_id, originals, current_row)
 
     def _process_groups(
@@ -464,7 +487,9 @@ class UseThisInsteadPanel(BaseModsPanel):
             logger.error(f"Error filtering alternatives: {e}")
             return {}
 
-    def _group_mods_by_package_id(self, alternatives: dict[str, Any]) -> dict[str, list[ModGroupItem]]:
+    def _group_mods_by_package_id(
+        self, alternatives: dict[str, Any]
+    ) -> dict[str, list[ModGroupItem]]:
         """
         Group mods by their replacement's package ID.
 
@@ -506,7 +531,9 @@ class UseThisInsteadPanel(BaseModsPanel):
         self._add_original_mods(originals, package_id, current_row + 1)
 
         # Add the replacement mod for this group
-        self._add_replacement_mod(originals[0].replacement, package_id, current_row + 1 + len(originals))
+        self._add_replacement_mod(
+            originals[0].replacement, package_id, current_row + 1 + len(originals)
+        )
 
     def _add_group_header(self, group_number: int, current_row: int) -> None:
         """
@@ -543,7 +570,11 @@ class UseThisInsteadPanel(BaseModsPanel):
 
             # Retrieve UUID for the mod from the directory mapper
             path = metadata.get("path")
-            uuid = self.metadata_manager.mod_metadata_dir_mapper.get(path) if isinstance(path, str) else None
+            uuid = (
+                self.metadata_manager.mod_metadata_dir_mapper.get(path)
+                if isinstance(path, str)
+                else None
+            )
 
             # Create ModInfo from metadata
             mod_info = self._extract_mod_info_from_metadata(uuid, metadata)
@@ -557,7 +588,9 @@ class UseThisInsteadPanel(BaseModsPanel):
         except Exception as e:
             logger.error(f"Error accessing metadata for mod in group {package_id}: {e}")
 
-    def _check_and_get_replacement_local_metadata(self, pfid: str) -> tuple[bool, str | None, dict[str, Any] | None]:
+    def _check_and_get_replacement_local_metadata(
+        self, pfid: str
+    ) -> tuple[bool, str | None, dict[str, Any] | None]:
         """
         Check if replacement mod exists locally by published file ID and retrieve local metadata.
 
@@ -575,7 +608,8 @@ class UseThisInsteadPanel(BaseModsPanel):
         local_metadata = None
         try:
             exists_locally = any(
-                mod.get("publishedfileid") == pfid for mod in self.metadata_manager.internal_local_metadata.values()
+                mod.get("publishedfileid") == pfid
+                for mod in self.metadata_manager.internal_local_metadata.values()
             )
             if exists_locally:
                 for (
@@ -587,7 +621,9 @@ class UseThisInsteadPanel(BaseModsPanel):
                         local_metadata = mod_metadata
                         break
         except Exception as e:
-            logger.error(f"Error checking local replacement metadata for pfid {pfid}: {e}")
+            logger.error(
+                f"Error checking local replacement metadata for pfid {pfid}: {e}"
+            )
         return exists_locally, uuid, local_metadata
 
     def _create_replacement_mod_info(self, mod_replacement: Any) -> "ModInfo":
@@ -600,7 +636,9 @@ class UseThisInsteadPanel(BaseModsPanel):
         Returns:
             ModInfo object for the replacement mod.
         """
-        exists_locally, uuid, local_metadata = self._check_and_get_replacement_local_metadata(mod_replacement.pfid)
+        exists_locally, uuid, local_metadata = (
+            self._check_and_get_replacement_local_metadata(mod_replacement.pfid)
+        )
 
         if exists_locally and uuid and local_metadata is not None:
             local_metadata_copy = dict(local_metadata)
@@ -611,7 +649,9 @@ class UseThisInsteadPanel(BaseModsPanel):
             metadata = self._create_base_replacement_metadata(mod_replacement, False)
             return ModInfo.from_metadata(None, metadata)
 
-    def _add_original_mods(self, originals: list[ModGroupItem], package_id: str, current_row: int) -> None:
+    def _add_original_mods(
+        self, originals: list[ModGroupItem], package_id: str, current_row: int
+    ) -> None:
         """
         Add original mods to the table.
 
@@ -621,9 +661,13 @@ class UseThisInsteadPanel(BaseModsPanel):
             current_row: The starting row index for adding mods.
         """
         for i, original in enumerate(originals):
-            self._add_mod_to_group(original, package_id, current_row + i, is_original=True)
+            self._add_mod_to_group(
+                original, package_id, current_row + i, is_original=True
+            )
 
-    def _add_replacement_mod(self, mod_replacement: Any, package_id: str, current_row: int) -> None:
+    def _add_replacement_mod(
+        self, mod_replacement: Any, package_id: str, current_row: int
+    ) -> None:
         """
         Add a replacement mod to the table.
 
@@ -642,7 +686,9 @@ class UseThisInsteadPanel(BaseModsPanel):
     def _clear_all_checkboxes(self) -> None:
         """Clear all checkboxes in the table."""
         for row in range(self.editor_model.rowCount()):
-            widget = self.editor_table_view.indexWidget(self.editor_model.item(row, 0).index())
+            widget = self.editor_table_view.indexWidget(
+                self.editor_model.item(row, 0).index()
+            )
             if isinstance(widget, QCheckBox):
                 widget.setChecked(False)
 
@@ -654,7 +700,9 @@ class UseThisInsteadPanel(BaseModsPanel):
             row_indices: Set of row indices to select.
         """
         for row in range(self.editor_model.rowCount()):
-            checkbox = self.editor_table_view.indexWidget(self.editor_model.item(row, 0).index())
+            checkbox = self.editor_table_view.indexWidget(
+                self.editor_model.item(row, 0).index()
+            )
             if isinstance(checkbox, QCheckBox):
                 checkbox.setChecked(row in row_indices)
 
@@ -684,9 +732,13 @@ class UseThisInsteadPanel(BaseModsPanel):
 
         # Set checkbox text based on type
         row = self.editor_model.rowCount() - 1  # Last added row
-        checkbox = self.editor_table_view.indexWidget(self.editor_model.item(row, 0).index())
+        checkbox = self.editor_table_view.indexWidget(
+            self.editor_model.item(row, 0).index()
+        )
         if isinstance(checkbox, QCheckBox):
             if mod_info.type == "Original":
                 checkbox.setText(self.tr("Original"))
             elif mod_info.type == "Replacement":
-                checkbox.setText(self.tr("Replacement [{0}]").format(mod_info.installed_status))
+                checkbox.setText(
+                    self.tr("Replacement [{0}]").format(mod_info.installed_status)
+                )

--- a/app/windows/workshop_mod_updater_panel.py
+++ b/app/windows/workshop_mod_updater_panel.py
@@ -38,7 +38,9 @@ class WorkshopModUpdaterPanel(BaseModsPanel):
             object_name="updateModsPanel",
             window_title=self.tr("RimSort - Updates found for Workshop mods"),
             title_text=self.tr("There are updates available for Workshop mods!"),
-            details_text=self.tr("\nThe following table displays Workshop mods available for update from Steam."),
+            details_text=self.tr(
+                "\nThe following table displays Workshop mods available for update from Steam."
+            ),
             additional_columns=self._get_standard_mod_columns(),
         )
 
@@ -85,7 +87,9 @@ class WorkshopModUpdaterPanel(BaseModsPanel):
         Returns:
             List of (uuid, metadata) tuples for mods eligible for update.
         """
-        eligible_mods = filter_eligible_mods_for_update(self.metadata_manager.internal_local_metadata)
+        eligible_mods = filter_eligible_mods_for_update(
+            self.metadata_manager.internal_local_metadata
+        )
         # Return tuples of (uuid, metadata) by looking up UUIDs from internal_local_metadata
         return [
             (uuid, metadata)
@@ -98,13 +102,17 @@ class WorkshopModUpdaterPanel(BaseModsPanel):
         Populate the table with mods that have available updates.
         """
         try:
-            logger.debug("Starting to populate table with mods that have updates available")
+            logger.debug(
+                "Starting to populate table with mods that have updates available"
+            )
 
             # Clear existing table data before populating since it shows duplicate rows if not cleared
             self._clear_table_model()
 
             self.eligible_metadata = self._filter_eligible_mods()
-            logger.debug(f"Found {len(self.eligible_metadata)} eligible mods for update")
+            logger.debug(
+                f"Found {len(self.eligible_metadata)} eligible mods for update"
+            )
 
             if not self.eligible_metadata:
                 logger.info("No mods with updates available")

--- a/distribute.py
+++ b/distribute.py
@@ -138,13 +138,21 @@ def build_steamworkspy(sdk_url: str | None = None, sdk_zip: str | None = None) -
         "exit",
     ]
     # SOURCE: "https://partner.steamgames.com/downloads/steamworks_sdk_*.zip"
-    STEAMWORKS_SDK_URL = sdk_url if sdk_url else "https://partner.steamgames.com/downloads/steamworks_sdk_163.zip"
+    STEAMWORKS_SDK_URL = (
+        sdk_url
+        if sdk_url
+        else "https://partner.steamgames.com/downloads/steamworks_sdk_163.zip"
+    )
     STEAMWORKS_PY_PATH = os.path.join(_CWD, "submodules", "SteamworksPy", "library")
     STEAMWORKS_SDK_PATH = os.path.join(STEAMWORKS_PY_PATH, "sdk")
     STEAMWORKS_SDK_HEADER_PATH = os.path.join(STEAMWORKS_SDK_PATH, "public", "steam")
     STEAMWORKS_SDK_HEADER_DEST_PATH = os.path.join(STEAMWORKS_PY_PATH, "sdk", "steam")
-    STEAMWORKS_SDK_REDIST_BIN_PATH = os.path.join(STEAMWORKS_SDK_PATH, "redistributable_bin")
-    STEAMWORKS_SDK_APILIB_PATH = os.path.join(STEAMWORKS_SDK_REDIST_BIN_PATH, "steam_api.lib")
+    STEAMWORKS_SDK_REDIST_BIN_PATH = os.path.join(
+        STEAMWORKS_SDK_PATH, "redistributable_bin"
+    )
+    STEAMWORKS_SDK_APILIB_PATH = os.path.join(
+        STEAMWORKS_SDK_REDIST_BIN_PATH, "steam_api.lib"
+    )
     STEAMWORKS_SDK_APILIB_DEST_PATH = os.path.join(STEAMWORKS_PY_PATH, "steam_api.lib")
     STEAMWORKS_SDK_APILIB_FIN_PATH = os.path.join(_CWD, "libs", "steam_api.lib")
 
@@ -152,50 +160,94 @@ def build_steamworkspy(sdk_url: str | None = None, sdk_zip: str | None = None) -
 
     if _SYSTEM == "Darwin":
         if _ARCH == "64bit":
-            STEAMWORKS_SDK_LIBSTEAM_PATH = os.path.join(STEAMWORKS_SDK_REDIST_BIN_PATH, "osx", "libsteam_api.dylib")
+            STEAMWORKS_SDK_LIBSTEAM_PATH = os.path.join(
+                STEAMWORKS_SDK_REDIST_BIN_PATH, "osx", "libsteam_api.dylib"
+            )
         else:
             print(f"Unsupported ARCH: {_SYSTEM} {_ARCH} with {_PROCESSOR}")
             sys.exit()
-        STEAMWORKS_SDK_LIBSTEAM_DEST_PATH = os.path.join(STEAMWORKS_PY_PATH, "libsteam_api.dylib")
-        STEAMWORKS_SDK_LIBSTEAM_FIN_PATH = os.path.join(_CWD, "libs", "libsteam_api.dylib")
+        STEAMWORKS_SDK_LIBSTEAM_DEST_PATH = os.path.join(
+            STEAMWORKS_PY_PATH, "libsteam_api.dylib"
+        )
+        STEAMWORKS_SDK_LIBSTEAM_FIN_PATH = os.path.join(
+            _CWD, "libs", "libsteam_api.dylib"
+        )
         COMPILE_CMD = DARWIN_COMPILE_CMD
-        STEAMWORKSPY_BIN_PATH = os.path.join(STEAMWORKS_PY_PATH, STEAMWORKSPY_BIN_DARWIN)
+        STEAMWORKSPY_BIN_PATH = os.path.join(
+            STEAMWORKS_PY_PATH, STEAMWORKSPY_BIN_DARWIN
+        )
         STEAMWORKSPY_BIN_FIN_PATH = os.path.join(_CWD, "libs", STEAMWORKSPY_BIN_DARWIN)
     elif _SYSTEM == "Linux":
         if _ARCH == "32bit":
-            STEAMWORKS_SDK_LIBSTEAM_PATH = os.path.join(STEAMWORKS_SDK_REDIST_BIN_PATH, "linux32", "libsteam_api.so")
+            STEAMWORKS_SDK_LIBSTEAM_PATH = os.path.join(
+                STEAMWORKS_SDK_REDIST_BIN_PATH, "linux32", "libsteam_api.so"
+            )
 
         elif _ARCH == "64bit":
-            STEAMWORKS_SDK_LIBSTEAM_PATH = os.path.join(STEAMWORKS_SDK_REDIST_BIN_PATH, "linux64", "libsteam_api.so")
+            STEAMWORKS_SDK_LIBSTEAM_PATH = os.path.join(
+                STEAMWORKS_SDK_REDIST_BIN_PATH, "linux64", "libsteam_api.so"
+            )
         else:
             print(f"Unsupported ARCH: {_SYSTEM} {_ARCH} with {_PROCESSOR}")
             sys.exit()
-        STEAMWORKS_SDK_LIBSTEAM_DEST_PATH = os.path.join(STEAMWORKS_PY_PATH, "libsteam_api.so")
+        STEAMWORKS_SDK_LIBSTEAM_DEST_PATH = os.path.join(
+            STEAMWORKS_PY_PATH, "libsteam_api.so"
+        )
         STEAMWORKS_SDK_LIBSTEAM_FIN_PATH = os.path.join(_CWD, "libs", "libsteam_api.so")
         COMPILE_CMD = LINUX_COMPILE_CMD
         STEAMWORKSPY_BIN_PATH = os.path.join(STEAMWORKS_PY_PATH, STEAMWORKSPY_BIN_LINUX)
         STEAMWORKSPY_BIN_FIN_PATH = os.path.join(_CWD, "libs", STEAMWORKSPY_BIN_LINUX)
     elif _SYSTEM == "Windows":
         if _ARCH == "32bit":
-            STEAMWORKS_SDK_LIBSTEAM_PATH = os.path.join(STEAMWORKS_SDK_REDIST_BIN_PATH, "steam_api.dll")
-            STEAMWORKS_SDK_APILIB_PATH = os.path.join(STEAMWORKS_SDK_REDIST_BIN_PATH, "steam_api.lib")
-            STEAMWORKS_SDK_LIBSTEAM_DEST_PATH = os.path.join(STEAMWORKS_PY_PATH, "steam_api.dll")
-            STEAMWORKS_SDK_LIBSTEAM_FIN_PATH = os.path.join(_CWD, "libs", "steam_api.dll")
-            STEAMWORKS_SDK_APILIB_DEST_PATH = os.path.join(STEAMWORKS_PY_PATH, "steam_api.lib")
+            STEAMWORKS_SDK_LIBSTEAM_PATH = os.path.join(
+                STEAMWORKS_SDK_REDIST_BIN_PATH, "steam_api.dll"
+            )
+            STEAMWORKS_SDK_APILIB_PATH = os.path.join(
+                STEAMWORKS_SDK_REDIST_BIN_PATH, "steam_api.lib"
+            )
+            STEAMWORKS_SDK_LIBSTEAM_DEST_PATH = os.path.join(
+                STEAMWORKS_PY_PATH, "steam_api.dll"
+            )
+            STEAMWORKS_SDK_LIBSTEAM_FIN_PATH = os.path.join(
+                _CWD, "libs", "steam_api.dll"
+            )
+            STEAMWORKS_SDK_APILIB_DEST_PATH = os.path.join(
+                STEAMWORKS_PY_PATH, "steam_api.lib"
+            )
             STEAMWORKS_SDK_APILIB_FIN_PATH = os.path.join(_CWD, "libs", "steam_api.lib")
             COMPILE_CMD = STEAMWORKS_COMPILE_CMD_WIN32
-            STEAMWORKSPY_BIN_PATH = os.path.join(STEAMWORKS_PY_PATH, STEAMWORKSPY_BIN_WIN32)
-            STEAMWORKSPY_BIN_FIN_PATH = os.path.join(_CWD, "libs", STEAMWORKSPY_BIN_WIN32)
+            STEAMWORKSPY_BIN_PATH = os.path.join(
+                STEAMWORKS_PY_PATH, STEAMWORKSPY_BIN_WIN32
+            )
+            STEAMWORKSPY_BIN_FIN_PATH = os.path.join(
+                _CWD, "libs", STEAMWORKSPY_BIN_WIN32
+            )
         elif _ARCH == "64bit":
-            STEAMWORKS_SDK_LIBSTEAM_PATH = os.path.join(STEAMWORKS_SDK_REDIST_BIN_PATH, "win64", "steam_api64.dll")
-            STEAMWORKS_SDK_APILIB_PATH = os.path.join(STEAMWORKS_SDK_REDIST_BIN_PATH, "win64", "steam_api64.lib")
-            STEAMWORKS_SDK_LIBSTEAM_DEST_PATH = os.path.join(STEAMWORKS_PY_PATH, "steam_api64.dll")
-            STEAMWORKS_SDK_LIBSTEAM_FIN_PATH = os.path.join(_CWD, "libs", "steam_api64.dll")
-            STEAMWORKS_SDK_APILIB_DEST_PATH = os.path.join(STEAMWORKS_PY_PATH, "steam_api64.lib")
-            STEAMWORKS_SDK_APILIB_FIN_PATH = os.path.join(_CWD, "libs", "steam_api64.lib")
+            STEAMWORKS_SDK_LIBSTEAM_PATH = os.path.join(
+                STEAMWORKS_SDK_REDIST_BIN_PATH, "win64", "steam_api64.dll"
+            )
+            STEAMWORKS_SDK_APILIB_PATH = os.path.join(
+                STEAMWORKS_SDK_REDIST_BIN_PATH, "win64", "steam_api64.lib"
+            )
+            STEAMWORKS_SDK_LIBSTEAM_DEST_PATH = os.path.join(
+                STEAMWORKS_PY_PATH, "steam_api64.dll"
+            )
+            STEAMWORKS_SDK_LIBSTEAM_FIN_PATH = os.path.join(
+                _CWD, "libs", "steam_api64.dll"
+            )
+            STEAMWORKS_SDK_APILIB_DEST_PATH = os.path.join(
+                STEAMWORKS_PY_PATH, "steam_api64.lib"
+            )
+            STEAMWORKS_SDK_APILIB_FIN_PATH = os.path.join(
+                _CWD, "libs", "steam_api64.lib"
+            )
             COMPILE_CMD = STEAMWORKS_COMPILE_CMD_WIN64
-            STEAMWORKSPY_BIN_PATH = os.path.join(STEAMWORKS_PY_PATH, STEAMWORKSPY_BIN_WIN64)
-            STEAMWORKSPY_BIN_FIN_PATH = os.path.join(_CWD, "libs", STEAMWORKSPY_BIN_WIN64)
+            STEAMWORKSPY_BIN_PATH = os.path.join(
+                STEAMWORKS_PY_PATH, STEAMWORKSPY_BIN_WIN64
+            )
+            STEAMWORKSPY_BIN_FIN_PATH = os.path.join(
+                _CWD, "libs", STEAMWORKSPY_BIN_WIN64
+            )
         else:
             print(f"Unsupported SYSTEM: {_SYSTEM} {_ARCH} with {_PROCESSOR}")
             sys.exit()
@@ -257,21 +309,29 @@ def build_steamworkspy(sdk_url: str | None = None, sdk_zip: str | None = None) -
     os.chdir(_CWD)
 
     # APILIB
-    print(f"Copying file {STEAMWORKS_SDK_APILIB_DEST_PATH} to: {STEAMWORKS_SDK_APILIB_FIN_PATH}")
+    print(
+        f"Copying file {STEAMWORKS_SDK_APILIB_DEST_PATH} to: {STEAMWORKS_SDK_APILIB_FIN_PATH}"
+    )
     shutil.copyfile(STEAMWORKS_SDK_APILIB_DEST_PATH, STEAMWORKS_SDK_APILIB_FIN_PATH)
 
     # LIBSTEAM
-    print(f"Copying file {STEAMWORKS_SDK_LIBSTEAM_DEST_PATH} to: {STEAMWORKS_SDK_LIBSTEAM_FIN_PATH}")
+    print(
+        f"Copying file {STEAMWORKS_SDK_LIBSTEAM_DEST_PATH} to: {STEAMWORKS_SDK_LIBSTEAM_FIN_PATH}"
+    )
     shutil.copyfile(STEAMWORKS_SDK_LIBSTEAM_DEST_PATH, STEAMWORKS_SDK_LIBSTEAM_FIN_PATH)
 
     # STEAMWORKSPY
     print(f"Copying file {STEAMWORKSPY_BIN_PATH} to: {STEAMWORKSPY_BIN_FIN_PATH}")
     shutil.copyfile(STEAMWORKSPY_BIN_PATH, STEAMWORKSPY_BIN_FIN_PATH)
     if _SYSTEM == "Darwin":
-        print(f"Copying file {STEAMWORKSPY_BIN_FIN_PATH} to: {STEAMWORKSPY_BIN_DARWIN_LINK_PATH}")
+        print(
+            f"Copying file {STEAMWORKSPY_BIN_FIN_PATH} to: {STEAMWORKSPY_BIN_DARWIN_LINK_PATH}"
+        )
         shutil.copyfile(STEAMWORKSPY_BIN_FIN_PATH, STEAMWORKSPY_BIN_DARWIN_LINK_PATH)
     elif _SYSTEM == "Linux":
-        print(f"Copying file {STEAMWORKSPY_BIN_FIN_PATH} to: {STEAMWORKSPY_BIN_LINUX_LINK_PATH}")
+        print(
+            f"Copying file {STEAMWORKSPY_BIN_FIN_PATH} to: {STEAMWORKSPY_BIN_LINUX_LINK_PATH}"
+        )
         shutil.copyfile(STEAMWORKSPY_BIN_FIN_PATH, STEAMWORKSPY_BIN_LINUX_LINK_PATH)
 
 
@@ -281,10 +341,14 @@ def copy_swp_libs() -> None:
     # Copy libs
     if _SYSTEM != "Windows":
         if _SYSTEM == "Darwin":
-            STEAMWORKSPY_BUILT_LIB = os.path.join(_CWD, "libs", f"SteamworksPy_{_PROCESSOR}.dylib")
+            STEAMWORKSPY_BUILT_LIB = os.path.join(
+                _CWD, "libs", f"SteamworksPy_{_PROCESSOR}.dylib"
+            )
             STEAMWORKSPY_LIB_FIN = os.path.join(_CWD, "libs", "SteamworksPy.dylib")
         elif _SYSTEM == "Linux":
-            STEAMWORKSPY_BUILT_LIB = os.path.join(_CWD, "libs", f"SteamworksPy_{_PROCESSOR}.so")
+            STEAMWORKSPY_BUILT_LIB = os.path.join(
+                _CWD, "libs", f"SteamworksPy_{_PROCESSOR}.so"
+            )
             STEAMWORKSPY_LIB_FIN = os.path.join(_CWD, "libs", "SteamworksPy.so")
         print("Copying libs for non-Windows platform")
         shutil.copyfile(STEAMWORKSPY_BUILT_LIB, STEAMWORKSPY_LIB_FIN)
@@ -297,7 +361,9 @@ def get_latest_todds_release() -> None:
     # If GITHUB_TOKEN is set, use it to authenticate the request
     if "GITHUB_TOKEN" in os.environ:
         headers = {"Authorization": f"token {os.environ['GITHUB_TOKEN']}"}
-    raw = handle_request("https://api.github.com/repos/joseasoler/todds/releases/latest", headers=headers)
+    raw = handle_request(
+        "https://api.github.com/repos/joseasoler/todds/releases/latest", headers=headers
+    )
 
     json_response = raw.json()
     tag_name = json_response["tag_name"]
@@ -317,14 +383,18 @@ def get_latest_todds_release() -> None:
         todds_executable_name = "todds.exe"
     else:
         print(f"Unsupported system {_SYSTEM} {_ARCH} {_PROCESSOR}")
-        print("Skipping todds download. The resultant RimSort build will not include todds!")
+        print(
+            "Skipping todds download. The resultant RimSort build will not include todds!"
+        )
         return
     # Try to find a valid release
     for asset in json_response["assets"]:
         if asset["name"] == target_archive:
             browser_download_url = asset["browser_download_url"]
     if "browser_download_url" not in locals():
-        print(f"Failed to find valid joseasoler/todds release for {_SYSTEM} {_ARCH} {_PROCESSOR}")
+        print(
+            f"Failed to find valid joseasoler/todds release for {_SYSTEM} {_ARCH} {_PROCESSOR}"
+        )
         return
 
     # Try to download & extract todds release from browser_download_url
@@ -339,7 +409,9 @@ def get_latest_todds_release() -> None:
             os.chmod(todds_executable_path, original_stat.st_mode | S_IEXEC)
     except Exception as e:
         print(f"Failed to download: {browser_download_url}")
-        print("Did the file/url change?\nDoes your environment have access to the Internet?")
+        print(
+            "Did the file/url change?\nDoes your environment have access to the Internet?"
+        )
         print(f"Error: {e}")
 
 
@@ -423,10 +495,14 @@ def _execute(cmd: list[str], env: os._Environ[str] | None = None) -> None:
         sys.exit(p.returncode)
 
 
-def handle_request(url: str, headers: dict[str, str] | None = None) -> requests.Response:
+def handle_request(
+    url: str, headers: dict[str, str] | None = None
+) -> requests.Response:
     raw = requests.get(url, headers=headers)
     if raw.status_code != 200:
-        raise Exception(f"Failed to get latest release: {raw.status_code}\nResponse: {raw.text}")
+        raise Exception(
+            f"Failed to get latest release: {raw.status_code}\nResponse: {raw.text}"
+        )
     return raw
 
 

--- a/tests/benchmarks/find_search_terms.py
+++ b/tests/benchmarks/find_search_terms.py
@@ -40,7 +40,9 @@ def extract_text_from_xml(file_path: str) -> list[str]:
         return []
 
 
-def analyze_terms(mods_path: str, sample_size: Optional[int] = 100) -> Tuple[dict[str, int], list[str], list[str]]:
+def analyze_terms(
+    mods_path: str, sample_size: Optional[int] = 100
+) -> Tuple[dict[str, int], list[str], list[str]]:
     """analyze xml files to find common and rare terms"""
     # get list of xml files
     xml_files = find_xml_files(mods_path)
@@ -63,7 +65,9 @@ def analyze_terms(mods_path: str, sample_size: Optional[int] = 100) -> Tuple[dic
 
     # find common and rare terms
     common_terms = [term for term, count in term_counter.most_common(10)]
-    rare_terms = [term for term, count in term_counter.most_common()[:-11:-1] if count > 1]
+    rare_terms = [
+        term for term, count in term_counter.most_common()[:-11:-1] if count > 1
+    ]
 
     return dict(term_counter), common_terms, rare_terms
 

--- a/tests/controllers/test_file_search.py
+++ b/tests/controllers/test_file_search.py
@@ -53,7 +53,9 @@ def setup_test_controller(test_dir: str, mods: set[str]) -> MagicMock:
             if col == 0
             else MagicMock(text="About.xml")
             if col == 1
-            else MagicMock(text=str(Path(test_dir) / f"TestMod{row + 1}/About/About.xml"))
+            else MagicMock(
+                text=str(Path(test_dir) / f"TestMod{row + 1}/About/About.xml")
+            )
         )
     )
     mock_table.isRowHidden = MagicMock(side_effect=lambda row: False)
@@ -131,7 +133,9 @@ def setup_test_files(request: pytest.FixtureRequest) -> Generator[str, None, Non
     lang_dir2 = test_mod2 / "Languages" / "English"
     lang_dir2.mkdir(parents=True, exist_ok=True)
     strings_file2 = lang_dir2 / "Strings.xml"
-    strings_file2.write_text("<languagedata><teststring>test</teststring></languagedata>")
+    strings_file2.write_text(
+        "<languagedata><teststring>test</teststring></languagedata>"
+    )
     print(f"Created Strings.xml in {strings_file2}")
 
     # create test.png in TestMod2
@@ -233,7 +237,11 @@ def test_filter_results(setup_test_files: str) -> None:
             MagicMock(spec=QTableWidget, text=MagicMock(return_value="About.xml")),
             MagicMock(
                 spec=QTableWidget,
-                text=MagicMock(return_value=str(Path(setup_test_files) / "TestMod1/About/About.xml")),
+                text=MagicMock(
+                    return_value=str(
+                        Path(setup_test_files) / "TestMod1/About/About.xml"
+                    )
+                ),
             ),
         ],
         [
@@ -241,7 +249,11 @@ def test_filter_results(setup_test_files: str) -> None:
             MagicMock(spec=QTableWidget, text=MagicMock(return_value="About.xml")),
             MagicMock(
                 spec=QTableWidget,
-                text=MagicMock(return_value=str(Path(setup_test_files) / "TestMod2/About/About.xml")),
+                text=MagicMock(
+                    return_value=str(
+                        Path(setup_test_files) / "TestMod2/About/About.xml"
+                    )
+                ),
             ),
         ],
     ]
@@ -261,7 +273,9 @@ def test_filter_results(setup_test_files: str) -> None:
         mod_item = dialog.results_table.item(row, 0)
         return mod_item is not None and filter_text.lower() in mod_item.text().lower()
 
-    visible_rows = sum(1 for row in range(dialog.results_table.rowCount()) if is_row_visible(row))
+    visible_rows = sum(
+        1 for row in range(dialog.results_table.rowCount()) if is_row_visible(row)
+    )
 
     # Log visible rows
     for row in range(dialog.results_table.rowCount()):
@@ -275,9 +289,13 @@ def test_filter_results(setup_test_files: str) -> None:
             file_text = file_item.text() if file_item else "<None>"
             path_text = path_item.text() if path_item else "<None>"
 
-            print(f"Visible after filter: mod={mod_text}, file={file_text}, path={path_text}")
+            print(
+                f"Visible after filter: mod={mod_text}, file={file_text}, path={path_text}"
+            )
 
-    assert visible_rows == 1, f"Expected exactly one visible row after filtering, got {visible_rows}"
+    assert visible_rows == 1, (
+        f"Expected exactly one visible row after filtering, got {visible_rows}"
+    )
 
 
 def test_xml_search_only_xml_files(setup_test_files: str) -> None:
@@ -289,7 +307,9 @@ def test_xml_search_only_xml_files(setup_test_files: str) -> None:
     mock_settings_controller = MagicMock()
 
     # Patch the instance method of SteamcmdInterface
-    with patch("app.utils.steam.steamcmd.wrapper.SteamcmdInterface.instance") as mock_instance_method:
+    with patch(
+        "app.utils.steam.steamcmd.wrapper.SteamcmdInterface.instance"
+    ) as mock_instance_method:
         mock_instance_method.return_value = MagicMock()  # Return a mock instance
 
         # Create a FileSearch instance with mocked MetadataManager

--- a/tests/controllers/test_metadata_controller.py
+++ b/tests/controllers/test_metadata_controller.py
@@ -64,7 +64,12 @@ def metadata_controller(
     ):
         steamcmd_instance.return_value = MagicMock(spec=SteamcmdInterface)
         steamcmd_instance.return_value.steamcmd_appworkshop_acf_path = str(
-            (Path("tests/data/instance/instance_1/steam") / "steamapps" / "workshop" / "appworkshop_294100.acf")
+            (
+                Path("tests/data/instance/instance_1/steam")
+                / "steamapps"
+                / "workshop"
+                / "appworkshop_294100.acf"
+            )
         )
         return MetadataController(settings_controller, temp_db)
 
@@ -80,9 +85,15 @@ def metadata_controller_p(
     metadata_controller: MetadataController,
 ) -> MetadataController:
     metadata_controller.settings_controller.settings.external_steam_metadata_file_path = "tests/data/dbs/steamDB.json"
-    metadata_controller.settings_controller.active_instance.game_folder = "tests/data/mod_examples/RimWorld"
-    metadata_controller.settings_controller.active_instance.local_folder = "tests/data/mod_examples/Local"
-    metadata_controller.settings_controller.active_instance.workshop_folder = "tests/data/mod_examples/Steam"
+    metadata_controller.settings_controller.active_instance.game_folder = (
+        "tests/data/mod_examples/RimWorld"
+    )
+    metadata_controller.settings_controller.active_instance.local_folder = (
+        "tests/data/mod_examples/Local"
+    )
+    metadata_controller.settings_controller.active_instance.workshop_folder = (
+        "tests/data/mod_examples/Steam"
+    )
 
     metadata_controller.reset_paths()
     return metadata_controller
@@ -121,7 +132,9 @@ def test_metadata_controller_get_metadata_with_path(
     assert mod.steam_app_id == 294100
 
     steamcmd_mod_1_path = Path("tests/data/mod_examples/Local/steamcmd_mod_1")
-    mod, aux_metadata = metadata_controller_p.get_metadata_with_path(steamcmd_mod_1_path)
+    mod, aux_metadata = metadata_controller_p.get_metadata_with_path(
+        steamcmd_mod_1_path
+    )
 
     assert mod is not None
     assert aux_metadata is not None
@@ -138,8 +151,12 @@ def test_metadata_controller_delete_mod(
 
     steam_mod_1_path = Path("tests/data/mod_examples/Steam/steam_mod_1")
     local_mod_2_path = Path("tests/data/mod_examples/Local/local_mod_2")
-    mod_1, aux_metadata_1 = metadata_controller_p.get_metadata_with_path(steam_mod_1_path)
-    mod_2, aux_metadata_2 = metadata_controller_p.get_metadata_with_path(local_mod_2_path)
+    mod_1, aux_metadata_1 = metadata_controller_p.get_metadata_with_path(
+        steam_mod_1_path
+    )
+    mod_2, aux_metadata_2 = metadata_controller_p.get_metadata_with_path(
+        local_mod_2_path
+    )
 
     assert mod_1 is not None
     assert aux_metadata_1 is not None
@@ -150,8 +167,12 @@ def test_metadata_controller_delete_mod(
     # Ensure mod_1 is deleted but not mod_2
     metadata_controller_p.delete_mod(steam_mod_1_path)
 
-    mod_1, aux_metadata_1 = metadata_controller_p.get_metadata_with_path(steam_mod_1_path)
-    mod_2, aux_metadata_2 = metadata_controller_p.get_metadata_with_path(local_mod_2_path)
+    mod_1, aux_metadata_1 = metadata_controller_p.get_metadata_with_path(
+        steam_mod_1_path
+    )
+    mod_2, aux_metadata_2 = metadata_controller_p.get_metadata_with_path(
+        local_mod_2_path
+    )
 
     assert mod_1 is None
     assert aux_metadata_1 is None
@@ -161,7 +182,9 @@ def test_metadata_controller_delete_mod(
 
     # Ensure mod_2 is deleted
     metadata_controller_p.delete_mod(local_mod_2_path)
-    mod_2, aux_metadata_2 = metadata_controller_p.get_metadata_with_path(local_mod_2_path)
+    mod_2, aux_metadata_2 = metadata_controller_p.get_metadata_with_path(
+        local_mod_2_path
+    )
 
     assert mod_2 is None
     assert aux_metadata_2 is None

--- a/tests/controllers/test_run_args_migration.py
+++ b/tests/controllers/test_run_args_migration.py
@@ -47,8 +47,12 @@ def test_migrate_multi_element_list() -> None:
 
 def test_migrate_comma_separated_string() -> None:
     """Old example: comma-separated string should be converted to space-separated."""
-    result = migrate_run_args(["-logfile,/path/to/file.log,-savedatafolder=/path/to/savedata,-popupwindow"])
-    assert result == ["-logfile /path/to/file.log -savedatafolder=/path/to/savedata -popupwindow"]
+    result = migrate_run_args(
+        ["-logfile,/path/to/file.log,-savedatafolder=/path/to/savedata,-popupwindow"]
+    )
+    assert result == [
+        "-logfile /path/to/file.log -savedatafolder=/path/to/savedata -popupwindow"
+    ]
 
 
 def test_migrate_comma_separated_with_spaces() -> None:
@@ -83,7 +87,9 @@ def test_migrate_single_arg_no_comma() -> None:
 
 def test_migrate_complex_paths() -> None:
     """Migration should handle complex paths correctly."""
-    result = migrate_run_args(["-logfile", "/home/user/logs/rimworld.log", "-savedatafolder=/data"])
+    result = migrate_run_args(
+        ["-logfile", "/home/user/logs/rimworld.log", "-savedatafolder=/data"]
+    )
     assert result == ["-logfile /home/user/logs/rimworld.log -savedatafolder=/data"]
 
 

--- a/tests/controllers/test_troubleshooting.py
+++ b/tests/controllers/test_troubleshooting.py
@@ -163,14 +163,18 @@ class TestUIInteractions:
         (test_mod / "About.xml").write_text("<ModMetaData></ModMetaData>")
 
         mods_config = config_dir / "ModsConfig.xml"
-        mods_config.write_text("<ModsConfigData><activeMods><li>test.mod</li></activeMods></ModsConfigData>")
+        mods_config.write_text(
+            "<ModsConfigData><activeMods><li>test.mod</li></activeMods></ModsConfigData>"
+        )
 
         with (
             patch(
                 "app.controllers.troubleshooting_controller.show_dialogue_conditional",
                 return_value=True,
             ),
-            patch("app.controllers.troubleshooting_controller.EventBus") as mock_event_bus,
+            patch(
+                "app.controllers.troubleshooting_controller.EventBus"
+            ) as mock_event_bus,
         ):
             mock_event_bus_instance = mock_event_bus.return_value
             mock_event_bus_instance.do_refresh_mods_lists = mock_event_bus_instance
@@ -251,7 +255,9 @@ class TestSteamUtilities:
 
         steam_path = Path("C:/Program Files (x86)/Steam")
         with (
-            patch("app.controllers.troubleshooting_controller.platform_specific_open") as mock_open,
+            patch(
+                "app.controllers.troubleshooting_controller.platform_specific_open"
+            ) as mock_open,
             patch(
                 "app.controllers.troubleshooting_controller.show_dialogue_conditional",
                 return_value=True,
@@ -266,7 +272,9 @@ class TestSteamUtilities:
             controller._on_steam_clear_cache_clicked()
 
         mock_open.reset_mock()
-        with patch("app.controllers.troubleshooting_controller.EventBus") as mock_eventbus:
+        with patch(
+            "app.controllers.troubleshooting_controller.EventBus"
+        ) as mock_eventbus:
             controller._on_steam_verify_game_clicked()
             mock_eventbus.return_value.do_steam_verify_game_files.emit.assert_called_once()
 
@@ -275,7 +283,9 @@ class TestSteamUtilities:
                 "pathlib.Path.exists",
                 side_effect=lambda p: False if str(p).endswith("downloading") else True,
             ),
-            patch("app.controllers.troubleshooting_controller.show_dialogue_conditional") as mock_dialog,
+            patch(
+                "app.controllers.troubleshooting_controller.show_dialogue_conditional"
+            ) as mock_dialog,
         ):
             controller._on_steam_clear_cache_clicked()
             assert mock_dialog.call_args.kwargs["title"] in [
@@ -305,7 +315,9 @@ class TestSteamUtilities:
                 "app.controllers.troubleshooting_controller.show_dialogue_conditional",
                 return_value=True,
             ),
-            patch("app.controllers.troubleshooting_controller.platform_specific_open") as mock_open,
+            patch(
+                "app.controllers.troubleshooting_controller.platform_specific_open"
+            ) as mock_open,
         ):
             controller._on_steam_repair_library_clicked()
             assert mock_open.call_count == 2
@@ -404,7 +416,9 @@ class TestModListImportExport:
             ),
             patch("builtins.open", create=True) as mock_open,
             patch("json.load", return_value=import_data),
-            patch("app.controllers.troubleshooting_controller.EventBus") as mock_event_bus,
+            patch(
+                "app.controllers.troubleshooting_controller.EventBus"
+            ) as mock_event_bus,
         ):
             controller._on_mod_import_list_button_clicked()
             mock_open.assert_called()

--- a/tests/models/metadata/test_metadata_factory.py
+++ b/tests/models/metadata/test_metadata_factory.py
@@ -222,7 +222,10 @@ def test_create_mod_dependency() -> None:
     mod = create_mod_dependency(input_dict)
     assert mod.package_id == "com.example.mod"
     assert mod.name == "Example Mod"
-    assert mod.workshop_url == "https://steamcommunity.com/sharedfiles/filedetails/?id=1234567890"
+    assert (
+        mod.workshop_url
+        == "https://steamcommunity.com/sharedfiles/filedetails/?id=1234567890"
+    )
 
 
 def test_create_mod_dependency_missing_fields() -> None:
@@ -241,7 +244,9 @@ def test_create_base_rules_ludeon_core() -> None:
     rules = create_base_rules(mod_data, "1.5")
 
     assert rules.dependencies == {}
-    assert rules.load_before == CaseInsensitiveSet({"ludeon.rimworld.ideology", "ludeon.rimworld.royalty"})
+    assert rules.load_before == CaseInsensitiveSet(
+        {"ludeon.rimworld.ideology", "ludeon.rimworld.royalty"}
+    )
     assert rules.load_after == CaseInsensitiveSet()
 
 
@@ -453,7 +458,9 @@ def test_read_write_steam_db(tmp_path: Path) -> None:
 
 
 def test_create_scenario_mod_from_rsc_invalid_meta() -> None:
-    path = Path("tests/data/mod_examples/Local/invalid_scenario_mod_meta/scenario abc.rsc")
+    path = Path(
+        "tests/data/mod_examples/Local/invalid_scenario_mod_meta/scenario abc.rsc"
+    )
 
     valid, mod = _create_scenario_mod_from_rsc(path.parent, path)
 
@@ -462,7 +469,9 @@ def test_create_scenario_mod_from_rsc_invalid_meta() -> None:
 
 
 def test_create_scenario_mod_from_rsc_invalid_scenario() -> None:
-    path = Path("tests/data/mod_examples/Local/invalid_scenario_mod_scenario/scenario abc.rsc")
+    path = Path(
+        "tests/data/mod_examples/Local/invalid_scenario_mod_scenario/scenario abc.rsc"
+    )
 
     valid, mod = _create_scenario_mod_from_rsc(path.parent, path)
 
@@ -487,7 +496,9 @@ def test_create_scenario_mod_from_rsc_valid() -> None:
 def test_create_listed_mod_from_path_invalid_folder() -> None:
     path = Path("tests/data/mod_examples/Local/invalid folder")
 
-    valid, mod = create_listed_mod_from_path(path, "1.5", LOCAL_MODS_PATH, RIMWORLD_PATH, STEAM_WORKSHOP_PATH)
+    valid, mod = create_listed_mod_from_path(
+        path, "1.5", LOCAL_MODS_PATH, RIMWORLD_PATH, STEAM_WORKSHOP_PATH
+    )
 
     assert not valid
     assert not mod.valid
@@ -496,7 +507,9 @@ def test_create_listed_mod_from_path_invalid_folder() -> None:
 
 def test_create_listed_mod_from_path_local_mod_1() -> None:
     path = Path("tests/data/mod_examples/Local/local_mod_1")
-    valid, mod = create_listed_mod_from_path(path, "1.5", LOCAL_MODS_PATH, RIMWORLD_PATH, STEAM_WORKSHOP_PATH)
+    valid, mod = create_listed_mod_from_path(
+        path, "1.5", LOCAL_MODS_PATH, RIMWORLD_PATH, STEAM_WORKSHOP_PATH
+    )
 
     assert valid
     assert mod.valid
@@ -508,7 +521,9 @@ def test_create_listed_mod_from_path_local_mod_1() -> None:
 
 def test_create_listed_mod_from_path_local_mod_2() -> None:
     path = Path("tests/data/mod_examples/Local/local_mod_2")
-    valid, mod = create_listed_mod_from_path(path, "1.5", LOCAL_MODS_PATH, RIMWORLD_PATH, STEAM_WORKSHOP_PATH)
+    valid, mod = create_listed_mod_from_path(
+        path, "1.5", LOCAL_MODS_PATH, RIMWORLD_PATH, STEAM_WORKSHOP_PATH
+    )
 
     assert valid
     assert mod.valid
@@ -520,7 +535,9 @@ def test_create_listed_mod_from_path_local_mod_2() -> None:
 
 def test_create_listed_mod_from_path_steamcmd_mod_1() -> None:
     path = Path("tests/data/mod_examples/Local/steamcmd_mod_1")
-    valid, mod = create_listed_mod_from_path(path, "1.5", LOCAL_MODS_PATH, RIMWORLD_PATH, STEAM_WORKSHOP_PATH)
+    valid, mod = create_listed_mod_from_path(
+        path, "1.5", LOCAL_MODS_PATH, RIMWORLD_PATH, STEAM_WORKSHOP_PATH
+    )
 
     assert valid
     assert mod.valid

--- a/tests/models/metadata/test_metadata_mediator.py
+++ b/tests/models/metadata/test_metadata_mediator.py
@@ -65,7 +65,9 @@ def test_user_rules_addition(mediator: MetadataMediator) -> None:
     assert mediator.mods_metadata is not None
     assert len(mediator.mods_metadata) > 0
 
-    mod = mediator.mods_metadata.get(str(Path("tests/data/mod_examples/Local/local_mod_1")), None)
+    mod = mediator.mods_metadata.get(
+        str(Path("tests/data/mod_examples/Local/local_mod_1")), None
+    )
     assert mod is not None
 
     assert isinstance(mod, AboutXmlMod)

--- a/tests/models/metadata/test_metadata_structure.py
+++ b/tests/models/metadata/test_metadata_structure.py
@@ -43,7 +43,9 @@ def test_case_insensitive_str(pid: str, string: str) -> None:
 
 
 def test_case_insensitive_set_contains() -> None:
-    package_id_set = metadata_structure.CaseInsensitiveSet(["TestPackage", "AnotherPackage"])
+    package_id_set = metadata_structure.CaseInsensitiveSet(
+        ["TestPackage", "AnotherPackage"]
+    )
     assert "TestPackage" in package_id_set
     assert "AnotherPackage" in package_id_set
     assert "NonExistingPackage" not in package_id_set
@@ -67,33 +69,51 @@ def test_case_insensitive_set_discard() -> None:
 
 
 def test_case_insensitive_set_len() -> None:
-    package_id_set = metadata_structure.CaseInsensitiveSet(["TestPackage", "AnotherPackage"])
+    package_id_set = metadata_structure.CaseInsensitiveSet(
+        ["TestPackage", "AnotherPackage"]
+    )
     assert len(package_id_set) == 2
 
-    package_id_set = metadata_structure.CaseInsensitiveSet(["TestPackage", "testpackage"])
+    package_id_set = metadata_structure.CaseInsensitiveSet(
+        ["TestPackage", "testpackage"]
+    )
     assert len(package_id_set) == 1
 
 
 def test_case_insensitive_set_iter() -> None:
-    package_id_set = metadata_structure.CaseInsensitiveSet(["TestPackage", "AnotherPackage"])
+    package_id_set = metadata_structure.CaseInsensitiveSet(
+        ["TestPackage", "AnotherPackage"]
+    )
     assert set(package_id_set) == {"testpackage", "anotherpackage"}
 
 
 def test_case_insensitive_set_and() -> None:
-    package_id_set1 = metadata_structure.CaseInsensitiveSet(["TestPackage", "AnotherPackage"])
-    package_id_set2 = metadata_structure.CaseInsensitiveSet(["anotherpackage", "AdditionalPackage"])
+    package_id_set1 = metadata_structure.CaseInsensitiveSet(
+        ["TestPackage", "AnotherPackage"]
+    )
+    package_id_set2 = metadata_structure.CaseInsensitiveSet(
+        ["anotherpackage", "AdditionalPackage"]
+    )
     intersection = package_id_set1 & package_id_set2
     assert set(intersection) == {"anotherpackage"}
 
 
 def test_case_insensitive_set_parametrize() -> None:
-    package_id_set = metadata_structure.CaseInsensitiveSet(["TestPackage", "AnotherPackage"])
-    assert package_id_set == metadata_structure.CaseInsensitiveSet(["testpackage", "anotherpackage"])
+    package_id_set = metadata_structure.CaseInsensitiveSet(
+        ["TestPackage", "AnotherPackage"]
+    )
+    assert package_id_set == metadata_structure.CaseInsensitiveSet(
+        ["testpackage", "anotherpackage"]
+    )
 
 
 def test_case_insensitive_set_union() -> None:
-    package_id_set1 = metadata_structure.CaseInsensitiveSet(["TestPackage", "AnotherPackage"])
-    package_id_set2 = metadata_structure.CaseInsensitiveSet(["anotherpackage", "AdditionalPackage"])
+    package_id_set1 = metadata_structure.CaseInsensitiveSet(
+        ["TestPackage", "AnotherPackage"]
+    )
+    package_id_set2 = metadata_structure.CaseInsensitiveSet(
+        ["anotherpackage", "AdditionalPackage"]
+    )
     union = package_id_set1 | package_id_set2
     assert set(union) == {"testpackage", "anotherpackage", "additionalpackage"}
 
@@ -149,19 +169,31 @@ def test_about_xml_mod_overall_rules() -> None:
     mod.about_rules.load_after = metadata_structure.CaseInsensitiveSet(["TestPackage"])
     assert mod.overall_rules.load_after == {}
     mod.clear_cache()
-    assert mod.overall_rules.load_after == metadata_structure.CaseInsensitiveSet(["TestPackage"])
+    assert mod.overall_rules.load_after == metadata_structure.CaseInsensitiveSet(
+        ["TestPackage"]
+    )
 
-    mod.about_rules.load_after = metadata_structure.CaseInsensitiveSet(["AnotherPackage", "testpackage"])
+    mod.about_rules.load_after = metadata_structure.CaseInsensitiveSet(
+        ["AnotherPackage", "testpackage"]
+    )
     mod.clear_cache()
     assert mod.overall_rules.load_after == {"testpackage", "anotherpackage"}
     assert mod.overall_rules.load_before == set()
 
-    mod.about_rules.load_before = metadata_structure.CaseInsensitiveSet(["TestPackage1"])
+    mod.about_rules.load_before = metadata_structure.CaseInsensitiveSet(
+        ["TestPackage1"]
+    )
     mod.clear_cache()
-    assert mod.overall_rules.load_before == metadata_structure.CaseInsensitiveSet(["TestPackage1"])
+    assert mod.overall_rules.load_before == metadata_structure.CaseInsensitiveSet(
+        ["TestPackage1"]
+    )
 
-    mod.user_rules.load_before = metadata_structure.CaseInsensitiveSet(["AnotherPackage1", "testpackage1"])
-    mod.community_rules.load_before = metadata_structure.CaseInsensitiveSet(["AnotherPackage2", "testpackage2"])
+    mod.user_rules.load_before = metadata_structure.CaseInsensitiveSet(
+        ["AnotherPackage1", "testpackage1"]
+    )
+    mod.community_rules.load_before = metadata_structure.CaseInsensitiveSet(
+        ["AnotherPackage2", "testpackage2"]
+    )
     mod.clear_cache()
     assert mod.overall_rules.load_before == {
         "testpackage1",

--- a/tests/test_translation_helper.py
+++ b/tests/test_translation_helper.py
@@ -538,7 +538,9 @@ class TestAutoTranslateFile:
         mock_exists = mocker.patch("pathlib.Path.exists", return_value=True)
         mock_is_dir = mocker.patch("pathlib.Path.is_dir", return_value=False)
         mock_is_file = mocker.patch("pathlib.Path.is_file", return_value=True)
-        mock_glob = mocker.patch("pathlib.Path.glob", return_value=[Path("locales/zh_CN.ts")])
+        mock_glob = mocker.patch(
+            "pathlib.Path.glob", return_value=[Path("locales/zh_CN.ts")]
+        )
         mock_copy2 = mocker.patch("shutil.copy2")
         mock_unlink = mocker.patch("pathlib.Path.unlink")
         mock_mkdir = mocker.patch("pathlib.Path.mkdir", return_value=None)
@@ -546,12 +548,16 @@ class TestAutoTranslateFile:
         # Mock open for reading/writing file content
         file_content: Dict[str, Any] = {}  # Stores content of mocked files
 
-        def mock_open_func(file_path: Any, mode: str = "r", encoding: str = "utf-8") -> Any:
+        def mock_open_func(
+            file_path: Any, mode: str = "r", encoding: str = "utf-8"
+        ) -> Any:
             if "w" in mode:
                 # Simulate writing to a file
                 file_content[str(file_path)] = []
                 mock_file = mocker.mock_open()
-                mock_file.return_value.write.side_effect = lambda data: file_content[str(file_path)].append(data)
+                mock_file.return_value.write.side_effect = lambda data: file_content[
+                    str(file_path)
+                ].append(data)
                 return mock_file.return_value
             else:
                 # Simulate reading from a file
@@ -629,8 +635,12 @@ class TestAutoTranslateFile:
         # Arrange
         mock_find_unfinished.extend(
             [
-                UnfinishedItem(context="MyContext", source="Hello", element=mocker.Mock(attrib={})),
-                UnfinishedItem(context="MyContext", source="World", element=mocker.Mock(attrib={})),
+                UnfinishedItem(
+                    context="MyContext", source="Hello", element=mocker.Mock(attrib={})
+                ),
+                UnfinishedItem(
+                    context="MyContext", source="World", element=mocker.Mock(attrib={})
+                ),
             ]
         )
         mock_translation_service.translate.side_effect = ["你好", "世界"]
@@ -638,11 +648,13 @@ class TestAutoTranslateFile:
 
         # Mock the XML structure for content writing
         mock_xml_parsing["root"].findall.return_value = []  # No contexts initially
-        mock_xml_parsing["tree"].write.side_effect = lambda file, encoding, xml_declaration: (
-            mock_filesystem["file_content"]
-            .setdefault(str(file), [])
-            .append(
-                "<TS><context><name>MyContext</name><message><source>Hello</source><translation>你好</translation></message><message><source>World</source><translation>世界</translation></message></context></TS>"
+        mock_xml_parsing["tree"].write.side_effect = (
+            lambda file, encoding, xml_declaration: (
+                mock_filesystem["file_content"]
+                .setdefault(str(file), [])
+                .append(
+                    "<TS><context><name>MyContext</name><message><source>Hello</source><translation>你好</translation></message><message><source>World</source><translation>世界</translation></message></context></TS>"
+                )
             )
         )
 
@@ -651,7 +663,9 @@ class TestAutoTranslateFile:
 
         # Assert
         assert result is True
-        mock_filesystem["copy2"].assert_called_once_with(Path("locales/zh_CN.ts"), Path("locales/zh_CN.ts.backup"))
+        mock_filesystem["copy2"].assert_called_once_with(
+            Path("locales/zh_CN.ts"), Path("locales/zh_CN.ts.backup")
+        )
         mock_translation_service.translate.assert_has_calls(
             [
                 mocker.call("Hello", "zh_CN", "en_US"),
@@ -681,7 +695,9 @@ class TestAutoTranslateFile:
         mock_element.text = None
         mock_find_unfinished.extend(
             [
-                UnfinishedItem(context="MyContext", source="Hello", element=mock_element),
+                UnfinishedItem(
+                    context="MyContext", source="Hello", element=mock_element
+                ),
             ]
         )
         mock_translation_service.translate.return_value = "你好"
@@ -694,7 +710,9 @@ class TestAutoTranslateFile:
         assert result is True  # Dry-run success doesn't depend on actual saves
         mock_filesystem["copy2"].assert_not_called()
         mock_translation_service.translate.assert_called_once()
-        assert mock_find_unfinished[0].element.text is None  # Element not updated in dry run
+        assert (
+            mock_find_unfinished[0].element.text is None
+        )  # Element not updated in dry run
         mock_xml_parsing["tree"].write.assert_not_called()
         mock_filesystem["unlink"].assert_not_called()
 
@@ -718,8 +736,12 @@ class TestAutoTranslateFile:
         # Arrange
         mock_find_unfinished.extend(
             [
-                UnfinishedItem(context="MyContext", source="Hello", element=mocker.Mock()),
-                UnfinishedItem(context="MyContext", source="World", element=mocker.Mock()),
+                UnfinishedItem(
+                    context="MyContext", source="Hello", element=mocker.Mock()
+                ),
+                UnfinishedItem(
+                    context="MyContext", source="World", element=mocker.Mock()
+                ),
             ]
         )
         # First translation succeeds, second fails
@@ -736,7 +758,9 @@ class TestAutoTranslateFile:
         set_translation_config(test_config)
 
         # Act
-        result = await auto_translate_file("zh_CN", service_name="google", continue_on_failure=False)
+        result = await auto_translate_file(
+            "zh_CN", service_name="google", continue_on_failure=False
+        )
 
         # Assert
         assert result is False
@@ -769,8 +793,12 @@ class TestAutoTranslateFile:
         # Arrange
         mock_find_unfinished.extend(
             [
-                UnfinishedItem(context="MyContext", source="Hello", element=mocker.Mock()),
-                UnfinishedItem(context="MyContext", source="World", element=mocker.Mock()),
+                UnfinishedItem(
+                    context="MyContext", source="Hello", element=mocker.Mock()
+                ),
+                UnfinishedItem(
+                    context="MyContext", source="World", element=mocker.Mock()
+                ),
             ]
         )
         # First translation succeeds, second fails
@@ -782,18 +810,24 @@ class TestAutoTranslateFile:
 
         # Mock the XML structure for content writing
         mock_xml_parsing["root"].findall.return_value = []  # No contexts initially
-        mock_xml_parsing["tree"].write.side_effect = lambda file, encoding, xml_declaration: mock_filesystem[
-            "file_content"
-        ][str(file)].append(
-            "<TS><context><name>MyContext</name><message><source>Hello</source><translation>你好</translation></message><message><source>World</source><translation type='unfinished'></translation></message></context></TS>"
+        mock_xml_parsing["tree"].write.side_effect = (
+            lambda file, encoding, xml_declaration: mock_filesystem["file_content"][
+                str(file)
+            ].append(
+                "<TS><context><name>MyContext</name><message><source>Hello</source><translation>你好</translation></message><message><source>World</source><translation type='unfinished'></translation></message></context></TS>"
+            )
         )
 
         # Act
         # continue_on_failure is True by default for auto_translate_file
-        result = await auto_translate_file("zh_CN", service_name="google", continue_on_failure=True)
+        result = await auto_translate_file(
+            "zh_CN", service_name="google", continue_on_failure=True
+        )
 
         # Assert
-        assert result is False  # Because one translation failed, overall result is False
+        assert (
+            result is False
+        )  # Because one translation failed, overall result is False
         # copy2 is called once for backup and once for restore (due to save error)
         assert mock_filesystem["copy2"].call_count == 2
         mock_translation_service.translate.assert_has_calls(
@@ -822,11 +856,15 @@ class TestAutoTranslateFile:
         # Arrange
         mock_find_unfinished.extend(
             [
-                UnfinishedItem(context="MyContext", source="Hello", element=mocker.Mock()),
+                UnfinishedItem(
+                    context="MyContext", source="Hello", element=mocker.Mock()
+                ),
             ]
         )
         # Simulate an unexpected exception during processing loop
-        mock_translation_service.translate.side_effect = Exception("Unexpected error outside translation")
+        mock_translation_service.translate.side_effect = Exception(
+            "Unexpected error outside translation"
+        )
         mocker.patch("asyncio.sleep")
 
         # Act
@@ -883,7 +921,9 @@ class TestCreateTranslationService:
         mocker.patch("translation_helper.GoogleTranslator", mocker.Mock())
 
         mock_service = mocker.Mock()
-        mocker.patch("translation_helper.GoogleTranslateService", return_value=mock_service)
+        mocker.patch(
+            "translation_helper.GoogleTranslateService", return_value=mock_service
+        )
 
         result = create_translation_service("google")
 
@@ -1047,22 +1087,32 @@ class TestProcessLanguage:
     def mock_filesystem(self, mocker: Any) -> Dict[str, Any]:
         """Fixture to mock filesystem operations."""
         mock_exists = mocker.patch("pathlib.Path.exists", return_value=True)
-        mock_glob = mocker.patch("pathlib.Path.glob", return_value=[Path("locales/zh_CN.ts")])
+        mock_glob = mocker.patch(
+            "pathlib.Path.glob", return_value=[Path("locales/zh_CN.ts")]
+        )
         return {"exists": mock_exists, "glob": mock_glob}
 
     @pytest.mark.asyncio
-    async def test_process_language_success(self, mocker: Any, mock_filesystem: Dict[str, Any]) -> None:
+    async def test_process_language_success(
+        self, mocker: Any, mock_filesystem: Dict[str, Any]
+    ) -> None:
         """Test successful language processing."""
-        mock_auto_translate = mocker.patch("translation_helper.auto_translate_file", return_value=True)
+        mock_auto_translate = mocker.patch(
+            "translation_helper.auto_translate_file", return_value=True
+        )
         mock_lupdate = mocker.patch("translation_helper.run_lupdate", return_value=True)
-        mock_lrelease = mocker.patch("translation_helper.run_lrelease", return_value=True)
+        mock_lrelease = mocker.patch(
+            "translation_helper.run_lrelease", return_value=True
+        )
 
         result = await process_language("zh_CN", "google", dry_run=False)
 
         assert result is True  # Process successful
         mock_lupdate.assert_called_once_with("zh_CN")
         # auto_translate_file is called with positional args: language, service, continue_on_failure
-        mock_auto_translate.assert_called_once_with("zh_CN", "google", True, dry_run=False)
+        mock_auto_translate.assert_called_once_with(
+            "zh_CN", "google", True, dry_run=False
+        )
         mock_lrelease.assert_called_once_with("zh_CN")
 
     @pytest.mark.asyncio

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -63,7 +63,9 @@ def setup_test_controller(
 
     settings_dialog = SettingsDialog()
     settings_controller = SettingsController(model=settings, view=settings_dialog)
-    controller = FileSearchController(settings=settings, settings_controller=settings_controller, dialog=dialog)
+    controller = FileSearchController(
+        settings=settings, settings_controller=settings_controller, dialog=dialog
+    )
     if active_mod_ids is not None:
         controller.set_active_mod_ids(active_mod_ids)
 

--- a/tests/utils/test_launch_command_parser.py
+++ b/tests/utils/test_launch_command_parser.py
@@ -74,7 +74,9 @@ class TestParseCombinedUsage:
         assert result.game_args == []
 
     def test_env_wrapper_and_args(self) -> None:
-        result = parse_launch_command("DXVK_HUD=1 gamemoderun %command% -logfile /tmp/log")
+        result = parse_launch_command(
+            "DXVK_HUD=1 gamemoderun %command% -logfile /tmp/log"
+        )
         assert result.env_vars == {"DXVK_HUD": "1"}
         assert result.wrapper_commands == ["gamemoderun"]
         assert result.game_args == ["-logfile", "/tmp/log"]
@@ -175,7 +177,9 @@ class TestParseDataclass:
 
     def test_explicit_construction(self) -> None:
         """Test explicit construction of ParsedLaunchCommand."""
-        parsed = ParsedLaunchCommand(env_vars={"FOO": "bar"}, wrapper_commands=["wrapper"], game_args=["-arg"])
+        parsed = ParsedLaunchCommand(
+            env_vars={"FOO": "bar"}, wrapper_commands=["wrapper"], game_args=["-arg"]
+        )
         assert parsed.env_vars == {"FOO": "bar"}
         assert parsed.wrapper_commands == ["wrapper"]
         assert parsed.game_args == ["-arg"]

--- a/tests/views/test_deletion_menu.py
+++ b/tests/views/test_deletion_menu.py
@@ -100,10 +100,14 @@ class TestModDeletionMenu:
             result = deletion_menu._confirm_deletion("Title", "Text", "Info")
             assert result is False
 
-    def test_perform_deletion_operation_no_mods(self, deletion_menu: ModDeletionMenu) -> None:
+    def test_perform_deletion_operation_no_mods(
+        self, deletion_menu: ModDeletionMenu
+    ) -> None:
         """Test deletion operation with no selected mods."""
         with patch("app.views.deletion_menu.show_information") as mock_info:
-            deletion_menu._perform_deletion_operation("Title", "Text", "Info", lambda x: True)
+            deletion_menu._perform_deletion_operation(
+                "Title", "Text", "Info", lambda x: True
+            )
             mock_info.assert_called_once()
 
     def test_perform_deletion_operation_with_mods(
@@ -113,13 +117,17 @@ class TestModDeletionMenu:
         deletion_menu.get_selected_mod_metadata = lambda: [sample_mod_metadata]
 
         with (
-            patch.object(deletion_menu, "_confirm_deletion", return_value=True) as mock_confirm,
+            patch.object(
+                deletion_menu, "_confirm_deletion", return_value=True
+            ) as mock_confirm,
             patch.object(deletion_menu, "_iterate_mods") as mock_iterate,
             patch.object(deletion_menu, "_process_deletion_result") as mock_process,
         ):
             mock_iterate.return_value = DeletionResult()
 
-            deletion_menu._perform_deletion_operation("Title", "Text", "Info", lambda x: True)
+            deletion_menu._perform_deletion_operation(
+                "Title", "Text", "Info", lambda x: True
+            )
 
             mock_confirm.assert_called_once()
             mock_iterate.assert_called_once()
@@ -183,7 +191,9 @@ class TestModDeletionMenu:
         mod = {"packageid": "author.modname", "data_source": "workshop"}
         assert deletion_menu._is_official_expansion(mod) is False
 
-    def test_process_deletion_result_success(self, deletion_menu: ModDeletionMenu) -> None:
+    def test_process_deletion_result_success(
+        self, deletion_menu: ModDeletionMenu
+    ) -> None:
         """Test processing successful deletion result."""
         result = DeletionResult()
         result.success_count = 2
@@ -192,7 +202,9 @@ class TestModDeletionMenu:
             deletion_menu._process_deletion_result(result)
             mock_info.assert_called_once()
 
-    def test_process_deletion_result_with_failures(self, deletion_menu: ModDeletionMenu) -> None:
+    def test_process_deletion_result_with_failures(
+        self, deletion_menu: ModDeletionMenu
+    ) -> None:
         """Test processing result with both success and failures."""
         result = DeletionResult()
         result.success_count = 1
@@ -218,10 +230,14 @@ class TestModDeletionMenu:
         ):
             deletion_menu._handle_steam_action("unsubscribe", mods)
 
-            mock_eventbus().do_steamworks_api_call.emit.assert_called_once_with(["unsubscribe", [123456789]])
+            mock_eventbus().do_steamworks_api_call.emit.assert_called_once_with(
+                ["unsubscribe", [123456789]]
+            )
             mock_info.assert_called_once()
 
-    def test_handle_steam_action_invalid_id(self, deletion_menu: ModDeletionMenu) -> None:
+    def test_handle_steam_action_invalid_id(
+        self, deletion_menu: ModDeletionMenu
+    ) -> None:
         """Test Steam action handling with invalid ID."""
         mod = {"publishedfileid": "invalid", "name": "Test"}
         mods = [mod]
@@ -230,7 +246,9 @@ class TestModDeletionMenu:
             deletion_menu._handle_steam_action("unsubscribe", mods)
             mock_logger.debug.assert_called_once()
 
-    def test_delete_mod_from_aux_db_time_limit_negative(self, deletion_menu: ModDeletionMenu) -> None:
+    def test_delete_mod_from_aux_db_time_limit_negative(
+        self, deletion_menu: ModDeletionMenu
+    ) -> None:
         """Test aux DB deletion when time limit is negative."""
         deletion_menu.settings_controller.settings.aux_db_time_limit = -1
 
@@ -238,7 +256,9 @@ class TestModDeletionMenu:
             deletion_menu.delete_mod_from_aux_db("/fake/path")
             mock_logger.debug.assert_called_once()
 
-    def test_delete_mod_from_aux_db_time_limit_positive(self, deletion_menu: ModDeletionMenu) -> None:
+    def test_delete_mod_from_aux_db_time_limit_positive(
+        self, deletion_menu: ModDeletionMenu
+    ) -> None:
         """Test aux DB marking as outdated when time limit is positive."""
         deletion_menu.settings_controller.settings.aux_db_time_limit = 1
 
@@ -252,7 +272,9 @@ class TestModDeletionMenu:
             deletion_menu.delete_mod_from_aux_db("/fake/path")
 
             # When time_limit > 0, it should call update with outdated=True
-            mock_instance.update.assert_called_once_with(mock_session, Path("/fake/path"), outdated=True)
+            mock_instance.update.assert_called_once_with(
+                mock_session, Path("/fake/path"), outdated=True
+            )
 
     def test_dummy_translations(self, deletion_menu: ModDeletionMenu) -> None:
         """Test dummy translations method."""
@@ -279,7 +301,9 @@ class TestModDeletionMenu:
         deletion_menu.metadata_manager = mock_metadata_manager
 
         # Patch the mod_deleted_signal.emit method to track calls
-        with patch.object(mock_metadata_manager.mod_deleted_signal, "emit") as mock_emit:
+        with patch.object(
+            mock_metadata_manager.mod_deleted_signal, "emit"
+        ) as mock_emit:
             deletion_menu._handle_uuid_removal(mod_metadata)
 
             # Assert that the UUID was added to mod_metadata

--- a/tests/views/test_dialogue.py
+++ b/tests/views/test_dialogue.py
@@ -43,7 +43,12 @@ class TestBinaryChoiceDialog:
             try:
                 dialog_args: dict[
                     str,
-                    str | QMessageBox.StandardButton | bool | QMessageBox.Icon | QWidget | None,
+                    str
+                    | QMessageBox.StandardButton
+                    | bool
+                    | QMessageBox.Icon
+                    | QWidget
+                    | None,
                 ] = {
                     "title": title,
                     "text": text,
@@ -85,9 +90,15 @@ class TestBinaryChoiceDialog:
             if negative_btn is not None:
                 assert dialog.button(negative_btn)
             if default_negative:
-                assert dialog.defaultButton().text() == dialog.button(dialog.negative_btn).text()
+                assert (
+                    dialog.defaultButton().text()
+                    == dialog.button(dialog.negative_btn).text()
+                )
             else:
-                assert dialog.defaultButton().text() == dialog.button(dialog.positive_btn).text()
+                assert (
+                    dialog.defaultButton().text()
+                    == dialog.button(dialog.positive_btn).text()
+                )
 
             if details is not None:
                 assert dialog.detailedText() == details
@@ -185,8 +196,12 @@ class TestBinaryChoiceDialog:
 
     @patch.object(BinaryChoiceDialog, "exec")
     def test_exec_is_positive(self, mock_exec: MagicMock, qtbot: QtBot) -> None:
-        def _test_exec_is_positive(dialog: BinaryChoiceDialog, positive_clicked: bool) -> None:
-            with patch.object(BinaryChoiceDialog, "clickedButton") as mock_clickedButton:
+        def _test_exec_is_positive(
+            dialog: BinaryChoiceDialog, positive_clicked: bool
+        ) -> None:
+            with patch.object(
+                BinaryChoiceDialog, "clickedButton"
+            ) as mock_clickedButton:
                 mock_clickedButton.return_value = dialog.button(
                     dialog.positive_btn if positive_clicked else dialog.negative_btn
                 )

--- a/tests/views/test_main_content_run.py
+++ b/tests/views/test_main_content_run.py
@@ -64,7 +64,9 @@ def patch_launch(monkeypatch: pytest.MonkeyPatch) -> List[Tuple[Path, List[str]]
     def fake_launch_game_process(game_install_path: str, args: List[str]) -> None:
         calls.append((Path(game_install_path), args))
 
-    monkeypatch.setattr(main_content_panel, "launch_game_process", fake_launch_game_process)
+    monkeypatch.setattr(
+        main_content_panel, "launch_game_process", fake_launch_game_process
+    )
     # Also patch platform_specific_open to avoid trying to open Steam protocol
     monkeypatch.setattr(main_content_panel, "platform_specific_open", Mock())
     return calls
@@ -76,7 +78,9 @@ def patch_steamcmd(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         steamcmd_wrapper.SteamcmdInterface,
         "instance",
-        classmethod(lambda cls: SimpleNamespace(setup=True, steamcmd_appworkshop_acf_path="")),
+        classmethod(
+            lambda cls: SimpleNamespace(setup=True, steamcmd_appworkshop_acf_path="")
+        ),
     )
 
 
@@ -105,7 +109,9 @@ def main_content(
     save_calls: List[bool] = []
     monkeypatch.setattr(mc, "_do_save", lambda: save_calls.append(True))
     # Mock check_if_essential_paths_are_set to return True
-    monkeypatch.setattr(mc, "check_if_essential_paths_are_set", lambda prompt=True: True)
+    monkeypatch.setattr(
+        mc, "check_if_essential_paths_are_set", lambda prompt=True: True
+    )
 
     yield mc, save_calls
 
@@ -145,7 +151,9 @@ def test_run_game_with_unsaved_changes(
 ) -> None:
     mc, save_calls = unsaved_main_content
     patch_dialogue.return_value = (
-        dialogue_return if isinstance(dialogue_return, QMessageBox.StandardButton) else mc.tr(dialogue_return)
+        dialogue_return
+        if isinstance(dialogue_return, QMessageBox.StandardButton)
+        else mc.tr(dialogue_return)
     )
     mc._do_run_game()
     assert save_calls == expected_save_calls

--- a/tests/views/test_menu_bar.py
+++ b/tests/views/test_menu_bar.py
@@ -56,7 +56,10 @@ class TestMenuBarUpdateMenuCreation:
             assert menu_bar.check_for_updates_on_startup_action is not None
 
             # Verify the menu exists
-            menus = [qt_menu_bar.actions()[i].text() for i in range(len(qt_menu_bar.actions()))]
+            menus = [
+                qt_menu_bar.actions()[i].text()
+                for i in range(len(qt_menu_bar.actions()))
+            ]
             assert "Update" in menus
 
     def test_update_menu_hidden_when_env_var_set(
@@ -75,7 +78,10 @@ class TestMenuBarUpdateMenuCreation:
             assert menu_bar.check_for_updates_on_startup_action is None
 
             # Verify the menu does not exist
-            menus = [qt_menu_bar.actions()[i].text() for i in range(len(qt_menu_bar.actions()))]
+            menus = [
+                qt_menu_bar.actions()[i].text()
+                for i in range(len(qt_menu_bar.actions()))
+            ]
             assert "Update" not in menus
 
 

--- a/tests/views/test_mod_info_panel.py
+++ b/tests/views/test_mod_info_panel.py
@@ -160,7 +160,9 @@ def test_mouse_press_path_scenarios(
     else:
         mock_open.assert_not_called()
     if expected_log_level:
-        getattr(mock_logger, expected_log_level).assert_called_once_with(expected_log_msg)
+        getattr(mock_logger, expected_log_level).assert_called_once_with(
+            expected_log_msg
+        )
 
 
 def test_mouse_press_event_not_left_button(

--- a/tests/windows/test_runner_panel_regex.py
+++ b/tests/windows/test_runner_panel_regex.py
@@ -9,9 +9,15 @@ def test_dbbuilder_progress_regex() -> None:
     IPublishedFileService/QueryFiles and IPublishedFileService/GetDetails
     in the DB Builder runner panel output.
     """
-    ipublishedfileservice_regex = r"IPublishedFileService/(QueryFiles|GetDetails) (page|chunk) \[(\d+)\/(\d+)\]"
+    ipublishedfileservice_regex = (
+        r"IPublishedFileService/(QueryFiles|GetDetails) (page|chunk) \[(\d+)\/(\d+)\]"
+    )
     # Test IPublishedFileService/QueryFiles output
-    ipublishedfileservice_queryfiles_test = "IPublishedFileService/QueryFiles page [40/100]"
-    ipublishedfileservice_getdetails_test = "IPublishedFileService/GetDetails chunk [40/100]"
+    ipublishedfileservice_queryfiles_test = (
+        "IPublishedFileService/QueryFiles page [40/100]"
+    )
+    ipublishedfileservice_getdetails_test = (
+        "IPublishedFileService/GetDetails chunk [40/100]"
+    )
     assert search(ipublishedfileservice_regex, ipublishedfileservice_queryfiles_test)
     assert search(ipublishedfileservice_regex, ipublishedfileservice_getdetails_test)

--- a/translation_helper.py
+++ b/translation_helper.py
@@ -243,7 +243,9 @@ class TranslationCache:
             try:
                 with open(self._cache_file, "r", encoding="utf-8") as f:
                     self._cache = json.load(f)
-                print(f"✅ Loaded {len(self._cache)} items from cache file: {self._cache_file}")
+                print(
+                    f"✅ Loaded {len(self._cache)} items from cache file: {self._cache_file}"
+                )
             except (IOError, json.JSONDecodeError) as e:
                 print(f"⚠️  Could not load cache file: {e}")
                 self._cache = {}
@@ -258,11 +260,15 @@ class TranslationCache:
                 self._cache_file.parent.mkdir(parents=True, exist_ok=True)
                 with open(self._cache_file, "w", encoding="utf-8") as f:
                     json.dump(self._cache, f, indent=2)
-                print(f"💾 Saved {len(self._cache)} items to cache file: {self._cache_file}")
+                print(
+                    f"💾 Saved {len(self._cache)} items to cache file: {self._cache_file}"
+                )
             except IOError as e:
                 print(f"❌ Could not save cache file: {e}")
 
-    def _get_cache_key(self, text: str, target_lang: str, source_lang: str, service: str) -> str:
+    def _get_cache_key(
+        self, text: str, target_lang: str, source_lang: str, service: str
+    ) -> str:
         """Generate a unique cache key from translation parameters.
 
         Uses SHA256 hash to create a compact, deterministic key from the
@@ -283,7 +289,9 @@ class TranslationCache:
         key_str = f"{text}:{target_lang}:{source_lang}:{service}"
         return hashlib.sha256(key_str.encode()).hexdigest()
 
-    def get(self, text: str, target_lang: str, source_lang: str, service: str) -> Optional[str]:
+    def get(
+        self, text: str, target_lang: str, source_lang: str, service: str
+    ) -> Optional[str]:
         """Retrieve a translation from cache if available.
 
         Args:
@@ -341,7 +349,9 @@ class TranslationCache:
 
 
 # Global cache instance
-_translation_cache = TranslationCache(_cache_file=Path(__file__).parent / ".translation_cache.json")
+_translation_cache = TranslationCache(
+    _cache_file=Path(__file__).parent / ".translation_cache.json"
+)
 
 
 def get_translation_cache() -> TranslationCache:
@@ -374,7 +384,9 @@ def validate_language_code(language: Optional[str]) -> Optional[str]:
 
     if language not in LANG_MAP:
         supported = ", ".join(sorted(LANG_MAP.keys()))
-        raise ValueError(f"Unsupported language: {language}\nSupported languages: {supported}")
+        raise ValueError(
+            f"Unsupported language: {language}\nSupported languages: {supported}"
+        )
 
     return language
 
@@ -549,7 +561,9 @@ def validate_retry_count(max_retries: int) -> int:
         raise ValueError(f"Retry count cannot be negative, got {max_retries}")
 
     if max_retries > 10:
-        raise ValueError(f"Retry count is very high ({max_retries}), max recommended is 10")
+        raise ValueError(
+            f"Retry count is very high ({max_retries}), max recommended is 10"
+        )
 
     return max_retries
 
@@ -570,13 +584,17 @@ def validate_concurrent_requests(max_concurrent: int) -> int:
         TypeError: If value is not an integer
     """
     if not isinstance(max_concurrent, int):
-        raise TypeError(f"Concurrent requests must be an integer, got {type(max_concurrent)}")
+        raise TypeError(
+            f"Concurrent requests must be an integer, got {type(max_concurrent)}"
+        )
 
     if max_concurrent <= 0:
         raise ValueError(f"Concurrent requests must be positive, got {max_concurrent}")
 
     if max_concurrent > 100:
-        raise ValueError(f"Concurrent requests is very high ({max_concurrent}), max recommended is 100")
+        raise ValueError(
+            f"Concurrent requests is very high ({max_concurrent}), max recommended is 100"
+        )
 
     return max_concurrent
 
@@ -649,7 +667,9 @@ async def retry_with_backoff(
             if attempt < config.max_retries - 1:
                 # Calculate exponential backoff delay
                 delay = config.get_delay(attempt)
-                print(f"⚠️  Attempt {attempt + 1} failed, retrying in {delay:.1f}s: {str(e)[:100]}")
+                print(
+                    f"⚠️  Attempt {attempt + 1} failed, retrying in {delay:.1f}s: {str(e)[:100]}"
+                )
                 # Wait before next attempt (prevents API rate limiting)
                 await asyncio.sleep(delay)
             else:
@@ -676,7 +696,9 @@ class TranslationService:
     (Google Translate, DeepL, OpenAI, etc.).
     """
 
-    async def translate(self, text: str, target_lang: str, source_lang: str = "en_US") -> Optional[str]:
+    async def translate(
+        self, text: str, target_lang: str, source_lang: str = "en_US"
+    ) -> Optional[str]:
         """Translate text from source language to target language.
 
         Args:
@@ -729,7 +751,9 @@ class GoogleTranslateService(TranslationService):
             # This is not a critical error, so we can safely ignore it.
             pass
 
-    async def translate(self, text: str, target_lang: str, source_lang: str = "en_US") -> Optional[str]:
+    async def translate(
+        self, text: str, target_lang: str, source_lang: str = "en_US"
+    ) -> Optional[str]:
         config = get_translation_config()
         cache = get_translation_cache()
 
@@ -751,7 +775,9 @@ class GoogleTranslateService(TranslationService):
         for attempt in range(self.config.retry_config.max_retries):
             try:
                 # The googletrans 4.0.0rc1 library has an async translate method
-                result_or_coro = self.translator.translate(text, dest=target, src=source)
+                result_or_coro = self.translator.translate(
+                    text, dest=target, src=source
+                )
 
                 # Handle both sync and async versions of googletrans
                 if inspect.iscoroutine(result_or_coro):
@@ -768,14 +794,20 @@ class GoogleTranslateService(TranslationService):
             except Exception as e:
                 error_str = str(e)
                 if attempt < self.config.retry_config.max_retries - 1:
-                    if "SSL" in error_str or "TLS" in error_str or "sslv3" in error_str.lower():
+                    if (
+                        "SSL" in error_str
+                        or "TLS" in error_str
+                        or "sslv3" in error_str.lower()
+                    ):
                         # Re-instantiate translator on SSL errors
                         assert GoogleTranslator is not None
                         self.translator = GoogleTranslator()
                         self._setup_translator()
 
                     delay = self.config.retry_config.get_delay(attempt)
-                    print(f"⚠️  Google translate attempt {attempt + 1} failed, retrying in {delay:.1f}s")
+                    print(
+                        f"⚠️  Google translate attempt {attempt + 1} failed, retrying in {delay:.1f}s"
+                    )
                     await asyncio.sleep(delay)
                 else:
                     print(f"❌ Google translate failed: {e}")
@@ -806,7 +838,9 @@ class DeepLService(TranslationService):
         self.base_url = "https://api-free.deepl.com/v2/translate"
         self.config = get_translation_config()
 
-    async def translate(self, text: str, target_lang: str, source_lang: str = "en_US") -> Optional[str]:
+    async def translate(
+        self, text: str, target_lang: str, source_lang: str = "en_US"
+    ) -> Optional[str]:
         # First, check if the translation is already in the cache.
         config = get_translation_config()
         cache = get_translation_cache()
@@ -847,11 +881,15 @@ class DeepLService(TranslationService):
         for attempt in range(self.config.retry_config.max_retries):
             try:
                 # Set the timeout for the request.
-                timeout = aiohttp.ClientTimeout(total=self.config.timeout_config.deepl_timeout)
+                timeout = aiohttp.ClientTimeout(
+                    total=self.config.timeout_config.deepl_timeout
+                )
                 # Create a new aiohttp session for each request.
                 async with aiohttp.ClientSession() as session:
                     # Send the request to the DeepL API.
-                    async with session.post(self.base_url, data=data, timeout=timeout) as response:
+                    async with session.post(
+                        self.base_url, data=data, timeout=timeout
+                    ) as response:
                         # Raise an exception if the request fails.
                         response.raise_for_status()
                         # Get the JSON response.
@@ -860,26 +898,34 @@ class DeepLService(TranslationService):
                         translation = result["translations"][0]["text"]
                         # Cache the translation.
                         if config.use_cache:
-                            cache.set(text, target_lang, source_lang, "deepl", translation)
+                            cache.set(
+                                text, target_lang, source_lang, "deepl", translation
+                            )
                         return translation
             except asyncio.TimeoutError:
                 # If the request times out, check if we should retry.
                 if attempt < self.config.retry_config.max_retries - 1:
                     # Calculate the delay for the next retry.
                     delay = self.config.retry_config.get_delay(attempt)
-                    print(f"⚠️  DeepL timeout, retrying in {delay:.1f}s: Request {text[:50]}...")
+                    print(
+                        f"⚠️  DeepL timeout, retrying in {delay:.1f}s: Request {text[:50]}..."
+                    )
                     # Wait for the calculated delay.
                     await asyncio.sleep(delay)
                 else:
                     # If all retries fail, print an error message.
-                    print(f"❌ DeepL translation timed out after {self.config.retry_config.max_retries} attempts")
+                    print(
+                        f"❌ DeepL translation timed out after {self.config.retry_config.max_retries} attempts"
+                    )
                     return None
             except Exception as e:
                 # If the request fails, check if we should retry.
                 if attempt < self.config.retry_config.max_retries - 1:
                     # Calculate the delay for the next retry.
                     delay = self.config.retry_config.get_delay(attempt)
-                    print(f"⚠️  DeepL attempt {attempt + 1} failed, retrying in {delay:.1f}s")
+                    print(
+                        f"⚠️  DeepL attempt {attempt + 1} failed, retrying in {delay:.1f}s"
+                    )
                     # Wait for the calculated delay.
                     await asyncio.sleep(delay)
                 else:
@@ -923,7 +969,9 @@ class OpenAIService(TranslationService):
         )
         self.model = model
 
-    async def translate(self, text: str, target_lang: str, source_lang: str = "en_US") -> Optional[str]:
+    async def translate(
+        self, text: str, target_lang: str, source_lang: str = "en_US"
+    ) -> Optional[str]:
         assert openai_module is not None
 
         config = get_translation_config()
@@ -985,15 +1033,21 @@ Only return the translation, no explanation:
                     # Calculate the delay for the next retry.
                     delay = self.config.retry_config.get_delay(attempt)
                     if is_timeout:
-                        print(f"⚠️  OpenAI timeout, retrying in {delay:.1f}s: Request {text[:50]}...")
+                        print(
+                            f"⚠️  OpenAI timeout, retrying in {delay:.1f}s: Request {text[:50]}..."
+                        )
                     else:
-                        print(f"⚠️  OpenAI attempt {attempt + 1} failed, retrying in {delay:.1f}s")
+                        print(
+                            f"⚠️  OpenAI attempt {attempt + 1} failed, retrying in {delay:.1f}s"
+                        )
                     # Wait for the calculated delay.
                     await asyncio.sleep(delay)
                 else:
                     # If all retries fail, print an error message.
                     if is_timeout:
-                        print(f"❌ OpenAI translation timed out after {self.config.retry_config.max_retries} attempts")
+                        print(
+                            f"❌ OpenAI translation timed out after {self.config.retry_config.max_retries} attempts"
+                        )
                     else:
                         print(f"❌ OpenAI translation failed: {e}")
                     return None
@@ -1038,7 +1092,9 @@ def get_source_keys(unfinished: list["UnfinishedItem"]) -> Dict[str, List[str]]:
     return result
 
 
-def parse_ts_file(file_path: Path, source_keys: Optional[Set[str]] = None) -> Dict[str, Any]:
+def parse_ts_file(
+    file_path: Path, source_keys: Optional[Set[str]] = None
+) -> Dict[str, Any]:
     """Parse a .ts file and extract translation information."""
     try:
         tree = ET.parse(file_path)
@@ -1078,17 +1134,23 @@ def parse_ts_file(file_path: Path, source_keys: Optional[Set[str]] = None) -> Di
                     if translation_type == "unfinished":
                         stats["unfinished"] += 1
                         stats["missing"] += 1
-                        issues.append(f"Unfinished: {context_name} - {source_text[:50]}...")
+                        issues.append(
+                            f"Unfinished: {context_name} - {source_text[:50]}..."
+                        )
                     elif translation_type == "obsolete":
                         stats["obsolete"] += 1
                     elif not translation_text.strip():
                         stats["missing"] += 1
-                        issues.append(f"Empty translation: {context_name} - {source_text[:50]}...")
+                        issues.append(
+                            f"Empty translation: {context_name} - {source_text[:50]}..."
+                        )
                     else:
                         stats["translated"] += 1
                 else:
                     stats["missing"] += 1
-                    issues.append(f"Missing translation tag: {context_name} - {source_text[:50]}...")
+                    issues.append(
+                        f"Missing translation tag: {context_name} - {source_text[:50]}..."
+                    )
 
         # Calculate missing keys based on source language
         if source_keys:
@@ -1097,7 +1159,9 @@ def parse_ts_file(file_path: Path, source_keys: Optional[Set[str]] = None) -> Di
 
             for key in list(missing_keys)[:5]:  # Show first 5 missing keys
                 context_key, source_text_key = key.split("::", 1)
-                issues.append(f"Missing from source: {context_key} - {source_text_key[:50]}...")
+                issues.append(
+                    f"Missing from source: {context_key} - {source_text_key[:50]}..."
+                )
 
         return {
             "stats": stats,
@@ -1208,7 +1272,9 @@ def create_translation_service(service_name: str, **kwargs: Any) -> TranslationS
     """
     if service_name == "google":
         if GoogleTranslator is None:
-            raise ImportError("googletrans not available. Install with: pip install googletrans==4.0.0rc1")
+            raise ImportError(
+                "googletrans not available. Install with: pip install googletrans==4.0.0rc1"
+            )
         return GoogleTranslateService()
 
     elif service_name == "deepl":
@@ -1297,7 +1363,9 @@ async def auto_translate_file(
             # Semaphore limits concurrent API requests to prevent rate limiting/overload
             semaphore = asyncio.Semaphore(config.max_concurrent_requests)
 
-            async def translate_item(i: int, item: UnfinishedItem) -> tuple[int, UnfinishedItem, Optional[str]]:
+            async def translate_item(
+                i: int, item: UnfinishedItem
+            ) -> tuple[int, UnfinishedItem, Optional[str]]:
                 """Inner coroutine to translate a single item with concurrency control."""
                 source_text = item.source
                 # Skip trivial strings (empty, single char, numbers, symbols)
@@ -1307,7 +1375,9 @@ async def auto_translate_file(
 
                 # Use semaphore to limit concurrent API requests
                 async with semaphore:
-                    print(f"🔄 Translating [{i}/{len(unfinished)}]: {source_text[:50]}...")
+                    print(
+                        f"🔄 Translating [{i}/{len(unfinished)}]: {source_text[:50]}..."
+                    )
                     try:
                         # Call translation service with configured timeout
                         translated = await asyncio.wait_for(
@@ -1364,9 +1434,13 @@ async def auto_translate_file(
                 print(f"   📁 Would update file: {ts_file}")
                 print("   💾 Use without --dry-run to apply changes")
                 if failed > 0:
-                    all_success = False  # Even in dry run, if failures, report overall failure
+                    all_success = (
+                        False  # Even in dry run, if failures, report overall failure
+                    )
             elif tree is not None:
-                if not translation_failed_midway and (continue_on_failure or failed == 0):
+                if not translation_failed_midway and (
+                    continue_on_failure or failed == 0
+                ):
                     try:
                         # Save file
                         tree.write(ts_file, encoding="utf-8", xml_declaration=True)
@@ -1402,7 +1476,9 @@ async def auto_translate_file(
                             shutil.copy2(backup_file, ts_file)
                         all_success = False
                 else:  # translation_failed_midway or (not continue_on_failure and failed > 0)
-                    print("\n❌ Auto-translation aborted due to failure. Restoring from backup.")
+                    print(
+                        "\n❌ Auto-translation aborted due to failure. Restoring from backup."
+                    )
                     if backup_file.exists():
                         shutil.copy2(backup_file, ts_file)
                         # No need to unlink backup here, it's the working copy now
@@ -1450,7 +1526,11 @@ def run_lupdate(language: Optional[str] = None) -> bool:
             locales_dir = Path("locales")
             ts_files = list(locales_dir.glob("*.ts"))
             if ts_files:
-                cmd.extend(["-ts"] + [str(f) for f in ts_files] + ["-no-obsolete", "-locations", "none"])
+                cmd.extend(
+                    ["-ts"]
+                    + [str(f) for f in ts_files]
+                    + ["-no-obsolete", "-locations", "none"]
+                )
             else:
                 print("⚠️ No .ts files found in locales/")
                 return False
@@ -1537,7 +1617,9 @@ def run_lrelease(language: Optional[str] = None) -> bool:
         return False
 
 
-def check_translation(language: Optional[str] = None, json_output: bool = False) -> None:
+def check_translation(
+    language: Optional[str] = None, json_output: bool = False
+) -> None:
     """Check translation completeness for a specific language or all languages.
 
     Compares each translation file against the source language (en_US) to verify
@@ -1601,7 +1683,9 @@ def check_translation(language: Optional[str] = None, json_output: bool = False)
         ts_file: Path = locales_dir / f"{lang}.ts"
         if not ts_file.exists():
             if json_output:
-                results.append({"language": lang, "error": "Translation file not found"})
+                results.append(
+                    {"language": lang, "error": "Translation file not found"}
+                )
             else:
                 print(f"❌ Translation file not found: {ts_file}")
             continue
@@ -1624,7 +1708,9 @@ def check_translation(language: Optional[str] = None, json_output: bool = False)
         issues: List[str] = result["issues"]
 
         # Calculate completion percentage: translated strings / total strings
-        completion: float = (stats["translated"] / stats["total"]) * 100 if stats["total"] > 0 else 0
+        completion: float = (
+            (stats["translated"] / stats["total"]) * 100 if stats["total"] > 0 else 0
+        )
 
         # Determine status level based on completion percentage
         status = (
@@ -1703,7 +1789,11 @@ def show_all_stats(json_output: bool = False) -> None:
     locales_dir = Path("locales")
     if not locales_dir.exists():
         if json_output:
-            print(json.dumps({"type": "stats", "error": "Locales directory not found"}, indent=2))
+            print(
+                json.dumps(
+                    {"type": "stats", "error": "Locales directory not found"}, indent=2
+                )
+            )
         else:
             print("❌ Locales directory not found")
         return
@@ -1711,7 +1801,11 @@ def show_all_stats(json_output: bool = False) -> None:
     ts_files = list(locales_dir.glob("*.ts"))
     if not ts_files:
         if json_output:
-            print(json.dumps({"type": "stats", "error": "No translation files found"}, indent=2))
+            print(
+                json.dumps(
+                    {"type": "stats", "error": "No translation files found"}, indent=2
+                )
+            )
         else:
             print("❌ No translation files found")
         return
@@ -1727,7 +1821,9 @@ def show_all_stats(json_output: bool = False) -> None:
     if not json_output:
         print("📊 Translation Statistics for All Languages:\n")
         print(f"Total files: {len(ts_files)}\n")
-        print(f"{'Language':<10} {'Progress':<10} {'Translated':<12} {'Unfinished ':<12} {'Missing':<12} {'Status'}")
+        print(
+            f"{'Language':<10} {'Progress':<10} {'Translated':<12} {'Unfinished ':<12} {'Missing':<12} {'Status'}"
+        )
         print("-" * 75)
 
     for ts_file in sorted(ts_files):
@@ -1743,11 +1839,15 @@ def show_all_stats(json_output: bool = False) -> None:
                     }
                 )
             else:
-                print(f"{language:<10} {'ERROR':<10} {'N/A':<12} {'N/A':<10} {'N/A':<12} ❌")
+                print(
+                    f"{language:<10} {'ERROR':<10} {'N/A':<12} {'N/A':<10} {'N/A':<12} ❌"
+                )
             continue
 
         stats = result["stats"]
-        completion = (stats["translated"] / stats["total"]) * 100 if stats["total"] > 0 else 0
+        completion = (
+            (stats["translated"] / stats["total"]) * 100 if stats["total"] > 0 else 0
+        )
 
         status = (
             "complete"
@@ -1776,7 +1876,13 @@ def show_all_stats(json_output: bool = False) -> None:
 
         if not json_output:
             status_emoji = (
-                "✅" if completion >= 95 else "🟡" if completion >= 80 else "🟠" if completion >= 50 else "🔴"
+                "✅"
+                if completion >= 95
+                else "🟡"
+                if completion >= 80
+                else "🟠"
+                if completion >= 50
+                else "🔴"
             )
 
             print(
@@ -1854,7 +1960,9 @@ def validate_translation(language: Optional[str] = None, dry_run: bool = False) 
                         trans_placeholders = set(re.findall(r"\{[^}]+\}", trans_text))
 
                         if source_placeholders != trans_placeholders and trans_text:
-                            issues.append(f"⚠️  Placeholder mismatch: '{source_text[:30]}...' -> '{trans_text[:30]}...'")
+                            issues.append(
+                                f"⚠️  Placeholder mismatch: '{source_text[:30]}...' -> '{trans_text[:30]}...'"
+                            )
                             made_changes = True
                             # Attempt to fix by aligning placeholders
                             # Remove placeholders not in source from translation
@@ -1866,7 +1974,9 @@ def validate_translation(language: Optional[str] = None, dry_run: bool = False) 
                                 if ph not in trans_text:
                                     trans_text += f" {ph}"
                             translation.text = trans_text.strip()
-                            print(f"🔧 Fixed placeholder mismatch in message: {source_text[:30]}...")
+                            print(
+                                f"🔧 Fixed placeholder mismatch in message: {source_text[:30]}..."
+                            )
 
                         # Check for HTML tag mismatches
                         source_tags_list = re.findall(r"<[^>]+>", source_text)
@@ -1875,7 +1985,9 @@ def validate_translation(language: Optional[str] = None, dry_run: bool = False) 
                         trans_tags_counts = Counter(trans_tags_list)
 
                         if source_tags_counts != trans_tags_counts and trans_text:
-                            issues.append(f"⚠️  HTML tag mismatch: '{source_text[:30]}...' -> '{trans_text[:30]}...'")
+                            issues.append(
+                                f"⚠️  HTML tag mismatch: '{source_text[:30]}...' -> '{trans_text[:30]}...'"
+                            )
                             made_changes = True
                             # Attempt to fix by adding/removing tags. This is naive.
 
@@ -1891,7 +2003,9 @@ def validate_translation(language: Optional[str] = None, dry_run: bool = False) 
                                     trans_text += f" {tag}"
 
                             translation.text = trans_text.strip()
-                            print(f"🔧 Fixed HTML tag mismatch in message: {source_text[:30]}...")
+                            print(
+                                f"🔧 Fixed HTML tag mismatch in message: {source_text[:30]}..."
+                            )
 
             if not issues:
                 print("✅ Translation file is valid!")
@@ -1958,7 +2072,9 @@ async def process_language(
             print(f"📋 Would run: pyside6-lupdate for {language}")
             print(f"📋 Would run: validate for {language}")
 
-        if not await auto_translate_file(language, service, continue_on_failure, dry_run=dry_run, **service_kwargs):
+        if not await auto_translate_file(
+            language, service, continue_on_failure, dry_run=dry_run, **service_kwargs
+        ):
             print("❌ Aborting: auto-translation failed.")
             return False
 
@@ -1969,7 +2085,9 @@ async def process_language(
             print(f"📋 Would run: pyside6-lrelease for {language}")
 
         if dry_run:
-            print("✅ Dry-run preview complete. Use without --dry-run to apply changes.")
+            print(
+                "✅ Dry-run preview complete. Use without --dry-run to apply changes."
+            )
         else:
             print("✅ One-click process completed successfully!")
         return True
@@ -1997,7 +2115,9 @@ async def process_language(
                 print(f"📋 Would run: pyside6-lupdate for {lang}")
                 print(f"📋 Would run: validate for {lang}")
 
-            if not await auto_translate_file(lang, service, continue_on_failure, dry_run=dry_run, **service_kwargs):
+            if not await auto_translate_file(
+                lang, service, continue_on_failure, dry_run=dry_run, **service_kwargs
+            ):
                 print(f"❌ Aborting {lang}: auto-translation failed.")
                 if not continue_on_failure:
                     return False
@@ -2016,7 +2136,9 @@ async def process_language(
             print(f"✅ {lang} process preview complete!")
 
         if dry_run:
-            print("\n✅ Dry-run preview complete for all languages. Use without --dry-run to apply changes.")
+            print(
+                "\n✅ Dry-run preview complete for all languages. Use without --dry-run to apply changes."
+            )
         else:
             print("\n✅ All languages processed!")
         return all_successful
@@ -2068,7 +2190,9 @@ def _interactive_check() -> None:
         print("❌ Locales directory not found")
         return
 
-    available_langs = sorted([f.stem for f in locales_dir.glob("*.ts") if f.stem != "en_US"])
+    available_langs = sorted(
+        [f.stem for f in locales_dir.glob("*.ts") if f.stem != "en_US"]
+    )
 
     print(f"\nAvailable languages: {', '.join(available_langs)}")
     print("(Press Enter to check all languages)")
@@ -2105,7 +2229,9 @@ def _interactive_validate() -> None:
         print("❌ Locales directory not found")
         return
 
-    available_langs = sorted([f.stem for f in locales_dir.glob("*.ts") if f.stem != "en_US"])
+    available_langs = sorted(
+        [f.stem for f in locales_dir.glob("*.ts") if f.stem != "en_US"]
+    )
 
     print(f"\nAvailable languages: {', '.join(available_langs)}")
     print("(Press Enter to validate all languages)")
@@ -2133,7 +2259,9 @@ def _get_interactive_translation_config() -> (
         print("❌ Locales directory not found")
         return None, None, None, None
 
-    available_langs = sorted([f.stem for f in locales_dir.glob("*.ts") if f.stem != "en_US"])
+    available_langs = sorted(
+        [f.stem for f in locales_dir.glob("*.ts") if f.stem != "en_US"]
+    )
 
     print(f"\nAvailable languages: {', '.join(available_langs)}")
     print("(Press Enter to process all languages)")
@@ -2183,7 +2311,11 @@ def _get_interactive_translation_config() -> (
 
     # Dry-run option
     dry_run_input = (
-        input("\nPreview mode (dry-run)? This shows what would change without saving (y/n): ").strip().lower()
+        input(
+            "\nPreview mode (dry-run)? This shows what would change without saving (y/n): "
+        )
+        .strip()
+        .lower()
     )
     dry_run = dry_run_input == "y"
 
@@ -2233,7 +2365,9 @@ def _interactive_auto_translate() -> None:
         print("\n🔄 Starting dry-run preview...")
     else:
         print("\n🔄 Starting auto-translation...")
-    asyncio.run(auto_translate_file(language, service, True, dry_run=dry_run, **service_kwargs))
+    asyncio.run(
+        auto_translate_file(language, service, True, dry_run=dry_run, **service_kwargs)
+    )
     if not dry_run:
         print("✅ Auto-translation complete!")
 
@@ -2258,7 +2392,9 @@ def _interactive_process() -> None:
         print("\n🔄 Starting dry-run preview...")
     else:
         print("\n🔄 Starting full translation process...")
-    asyncio.run(process_language(language, service, True, dry_run=dry_run, **service_kwargs))
+    asyncio.run(
+        process_language(language, service, True, dry_run=dry_run, **service_kwargs)
+    )
     if not dry_run:
         print("✅ Full process complete!")
 
@@ -2375,16 +2511,28 @@ def main() -> None:
 
     # Check command
     check_parser = subparsers.add_parser("check", help="Check translation completeness")
-    check_parser.add_argument("language", nargs="?", help="Language code (e.g., zh_CN), optional")
-    check_parser.add_argument("--json", action="store_true", help="Output results as structured JSON")
+    check_parser.add_argument(
+        "language", nargs="?", help="Language code (e.g., zh_CN), optional"
+    )
+    check_parser.add_argument(
+        "--json", action="store_true", help="Output results as structured JSON"
+    )
 
     # Stats command
-    stats_parser = subparsers.add_parser("stats", help="Show statistics for all translations")
-    stats_parser.add_argument("--json", action="store_true", help="Output results as structured JSON")
+    stats_parser = subparsers.add_parser(
+        "stats", help="Show statistics for all translations"
+    )
+    stats_parser.add_argument(
+        "--json", action="store_true", help="Output results as structured JSON"
+    )
 
     # Validate command
-    validate_parser = subparsers.add_parser("validate", help="Validate translation file")
-    validate_parser.add_argument("language", nargs="?", help="Language code (e.g., zh_CN), optional")
+    validate_parser = subparsers.add_parser(
+        "validate", help="Validate translation file"
+    )
+    validate_parser.add_argument(
+        "language", nargs="?", help="Language code (e.g., zh_CN), optional"
+    )
     validate_parser.add_argument(
         "--dry-run",
         action="store_true",
@@ -2392,7 +2540,9 @@ def main() -> None:
     )
 
     # Update command
-    update_parser = subparsers.add_parser("update-ts", help="Update translation files using lupdate")
+    update_parser = subparsers.add_parser(
+        "update-ts", help="Update translation files using lupdate"
+    )
     update_parser.add_argument(
         "language",
         nargs="?",
@@ -2400,19 +2550,29 @@ def main() -> None:
     )
 
     # Compile command
-    compile_parser = subparsers.add_parser("compile", help="Compile translation file using lrelease")
-    compile_parser.add_argument("language", nargs="?", help="Language code (e.g., zh_CN), optional")
+    compile_parser = subparsers.add_parser(
+        "compile", help="Compile translation file using lrelease"
+    )
+    compile_parser.add_argument(
+        "language", nargs="?", help="Language code (e.g., zh_CN), optional"
+    )
 
     # Auto-translate command
-    auto_parser = subparsers.add_parser("auto-translate", help="Auto-translate unfinished strings")
-    auto_parser.add_argument("language", nargs="?", help="Language code (e.g., zh_CN), optional")
+    auto_parser = subparsers.add_parser(
+        "auto-translate", help="Auto-translate unfinished strings"
+    )
+    auto_parser.add_argument(
+        "language", nargs="?", help="Language code (e.g., zh_CN), optional"
+    )
     add_translation_args(auto_parser)
 
     process_parser = subparsers.add_parser(
         "process",
         help="One-click workflow: update .ts → validate → auto-translate → compile .qm",
     )
-    process_parser.add_argument("language", nargs="?", help="Language code, e.g. zh_CN, optional")
+    process_parser.add_argument(
+        "language", nargs="?", help="Language code, e.g. zh_CN, optional"
+    )
     add_translation_args(process_parser)
 
     args = parser.parse_args()


### PR DESCRIPTION
The previous syntax '# nuitka-project: --noinclude-qt-translations=yes' included '=yes' which is not valid Nuitka project syntax for this option. Removing '=yes' sets it as a plain directive (--noinclude-qt-translations), This correctly instructs Nuitka to exclude Qt translations during standalone compilation, reducing bundle size and avoiding unnecessary language files.

This aligns with Nuitka documentation for project options where boolean flags are specified without explicit values when enabled.