### PR TITLE
Attempt at producing an AppImage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -257,6 +257,10 @@ jobs:
         id: find_appimage
         run: |
           APPIMAGE=$(find build/ -name "RimSort-*.AppImage" | head -n 1)
+          if [[ -z "$APPIMAGE" ]]; then
+            echo "ERROR: No AppImage found in build/" >&2
+            exit 1
+          fi
           echo "APPIMAGE=$APPIMAGE" >> "$GITHUB_OUTPUT"
           echo "AppImage found at $APPIMAGE"
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -245,7 +245,7 @@ jobs:
           subject-path: ./RimSort-${{ steps.sem_version.outputs.version }}-${{ matrix.platform }}-${{ matrix.arch }}.msi
 
       - name: Build AppImage
-        if: startsWith(matrix.platform, 'Ubuntu')
+        if: matrix.platform == 'Ubuntu-22.04'
         run: |
           bash packaging/appimage/build-appimage.sh \
             "build/${{ matrix.env.BUILD_OUTPUT }}" \
@@ -253,7 +253,7 @@ jobs:
         shell: bash
 
       - name: Find AppImage
-        if: startsWith(matrix.platform, 'Ubuntu')
+        if: matrix.platform == 'Ubuntu-22.04'
         id: find_appimage
         run: |
           APPIMAGE=$(find build/ -name "RimSort-*.AppImage" | head -n 1)
@@ -267,12 +267,12 @@ jobs:
 
       - name: Generate AppImage attestation
         uses: actions/attest-build-provenance@v4.1.0
-        if: ${{ inputs.attest && startsWith(matrix.platform, 'Ubuntu') }}
+        if: ${{ inputs.attest && matrix.platform == 'Ubuntu-22.04' }}
         with:
           subject-path: ${{ steps.find_appimage.outputs.APPIMAGE }}
 
       - name: Upload AppImage
-        if: startsWith(matrix.platform, 'Ubuntu')
+        if: matrix.platform == 'Ubuntu-22.04'
         uses: actions/upload-artifact@main
         with:
           name: ${{ matrix.platform }}_${{ matrix.arch }}_appimage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -244,6 +244,37 @@ jobs:
         with:
           subject-path: ./RimSort-${{ steps.sem_version.outputs.version }}-${{ matrix.platform }}-${{ matrix.arch }}.msi
 
+      - name: Build AppImage
+        if: startsWith(matrix.platform, 'Ubuntu')
+        run: |
+          bash packaging/appimage/build-appimage.sh \
+            "build/${{ matrix.env.BUILD_OUTPUT }}" \
+            "${{ steps.sem_version.outputs.major }}.${{ steps.sem_version.outputs.minor }}.${{ steps.sem_version.outputs.patch }}"
+        shell: bash
+
+      - name: Find AppImage
+        if: startsWith(matrix.platform, 'Ubuntu')
+        id: find_appimage
+        run: |
+          APPIMAGE=$(find build/ -name "RimSort-*.AppImage" | head -n 1)
+          echo "APPIMAGE=$APPIMAGE" >> "$GITHUB_OUTPUT"
+          echo "AppImage found at $APPIMAGE"
+        shell: bash
+
+      - name: Generate AppImage attestation
+        uses: actions/attest-build-provenance@v4.1.0
+        if: ${{ inputs.attest && startsWith(matrix.platform, 'Ubuntu') }}
+        with:
+          subject-path: ${{ steps.find_appimage.outputs.APPIMAGE }}
+
+      - name: Upload AppImage
+        if: startsWith(matrix.platform, 'Ubuntu')
+        uses: actions/upload-artifact@main
+        with:
+          name: ${{ matrix.platform }}_${{ matrix.arch }}_appimage
+          path: ${{ steps.find_appimage.outputs.APPIMAGE }}
+          if-no-files-found: error
+
       - name: Rename new build
         run: |
           cd build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,7 +180,7 @@ jobs:
           wait
           echo "Cleaning up - Removing non-zip files"
           shopt -s extglob
-          rm -rf -- ./!(*.zip|*.msi|*.AppImage)
+          rm -rf -- ./!(*.zip|*.msi|*.rpm|*.AppImage)
         shell: bash
 
       - name: Create body

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,6 +119,8 @@ jobs:
           mv artifacts/Windows_x86_64_msi artifacts/msi
           mv artifacts/Fedora-42_x86_64_rpm artifacts/rpm-f42 || true
           mv artifacts/Fedora-43_x86_64_rpm artifacts/rpm-f43 || true
+          mv artifacts/Ubuntu-22.04_x86_64_appimage artifacts/appimage-u2204 || true
+          mv artifacts/Ubuntu-24.04_x86_64_appimage artifacts/appimage-u2404 || true
           cd artifacts
           for artifact in ./*; do
             file=${artifact##*/}
@@ -136,6 +138,16 @@ jobs:
               cd "$artifact"
               name="RimSort-${{ needs.pre-build.outputs.version }}-Fedora-43_x86_64.rpm"
               mv ./*.rpm "../$name"
+              cd ..
+            elif [[ "$file" == "appimage-u2204" ]]; then
+              cd "$artifact"
+              name="RimSort-${{ needs.pre-build.outputs.version }}-Ubuntu-22.04_x86_64.AppImage"
+              mv ./*.AppImage "../$name"
+              cd ..
+            elif [[ "$file" == "appimage-u2404" ]]; then
+              cd "$artifact"
+              name="RimSort-${{ needs.pre-build.outputs.version }}-Ubuntu-24.04_x86_64.AppImage"
+              mv ./*.AppImage "../$name"
               cd ..
             else
               base=${file%%.tar}
@@ -168,7 +180,7 @@ jobs:
           wait
           echo "Cleaning up - Removing non-zip files"
           shopt -s extglob
-          rm -rf -- ./!(*.zip|*.msi)
+          rm -rf -- ./!(*.zip|*.msi|*.AppImage)
         shell: bash
 
       - name: Create body
@@ -195,7 +207,7 @@ jobs:
         uses: ncipollo/release-action@v1.21.0
         id: release
         with:
-          artifacts: "artifacts/*.zip,artifacts/*.msi,artifacts/*.rpm"
+          artifacts: "artifacts/*.zip,artifacts/*.msi,artifacts/*.rpm,artifacts/*.AppImage"
           tag: ${{ steps.tag.outputs.tag }}
           generateReleaseNotes: true
           prerelease: ${{ needs.pre-build.outputs.prerelease }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,6 @@ jobs:
           mv artifacts/Fedora-42_x86_64_rpm artifacts/rpm-f42 || true
           mv artifacts/Fedora-43_x86_64_rpm artifacts/rpm-f43 || true
           mv artifacts/Ubuntu-22.04_x86_64_appimage artifacts/appimage-u2204 || true
-          mv artifacts/Ubuntu-24.04_x86_64_appimage artifacts/appimage-u2404 || true
           cd artifacts
           for artifact in ./*; do
             file=${artifact##*/}
@@ -141,12 +140,7 @@ jobs:
               cd ..
             elif [[ "$file" == "appimage-u2204" ]]; then
               cd "$artifact"
-              name="RimSort-${{ needs.pre-build.outputs.version }}-Ubuntu-22.04_x86_64.AppImage"
-              mv ./*.AppImage "../$name"
-              cd ..
-            elif [[ "$file" == "appimage-u2404" ]]; then
-              cd "$artifact"
-              name="RimSort-${{ needs.pre-build.outputs.version }}-Ubuntu-24.04_x86_64.AppImage"
+              name="RimSort-${{ needs.pre-build.outputs.version }}-x86_64.AppImage"
               mv ./*.AppImage "../$name"
               cd ..
             else

--- a/.github/workflows/test_builds.yml
+++ b/.github/workflows/test_builds.yml
@@ -71,14 +71,14 @@ jobs:
         shell: bash
 
       - name: Download AppImage artifact
-        if: startsWith(matrix.platform, 'Ubuntu')
+        if: matrix.platform == 'Ubuntu-22.04'
         uses: actions/download-artifact@v8.0.1
         with:
           pattern: "${{ matrix.platform }}_${{ matrix.arch }}_appimage"
           path: appimage-test
 
       - name: Install libfuse2 for AppImage
-        if: startsWith(matrix.platform, 'Ubuntu')
+        if: matrix.platform == 'Ubuntu-22.04'
         run: |
           sudo apt-get update
           sudo apt-get install -y libfuse2 || sudo apt-get install -y libfuse2t64
@@ -133,7 +133,7 @@ jobs:
         shell: bash
 
       - name: Test AppImage
-        if: startsWith(matrix.platform, 'Ubuntu')
+        if: matrix.platform == 'Ubuntu-22.04'
         run: |
           APPIMAGE=$(find appimage-test/ -name "*.AppImage" | head -n 1)
           if [[ -z "$APPIMAGE" ]]; then

--- a/.github/workflows/test_builds.yml
+++ b/.github/workflows/test_builds.yml
@@ -70,6 +70,20 @@ jobs:
           tar -xf ./*.tar
         shell: bash
 
+      - name: Download AppImage artifact
+        if: startsWith(matrix.platform, 'Ubuntu')
+        uses: actions/download-artifact@v8.0.1
+        with:
+          pattern: "${{ matrix.platform }}_${{ matrix.arch }}_appimage"
+          path: appimage-test
+
+      - name: Install libfuse2 for AppImage
+        if: startsWith(matrix.platform, 'Ubuntu')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libfuse2
+        shell: bash
+
       - name: Find executable
         id: find
         run: |
@@ -115,5 +129,27 @@ jobs:
             exit "$EXIT_CODE"
           else
             echo "Executable ran successfully"
+          fi
+        shell: bash
+
+      - name: Test AppImage
+        if: startsWith(matrix.platform, 'Ubuntu')
+        run: |
+          APPIMAGE=$(find appimage-test/ -name "*.AppImage" | head -n 1)
+          if [[ -z "$APPIMAGE" ]]; then
+            echo "ERROR: No AppImage found in appimage-test/" >&2
+            exit 1
+          fi
+          chmod +x "$APPIMAGE"
+          export QT_QPA_PLATFORM=offscreen
+          timeout 10 "$APPIMAGE" || EXIT_CODE="$?"
+
+          if [[ ${EXIT_CODE:-0} == 124 ]]; then
+            echo "AppImage ran and timed out correctly"
+          elif [[ ${EXIT_CODE:-0} != 0 ]]; then
+            echo "AppImage failed with exit code $EXIT_CODE"
+            exit "$EXIT_CODE"
+          else
+            echo "AppImage ran successfully"
           fi
         shell: bash

--- a/.github/workflows/test_builds.yml
+++ b/.github/workflows/test_builds.yml
@@ -32,14 +32,14 @@ jobs:
             platform: "Ubuntu-22.04"
             arch: "x86_64"
             env:
-              ARTIFACT_KEY_GLOB: "*Ubuntu-22*"
-              ARTIFACT_KEY: "Ubuntu-22.04_x86_64 "
+              ARTIFACT_KEY_GLOB: "Ubuntu-22.04_x86_64"
+              ARTIFACT_KEY: "Ubuntu-22.04_x86_64"
               EXPECTED_NAME: "RimSort"
           - os: ubuntu-24.04
             platform: "Ubuntu-24.04"
             arch: "x86_64"
             env:
-              ARTIFACT_KEY_GLOB: "*Ubuntu-24*"
+              ARTIFACT_KEY_GLOB: "Ubuntu-24.04_x86_64"
               ARTIFACT_KEY: "Ubuntu-24.04_x86_64"
               EXPECTED_NAME: "RimSort"
           - os: windows-latest
@@ -81,7 +81,7 @@ jobs:
         if: startsWith(matrix.platform, 'Ubuntu')
         run: |
           sudo apt-get update
-          sudo apt-get install -y libfuse2
+          sudo apt-get install -y libfuse2 || sudo apt-get install -y libfuse2t64
         shell: bash
 
       - name: Find executable

--- a/app/controllers/app_controller.py
+++ b/app/controllers/app_controller.py
@@ -25,6 +25,7 @@ class AppController(QObject):
         super().__init__()
 
         self.app = QApplication(sys.argv)
+        self.app.setDesktopFileName("io.github.rimsort.RimSort")
         self.app.setWindowIcon(GUIInfo().app_icon)
 
         # Initialize the application settings.

--- a/data/io.github.rimsort.RimSort.desktop
+++ b/data/io.github.rimsort.RimSort.desktop
@@ -8,4 +8,5 @@ Categories=Game;Qt;
 
 Icon=io.github.rimsort.RimSort
 Exec=RimSort
+StartupWMClass=io.github.rimsort.RimSort
 Terminal=false

--- a/justfile
+++ b/justfile
@@ -143,6 +143,10 @@ build-rpm VERSION='1.0.0': check (rpm-tarball VERSION)
         echo "Warning: Could not find built RPM"
     fi
 
+# Build AppImage from existing Nuitka output (Linux only)
+build-appimage VERSION='1.0.0':
+    bash packaging/appimage/build-appimage.sh build/app.dist "{{VERSION}}"
+
 # Utilities
 
 # Initialize and update git submodules (run after cloning)

--- a/packaging/appimage/build-appimage.sh
+++ b/packaging/appimage/build-appimage.sh
@@ -69,9 +69,10 @@ fi
 # Build the AppImage
 echo "Running linuxdeploy..."
 export LDAI_OUTPUT="$OUTPUT"
-export VERSION="$VERSION"
+export LINUXDEPLOY_OUTPUT_VERSION="$VERSION"
 
-"$LINUXDEPLOY" \
+# Use --appimage-extract-and-run to avoid FUSE dependency in CI
+APPIMAGE_EXTRACT_AND_RUN=1 "$LINUXDEPLOY" \
     --appdir "$APPDIR" \
     --executable "${APPDIR}/usr/bin/RimSort" \
     --desktop-file "${APPDIR}/usr/share/applications/io.github.rimsort.RimSort.desktop" \

--- a/packaging/appimage/build-appimage.sh
+++ b/packaging/appimage/build-appimage.sh
@@ -10,7 +10,7 @@ VERSION="${2:?Usage: build-appimage.sh <app.dist path> <version>}"
 APP_DIST="$(cd "$APP_DIST" && pwd)"
 BUILD_DIR="${REPO_ROOT}/build"
 APPDIR="${BUILD_DIR}/RimSort-x86_64.AppDir"
-LINUXDEPLOY="${BUILD_DIR}/linuxdeploy-x86_64.AppImage"
+APPIMAGETOOL="${BUILD_DIR}/appimagetool-x86_64.AppImage"
 OUTPUT="${BUILD_DIR}/RimSort-${VERSION}-x86_64.AppImage"
 
 DESKTOP_FILE="${REPO_ROOT}/data/io.github.rimsort.RimSort.desktop"
@@ -43,7 +43,9 @@ done
 rm -rf "$APPDIR" "$OUTPUT"
 mkdir -p "$APPDIR"
 
-# Copy entire Nuitka output into usr/bin/ to preserve relative path layout
+# Copy entire Nuitka output into usr/bin/ to preserve relative path layout.
+# Nuitka standalone mode places the executable alongside its bundled .so files
+# and expects them to remain as siblings — do NOT split into usr/bin and usr/lib.
 echo "Copying Nuitka output to AppDir..."
 mkdir -p "${APPDIR}/usr/bin"
 cp -a "${APP_DIST}/." "${APPDIR}/usr/bin/"
@@ -58,26 +60,36 @@ cp "$DESKTOP_FILE" "${APPDIR}/usr/share/applications/"
 cp "$ICON_FILE" "${APPDIR}/usr/share/icons/hicolor/256x256/apps/io.github.rimsort.RimSort.png"
 cp "$METAINFO_FILE" "${APPDIR}/usr/share/metainfo/"
 
-# Download linuxdeploy if not cached
-if [[ ! -f "$LINUXDEPLOY" ]]; then
-    echo "Downloading linuxdeploy..."
-    curl -fSL -o "$LINUXDEPLOY" \
-        "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage"
-    chmod +x "$LINUXDEPLOY"
+# Create AppRun entry point — a simple wrapper that execs the Nuitka binary.
+# We use a custom AppRun instead of linuxdeploy's --executable flag to avoid
+# patchelf rewriting Nuitka's RPATH layout.
+cat > "${APPDIR}/AppRun" << 'APPRUN_EOF'
+#!/usr/bin/env bash
+SELF="$(readlink -f "${BASH_SOURCE[0]}")"
+HERE="${SELF%/*}"
+exec "${HERE}/usr/bin/RimSort" "$@"
+APPRUN_EOF
+chmod +x "${APPDIR}/AppRun"
+
+# Symlink desktop file and icon to AppDir root (required by AppImage spec)
+ln -sf usr/share/applications/io.github.rimsort.RimSort.desktop "${APPDIR}/io.github.rimsort.RimSort.desktop"
+ln -sf usr/share/icons/hicolor/256x256/apps/io.github.rimsort.RimSort.png "${APPDIR}/io.github.rimsort.RimSort.png"
+ln -sf io.github.rimsort.RimSort.png "${APPDIR}/.DirIcon"
+
+# Download appimagetool if not cached
+if [[ ! -f "$APPIMAGETOOL" ]]; then
+    echo "Downloading appimagetool..."
+    curl -fSL -o "$APPIMAGETOOL" \
+        "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage"
+    chmod +x "$APPIMAGETOOL"
 fi
 
-# Build the AppImage
-echo "Running linuxdeploy..."
-export LDAI_OUTPUT="$OUTPUT"
-export LINUXDEPLOY_OUTPUT_VERSION="$VERSION"
-
-# Use --appimage-extract-and-run to avoid FUSE dependency in CI
-APPIMAGE_EXTRACT_AND_RUN=1 "$LINUXDEPLOY" \
-    --appdir "$APPDIR" \
-    --executable "${APPDIR}/usr/bin/RimSort" \
-    --desktop-file "${APPDIR}/usr/share/applications/io.github.rimsort.RimSort.desktop" \
-    --icon-file "${APPDIR}/usr/share/icons/hicolor/256x256/apps/io.github.rimsort.RimSort.png" \
-    --output appimage
+# Build the AppImage using appimagetool directly.
+# We skip linuxdeploy because Nuitka already bundles all dependencies —
+# linuxdeploy's --executable flag would run patchelf and corrupt Nuitka's RPATHs.
+echo "Running appimagetool..."
+export VERSION="$VERSION"
+ARCH=x86_64 APPIMAGE_EXTRACT_AND_RUN=1 "$APPIMAGETOOL" "$APPDIR" "$OUTPUT"
 
 echo "=== AppImage built successfully ==="
 ls -lh "$OUTPUT"

--- a/packaging/appimage/build-appimage.sh
+++ b/packaging/appimage/build-appimage.sh
@@ -124,12 +124,23 @@ if ! "$APPIMAGETOOL_CMD" --version &>/dev/null; then
     fi
 fi
 
+# Remove .ts translation source files — only compiled .qm files are needed at runtime
+echo "Removing .ts locale source files..."
+find "${APPDIR}" -name "*.ts" -type f | while read -r ts_file; do
+    qm_file="${ts_file%.ts}.qm"
+    if [[ -f "$qm_file" ]]; then
+        rm -f "$ts_file"
+    fi
+done
+
 # Build the AppImage using appimagetool directly.
 # We skip linuxdeploy because Nuitka already bundles all dependencies —
 # linuxdeploy's --executable flag would run patchelf and corrupt Nuitka's RPATHs.
 echo "Running appimagetool..."
 export VERSION
-ARCH="$APPIMAGE_ARCH" "$APPIMAGETOOL_CMD" "$APPDIR" "$OUTPUT"
+ARCH="$APPIMAGE_ARCH" "$APPIMAGETOOL_CMD" \
+    --mksquashfs-opt -Xcompression-level --mksquashfs-opt 19 \
+    "$APPDIR" "$OUTPUT"
 
 echo "=== AppImage built successfully ==="
 ls -lh "$OUTPUT"

--- a/packaging/appimage/build-appimage.sh
+++ b/packaging/appimage/build-appimage.sh
@@ -7,17 +7,31 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 APP_DIST="${1:?Usage: build-appimage.sh <app.dist path> <version>}"
 VERSION="${2:?Usage: build-appimage.sh <app.dist path> <version>}"
 
+# Detect architecture from the host or allow override via ARCH env var
+ARCH="${ARCH:-$(uname -m)}"
+case "$ARCH" in
+    x86_64)  APPIMAGE_ARCH="x86_64" ;;
+    aarch64) APPIMAGE_ARCH="aarch64" ;;
+    armv7l)  APPIMAGE_ARCH="armhf" ;;
+    i686)    APPIMAGE_ARCH="i686" ;;
+    *)
+        echo "ERROR: Unsupported architecture: ${ARCH}" >&2
+        exit 1
+        ;;
+esac
+
 APP_DIST="$(cd "$APP_DIST" && pwd)"
 BUILD_DIR="${REPO_ROOT}/build"
-APPDIR="${BUILD_DIR}/RimSort-x86_64.AppDir"
-APPIMAGETOOL="${BUILD_DIR}/appimagetool-x86_64.AppImage"
-OUTPUT="${BUILD_DIR}/RimSort-${VERSION}-x86_64.AppImage"
+APPDIR="${BUILD_DIR}/RimSort-${APPIMAGE_ARCH}.AppDir"
+APPIMAGETOOL="${BUILD_DIR}/appimagetool-${APPIMAGE_ARCH}.AppImage"
+APPIMAGETOOL_EXTRACTED="${BUILD_DIR}/appimagetool-extracted/AppRun"
+OUTPUT="${BUILD_DIR}/RimSort-${VERSION}-${APPIMAGE_ARCH}.AppImage"
 
 DESKTOP_FILE="${REPO_ROOT}/data/io.github.rimsort.RimSort.desktop"
 ICON_FILE="${REPO_ROOT}/themes/default-icons/AppIcon_a.png"
 METAINFO_FILE="${REPO_ROOT}/data/io.github.rimsort.RimSort.metainfo.xml"
 
-echo "=== Building AppImage for RimSort ${VERSION} ==="
+echo "=== Building AppImage for RimSort ${VERSION} (${APPIMAGE_ARCH}) ==="
 echo "  app.dist: ${APP_DIST}"
 echo "  AppDir:   ${APPDIR}"
 
@@ -76,12 +90,22 @@ ln -sf usr/share/applications/io.github.rimsort.RimSort.desktop "${APPDIR}/io.gi
 ln -sf usr/share/icons/hicolor/256x256/apps/io.github.rimsort.RimSort.png "${APPDIR}/io.github.rimsort.RimSort.png"
 ln -sf io.github.rimsort.RimSort.png "${APPDIR}/.DirIcon"
 
-# Download appimagetool if not cached
-if [[ ! -f "$APPIMAGETOOL" ]]; then
-    echo "Downloading appimagetool..."
+# Download appimagetool if not present (either as AppImage or pre-extracted)
+if [[ ! -f "$APPIMAGETOOL_EXTRACTED" && ! -f "$APPIMAGETOOL" ]]; then
+    echo "Downloading appimagetool (${APPIMAGE_ARCH})..."
     curl -fSL -o "$APPIMAGETOOL" \
-        "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage"
+        "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-${APPIMAGE_ARCH}.AppImage"
     chmod +x "$APPIMAGETOOL"
+fi
+
+# Determine how to run appimagetool:
+# 1. If pre-extracted (e.g. in environments where AppImage execution is problematic), use that
+# 2. Otherwise use APPIMAGE_EXTRACT_AND_RUN=1 to avoid FUSE dependency
+if [[ -f "$APPIMAGETOOL_EXTRACTED" ]]; then
+    APPIMAGETOOL_CMD="$APPIMAGETOOL_EXTRACTED"
+else
+    APPIMAGETOOL_CMD="$APPIMAGETOOL"
+    export APPIMAGE_EXTRACT_AND_RUN=1
 fi
 
 # Build the AppImage using appimagetool directly.
@@ -89,7 +113,7 @@ fi
 # linuxdeploy's --executable flag would run patchelf and corrupt Nuitka's RPATHs.
 echo "Running appimagetool..."
 export VERSION="$VERSION"
-ARCH=x86_64 APPIMAGE_EXTRACT_AND_RUN=1 "$APPIMAGETOOL" "$APPDIR" "$OUTPUT"
+ARCH="$APPIMAGE_ARCH" "$APPIMAGETOOL_CMD" "$APPDIR" "$OUTPUT"
 
 echo "=== AppImage built successfully ==="
 ls -lh "$OUTPUT"

--- a/packaging/appimage/build-appimage.sh
+++ b/packaging/appimage/build-appimage.sh
@@ -7,6 +7,8 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 APP_DIST="${1:?Usage: build-appimage.sh <app.dist path> <version>}"
 VERSION="${2:?Usage: build-appimage.sh <app.dist path> <version>}"
 
+APPIMAGETOOL_VERSION="1.9.1"
+
 # Detect architecture from the host or allow override via ARCH env var
 ARCH="${ARCH:-$(uname -m)}"
 case "$ARCH" in
@@ -24,11 +26,10 @@ APP_DIST="$(cd "$APP_DIST" && pwd)"
 BUILD_DIR="${REPO_ROOT}/build"
 APPDIR="${BUILD_DIR}/RimSort-${APPIMAGE_ARCH}.AppDir"
 APPIMAGETOOL="${BUILD_DIR}/appimagetool-${APPIMAGE_ARCH}.AppImage"
-APPIMAGETOOL_EXTRACTED="${BUILD_DIR}/appimagetool-extracted/AppRun"
 OUTPUT="${BUILD_DIR}/RimSort-${VERSION}-${APPIMAGE_ARCH}.AppImage"
 
 DESKTOP_FILE="${REPO_ROOT}/data/io.github.rimsort.RimSort.desktop"
-ICON_FILE="${REPO_ROOT}/themes/default-icons/AppIcon_a.png"
+ICON_FILE="${REPO_ROOT}/themes/default-icons/RimSort_Icon_64x64.svg"
 METAINFO_FILE="${REPO_ROOT}/data/io.github.rimsort.RimSort.metainfo.xml"
 
 echo "=== Building AppImage for RimSort ${VERSION} (${APPIMAGE_ARCH}) ==="
@@ -57,62 +58,77 @@ done
 rm -rf "$APPDIR" "$OUTPUT"
 mkdir -p "$APPDIR"
 
-# Copy entire Nuitka output into usr/bin/ to preserve relative path layout.
-# Nuitka standalone mode places the executable alongside its bundled .so files
-# and expects them to remain as siblings — do NOT split into usr/bin and usr/lib.
+# Copy entire Nuitka output into usr/share/RimSort/ to preserve relative path
+# layout. Nuitka standalone mode places the executable alongside its bundled
+# .so files and expects them to remain as siblings.
 echo "Copying Nuitka output to AppDir..."
+mkdir -p "${APPDIR}/usr/share/RimSort"
+cp -a "${APP_DIST}/." "${APPDIR}/usr/share/RimSort/"
+
+# Create usr/bin symlink pointing to the actual binary
 mkdir -p "${APPDIR}/usr/bin"
-cp -a "${APP_DIST}/." "${APPDIR}/usr/bin/"
+ln -rs "${APPDIR}/usr/share/RimSort/RimSort" "${APPDIR}/usr/bin/RimSort"
 
 # Install desktop integration files
 echo "Installing desktop integration files..."
 mkdir -p "${APPDIR}/usr/share/applications"
-mkdir -p "${APPDIR}/usr/share/icons/hicolor/256x256/apps"
+mkdir -p "${APPDIR}/usr/share/icons/hicolor/scalable/apps"
 mkdir -p "${APPDIR}/usr/share/metainfo"
 
 cp "$DESKTOP_FILE" "${APPDIR}/usr/share/applications/"
-cp "$ICON_FILE" "${APPDIR}/usr/share/icons/hicolor/256x256/apps/io.github.rimsort.RimSort.png"
+cp "$ICON_FILE" "${APPDIR}/usr/share/icons/hicolor/scalable/apps/io.github.rimsort.RimSort.svg"
 cp "$METAINFO_FILE" "${APPDIR}/usr/share/metainfo/"
 
-# Create AppRun entry point — a simple wrapper that execs the Nuitka binary.
-# We use a custom AppRun instead of linuxdeploy's --executable flag to avoid
-# patchelf rewriting Nuitka's RPATH layout.
+# Create AppRun entry point — a wrapper that sets cwd to the AppDir root and
+# execs the Nuitka binary. We use a custom AppRun instead of linuxdeploy's
+# --executable flag to avoid patchelf rewriting Nuitka's RPATH layout.
 cat > "${APPDIR}/AppRun" << 'APPRUN_EOF'
 #!/usr/bin/env bash
 SELF="$(readlink -f "${BASH_SOURCE[0]}")"
 HERE="${SELF%/*}"
-exec "${HERE}/usr/bin/RimSort" "$@"
+cd "$HERE"
+exec "${HERE}/usr/share/RimSort/RimSort" "$@"
 APPRUN_EOF
 chmod +x "${APPDIR}/AppRun"
 
 # Symlink desktop file and icon to AppDir root (required by AppImage spec)
 ln -sf usr/share/applications/io.github.rimsort.RimSort.desktop "${APPDIR}/io.github.rimsort.RimSort.desktop"
-ln -sf usr/share/icons/hicolor/256x256/apps/io.github.rimsort.RimSort.png "${APPDIR}/io.github.rimsort.RimSort.png"
-ln -sf io.github.rimsort.RimSort.png "${APPDIR}/.DirIcon"
+ln -sf usr/share/icons/hicolor/scalable/apps/io.github.rimsort.RimSort.svg "${APPDIR}/io.github.rimsort.RimSort.svg"
+# .DirIcon must be PNG per AppImage spec (some file managers don't render SVG)
+cp "${REPO_ROOT}/themes/default-icons/AppIcon_a.png" "${APPDIR}/.DirIcon"
 
-# Download appimagetool if not present (either as AppImage or pre-extracted)
-if [[ ! -f "$APPIMAGETOOL_EXTRACTED" && ! -f "$APPIMAGETOOL" ]]; then
-    echo "Downloading appimagetool (${APPIMAGE_ARCH})..."
+# Download appimagetool if not present
+if [[ ! -f "$APPIMAGETOOL" ]]; then
+    echo "Downloading appimagetool ${APPIMAGETOOL_VERSION} (${APPIMAGE_ARCH})..."
     curl -fSL -o "$APPIMAGETOOL" \
-        "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-${APPIMAGE_ARCH}.AppImage"
+        "https://github.com/AppImage/appimagetool/releases/download/${APPIMAGETOOL_VERSION}/appimagetool-${APPIMAGE_ARCH}.AppImage"
     chmod +x "$APPIMAGETOOL"
 fi
 
-# Determine how to run appimagetool:
-# 1. If pre-extracted (e.g. in environments where AppImage execution is problematic), use that
-# 2. Otherwise use APPIMAGE_EXTRACT_AND_RUN=1 to avoid FUSE dependency
-if [[ -f "$APPIMAGETOOL_EXTRACTED" ]]; then
-    APPIMAGETOOL_CMD="$APPIMAGETOOL_EXTRACTED"
-else
-    APPIMAGETOOL_CMD="$APPIMAGETOOL"
-    export APPIMAGE_EXTRACT_AND_RUN=1
+# Determine how to run appimagetool.
+# Try direct execution first (with FUSE bypass), fall back to extracting if
+# that fails (e.g. inside Docker containers where even extract-and-run can
+# fail on older appimagetool builds).
+APPIMAGETOOL_CMD="$APPIMAGETOOL"
+export APPIMAGE_EXTRACT_AND_RUN=1
+
+if ! "$APPIMAGETOOL_CMD" --version &>/dev/null; then
+    echo "Direct execution failed, extracting appimagetool..."
+    if ! (cd "$BUILD_DIR" && "$APPIMAGETOOL" --appimage-extract); then
+        echo "WARNING: --appimage-extract returned non-zero" >&2
+    fi
+    APPIMAGETOOL_CMD="${BUILD_DIR}/squashfs-root/AppRun"
+    if [[ ! -f "$APPIMAGETOOL_CMD" ]]; then
+        echo "ERROR: Failed to extract appimagetool" >&2
+        exit 1
+    fi
 fi
 
 # Build the AppImage using appimagetool directly.
 # We skip linuxdeploy because Nuitka already bundles all dependencies —
 # linuxdeploy's --executable flag would run patchelf and corrupt Nuitka's RPATHs.
 echo "Running appimagetool..."
-export VERSION="$VERSION"
+export VERSION
 ARCH="$APPIMAGE_ARCH" "$APPIMAGETOOL_CMD" "$APPDIR" "$OUTPUT"
 
 echo "=== AppImage built successfully ==="

--- a/packaging/appimage/build-appimage.sh
+++ b/packaging/appimage/build-appimage.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+APP_DIST="${1:?Usage: build-appimage.sh <app.dist path> <version>}"
+VERSION="${2:?Usage: build-appimage.sh <app.dist path> <version>}"
+
+APP_DIST="$(cd "$APP_DIST" && pwd)"
+BUILD_DIR="${REPO_ROOT}/build"
+APPDIR="${BUILD_DIR}/RimSort-x86_64.AppDir"
+LINUXDEPLOY="${BUILD_DIR}/linuxdeploy-x86_64.AppImage"
+OUTPUT="${BUILD_DIR}/RimSort-${VERSION}-x86_64.AppImage"
+
+DESKTOP_FILE="${REPO_ROOT}/data/io.github.rimsort.RimSort.desktop"
+ICON_FILE="${REPO_ROOT}/themes/default-icons/AppIcon_a.png"
+METAINFO_FILE="${REPO_ROOT}/data/io.github.rimsort.RimSort.metainfo.xml"
+
+echo "=== Building AppImage for RimSort ${VERSION} ==="
+echo "  app.dist: ${APP_DIST}"
+echo "  AppDir:   ${APPDIR}"
+
+# Validate inputs
+if [[ ! -d "$APP_DIST" ]]; then
+    echo "ERROR: app.dist directory not found: ${APP_DIST}" >&2
+    exit 1
+fi
+
+if [[ ! -f "${APP_DIST}/RimSort" ]]; then
+    echo "ERROR: RimSort executable not found in ${APP_DIST}" >&2
+    exit 1
+fi
+
+for f in "$DESKTOP_FILE" "$ICON_FILE" "$METAINFO_FILE"; do
+    if [[ ! -f "$f" ]]; then
+        echo "ERROR: Required file not found: $f" >&2
+        exit 1
+    fi
+done
+
+# Clean previous AppDir
+rm -rf "$APPDIR" "$OUTPUT"
+mkdir -p "$APPDIR"
+
+# Copy entire Nuitka output into usr/bin/ to preserve relative path layout
+echo "Copying Nuitka output to AppDir..."
+mkdir -p "${APPDIR}/usr/bin"
+cp -a "${APP_DIST}/." "${APPDIR}/usr/bin/"
+
+# Install desktop integration files
+echo "Installing desktop integration files..."
+mkdir -p "${APPDIR}/usr/share/applications"
+mkdir -p "${APPDIR}/usr/share/icons/hicolor/256x256/apps"
+mkdir -p "${APPDIR}/usr/share/metainfo"
+
+cp "$DESKTOP_FILE" "${APPDIR}/usr/share/applications/"
+cp "$ICON_FILE" "${APPDIR}/usr/share/icons/hicolor/256x256/apps/io.github.rimsort.RimSort.png"
+cp "$METAINFO_FILE" "${APPDIR}/usr/share/metainfo/"
+
+# Download linuxdeploy if not cached
+if [[ ! -f "$LINUXDEPLOY" ]]; then
+    echo "Downloading linuxdeploy..."
+    curl -fSL -o "$LINUXDEPLOY" \
+        "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage"
+    chmod +x "$LINUXDEPLOY"
+fi
+
+# Build the AppImage
+echo "Running linuxdeploy..."
+export LDAI_OUTPUT="$OUTPUT"
+export VERSION="$VERSION"
+
+"$LINUXDEPLOY" \
+    --appdir "$APPDIR" \
+    --executable "${APPDIR}/usr/bin/RimSort" \
+    --desktop-file "${APPDIR}/usr/share/applications/io.github.rimsort.RimSort.desktop" \
+    --icon-file "${APPDIR}/usr/share/icons/hicolor/256x256/apps/io.github.rimsort.RimSort.png" \
+    --output appimage
+
+echo "=== AppImage built successfully ==="
+ls -lh "$OUTPUT"


### PR DESCRIPTION
Create an AppImage distribution for linux that should be distribution agnostic.

I referenced this script by @usagirei (https://github.com/RimSort/RimSort/issues/35#issuecomment-3233693419) with some help from Claude to adapt it to the github CI.

I was able to successfully build it locally in a fedora 44 aarch64 so far.

Relates to #35