### PR TITLE
Remove Nuitka Qt translation exclusion

### DIFF
--- a/app/__main__.py
+++ b/app/__main__.py
@@ -15,7 +15,6 @@
 
 # The PySide6 plugin covers qt-plugins
 # nuitka-project: --enable-plugin=pyside6
-# nuitka-project: --noinclude-qt-translations
 
 # OS-Specific options
 # nuitka-project-if: {OS} == "Darwin":


### PR DESCRIPTION
Remove the `--noinclude-qt-translations` Nuitka flag so Qt translation files are bundled with the application.

This fixes missing `qtbase_*.qm` warnings during runtime and allows native Qt dialogs/widgets to properly localize alongside RimSort’s existing multi-language support.

RimSort already ships and maintains compiled `.qm` translation files, so excluding Qt translations caused incomplete localization behavior in packaged builds.