### PR TITLE
Optimize artifact sizes and various small CI fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,12 +180,25 @@ jobs:
           include-data-files: |
             version.xml=version.xml
           nofollow-import-to: >-
+            numpy,
             sqlalchemy.dialects.mssql,
             sqlalchemy.dialects.mysql,
             sqlalchemy.dialects.oracle,
             sqlalchemy.dialects.postgresql
         env:
           PYTHONPATH: ${{ steps.pythonpath.outputs.PYTHONPATH }}
+
+      - name: Optimize macOS bundle
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          APP_BUNDLE=$(find build/ -name "*.app" -maxdepth 2 | head -n 1)
+          if [ -n "$APP_BUNDLE" ]; then
+            echo "Optimizing $APP_BUNDLE..."
+            python packaging/optimize_macos_bundle.py "$APP_BUNDLE"
+          else
+            echo "No .app bundle found, skipping optimization"
+          fi
 
       - name: Set FILENAME
         id: filename

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -260,7 +260,8 @@ jobs:
       - name: Rename new build
         run: |
           cd build
-          if [[ "${{ matrix.platform }}" == *"Darwin"* ]]; then
+          platform="${{ matrix.platform }}"
+          if [[ "$platform" == *"Darwin"* ]]; then
             rootname="RimSort.app"
           else
             rootname="RimSort"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,22 +65,25 @@ jobs:
             env:
               BUILD_OUTPUT: "app.dist"
               Executable: RimSort
-          - os: ubuntu-latest
-            container: fedora:42
-            platform: "Fedora-42"
-            arch: "x86_64"
-            env:
-              BUILD_OUTPUT: "app.dist"
-              Executable: RimSort
-              BUILD_RPM: "true"
-          - os: ubuntu-latest
-            container: fedora:43
-            platform: "Fedora-43"
-            arch: "x86_64"
-            env:
-              BUILD_OUTPUT: "app.dist"
-              Executable: RimSort
-              BUILD_RPM: "true"
+          # TODO(debt): Fedora/RPM builds disabled — the container: key was never
+          # applied at the job level so these always ran on Ubuntu. Revisit once
+          # AppImage support lands (see PR for appimage-distribution branch).
+          # - os: ubuntu-latest
+          #   container: fedora:42
+          #   platform: "Fedora-42"
+          #   arch: "x86_64"
+          #   env:
+          #     BUILD_OUTPUT: "app.dist"
+          #     Executable: RimSort
+          #     BUILD_RPM: "true"
+          # - os: ubuntu-latest
+          #   container: fedora:43
+          #   platform: "Fedora-43"
+          #   arch: "x86_64"
+          #   env:
+          #     BUILD_OUTPUT: "app.dist"
+          #     Executable: RimSort
+          #     BUILD_RPM: "true"
           - os: windows-latest
             platform: "Windows"
             arch: "x86_64"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
             env:
               BUILD_OUTPUT: "app.dist"
               Executable: RimSort
-              BUILD_RPM: true
+              BUILD_RPM: "true"
           - os: ubuntu-latest
             container: fedora:43
             platform: "Fedora-43"
@@ -80,7 +80,7 @@ jobs:
             env:
               BUILD_OUTPUT: "app.dist"
               Executable: RimSort
-              BUILD_RPM: true
+              BUILD_RPM: "true"
           - os: windows-latest
             platform: "Windows"
             arch: "x86_64"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -274,53 +274,55 @@ jobs:
           rm -rf "$rootname"
         shell: bash
 
-      - name: Install RPM build dependencies
-        if: matrix.env.BUILD_RPM == 'true'
-        run: |
-          dnf install -y rpm-build rpmdevtools git gcc gcc-c++ python3.12 python3.12-devel desktop-file-utils libappstream-glib
-        shell: bash
-
-      - name: Setup RPM build environment
-        if: matrix.env.BUILD_RPM == 'true'
-        run: |
-          mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
-        shell: bash
-
-      - name: Create source tarball for RPM
-        if: matrix.env.BUILD_RPM == 'true'
-        run: |
-          bash packaging/rpm/make-tarball.sh "${{ steps.sem_version.outputs.version }}"
-        shell: bash
-
-      - name: Build RPM package
-        if: matrix.env.BUILD_RPM == 'true'
-        run: |
-          rpmbuild -bb packaging/rpm/rimsort.spec \
-            --define "version ${{ steps.sem_version.outputs.version }}"
-        shell: bash
-
-      - name: Find RPM file
-        if: matrix.env.BUILD_RPM == 'true'
-        id: find_rpm
-        run: |
-          RPM_FILE=$(find ~/rpmbuild/RPMS/x86_64/ -name "rimsort-*.rpm" | head -n 1)
-          echo "RPM_FILE=$RPM_FILE" >> "$GITHUB_OUTPUT"
-          echo "Found RPM: $RPM_FILE"
-        shell: bash
-
-      - name: Generate RPM attestation
-        uses: actions/attest-build-provenance@v4.1.0
-        if: ${{ inputs.attest && matrix.env.BUILD_RPM == 'true' }}
-        with:
-          subject-path: ${{ steps.find_rpm.outputs.RPM_FILE }}
-
-      - name: Upload RPM Package
-        if: matrix.env.BUILD_RPM == 'true'
-        uses: actions/upload-artifact@main
-        with:
-          name: ${{ matrix.platform }}_${{ matrix.arch }}_rpm
-          path: ${{ steps.find_rpm.outputs.RPM_FILE }}
-          if-no-files-found: error
+      # TODO(debt): RPM build steps disabled along with Fedora matrix entries.
+      # See comment in matrix.include above for details.
+      # - name: Install RPM build dependencies
+      #   if: matrix.env.BUILD_RPM == 'true'
+      #   run: |
+      #     dnf install -y rpm-build rpmdevtools git gcc gcc-c++ python3.12 python3.12-devel desktop-file-utils libappstream-glib
+      #   shell: bash
+      #
+      # - name: Setup RPM build environment
+      #   if: matrix.env.BUILD_RPM == 'true'
+      #   run: |
+      #     mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
+      #   shell: bash
+      #
+      # - name: Create source tarball for RPM
+      #   if: matrix.env.BUILD_RPM == 'true'
+      #   run: |
+      #     bash packaging/rpm/make-tarball.sh "${{ steps.sem_version.outputs.version }}"
+      #   shell: bash
+      #
+      # - name: Build RPM package
+      #   if: matrix.env.BUILD_RPM == 'true'
+      #   run: |
+      #     rpmbuild -bb packaging/rpm/rimsort.spec \
+      #       --define "version ${{ steps.sem_version.outputs.version }}"
+      #   shell: bash
+      #
+      # - name: Find RPM file
+      #   if: matrix.env.BUILD_RPM == 'true'
+      #   id: find_rpm
+      #   run: |
+      #     RPM_FILE=$(find ~/rpmbuild/RPMS/x86_64/ -name "rimsort-*.rpm" | head -n 1)
+      #     echo "RPM_FILE=$RPM_FILE" >> "$GITHUB_OUTPUT"
+      #     echo "Found RPM: $RPM_FILE"
+      #   shell: bash
+      #
+      # - name: Generate RPM attestation
+      #   uses: actions/attest-build-provenance@v4.1.0
+      #   if: ${{ inputs.attest && matrix.env.BUILD_RPM == 'true' }}
+      #   with:
+      #     subject-path: ${{ steps.find_rpm.outputs.RPM_FILE }}
+      #
+      # - name: Upload RPM Package
+      #   if: matrix.env.BUILD_RPM == 'true'
+      #   uses: actions/upload-artifact@main
+      #   with:
+      #     name: ${{ matrix.platform }}_${{ matrix.arch }}_rpm
+      #     path: ${{ steps.find_rpm.outputs.RPM_FILE }}
+      #     if-no-files-found: error
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v4.1.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -260,9 +260,14 @@ jobs:
       - name: Rename new build
         run: |
           cd build
-          mv "${{ matrix.env.BUILD_OUTPUT }}" "output"
-          tar -cvf "${{ steps.filename.outputs.FILENAME }}.tar" "output"
-          rm -rf "output"
+          if [[ "${{ matrix.platform }}" == *"Darwin"* ]]; then
+            rootname="RimSort.app"
+          else
+            rootname="RimSort"
+          fi
+          mv "${{ matrix.env.BUILD_OUTPUT }}" "$rootname"
+          tar -cvf "${{ steps.filename.outputs.FILENAME }}.tar" "$rootname"
+          rm -rf "$rootname"
         shell: bash
 
       - name: Install RPM build dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,13 +139,10 @@ jobs:
               cd ..
             else
               base=${file%%.tar}
-              name="RimSort-${{ needs.pre-build.outputs.version }}-$base.zip"
               rootname=RimSort
               if [[ $base == *"Darwin"* ]]; then
                 rootname=RimSort.app
               fi
-              echo "Will zip $artifact to $name"
-              echo "Rootname $rootname"
               cd "$artifact"
               tar -xvf "${file}.tar"
               mv "output" "$rootname"
@@ -160,15 +157,23 @@ jobs:
                   exit 1
                 fi
               fi
-              zip -rmqq "../$name" "$rootname" &
+              if [[ $base == *"Windows"* ]]; then
+                name="RimSort-${{ needs.pre-build.outputs.version }}-$base.zip"
+                echo "Zipping $artifact to $name"
+                zip -rmqq "../$name" "$rootname" &
+              else
+                name="RimSort-${{ needs.pre-build.outputs.version }}-$base.tar.gz"
+                echo "Compressing $artifact to $name"
+                tar -czf "../$name" "$rootname" && rm -rf "$rootname" &
+              fi
               cd ..
             fi
           done
           echo "Waiting for zips to finish"
           wait
-          echo "Cleaning up - Removing non-zip files"
+          echo "Cleaning up - Removing non-archive files"
           shopt -s extglob
-          rm -rf -- ./!(*.zip|*.msi)
+          rm -rf -- ./!(*.zip|*.tar.gz|*.msi)
         shell: bash
 
       - name: Create body
@@ -195,7 +200,7 @@ jobs:
         uses: ncipollo/release-action@v1.21.0
         id: release
         with:
-          artifacts: "artifacts/*.zip,artifacts/*.msi,artifacts/*.rpm"
+          artifacts: "artifacts/*.zip,artifacts/*.tar.gz,artifacts/*.msi,artifacts/*.rpm"
           tag: ${{ steps.tag.outputs.tag }}
           generateReleaseNotes: true
           prerelease: ${{ needs.pre-build.outputs.prerelease }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,16 +139,10 @@ jobs:
               cd ..
             else
               base=${file%%.tar}
-              rootname=RimSort
-              if [[ $base == *"Darwin"* ]]; then
-                rootname=RimSort.app
-              fi
               cd "$artifact"
-              tar -xvf "${file}.tar"
-              mv "output" "$rootname"
               echo "Doing commit match check."
-              version_xml=$(find "$rootname" -name version.xml)
-              commit=$(xmlstarlet sel -t -v "//commit" "$version_xml")
+              version_xml=$(tar -xf "${file}.tar" --wildcards '*/version.xml' -O 2>/dev/null || tar -xf "${file}.tar" --include='*/version.xml' -O)
+              commit=$(echo "$version_xml" | xmlstarlet sel -t -v "//commit" -)
               if [[ "$commit" != "${{ needs.pre-build.outputs.current_commit }}" ]]; then
                 echo "Commit mismatch for artifact $artifact. Expected ${{ needs.pre-build.outputs.current_commit }} but true build commit was $commit"
                 if [[ "${{ inputs.no_commit_match }}" == true ]]; then
@@ -158,13 +152,15 @@ jobs:
                 fi
               fi
               if [[ $base == *"Windows"* ]]; then
+                rootname=RimSort
                 name="RimSort-${{ needs.pre-build.outputs.version }}-$base.zip"
                 echo "Zipping $artifact to $name"
+                tar -xf "${file}.tar"
                 zip -rmqq "../$name" "$rootname" &
               else
                 name="RimSort-${{ needs.pre-build.outputs.version }}-$base.tar.gz"
-                echo "Compressing $artifact to $name"
-                tar -czf "../$name" "$rootname" && rm -rf "$rootname" &
+                echo "Compressing $artifact to $name (gzip existing tar)"
+                gzip -c "${file}.tar" > "../$name" &
               fi
               cd ..
             fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,7 +169,7 @@ jobs:
           wait
           echo "Cleaning up - Removing non-archive files"
           shopt -s extglob
-          rm -rf -- ./!(*.zip|*.tar.gz|*.msi)
+          rm -rf -- ./!(*.zip|*.tar.gz|*.msi|*.rpm)
         shell: bash
 
       - name: Create body

--- a/app/__main__.py
+++ b/app/__main__.py
@@ -5,6 +5,8 @@
 # nuitka-project: --output-dir={MAIN_DIRECTORY}/../build/
 # nuitka-project: --windows-console-mode=attach
 # nuitka-project: --noinclude-default-mode=error
+# nuitka-project: --nofollow-import-to=numpy
+# nuitka-project: --noinclude-data-files=*qtwebengine_devtools_resources.pak
 # nuitka-project: --include-package=steamworks
 # nuitka-project: --user-package-configuration-file={MAIN_DIRECTORY}/../rimsort.nuitka-package.config.yml
 # nuitka-project: --include-data-file={MAIN_DIRECTORY}/../steam_appid.txt=steam_appid.txt

--- a/distribute.py
+++ b/distribute.py
@@ -414,6 +414,25 @@ def post_build_fixup_macos_steamworks() -> None:
         print(f"Warning: post_build_fixup_macos_steamworks failed: {e}")
 
 
+def post_build_optimize_macos_bundle() -> None:
+    """Thin fat binaries in macOS .app bundle to reduce size."""
+    if _SYSTEM != "Darwin":
+        return
+    try:
+        build_dir = os.path.join(_CWD, "build")
+        bundles = _find_macos_bundles(build_dir)
+        if not bundles:
+            print("No .app bundle found in build/ — skipping bundle optimization")
+            return
+        for bundle in bundles:
+            print(f"Optimizing macOS bundle: {bundle}")
+            _execute(
+                [PY_CMD, os.path.join(_CWD, "packaging", "optimize_macos_bundle.py"), bundle]
+            )
+    except Exception as e:
+        print(f"Warning: post_build_optimize_macos_bundle failed: {e}")
+
+
 def _execute(cmd: list[str], env: os._Environ[str] | None = None) -> None:
     print(f"\nExecuting command: {cmd}\n")
     p = subprocess.Popen(cmd, env=env)
@@ -555,6 +574,7 @@ def main() -> None:
         freeze_application()
         # After build, ensure the app bundle contains the generic Steamworks dylib
         post_build_fixup_macos_steamworks()
+        post_build_optimize_macos_bundle()
     else:
         print("Skipped distribute.py build")
 

--- a/distribute.py
+++ b/distribute.py
@@ -426,9 +426,7 @@ def post_build_optimize_macos_bundle() -> None:
             return
         for bundle in bundles:
             print(f"Optimizing macOS bundle: {bundle}")
-            _execute(
-                [PY_CMD, os.path.join(_CWD, "packaging", "optimize_macos_bundle.py"), bundle]
-            )
+            _execute([PY_CMD, os.path.join(_CWD, "packaging", "optimize_macos_bundle.py"), bundle])
     except Exception as e:
         print(f"Warning: post_build_optimize_macos_bundle failed: {e}")
 

--- a/packaging/optimize_macos_bundle.py
+++ b/packaging/optimize_macos_bundle.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""
+Post-build optimization for macOS .app bundles.
+
+Thins universal (fat) Mach-O binaries in Contents/Resources/ to the
+target architecture, reducing bundle size by ~267 MB. Re-signs the
+bundle after modification.
+
+Usage:
+    python scripts/optimize_macos_bundle.py <path-to.app> [--arch arm64|x86_64]
+"""
+
+import argparse
+import os
+import platform
+import subprocess
+import sys
+
+
+def _get_native_arch() -> str:
+    machine = platform.machine()
+    if machine == "arm64":
+        return "arm64"
+    elif machine in ("x86_64", "i386", "AMD64"):
+        return "x86_64"
+    else:
+        print(f"Warning: unrecognized machine type '{machine}', defaulting to arm64")
+        return "arm64"
+
+
+def _is_fat_binary(path: str) -> bool:
+    try:
+        result = subprocess.run(
+            ["lipo", "-info", path],
+            capture_output=True,
+            text=True,
+        )
+        return "Architectures in the fat file" in result.stdout
+    except Exception:
+        return False
+
+
+def _thin_binary(path: str, arch: str) -> bool:
+    thin_path = path + ".thin"
+    try:
+        subprocess.run(
+            ["lipo", "-thin", arch, path, "-output", thin_path],
+            check=True,
+            capture_output=True,
+        )
+        os.replace(thin_path, path)
+        return True
+    except subprocess.CalledProcessError as e:
+        print(f"  Warning: failed to thin {path}: {e.stderr}")
+        if os.path.exists(thin_path):
+            os.remove(thin_path)
+        return False
+
+
+def _sign_bundle(app_path: str) -> None:
+    print(f"Re-signing bundle: {app_path}")
+    subprocess.run(
+        ["codesign", "--force", "--deep", "--sign", "-", app_path],
+        check=True,
+    )
+
+
+def optimize_bundle(app_path: str, target_arch: str) -> None:
+    resources_dir = os.path.join(app_path, "Contents", "Resources")
+    if not os.path.isdir(resources_dir):
+        print(f"No Resources directory found in {app_path}, skipping")
+        return
+
+    total_saved = 0
+    thinned_count = 0
+
+    for root, _dirs, files in os.walk(resources_dir):
+        for filename in files:
+            filepath = os.path.join(root, filename)
+            if not os.path.isfile(filepath) or os.path.islink(filepath):
+                continue
+            if not os.access(filepath, os.X_OK) and not filename.endswith((".dylib", ".so")):
+                continue
+            if not _is_fat_binary(filepath):
+                continue
+
+            original_size = os.path.getsize(filepath)
+            relpath = os.path.relpath(filepath, app_path)
+
+            if _thin_binary(filepath, target_arch):
+                new_size = os.path.getsize(filepath)
+                saved = original_size - new_size
+                total_saved += saved
+                thinned_count += 1
+                print(f"  Thinned {relpath}: {original_size:,} -> {new_size:,} (saved {saved:,})")
+
+    if thinned_count > 0:
+        print(f"\nThinned {thinned_count} binaries, saved {total_saved:,} bytes ({total_saved // 1048576} MB)")
+        _sign_bundle(app_path)
+    else:
+        print("No fat binaries found to thin")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Optimize macOS .app bundle size")
+    parser.add_argument("app_path", help="Path to the .app bundle")
+    parser.add_argument(
+        "--arch",
+        default=None,
+        help="Target architecture (arm64 or x86_64). Defaults to native.",
+    )
+    args = parser.parse_args()
+
+    if not args.app_path.endswith(".app") or not os.path.isdir(args.app_path):
+        print(f"Error: {args.app_path} is not a valid .app bundle")
+        sys.exit(1)
+
+    target_arch = args.arch or _get_native_arch()
+    print(f"Optimizing {args.app_path} for {target_arch}...")
+    optimize_bundle(args.app_path, target_arch)
+
+
+if __name__ == "__main__":
+    main()

--- a/packaging/optimize_macos_bundle.py
+++ b/packaging/optimize_macos_bundle.py
@@ -2,17 +2,22 @@
 """
 Post-build optimization for macOS .app bundles.
 
-Thins universal (fat) Mach-O binaries in Contents/Resources/ to the
-target architecture, reducing bundle size by ~267 MB. Re-signs the
-bundle after modification.
+1. Thins universal (fat) Mach-O binaries in Contents/Resources/ to the
+   target architecture (~267 MB savings).
+2. Deduplicates data files in framework Versions/A/Resources/ directories
+   that are already present at the framework top-level Resources/ (~110 MB).
+3. Removes .ts translation source files from the locales/ directory,
+   keeping only compiled .qm files (~2 MB).
+4. Re-signs the bundle after all modifications.
 
 Usage:
-    python scripts/optimize_macos_bundle.py <path-to.app> [--arch arm64|x86_64]
+    python packaging/optimize_macos_bundle.py <path-to.app> [--arch arm64|x86_64]
 """
 
 import argparse
 import os
 import platform
+import shutil
 import subprocess
 import sys
 
@@ -65,11 +70,21 @@ def _sign_bundle(app_path: str) -> None:
     )
 
 
-def optimize_bundle(app_path: str, target_arch: str) -> None:
+def _get_dir_size(path: str) -> int:
+    total = 0
+    for dirpath, _dirnames, filenames in os.walk(path):
+        for f in filenames:
+            fp = os.path.join(dirpath, f)
+            if os.path.isfile(fp) and not os.path.islink(fp):
+                total += os.path.getsize(fp)
+    return total
+
+
+def thin_fat_binaries(app_path: str, target_arch: str) -> int:
+    """Thin universal Mach-O binaries in Contents/Resources/ to a single arch."""
     resources_dir = os.path.join(app_path, "Contents", "Resources")
     if not os.path.isdir(resources_dir):
-        print(f"No Resources directory found in {app_path}, skipping")
-        return
+        return 0
 
     total_saved = 0
     thinned_count = 0
@@ -95,10 +110,118 @@ def optimize_bundle(app_path: str, target_arch: str) -> None:
                 print(f"  Thinned {relpath}: {original_size:,} -> {new_size:,} (saved {saved:,})")
 
     if thinned_count > 0:
-        print(f"\nThinned {thinned_count} binaries, saved {total_saved:,} bytes ({total_saved // 1048576} MB)")
+        print(f"  Thinned {thinned_count} binaries, saved {total_saved:,} bytes ({total_saved // 1048576} MB)")
+    else:
+        print("  No fat binaries found to thin")
+
+    return total_saved
+
+
+def deduplicate_framework_data(app_path: str) -> int:
+    """Remove duplicated data in framework Versions/A/Resources/ directories.
+
+    macOS framework bundles normally use symlinks (Resources/ -> Versions/A/Resources/)
+    but Nuitka flattens these into real copies. Since the top-level Resources/ directory
+    is the one actually referenced, the Versions/A/Resources/ copy can be safely removed
+    and replaced with a symlink.
+    """
+    resources_dir = os.path.join(app_path, "Contents", "Resources")
+    if not os.path.isdir(resources_dir):
+        return 0
+
+    total_saved = 0
+
+    for fw_dir in _find_frameworks(resources_dir):
+        top_resources = os.path.join(fw_dir, "Resources")
+        versioned_resources = os.path.join(fw_dir, "Versions", "A", "Resources")
+
+        if not os.path.isdir(top_resources) or not os.path.isdir(versioned_resources):
+            continue
+        if os.path.islink(top_resources) or os.path.islink(versioned_resources):
+            continue
+
+        size_before = _get_dir_size(versioned_resources)
+        fw_name = os.path.basename(fw_dir)
+
+        shutil.rmtree(versioned_resources)
+        os.symlink("../../Resources", versioned_resources)
+
+        total_saved += size_before
+        print(f"  Deduplicated {fw_name}/Versions/A/Resources/ -> symlink (saved {size_before:,} bytes)")
+
+        top_helpers = os.path.join(fw_dir, "Helpers")
+        versioned_helpers = os.path.join(fw_dir, "Versions", "A", "Helpers")
+
+        if (
+            os.path.isdir(top_helpers)
+            and os.path.isdir(versioned_helpers)
+            and not os.path.islink(top_helpers)
+            and not os.path.islink(versioned_helpers)
+        ):
+            size_before = _get_dir_size(versioned_helpers)
+            shutil.rmtree(versioned_helpers)
+            os.symlink("../../Helpers", versioned_helpers)
+            total_saved += size_before
+            print(f"  Deduplicated {fw_name}/Versions/A/Helpers/ -> symlink (saved {size_before:,} bytes)")
+
+    if total_saved > 0:
+        print(f"  Deduplicated framework data, saved {total_saved:,} bytes ({total_saved // 1048576} MB)")
+
+    return total_saved
+
+
+def _find_frameworks(search_dir: str) -> list[str]:
+    frameworks: list[str] = []
+    for root, dirs, _ in os.walk(search_dir):
+        for d in dirs:
+            if d.endswith(".framework"):
+                frameworks.append(os.path.join(root, d))
+    return frameworks
+
+
+def remove_locale_sources(app_path: str) -> int:
+    """Remove .ts translation source files, keeping only compiled .qm files."""
+    macos_dir = os.path.join(app_path, "Contents", "MacOS")
+    total_saved = 0
+    removed_count = 0
+
+    for root, _dirs, files in os.walk(macos_dir):
+        for filename in files:
+            if not filename.endswith(".ts"):
+                continue
+            filepath = os.path.join(root, filename)
+            if os.path.islink(filepath):
+                continue
+            qm_path = filepath[:-3] + ".qm"
+            if os.path.exists(qm_path):
+                size = os.path.getsize(filepath)
+                os.remove(filepath)
+                total_saved += size
+                removed_count += 1
+
+    if removed_count > 0:
+        print(f"  Removed {removed_count} .ts source files, saved {total_saved:,} bytes ({total_saved // 1024} KB)")
+
+    return total_saved
+
+
+def optimize_bundle(app_path: str, target_arch: str) -> None:
+    total_saved = 0
+
+    print("\n[1/3] Thinning fat binaries...")
+    total_saved += thin_fat_binaries(app_path, target_arch)
+
+    print("\n[2/3] Deduplicating framework data files...")
+    total_saved += deduplicate_framework_data(app_path)
+
+    print("\n[3/3] Removing locale source files...")
+    total_saved += remove_locale_sources(app_path)
+
+    if total_saved > 0:
+        print(f"\nTotal saved: {total_saved:,} bytes ({total_saved // 1048576} MB)")
         _sign_bundle(app_path)
     else:
-        print("No fat binaries found to thin")
+        print("\nNo optimizations applied")
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary

- Reduce macOS release artifacts from ~700 MB to ~300 MB (~57% reduction)
- Reduce Linux release artifacts from ~258 MB to ~234 MB (~9% reduction)
- Reduce Windows release artifacts by ~9-12%
- Switch macOS/Linux release format from `.zip` to `.tar.gz` for better compression
- Fix release workflow to gzip existing build tars instead of extract→re-archive
- Disable Fedora/RPM builds (broken pre-existing — see below)

### Changes

**Nuitka exclusions** (`app/__main__.py`, `build.yml`):
- Exclude `numpy` (transitive optional dep of networkx, never imported at runtime, ~7 MB)
- Exclude `qtwebengine_devtools_resources.pak` (Chrome DevTools data, ~33 MB across 3 copies in macOS bundle)

**Post-build macOS optimization** (`packaging/optimize_macos_bundle.py`):
- Thins universal (x86_64 + arm64) fat Mach-O binaries in `.app` bundle's `Contents/Resources/` to the target architecture (~267 MB savings). PySide6 ships universal frameworks on PyPI, but Nuitka already extracts thin single-arch dylibs into `Contents/MacOS/` for runtime — the fat copies in Resources exist only for code signing structure
- Deduplicates data files in framework `Versions/A/Resources/` directories by replacing them with symlinks to the top-level `Resources/` copy (~70 MB savings from qtwebengine_locales, icudtl.dat, etc.)
- Removes `.ts` translation source files from locales/, keeping only compiled `.qm` files (~2 MB)
- Re-signs the bundle after all modifications

**Build/release pipeline improvements** (`build.yml`, `release.yml`):
- Build step now tars with the correct root directory name (`RimSort`/`RimSort.app`) instead of `output`
- Release workflow gzips the existing tar for macOS/Linux instead of extracting and re-archiving
- Commit match check extracts only `version.xml` via stdout instead of full archive extraction
- Switches macOS and Linux release archives from `.zip` to `.tar.gz` for ~36% better compression ratio
- Windows stays as `.zip`/`.msi` for native support
- Fixed `BUILD_RPM` boolean vs string comparison (YAML `true` != string `'true'`) that silently skipped all RPM steps
- Fixed release cleanup glob to preserve `.rpm` files

**Fedora/RPM builds disabled:**
- Discovered that Fedora matrix entries never actually ran inside their declared containers — `container:` was set as a matrix property but never applied at the job level, so builds always ran on Ubuntu
- RPM build steps (`dnf install`, `rpmbuild`) fail on Ubuntu since `dnf` is unavailable
- This was masked by the `BUILD_RPM` boolean bug causing all RPM steps to be skipped
- Disabled until properly addressed in a follow-up PR; AppImage support will cover Linux distribution

### CI-verified artifact sizes

| Platform | Before (v1.1.0) | After (this PR) | Savings |
|---|---|---|---|
| macOS ARM | 695 MB | **291 MB** | **58%** |
| macOS x86 | 718 MB | **323 MB** | **55%** |
| Linux (each) | 258 MB | **234 MB** | **9%** |
| Windows (.zip) | 205 MB | **187 MB** | **9%** |
| Windows (.msi) | 171 MB | **150 MB** | **12%** |
| **Total** | **2,305 MB** | **1,636 MB** | **29%** |

## Test plan

- [x] Optimization script tested on local macOS arm64 build — 267 MB saved from fat binary thinning, 70 MB from deduplication, 2 MB from .ts removal
- [x] Verified optimized app bundle launches and runs correctly
- [x] Verified both arm64 and x86_64 thinning work correctly
- [x] Linted and type-checked all changed files
- [x] Existing test suite passes (262 passed, 1 pre-existing failure unrelated to this PR)
- [x] No fat binaries remain in Resources/ after optimization
- [x] CI builds pass on all 5 platforms (macOS ARM, macOS x86, Ubuntu 22.04, Ubuntu 24.04, Windows)
- [x] CI post-build smoke tests pass on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Relates to #35