### PR TITLE
fix(git): prevent segfault crash on pygit2 fetch timeouts

### DIFF
--- a/app/utils/git_utils.py
+++ b/app/utils/git_utils.py
@@ -119,10 +119,11 @@ class GitOperationConfig:
         return cls(fetch_timeout=fetch_timeout, connection_timeout=connection_timeout)
 
 
-def _fetch_with_timeout(remote: pygit2.Remote, timeout: int) -> bool:
+def _fetch_with_timeout(repo: Repository, remote: pygit2.Remote, timeout: int) -> bool:
     """Fetch from remote with timeout handling.
 
     Args:
+        repo: The git repository object.
         remote: The pygit2 remote object.
         timeout: Timeout in seconds.
 
@@ -149,6 +150,8 @@ def _fetch_with_timeout(remote: pygit2.Remote, timeout: int) -> bool:
     if fetch_thread.is_alive():
         # Timeout occurred
         logger.warning(f"Fetch operation timed out after {timeout} seconds")
+        # Prevent the repository from being freed while the C-level fetch is still running
+        setattr(repo, "_has_hanging_threads", True)
         return False
 
     if result["error"]:
@@ -737,7 +740,7 @@ def git_check_updates(repo: Repository, config: Optional[GitOperationConfig] = N
             logger.warning("No 'origin' remote found in repository")
             return None  # Fetch updates from remote with timeout
         try:
-            if not _fetch_with_timeout(remote, config.fetch_timeout):
+            if not _fetch_with_timeout(repo, remote, config.fetch_timeout):
                 logger.error(f"Fetch operation timed out after {config.fetch_timeout} seconds")
                 return None
         except Exception as e:
@@ -838,7 +841,7 @@ def git_pull(
 
         # Fetch updates from remote with timeout
         try:
-            if not _fetch_with_timeout(remote, config.fetch_timeout):
+            if not _fetch_with_timeout(repo, remote, config.fetch_timeout):
                 logger.error(f"Fetch operation timed out after {config.fetch_timeout} seconds")
                 return GitPullResult.GIT_ERROR
         except Exception as e:
@@ -1348,6 +1351,10 @@ def git_cleanup(repo: Repository) -> None:
     Args:
         repo: The repository to clean up.
     """
+    if getattr(repo, "_has_hanging_threads", False):
+        logger.warning(f"Skipping repo.free() for {repo.path} because of hanging fetch thread")
+        return
+
     repo.state_cleanup()
     repo.free()
     logger.debug(f"Git repository cleaned up: {repo.path}")


### PR DESCRIPTION
Fixes #1932

### Description
This PR resolves a silent crash (segmentation fault) that caused the launcher to abruptly terminate without an error dialog or traceback exactly one minute after starting. This occurred specifically on slower network connections during background database updates.

**1. Prevented Segfaults on pygit2 Fetch Timeouts**
Previously, when a background git database fetch exceeded its time limit, `_fetch_with_timeout()` correctly threw a timeout warning, but the C-level `pygit2.Remote.fetch()` daemon thread was left running in the background. Shortly after, the application correctly attempted to clean up the git operation by calling `repo.free()`, which forcibly released the underlying C structs from memory. When the hanging daemon thread eventually tried to interact with that manually freed memory, it caused a fatal Segmentation Fault. To resolve this, a `_has_hanging_threads` flag is now set on the repository object whenever a timeout occurs. The `git_cleanup()` method checks for this flag and bypasses the explicit `repo.free()` call if a thread is still active, safely offloading memory cleanup to Python's garbage collector and keeping the structures intact until the daemon thread finishes.