### PR TITLE
Fix EULA text in MSI installer

### DIFF
--- a/data/RimSort.wxs
+++ b/data/RimSort.wxs
@@ -23,7 +23,7 @@
         <!-- ===================================================== -->
 
         <!-- License file path for the installer UI -->
-        <Property Id="WixUILicenseRtf" Value="$(License)" />
+        <WixVariable Id="WixUILicenseRtf" Value="$(License)" />
 
         <!-- Force complete reinstall like app is new - a=all files, e=even if not installed,
         c=recache source, m=missing files, u=user registry, s=shortcuts -->


### PR DESCRIPTION
Fixes #1931
Fixes #1811

### Description
This PR resolves an issue where the Windows MSI installer displayed placeholder "Lorem ipsum" text instead of the actual End-User License Agreement (EULA).

**1. Fixed EULA text in MSI installer**
Previously, in the WiX Toolset configuration (`RimSort.wxs`), the `WixUILicenseRtf` setting was incorrectly defined as a standard `<Property>`. Because WiX requires default UI variables to be overridden using `<WixVariable>`, the provided license file path was ignored and WiX defaulted to its placeholder text. To resolve this, the definition was changed from a `<Property>` to a `<WixVariable>`, ensuring that the correct GNU Affero General Public License (`EULA.rtf`) text is now properly loaded and displayed during installation.