### PR TITLE
[TO BE REPLACED] Better logging (improved log rotation, optional JSON log file, replace bare print() calls with logger.info)

### DIFF
--- a/app/__main__.py
+++ b/app/__main__.py
@@ -66,7 +66,9 @@ def handle_exception(
             title="RimSort crashed",
             text="The RimSort application crashed! Sorry for the inconvenience!",
             information="Please contact us on the Discord/Github to report the issue.",
-            details="".join(traceback.format_exception(exc_type, exc_value, exc_traceback)),
+            details="".join(
+                traceback.format_exception(exc_type, exc_value, exc_traceback)
+            ),
         )
 
     sys.exit()
@@ -104,8 +106,12 @@ def main_thread() -> None:
             logger.warning("Exiting application")
         else:
             stacktrace = traceback.format_exc()
-            stacktrace = re.sub(r"([?&])key=[^&\s\"']+", r"\1key=[REDACTED]", stacktrace)
-        logger.error("The main application instantiation has failed with an uncaught exception:")
+            stacktrace = re.sub(
+                r"([?&])key=[^&\s\"']+", r"\1key=[REDACTED]", stacktrace
+            )
+        logger.error(
+            "The main application instantiation has failed with an uncaught exception:"
+        )
         logger.error(stacktrace)
         show_fatal_error(details=stacktrace)
     finally:
@@ -116,7 +122,9 @@ def main_thread() -> None:
             except Exception as e:
                 stacktrace = traceback.format_exc()
                 logger.warning(f"Exception: {e}")
-                logger.warning(f"watchdog received the following exception while exiting: {stacktrace}")
+                logger.warning(
+                    f"watchdog received the following exception while exiting: {stacktrace}"
+                )
         logger.info("Exiting application!")
         sys.exit()
 
@@ -156,6 +164,14 @@ if __name__ == "__main__":
         sys.exit(0)
 
     # GUI mode continues below with normal initialization
+
+    # Compiled non-Linux builds must call freeze_support() and set_start_method()
+    # BEFORE anything that touches multiprocessing (loguru's enqueue=True creates
+    # an internal multiprocessing queue, locking in the start method context).
+    if "__compiled__" in globals() and SYSTEM != "Linux":
+        freeze_support()
+        set_start_method("spawn")
+
     # Determine debug mode from --debug flag or DEBUG file
     debug_file_path = AppInfo().app_storage_folder / "DEBUG"
     if not DEBUG_MODE:
@@ -172,16 +188,13 @@ if __name__ == "__main__":
         logger.debug("Running using Python interpreter")
     else:
         # Configure QtWebEngine locales path
-        os.environ["QTWEBENGINE_LOCALES_PATH"] = str(AppInfo().application_folder / "qtwebengine_locales")
-
-        # MacOS and Windows do not support fork, and can only use spawn
+        os.environ["QTWEBENGINE_LOCALES_PATH"] = str(
+            AppInfo().application_folder / "qtwebengine_locales"
+        )
         if SYSTEM != "Linux":
             logger.warning(
                 "Non-Linux platform detected: using multiprocessing.freeze_support() & setting 'spawn' as MP method"
             )
-            freeze_support()
-            set_start_method("spawn")
-
         logger.debug("Running using Nuitka bundle")
 
     logger.info(f"Initializing RimSort application: {AppInfo().app_version}")

--- a/app/__main__.py
+++ b/app/__main__.py
@@ -28,6 +28,7 @@
 
 import os
 import platform
+import re
 import sys
 import traceback
 from multiprocessing import freeze_support, set_start_method
@@ -103,19 +104,11 @@ def main_thread() -> None:
         stacktrace: str = ""
         if isinstance(e, SystemExit):
             logger.warning("Exiting application")
-        elif (
-            e.__class__.__name__ == "HTTPError" or e.__class__.__name__ == "SSLError"
-        ):  # requests.exceptions.HTTPError OR urllib3.exceptions.SSLError
-            stacktrace = traceback.format_exc()
-            # If an HTTPError from steam/urllib3 module(s) somehow is uncaught,
-            # try to remove the Steam API key from the stacktrace
-            pattern = "&key="
-            stacktrace = stacktrace[
-                : len(stacktrace)
-                - (len(stacktrace) - (stacktrace.find(pattern) + len(pattern)))
-            ]
         else:
             stacktrace = traceback.format_exc()
+            stacktrace = re.sub(
+                r"([?&])key=[^&\s\"']+", r"\1key=[REDACTED]", stacktrace
+            )
         logger.error(
             "The main application instantiation has failed with an uncaught exception:"
         )
@@ -163,10 +156,10 @@ if __name__ == "__main__":
             cli()
         except Exception as e:
             # Handle CLI errors without Qt dialogs
-            import traceback
-
+            tb = traceback.format_exc()
+            tb = re.sub(r"([?&])key=[^&\s\"']+", r"\1key=[REDACTED]", tb)
             print(f"Error: {e}", file=sys.stderr)
-            traceback.print_exc(file=sys.stderr)
+            print(tb, file=sys.stderr)
             sys.exit(1)
         sys.exit(0)
 

--- a/app/__main__.py
+++ b/app/__main__.py
@@ -66,9 +66,7 @@ def handle_exception(
             title="RimSort crashed",
             text="The RimSort application crashed! Sorry for the inconvenience!",
             information="Please contact us on the Discord/Github to report the issue.",
-            details="".join(
-                traceback.format_exception(exc_type, exc_value, exc_traceback)
-            ),
+            details="".join(traceback.format_exception(exc_type, exc_value, exc_traceback)),
         )
 
     sys.exit()
@@ -106,12 +104,8 @@ def main_thread() -> None:
             logger.warning("Exiting application")
         else:
             stacktrace = traceback.format_exc()
-            stacktrace = re.sub(
-                r"([?&])key=[^&\s\"']+", r"\1key=[REDACTED]", stacktrace
-            )
-        logger.error(
-            "The main application instantiation has failed with an uncaught exception:"
-        )
+            stacktrace = re.sub(r"([?&])key=[^&\s\"']+", r"\1key=[REDACTED]", stacktrace)
+        logger.error("The main application instantiation has failed with an uncaught exception:")
         logger.error(stacktrace)
         show_fatal_error(details=stacktrace)
     finally:
@@ -122,9 +116,7 @@ def main_thread() -> None:
             except Exception as e:
                 stacktrace = traceback.format_exc()
                 logger.warning(f"Exception: {e}")
-                logger.warning(
-                    f"watchdog received the following exception while exiting: {stacktrace}"
-                )
+                logger.warning(f"watchdog received the following exception while exiting: {stacktrace}")
         logger.info("Exiting application!")
         sys.exit()
 
@@ -188,9 +180,7 @@ if __name__ == "__main__":
         logger.debug("Running using Python interpreter")
     else:
         # Configure QtWebEngine locales path
-        os.environ["QTWEBENGINE_LOCALES_PATH"] = str(
-            AppInfo().application_folder / "qtwebengine_locales"
-        )
+        os.environ["QTWEBENGINE_LOCALES_PATH"] = str(AppInfo().application_folder / "qtwebengine_locales")
         if SYSTEM != "Linux":
             logger.warning(
                 "Non-Linux platform detected: using multiprocessing.freeze_support() & setting 'spawn' as MP method"

--- a/app/__main__.py
+++ b/app/__main__.py
@@ -30,34 +30,17 @@ import os
 import platform
 import sys
 import traceback
-from logging import WARNING, getLogger
 from multiprocessing import freeze_support, set_start_method
 from types import TracebackType
 from typing import Type
 
-import loguru
 from loguru import logger
 
 from app.controllers.app_controller import AppController
 from app.utils.app_info import AppInfo
-from app.utils.obfuscate_message import obfuscate_message
 from app.views.dialogue import show_fatal_error
 
 SYSTEM = platform.system()
-# Watchdog conditionals
-if SYSTEM == "Darwin":
-    # Comment to see logging for watchdog handler on Darwin
-    getLogger("watchdog.observers.fsevents").setLevel(WARNING)
-elif SYSTEM == "Linux":
-    # Comment to see logging for watchdog handler on Linux
-    getLogger("watchdog.observers.inotify_buffer").setLevel(WARNING)
-elif SYSTEM == "Windows":
-    pass
-
-    # Comment to see logging for watchdog handler on Windows
-    # This is a stub if it's ever even needed...
-    # I still can't figure out why it won't log at all on Windows...?
-    # getLogger("").setLevel(WARNING)
 
 
 def handle_exception(
@@ -75,9 +58,8 @@ def handle_exception(
     if issubclass(exc_type, KeyboardInterrupt):
         sys.__excepthook__(exc_type, exc_value, exc_traceback)
     else:  # Anything else, we want to log an error and notify the user
-        logger.error(
-            "The main application loop has failed with an uncaught exception",
-            exc_info=(exc_type, exc_value, exc_traceback),
+        logger.opt(exception=(exc_type, exc_value, exc_traceback)).error(
+            "The main application loop has failed with an uncaught exception"
         )
         show_fatal_error(
             title="RimSort crashed",
@@ -103,6 +85,11 @@ if "--disable-updater" in sys.argv:
     while "--disable-updater" in sys.argv:
         sys.argv.remove("--disable-updater")
     # Note: logger not yet configured, so can't log here
+
+# Process --debug flag if present (before any other initialization)
+DEBUG_MODE = "--debug" in sys.argv
+while "--debug" in sys.argv:
+    sys.argv.remove("--debug")
 
 
 def main_thread() -> None:
@@ -162,6 +149,15 @@ if __name__ == "__main__":
     if len(sys.argv) > 1 and sys.argv[1] in ["build-db", "--help", "--version"]:
         # CLI mode - import and run without any GUI setup
         try:
+            from app.utils.log_config import setup_logging
+
+            setup_logging(
+                log_dir=AppInfo().user_log_folder,
+                debug=DEBUG_MODE,
+                file_logging=DEBUG_MODE,
+                json_logging=False,
+            )
+
             from app.cli.main import cli
 
             cli()
@@ -175,44 +171,16 @@ if __name__ == "__main__":
         sys.exit(0)
 
     # GUI mode continues below with normal initialization
-    # Set the log level from the presence (or absence) of a "DEBUG" file in the app_data_folder
+    # Determine debug mode from --debug flag or DEBUG file
     debug_file_path = AppInfo().app_storage_folder / "DEBUG"
-    if debug_file_path.exists() and debug_file_path.is_file():
-        DEBUG_MODE = True
-    else:
-        DEBUG_MODE = False
+    if not DEBUG_MODE:
+        DEBUG_MODE = debug_file_path.exists() and debug_file_path.is_file()
 
-    # We have log_file (foo.log) and old_log_file (foo.old.log). If old_log_file exists,
-    # remove it. If log_file exists, rename it to old_log_file. When we pass log_file to
-    # the logger as an argument, it will automatically be created.
-    log_file = AppInfo().user_log_folder / (AppInfo().app_name + ".log")
-    old_log_file = AppInfo().user_log_folder / (AppInfo().app_name + ".old.log")
-    if old_log_file.exists() and old_log_file.is_file():
-        old_log_file.unlink()
-    if log_file.exists() and log_file.is_file():
-        log_file.rename(old_log_file)
+    from app.utils.log_config import setup_logging
 
-    # Define the log format string
-
-    def formatter(record: "loguru.Record") -> str:
-        """Custom formatter for loguru logger"""
-        format_string = "[{level}][{time:YYYY-MM-DD HH:mm:ss}][{process.id}][{thread.name}][{module}][{function}][{line}] : "
-
-        record["extra"]["obfuscated_message"] = obfuscate_message(record["message"])
-        return format_string + "{extra[obfuscated_message]}\n"
-
-    # Remove the default stderr logger
-    logger.remove()
-
-    # Create the file logger
-    logger.add(log_file, level="DEBUG" if DEBUG_MODE else "INFO", format=formatter)
-
-    # Add a "WARNING" or higher stderr logger
-    logger.add(
-        sys.stderr,
-        level="WARNING",
-        format=formatter,
-        colorize=False,
+    setup_logging(
+        log_dir=AppInfo().user_log_folder,
+        debug=DEBUG_MODE,
     )
 
     if "__compiled__" not in globals():

--- a/app/__main__.py
+++ b/app/__main__.py
@@ -66,7 +66,9 @@ def handle_exception(
             title="RimSort crashed",
             text="The RimSort application crashed! Sorry for the inconvenience!",
             information="Please contact us on the Discord/Github to report the issue.",
-            details="".join(traceback.format_exception(exc_type, exc_value, exc_traceback)),
+            details="".join(
+                traceback.format_exception(exc_type, exc_value, exc_traceback)
+            ),
         )
 
     sys.exit()
@@ -104,8 +106,12 @@ def main_thread() -> None:
             logger.warning("Exiting application")
         else:
             stacktrace = traceback.format_exc()
-            stacktrace = re.sub(r"([?&])key=[^&\s\"']+", r"\1key=[REDACTED]", stacktrace)
-        logger.error("The main application instantiation has failed with an uncaught exception:")
+            stacktrace = re.sub(
+                r"([?&])key=[^&\s\"']+", r"\1key=[REDACTED]", stacktrace
+            )
+        logger.error(
+            "The main application instantiation has failed with an uncaught exception:"
+        )
         logger.error(stacktrace)
         show_fatal_error(details=stacktrace)
     finally:
@@ -116,7 +122,9 @@ def main_thread() -> None:
             except Exception as e:
                 stacktrace = traceback.format_exc()
                 logger.warning(f"Exception: {e}")
-                logger.warning(f"watchdog received the following exception while exiting: {stacktrace}")
+                logger.warning(
+                    f"watchdog received the following exception while exiting: {stacktrace}"
+                )
         logger.info("Exiting application!")
         sys.exit()
 
@@ -180,7 +188,9 @@ if __name__ == "__main__":
         logger.debug("Running using Python interpreter")
     else:
         # Configure QtWebEngine locales path
-        os.environ["QTWEBENGINE_LOCALES_PATH"] = str(AppInfo().application_folder / "qtwebengine_locales")
+        os.environ["QTWEBENGINE_LOCALES_PATH"] = str(
+            AppInfo().application_folder / "qtwebengine_locales"
+        )
         if SYSTEM != "Linux":
             logger.warning(
                 "Non-Linux platform detected: using multiprocessing.freeze_support() & setting 'spawn' as MP method"

--- a/app/__main__.py
+++ b/app/__main__.py
@@ -66,9 +66,7 @@ def handle_exception(
             title="RimSort crashed",
             text="The RimSort application crashed! Sorry for the inconvenience!",
             information="Please contact us on the Discord/Github to report the issue.",
-            details="".join(
-                traceback.format_exception(exc_type, exc_value, exc_traceback)
-            ),
+            details="".join(traceback.format_exception(exc_type, exc_value, exc_traceback)),
         )
 
     sys.exit()
@@ -106,12 +104,8 @@ def main_thread() -> None:
             logger.warning("Exiting application")
         else:
             stacktrace = traceback.format_exc()
-            stacktrace = re.sub(
-                r"([?&])key=[^&\s\"']+", r"\1key=[REDACTED]", stacktrace
-            )
-        logger.error(
-            "The main application instantiation has failed with an uncaught exception:"
-        )
+            stacktrace = re.sub(r"([?&])key=[^&\s\"']+", r"\1key=[REDACTED]", stacktrace)
+        logger.error("The main application instantiation has failed with an uncaught exception:")
         logger.error(stacktrace)
         show_fatal_error(details=stacktrace)
     finally:
@@ -122,9 +116,7 @@ def main_thread() -> None:
             except Exception as e:
                 stacktrace = traceback.format_exc()
                 logger.warning(f"Exception: {e}")
-                logger.warning(
-                    f"watchdog received the following exception while exiting: {stacktrace}"
-                )
+                logger.warning(f"watchdog received the following exception while exiting: {stacktrace}")
         logger.info("Exiting application!")
         sys.exit()
 
@@ -180,9 +172,7 @@ if __name__ == "__main__":
         logger.debug("Running using Python interpreter")
     else:
         # Configure QtWebEngine locales path
-        os.environ["QTWEBENGINE_LOCALES_PATH"] = str(
-            AppInfo().application_folder / "qtwebengine_locales"
-        )
+        os.environ["QTWEBENGINE_LOCALES_PATH"] = str(AppInfo().application_folder / "qtwebengine_locales")
 
         # MacOS and Windows do not support fork, and can only use spawn
         if SYSTEM != "Linux":

--- a/app/cli/build_db.py
+++ b/app/cli/build_db.py
@@ -201,8 +201,11 @@ def build_db(
             err=True,
         )
         if not quiet:
+            import re
             import traceback
 
+            tb = traceback.format_exc()
+            tb = re.sub(r"([?&])key=[^&\s\"']+", r"\1key=[REDACTED]", tb)
             click.echo("\nFull traceback:", err=True)
-            click.echo(traceback.format_exc(), err=True)
+            click.echo(tb, err=True)
         sys.exit(1)

--- a/app/controllers/app_controller.py
+++ b/app/controllers/app_controller.py
@@ -1,6 +1,7 @@
 import os
 import sys
 
+from loguru import logger
 from PySide6.QtCore import QCoreApplication, QLibraryInfo, QObject, QTranslator
 from PySide6.QtWidgets import QApplication
 
@@ -87,7 +88,7 @@ class AppController(QObject):
         if app_translator.load(str(path)):
             QCoreApplication.installTranslator(app_translator)
         else:
-            print(f"Translation file {path} not found.")
+            logger.warning(f"Translation file {path} not found.")
 
         qt_translations_path = QLibraryInfo.path(
             QLibraryInfo.LibraryPath.TranslationsPath
@@ -97,7 +98,7 @@ class AppController(QObject):
         if qt_translator.load(qt_file_path):
             QCoreApplication.installTranslator(qt_translator)
         else:
-            print(f"Qt translation file {qt_file_path} not found.")
+            logger.warning(f"Qt translation file {qt_file_path} not found.")
 
     def initialize_steamcmd_interface(self) -> None:
         """Initializes the SteamcmdInterface."""

--- a/app/controllers/troubleshooting_controller.py
+++ b/app/controllers/troubleshooting_controller.py
@@ -230,7 +230,7 @@ class TroubleshootingController:
         for item in config_dir.iterdir():
             if item.is_file() and item.name not in protected_files:
                 try:
-                    print(f"Deleting {item}...")
+                    logger.info(f"Deleting {item}...")
                     item.unlink()
                     deleted_any = True
                     logger.info(f"Deleted {item} successfully.")

--- a/app/utils/csv_export_utils.py
+++ b/app/utils/csv_export_utils.py
@@ -269,7 +269,7 @@ def _handle_csv_export_error(
         title: The dialog title.
         details: Optional additional details (technical info) to show in the dialog.
     """
-    logger.error(f"CSV Export error: {message}", exc_info=True)
+    logger.exception(f"CSV Export error: {message}")
     show_warning(
         title=panel.tr(title),
         text=message,

--- a/app/utils/log_config.py
+++ b/app/utils/log_config.py
@@ -2,8 +2,43 @@
 
 from __future__ import annotations
 
+import atexit
+import json
+import platform
 import sys
+import traceback
 from pathlib import Path
+from typing import IO, TYPE_CHECKING
+from collections.abc import Callable
+
+from loguru import logger
+
+from app.utils.obfuscate_message import obfuscate_message
+
+if TYPE_CHECKING:
+    import loguru as loguru_module
+
+
+def _formatter(record: "loguru_module.Record") -> str:
+    """Custom formatter for loguru logger with obfuscation and exception support."""
+    format_string = (
+        "[{level}][{time:YYYY-MM-DD HH:mm:ss}][{process.id}]"
+        "[{thread.name}][{module}][{function}][{line}] : "
+    )
+    record["extra"]["obfuscated_message"] = obfuscate_message(record["message"])
+    return format_string + "{extra[obfuscated_message]}\n{exception}"
+
+
+def _suppress_noisy_loggers() -> None:
+    """Suppress verbose third-party loggers that use stdlib logging."""
+    from logging import WARNING, getLogger
+
+    system = platform.system()
+    if system == "Darwin":
+        getLogger("watchdog.observers.fsevents").setLevel(WARNING)
+    elif system == "Linux":
+        getLogger("watchdog.observers.inotify_buffer").setLevel(WARNING)
+    getLogger("urllib3").setLevel(WARNING)
 
 
 def _rotate_session_logs(
@@ -71,3 +106,52 @@ def _rotate_session_logs(
                 old_legacy.unlink()
             except OSError:
                 pass
+
+
+def setup_logging(
+    log_dir: Path,
+    debug: bool = False,
+    session_history: int = 5,
+    json_logging: bool = True,
+    file_logging: bool = True,
+) -> None:
+    """
+    Configure loguru sinks for the application.
+
+    :param log_dir: Directory for log files
+    :param debug: Enable DEBUG level logging (otherwise INFO)
+    :param session_history: Number of past session logs to keep
+    :param json_logging: Enable JSON log file alongside human-readable
+    :param file_logging: Enable file sinks (False for CLI-only mode)
+    """
+    logger.remove()
+
+    file_level = "DEBUG" if debug else "INFO"
+
+    if file_logging:
+        log_dir.mkdir(parents=True, exist_ok=True)
+
+        # Rotate session logs
+        _rotate_session_logs(log_dir, "RimSort.log", session_history)
+        if json_logging:
+            _rotate_session_logs(log_dir, "RimSort.json.log", session_history)
+
+        # Human-readable file sink
+        log_file = log_dir / "RimSort.log"
+        logger.add(
+            log_file,
+            level=file_level,
+            format=_formatter,
+            enqueue=True,
+        )
+
+    # stderr sink
+    stderr_level = "DEBUG" if (debug and not file_logging) else "WARNING"
+    logger.add(
+        sys.stderr,
+        level=stderr_level,
+        format=_formatter,
+        colorize=False,
+    )
+
+    _suppress_noisy_loggers()

--- a/app/utils/log_config.py
+++ b/app/utils/log_config.py
@@ -1,0 +1,73 @@
+"""Centralized loguru logging configuration for RimSort."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def _rotate_session_logs(
+    log_dir: Path, base_name: str, session_history: int
+) -> None:
+    """
+    Rotate session-based log files using numbered suffixes.
+
+    Cascades existing logs upward (RimSort.log -> RimSort.1.log -> RimSort.2.log)
+    and deletes logs beyond the history limit. Migrates legacy .old.log files.
+
+    :param log_dir: Directory containing log files
+    :param base_name: Base log filename (e.g., "RimSort.log")
+    :param session_history: Maximum number of past session logs to keep
+    """
+    stem = Path(base_name).stem
+    suffix = "".join(Path(base_name).suffixes)
+
+    # Migrate legacy .old.log format if present
+    old_legacy = log_dir / f"{stem}.old{suffix}"
+
+    # Cascade: move from highest to lowest, deleting if target would exceed history limit
+    # We need to scan higher than session_history to catch any that may exist
+    for i in range(session_history + 10, 0, -1):
+        source = log_dir / f"{stem}.{i}{suffix}"
+        if source.exists():
+            target_index = i + 1
+            if target_index >= session_history:
+                # This file would be moved to or beyond the history limit, delete it
+                try:
+                    source.unlink()
+                except OSError:
+                    print(f"Warning: failed to delete old log {source}", file=sys.stderr)
+            else:
+                # Move it up one position
+                target = log_dir / f"{stem}.{target_index}{suffix}"
+                try:
+                    if target.exists():
+                        target.unlink()
+                    source.rename(target)
+                except OSError:
+                    print(f"Warning: failed to rotate log {source} -> {target}", file=sys.stderr)
+
+    # Move current log to .1
+    current = log_dir / base_name
+    first_rotated = log_dir / f"{stem}.1{suffix}"
+    if current.exists():
+        try:
+            current.rename(first_rotated)
+        except OSError:
+            print(f"Warning: failed to rotate log {current} -> {first_rotated}", file=sys.stderr)
+
+    # Now handle legacy .old.log — place it after the newly rotated current
+    if old_legacy.exists():
+        for i in range(2, session_history + 1):
+            slot = log_dir / f"{stem}.{i}{suffix}"
+            if not slot.exists():
+                try:
+                    old_legacy.rename(slot)
+                except OSError:
+                    print(f"Warning: failed to migrate legacy log {old_legacy}", file=sys.stderr)
+                break
+        else:
+            try:
+                old_legacy.unlink()
+            except OSError:
+                pass

--- a/app/utils/log_config.py
+++ b/app/utils/log_config.py
@@ -22,8 +22,7 @@ if TYPE_CHECKING:
 def _formatter(record: "loguru_module.Record") -> str:
     """Custom formatter for loguru logger with obfuscation and exception support."""
     format_string = (
-        "[{level}][{time:YYYY-MM-DD HH:mm:ss}][{process.id}]"
-        "[{thread.name}][{module}][{function}][{line}] : "
+        "[{level}][{time:YYYY-MM-DD HH:mm:ss}][{process.id}][{thread.name}][{module}][{function}][{line}] : "
     )
     record["extra"]["obfuscated_message"] = obfuscate_message(record["message"])
     return format_string + "{extra[obfuscated_message]}\n{exception}"
@@ -69,9 +68,7 @@ def _rotate_session_logs(log_dir: Path, base_name: str, session_history: int) ->
                 try:
                     source.unlink()
                 except OSError:
-                    print(
-                        f"Warning: failed to delete old log {source}", file=sys.stderr
-                    )
+                    print(f"Warning: failed to delete old log {source}", file=sys.stderr)
             else:
                 # Move it up one position
                 target = log_dir / f"{stem}.{target_index}{suffix}"

--- a/app/utils/log_config.py
+++ b/app/utils/log_config.py
@@ -21,9 +21,7 @@ if TYPE_CHECKING:
 
 def _formatter(record: "loguru_module.Record") -> str:
     """Custom formatter for loguru logger with obfuscation and exception support."""
-    format_string = (
-        "[{level}][{time:YYYY-MM-DD HH:mm:ss}][{process.id}][{thread.name}][{module}][{function}][{line}] : "
-    )
+    format_string = "[{level}][{time:YYYY-MM-DD HH:mm:ss}][{process.id}][{thread.name}][{module}][{function}][{line}] : "
     record["extra"]["obfuscated_message"] = obfuscate_message(record["message"])
     return format_string + "{extra[obfuscated_message]}\n{exception}"
 
@@ -68,7 +66,9 @@ def _rotate_session_logs(log_dir: Path, base_name: str, session_history: int) ->
                 try:
                     source.unlink()
                 except OSError:
-                    print(f"Warning: failed to delete old log {source}", file=sys.stderr)
+                    print(
+                        f"Warning: failed to delete old log {source}", file=sys.stderr
+                    )
             else:
                 # Move it up one position
                 target = log_dir / f"{stem}.{target_index}{suffix}"

--- a/app/utils/log_config.py
+++ b/app/utils/log_config.py
@@ -108,6 +108,38 @@ def _rotate_session_logs(
                 pass
 
 
+def _make_json_sink(json_file: IO[str]) -> Callable[["loguru_module.Message"], None]:
+    """Create a JSON sink closure that obfuscates before serializing."""
+
+    def _json_sink(message: "loguru_module.Message") -> None:
+        record = message.record
+        serialized: dict[str, object] = {
+            "time": record["time"].isoformat(),
+            "level": record["level"].name,
+            "module": record["module"],
+            "name": record["name"],
+            "function": record["function"],
+            "line": record["line"],
+            "process": record["process"].id,
+            "thread": record["thread"].name,
+            "message": obfuscate_message(record["message"]),
+        }
+        if record["exception"] is not None:
+            serialized["exception"] = obfuscate_message(
+                "".join(
+                    traceback.format_exception(
+                        record["exception"].type,
+                        record["exception"].value,
+                        record["exception"].traceback,
+                    )
+                )
+            )
+        json_file.write(json.dumps(serialized) + "\n")
+        json_file.flush()
+
+    return _json_sink
+
+
 def setup_logging(
     log_dir: Path,
     debug: bool = False,
@@ -144,6 +176,17 @@ def setup_logging(
             format=_formatter,
             enqueue=True,
         )
+
+        # JSON file sink
+        if json_logging:
+            json_log_path = log_dir / "RimSort.json.log"
+            json_file = open(json_log_path, "w", encoding="utf-8")  # noqa: SIM115
+            atexit.register(json_file.close)
+            logger.add(
+                _make_json_sink(json_file),
+                level="DEBUG",
+                enqueue=True,
+            )
 
     # stderr sink
     stderr_level = "DEBUG" if (debug and not file_logging) else "WARNING"

--- a/app/utils/log_config.py
+++ b/app/utils/log_config.py
@@ -7,9 +7,9 @@ import json
 import platform
 import sys
 import traceback
+from collections.abc import Callable
 from pathlib import Path
 from typing import IO, TYPE_CHECKING
-from collections.abc import Callable
 
 from loguru import logger
 
@@ -41,9 +41,7 @@ def _suppress_noisy_loggers() -> None:
     getLogger("urllib3").setLevel(WARNING)
 
 
-def _rotate_session_logs(
-    log_dir: Path, base_name: str, session_history: int
-) -> None:
+def _rotate_session_logs(log_dir: Path, base_name: str, session_history: int) -> None:
     """
     Rotate session-based log files using numbered suffixes.
 
@@ -71,7 +69,9 @@ def _rotate_session_logs(
                 try:
                     source.unlink()
                 except OSError:
-                    print(f"Warning: failed to delete old log {source}", file=sys.stderr)
+                    print(
+                        f"Warning: failed to delete old log {source}", file=sys.stderr
+                    )
             else:
                 # Move it up one position
                 target = log_dir / f"{stem}.{target_index}{suffix}"
@@ -80,7 +80,10 @@ def _rotate_session_logs(
                         target.unlink()
                     source.rename(target)
                 except OSError:
-                    print(f"Warning: failed to rotate log {source} -> {target}", file=sys.stderr)
+                    print(
+                        f"Warning: failed to rotate log {source} -> {target}",
+                        file=sys.stderr,
+                    )
 
     # Move current log to .1
     current = log_dir / base_name
@@ -89,7 +92,10 @@ def _rotate_session_logs(
         try:
             current.rename(first_rotated)
         except OSError:
-            print(f"Warning: failed to rotate log {current} -> {first_rotated}", file=sys.stderr)
+            print(
+                f"Warning: failed to rotate log {current} -> {first_rotated}",
+                file=sys.stderr,
+            )
 
     # Now handle legacy .old.log — place it after the newly rotated current
     if old_legacy.exists():
@@ -99,7 +105,10 @@ def _rotate_session_logs(
                 try:
                     old_legacy.rename(slot)
                 except OSError:
-                    print(f"Warning: failed to migrate legacy log {old_legacy}", file=sys.stderr)
+                    print(
+                        f"Warning: failed to migrate legacy log {old_legacy}",
+                        file=sys.stderr,
+                    )
                 break
         else:
             try:

--- a/app/utils/obfuscate_message.py
+++ b/app/utils/obfuscate_message.py
@@ -35,6 +35,8 @@ def _anonymize_path(message: str) -> str:
     """
     # Windows - Only remove the username, keep the drive letter
     message = message = re.sub(r"([A-Z]:\\Users\\)[^\\]+\\", r"\1...\\", message)
+    # macOS - Only remove the username
+    message = re.sub(r"/Users/[^/]+/", r"/Users/.../", message)
     # Linux - Only remove the username
     message = re.sub(r"/home/[^/]+/", r"/home/.../", message)
 

--- a/app/utils/obfuscate_message.py
+++ b/app/utils/obfuscate_message.py
@@ -20,6 +20,7 @@ def obfuscate_message(message: str, anonymize_path: bool = True) -> str:
     """
     if anonymize_path:
         message = _anonymize_path(message)
+    message = _redact_secrets(message)
 
     return message
 
@@ -40,4 +41,10 @@ def _anonymize_path(message: str) -> str:
     # Linux - Only remove the username
     message = re.sub(r"/home/[^/]+/", r"/home/.../", message)
 
+    return message
+
+
+def _redact_secrets(message: str) -> str:
+    """Redact API keys and tokens from log messages."""
+    message = re.sub(r"([?&])key=[^&\s\"']+", r"\1key=[REDACTED]", message)
     return message

--- a/app/utils/steam/steamworks/wrapper.py
+++ b/app/utils/steam/steamworks/wrapper.py
@@ -418,9 +418,7 @@ class SteamworksSubscriptionHandler(Process):
             )
 
         except Exception as e:
-            logger.error(
-                f"✗ Error during subscription action {self.action}: {e}", exc_info=True
-            )
+            logger.exception(f"✗ Error during subscription action {self.action}: {e}")
         finally:
             # Cleanup
             logger.warning(

--- a/app/utils/steam/webapi/wrapper.py
+++ b/app/utils/steam/webapi/wrapper.py
@@ -1,3 +1,4 @@
+import re
 import sys
 import traceback
 from math import ceil
@@ -317,14 +318,10 @@ class DynamicQuery(QObject):
             self.api = WebAPI(self.apikey, format="json", https=True)
         except Exception as e:
             self.api = None
-            # Catch exceptions that can potentially leak Steam API key
             stacktrace = traceback.format_exc()
-            pattern = "&key="
-            if pattern in stacktrace:
-                stacktrace = stacktrace[
-                    : len(stacktrace)
-                    - (len(stacktrace) - (stacktrace.find(pattern) + len(pattern)))
-                ]  # If an HTTPError/SSLError from steam/urllib3 module(s) somehow is uncaught, try to remove the Steam API key from the stacktrace
+            stacktrace = re.sub(
+                r"([?&])key=[^&\s\"']+", r"\1key=[REDACTED]", stacktrace
+            )
             logger.warning(
                 f"Dynamic Query received an uncaught exception: {e.__class__.__name__}"
             )
@@ -588,19 +585,11 @@ class DynamicQuery(QObject):
                                             f"Could not find pfid {child_pfid} in database. Adding child to missing_children"
                                         )
                                         missing_children.append(child_pfid)
-            except Exception as e:
+            except Exception:
                 stacktrace = traceback.format_exc()
-                if (
-                    e.__class__.__name__ == "HTTPError"
-                    or e.__class__.__name__ == "SSLError"
-                ):  # requests.exceptions.HTTPError OR urllib3.exceptions.SSLError
-                    # If an HTTPError from steam/urllib3 module(s) somehow is uncaught,
-                    # try to remove the Steam API key from the stacktrace
-                    pattern = "&key="
-                    stacktrace = stacktrace[
-                        : len(stacktrace)
-                        - (len(stacktrace) - (stacktrace.find(pattern) + len(pattern)))
-                    ]
+                stacktrace = re.sub(
+                    r"([?&])key=[^&\s\"']+", r"\1key=[REDACTED]", stacktrace
+                )
                 logger.error(
                     f"IPublishedFileService/GetDetails errored querying batch [{chunks_processed}/{total}]: {stacktrace}"
                 )

--- a/app/utils/steam/webapi/wrapper.py
+++ b/app/utils/steam/webapi/wrapper.py
@@ -1,6 +1,5 @@
 import sys
 import traceback
-from logging import WARNING, getLogger
 from math import ceil
 from multiprocessing import Pool, cpu_count
 from pathlib import Path
@@ -27,12 +26,6 @@ STEAM_THERE_WAS_A_PROBLEM_FLAG = "There was a problem accessing the item. "
 if TYPE_CHECKING:
     from app.utils.metadata import MetadataManager
 
-
-# This is redundant since it is also done in `logger-tt` config,
-# however, it can't hurt, just in case!
-# Uncomment this if you want to see the full urllib3 request
-# THIS CONTAINS THE STEAM API KEY
-getLogger("urllib3").setLevel(WARNING)
 
 BASE_URL = "https://steamcommunity.com"
 BASE_URL_STEAMFILES = "https://steamcommunity.com/sharedfiles/filedetails/?id="

--- a/app/utils/steam/webapi/wrapper.py
+++ b/app/utils/steam/webapi/wrapper.py
@@ -47,9 +47,7 @@ class CollectionImport:
         """
         self.metadata_manager = metadata_manager
         self.translate = QCoreApplication.translate
-        self.package_ids: list[
-            str
-        ] = []  # Initialize an empty list to store package IDs
+        self.package_ids: list[str] = []  # Initialize an empty list to store package IDs
         self.publishedfileids: list[str] = []  # Initialize an empty list to store pfids
         self.input_dialog()  # Call the input_dialog method to set up the UI
 
@@ -89,9 +87,7 @@ class CollectionImport:
 
         # Check if the input link is a valid workshop collection link
         if not self.is_valid_collection_link(collection_link):
-            logger.error(
-                "Invalid Workshop collection link. Please enter a valid Workshop collection link."
-            )
+            logger.error("Invalid Workshop collection link. Please enter a valid Workshop collection link.")
             # Show warning message box
             show_warning(
                 title=self.translate("CollectionImport", "Invalid Link"),
@@ -107,13 +103,8 @@ class CollectionImport:
                 collection_link = collection_link.split(BASE_URL_STEAMFILES, 1)[1]
             elif BASE_URL_WORKSHOP in collection_link:
                 collection_link = collection_link.split(BASE_URL_WORKSHOP, 1)[1]
-            collection_webapi_result = ISteamRemoteStorage_GetCollectionDetails(
-                [collection_link]
-            )
-            if (
-                collection_webapi_result is not None
-                and len(collection_webapi_result) > 0
-            ):
+            collection_webapi_result = ISteamRemoteStorage_GetCollectionDetails([collection_link])
+            if collection_webapi_result is not None and len(collection_webapi_result) > 0:
                 self.publishedfileids = [
                     pfid
                     for mod in collection_webapi_result[0]["children"]
@@ -164,9 +155,7 @@ class CollectionImport:
                         details="\n".join(failed_mods),
                     )
         except Exception as e:
-            logger.error(
-                f"An error occurred while fetching collection content: {str(e)}"
-            )
+            logger.error(f"An error occurred while fetching collection content: {str(e)}")
 
     def _get_package_id_from_pfid(self, pfid: str | int | None) -> str | None:
         """Map published id to package id if possible
@@ -181,9 +170,7 @@ class CollectionImport:
             return None
         pfid_str = str(pfid).strip()
         if not pfid_str.isdigit():
-            raise ValueError(
-                f"PublishedFileId (pfid) is expected to be a numeric sequence, not {pfid_str}"
-            )
+            raise ValueError(f"PublishedFileId (pfid) is expected to be a numeric sequence, not {pfid_str}")
         return (
             self._get_package_id_from_pfid_using_steamdb(pfid_str)
             or self._get_package_id_from_pfid_using_metadata(pfid_str)
@@ -205,11 +192,7 @@ class CollectionImport:
         )
 
     def _get_package_id_from_pfid_using_steamdb(self, pfid: str) -> str | None:
-        steamdb = (
-            self.metadata_manager.external_steam_metadata
-            if self.metadata_manager
-            else None
-        )
+        steamdb = self.metadata_manager.external_steam_metadata if self.metadata_manager else None
         if not steamdb:
             return None
         mod = steamdb.get(pfid)
@@ -319,20 +302,14 @@ class DynamicQuery(QObject):
         except Exception as e:
             self.api = None
             stacktrace = traceback.format_exc()
-            stacktrace = re.sub(
-                r"([?&])key=[^&\s\"']+", r"\1key=[REDACTED]", stacktrace
-            )
-            logger.warning(
-                f"Dynamic Query received an uncaught exception: {e.__class__.__name__}"
-            )
+            stacktrace = re.sub(r"([?&])key=[^&\s\"']+", r"\1key=[REDACTED]", stacktrace)
+            logger.warning(f"Dynamic Query received an uncaught exception: {e.__class__.__name__}")
             self._emit_message(
                 "\nDynamicQuery failed to initialize WebAPI query!"
                 + "\nAre you connected to the internet?\nIs your configured key invalid or revoked?\n"
             )
 
-    def create_steam_db(
-        self, database: Dict[str, Any], publishedfileids: list[str]
-    ) -> None:
+    def create_steam_db(self, database: Dict[str, Any], publishedfileids: list[str]) -> None:
         """
         Builds a database using a chunked WebAPI query of all available
         PublishedFileIds supplied.
@@ -359,14 +336,10 @@ class DynamicQuery(QObject):
             # Returns WHAT we can get remotely, FROM what we have locally
             query, missing_children = result
 
-            if (
-                missing_children and len(missing_children) > 0
-            ):  # If we have missing data for any dependency...
+            if missing_children and len(missing_children) > 0:  # If we have missing data for any dependency...
                 # Uncomment to see the contents of missing_children
                 # logger.debug(missing_children)
-                self._emit_message(
-                    f"\nRetrieving dependency information for {len(missing_children)} missing children"
-                )
+                self._emit_message(f"\nRetrieving dependency information for {len(missing_children)} missing children")
                 # Extend publishedfileids with the missing_children PublishedFileIds for final query
                 publishedfileids.extend(missing_children)
                 # Launch a separate query from the initial, to recursively append
@@ -396,17 +369,11 @@ class DynamicQuery(QObject):
                 querying = False
 
         if self.get_appid_deps:
-            self._emit_message(
-                "\nAppID dependency retrieval enabled. Starting Steamworks API call(s)"
-            )
+            self._emit_message("\nAppID dependency retrieval enabled. Starting Steamworks API call(s)")
             # ISteamUGC/GetAppDependencies
-            self.ISteamUGC_GetAppDependencies(
-                publishedfileids=publishedfileids, query=query
-            )
+            self.ISteamUGC_GetAppDependencies(publishedfileids=publishedfileids, query=query)
         else:
-            self._emit_message(
-                "\nAppID dependency retrieval disabled. Skipping Steamworks API call(s)!"
-            )
+            self._emit_message("\nAppID dependency retrieval disabled. Skipping Steamworks API call(s)!")
 
         # Notify & return
         total = len(query["database"])
@@ -427,9 +394,7 @@ class DynamicQuery(QObject):
                 if self.pagenum > self.pages:
                     query = False
                     break
-                self.next_cursor = self.IPublishedFileService_QueryFiles(
-                    self.next_cursor
-                )
+                self.next_cursor = self.IPublishedFileService_QueryFiles(self.next_cursor)
         else:
             self._emit_message("AppIDQuery: WebAPI failed to initialize!")
 
@@ -453,9 +418,7 @@ class DynamicQuery(QObject):
         """
         chunks_processed = 0
         total = len(publishedfileids)
-        self._emit_message(
-            f"\nSteam WebAPI: IPublishedFileService/GetDetails initializing for {total} mods\n\n"
-        )
+        self._emit_message(f"\nSteam WebAPI: IPublishedFileService/GetDetails initializing for {total} mods\n\n")
         self._emit_message(f"IPublishedFileService/GetDetails chunk [0/{total}]")
         if not self.api:  # If we don't have API initialized
             return None  # Exit query
@@ -498,9 +461,7 @@ class DynamicQuery(QObject):
                     # logger.debug(f"{publishedfileid}: {metadata}")
                     # If the mod is no longer published
                     if metadata["result"] != 1:
-                        if not result[
-                            "database"
-                        ].get(
+                        if not result["database"].get(
                             publishedfileid
                         ):  # If we don't already have a ["database"] entry for this pfid
                             result["database"][publishedfileid] = {}
@@ -514,26 +475,18 @@ class DynamicQuery(QObject):
                         # This case is mostly intended for any missing_children passed back thru
                         # If this is part of an AppIDQuery, then it is useful for population of
                         # child_name and/or child_url below as part of the dependency data being collected
-                        if not result[
-                            "database"
-                        ].get(
+                        if not result["database"].get(
                             publishedfileid
                         ):  # If we don't already have a ["database"] entry for this pfid
-                            result["database"][
-                                publishedfileid
-                            ] = {}  # Add in skeleton data
+                            result["database"][publishedfileid] = {}  # Add in skeleton data
                         # We populate the data
-                        result["database"][publishedfileid]["steamName"] = metadata[
-                            "title"
-                        ]
+                        result["database"][publishedfileid]["steamName"] = metadata["title"]
                         result["database"][publishedfileid]["url"] = (
                             f"https://steamcommunity.com/sharedfiles/filedetails/?id={publishedfileid}"
                         )
                         # Save tags information
                         if metadata.get("tags"):
-                            result["database"][publishedfileid]["tags"] = metadata[
-                                "tags"
-                            ]
+                            result["database"][publishedfileid]["tags"] = metadata["tags"]
                         # Track time publishing created
                         # result["database"][publishedfileid][
                         #     "external_time_created"
@@ -545,37 +498,23 @@ class DynamicQuery(QObject):
                         result["database"][publishedfileid]["dependencies"] = {}
                         # If the publishing has listed mod dependencies
                         if metadata.get("children"):
-                            for children in metadata[
-                                "children"
-                            ]:  # Check if children present in database
+                            for children in metadata["children"]:  # Check if children present in database
                                 child_pfid = children["publishedfileid"]
-                                if result["database"].get(
-                                    child_pfid
-                                ):  # If we have data for this child already cached
+                                if result["database"].get(child_pfid):  # If we have data for this child already cached
                                     if not result["database"][child_pfid].get(
                                         "unpublished"
                                     ):  # ... and the mod is published, populate it
                                         if result["database"][child_pfid].get(
                                             "name"
                                         ):  # Use local name over Steam name if possible
-                                            child_name = result["database"][child_pfid][
-                                                "name"
-                                            ]
-                                        elif result["database"][child_pfid].get(
-                                            "steamName"
-                                        ):
-                                            child_name = result["database"][child_pfid][
-                                                "steamName"
-                                            ]
+                                            child_name = result["database"][child_pfid]["name"]
+                                        elif result["database"][child_pfid].get("steamName"):
+                                            child_name = result["database"][child_pfid]["steamName"]
                                         else:  # This is a stub value used in-memory only (hopefully)
                                             # and is intended for AppIdQuery first pass
                                             child_name = "UNKNOWN"
-                                        child_url = result["database"][child_pfid][
-                                            "url"
-                                        ]
-                                        result["database"][publishedfileid][
-                                            "dependencies"
-                                        ][child_pfid] = [
+                                        child_url = result["database"][child_pfid]["url"]
+                                        result["database"][publishedfileid]["dependencies"][child_pfid] = [
                                             child_name,
                                             child_url,
                                         ]
@@ -587,19 +526,13 @@ class DynamicQuery(QObject):
                                         missing_children.append(child_pfid)
             except Exception:
                 stacktrace = traceback.format_exc()
-                stacktrace = re.sub(
-                    r"([?&])key=[^&\s\"']+", r"\1key=[REDACTED]", stacktrace
-                )
+                stacktrace = re.sub(r"([?&])key=[^&\s\"']+", r"\1key=[REDACTED]", stacktrace)
                 logger.error(
                     f"IPublishedFileService/GetDetails errored querying batch [{chunks_processed}/{total}]: {stacktrace}"
                 )
-            self._emit_message(
-                f"IPublishedFileService/GetDetails chunk [{chunks_processed}/{total}]"
-            )
+            self._emit_message(f"IPublishedFileService/GetDetails chunk [{chunks_processed}/{total}]")
         for missing_child in missing_children:
-            if result["database"].get(missing_child) and result["database"][
-                missing_child
-            ].get(
+            if result["database"].get(missing_child) and result["database"][missing_child].get(
                 "unpublished"
             ):  # If there is somehow an unpublished mod in missing_children, remove it
                 missing_children.remove(missing_child)
@@ -625,9 +558,7 @@ class DynamicQuery(QObject):
         WebAPI.call() results that are being are parsing
         """
         if self.api is None:
-            raise Exception(
-                "Tried to query files while API was not properly initialized."
-            )  # Exit query
+            raise Exception("Tried to query files while API was not properly initialized.")  # Exit query
 
         result = self.api.call(
             method_path="IPublishedFileService.QueryFiles",
@@ -672,24 +603,15 @@ class DynamicQuery(QObject):
             admin_query=False,
         )
         # Print total mods found we need to iter through paginations to get info for
-        if (
-            self.pagenum and self.total == 0
-        ):  # If True, this is initial loop; we properly set them in initial loop
+        if self.pagenum and self.total == 0:  # If True, this is initial loop; we properly set them in initial loop
             if result["response"]["total"]:
                 self.pagenum = 1
                 self.total = result["response"]["total"]
-                self.pages = ceil(
-                    self.total / len(result["response"]["publishedfiledetails"])
-                )
+                self.pages = ceil(self.total / len(result["response"]["publishedfiledetails"]))
                 # Since this is only run during the initial loop, we print out the 0
                 # needed for RunnerPanel progress bar calculations
-                self._emit_message(
-                    "IPublishedFileService/QueryFiles page [0" + f"/{str(self.pages)}]"
-                )
-        self._emit_message(
-            f"IPublishedFileService/QueryFiles page [{str(self.pagenum)}"
-            + f"/{str(self.pages)}]"
-        )
+                self._emit_message("IPublishedFileService/QueryFiles page [0" + f"/{str(self.pages)}]")
+        self._emit_message(f"IPublishedFileService/QueryFiles page [{str(self.pagenum)}" + f"/{str(self.pages)}]")
         ids_from_page = []
         for item in result["response"]["publishedfiledetails"]:
             self.publishedfileids.append(item["publishedfileid"])
@@ -697,9 +619,7 @@ class DynamicQuery(QObject):
         self.pagenum += 1
         return result["response"]["next_cursor"]
 
-    def ISteamUGC_GetAppDependencies(
-        self, publishedfileids: list[str], query: Dict[str, Any]
-    ) -> None:
+    def ISteamUGC_GetAppDependencies(self, publishedfileids: list[str], query: Dict[str, Any]) -> None:
         """
         Given a list of PublishedFileIds and a query, return the query after looking up
         and appending DLC dependency data from the Steamworks API.
@@ -778,9 +698,7 @@ def ISteamRemoteStorage_GetCollectionDetails(
     # Construct arguments to pass to the API call
     metadata = []
     for chunk in list(chunks(_list=publishedfileids, limit=5000)):
-        logger.debug(
-            f"Querying details for {len(chunk)} collection(s) via Steam WebAPI"
-        )
+        logger.debug(f"Querying details for {len(chunk)} collection(s) via Steam WebAPI")
         # Construct arguments to pass to the API call
         data = {"collectioncount": f"{str(len(chunk))}"}
         for publishedfileid in chunk:

--- a/app/utils/steam/webapi/wrapper.py
+++ b/app/utils/steam/webapi/wrapper.py
@@ -47,7 +47,9 @@ class CollectionImport:
         """
         self.metadata_manager = metadata_manager
         self.translate = QCoreApplication.translate
-        self.package_ids: list[str] = []  # Initialize an empty list to store package IDs
+        self.package_ids: list[
+            str
+        ] = []  # Initialize an empty list to store package IDs
         self.publishedfileids: list[str] = []  # Initialize an empty list to store pfids
         self.input_dialog()  # Call the input_dialog method to set up the UI
 
@@ -87,7 +89,9 @@ class CollectionImport:
 
         # Check if the input link is a valid workshop collection link
         if not self.is_valid_collection_link(collection_link):
-            logger.error("Invalid Workshop collection link. Please enter a valid Workshop collection link.")
+            logger.error(
+                "Invalid Workshop collection link. Please enter a valid Workshop collection link."
+            )
             # Show warning message box
             show_warning(
                 title=self.translate("CollectionImport", "Invalid Link"),
@@ -103,8 +107,13 @@ class CollectionImport:
                 collection_link = collection_link.split(BASE_URL_STEAMFILES, 1)[1]
             elif BASE_URL_WORKSHOP in collection_link:
                 collection_link = collection_link.split(BASE_URL_WORKSHOP, 1)[1]
-            collection_webapi_result = ISteamRemoteStorage_GetCollectionDetails([collection_link])
-            if collection_webapi_result is not None and len(collection_webapi_result) > 0:
+            collection_webapi_result = ISteamRemoteStorage_GetCollectionDetails(
+                [collection_link]
+            )
+            if (
+                collection_webapi_result is not None
+                and len(collection_webapi_result) > 0
+            ):
                 self.publishedfileids = [
                     pfid
                     for mod in collection_webapi_result[0]["children"]
@@ -155,7 +164,9 @@ class CollectionImport:
                         details="\n".join(failed_mods),
                     )
         except Exception as e:
-            logger.error(f"An error occurred while fetching collection content: {str(e)}")
+            logger.error(
+                f"An error occurred while fetching collection content: {str(e)}"
+            )
 
     def _get_package_id_from_pfid(self, pfid: str | int | None) -> str | None:
         """Map published id to package id if possible
@@ -170,7 +181,9 @@ class CollectionImport:
             return None
         pfid_str = str(pfid).strip()
         if not pfid_str.isdigit():
-            raise ValueError(f"PublishedFileId (pfid) is expected to be a numeric sequence, not {pfid_str}")
+            raise ValueError(
+                f"PublishedFileId (pfid) is expected to be a numeric sequence, not {pfid_str}"
+            )
         return (
             self._get_package_id_from_pfid_using_steamdb(pfid_str)
             or self._get_package_id_from_pfid_using_metadata(pfid_str)
@@ -192,7 +205,11 @@ class CollectionImport:
         )
 
     def _get_package_id_from_pfid_using_steamdb(self, pfid: str) -> str | None:
-        steamdb = self.metadata_manager.external_steam_metadata if self.metadata_manager else None
+        steamdb = (
+            self.metadata_manager.external_steam_metadata
+            if self.metadata_manager
+            else None
+        )
         if not steamdb:
             return None
         mod = steamdb.get(pfid)
@@ -302,14 +319,20 @@ class DynamicQuery(QObject):
         except Exception as e:
             self.api = None
             stacktrace = traceback.format_exc()
-            stacktrace = re.sub(r"([?&])key=[^&\s\"']+", r"\1key=[REDACTED]", stacktrace)
-            logger.warning(f"Dynamic Query received an uncaught exception: {e.__class__.__name__}")
+            stacktrace = re.sub(
+                r"([?&])key=[^&\s\"']+", r"\1key=[REDACTED]", stacktrace
+            )
+            logger.warning(
+                f"Dynamic Query received an uncaught exception: {e.__class__.__name__}"
+            )
             self._emit_message(
                 "\nDynamicQuery failed to initialize WebAPI query!"
                 + "\nAre you connected to the internet?\nIs your configured key invalid or revoked?\n"
             )
 
-    def create_steam_db(self, database: Dict[str, Any], publishedfileids: list[str]) -> None:
+    def create_steam_db(
+        self, database: Dict[str, Any], publishedfileids: list[str]
+    ) -> None:
         """
         Builds a database using a chunked WebAPI query of all available
         PublishedFileIds supplied.
@@ -336,10 +359,14 @@ class DynamicQuery(QObject):
             # Returns WHAT we can get remotely, FROM what we have locally
             query, missing_children = result
 
-            if missing_children and len(missing_children) > 0:  # If we have missing data for any dependency...
+            if (
+                missing_children and len(missing_children) > 0
+            ):  # If we have missing data for any dependency...
                 # Uncomment to see the contents of missing_children
                 # logger.debug(missing_children)
-                self._emit_message(f"\nRetrieving dependency information for {len(missing_children)} missing children")
+                self._emit_message(
+                    f"\nRetrieving dependency information for {len(missing_children)} missing children"
+                )
                 # Extend publishedfileids with the missing_children PublishedFileIds for final query
                 publishedfileids.extend(missing_children)
                 # Launch a separate query from the initial, to recursively append
@@ -369,11 +396,17 @@ class DynamicQuery(QObject):
                 querying = False
 
         if self.get_appid_deps:
-            self._emit_message("\nAppID dependency retrieval enabled. Starting Steamworks API call(s)")
+            self._emit_message(
+                "\nAppID dependency retrieval enabled. Starting Steamworks API call(s)"
+            )
             # ISteamUGC/GetAppDependencies
-            self.ISteamUGC_GetAppDependencies(publishedfileids=publishedfileids, query=query)
+            self.ISteamUGC_GetAppDependencies(
+                publishedfileids=publishedfileids, query=query
+            )
         else:
-            self._emit_message("\nAppID dependency retrieval disabled. Skipping Steamworks API call(s)!")
+            self._emit_message(
+                "\nAppID dependency retrieval disabled. Skipping Steamworks API call(s)!"
+            )
 
         # Notify & return
         total = len(query["database"])
@@ -394,7 +427,9 @@ class DynamicQuery(QObject):
                 if self.pagenum > self.pages:
                     query = False
                     break
-                self.next_cursor = self.IPublishedFileService_QueryFiles(self.next_cursor)
+                self.next_cursor = self.IPublishedFileService_QueryFiles(
+                    self.next_cursor
+                )
         else:
             self._emit_message("AppIDQuery: WebAPI failed to initialize!")
 
@@ -418,7 +453,9 @@ class DynamicQuery(QObject):
         """
         chunks_processed = 0
         total = len(publishedfileids)
-        self._emit_message(f"\nSteam WebAPI: IPublishedFileService/GetDetails initializing for {total} mods\n\n")
+        self._emit_message(
+            f"\nSteam WebAPI: IPublishedFileService/GetDetails initializing for {total} mods\n\n"
+        )
         self._emit_message(f"IPublishedFileService/GetDetails chunk [0/{total}]")
         if not self.api:  # If we don't have API initialized
             return None  # Exit query
@@ -461,7 +498,9 @@ class DynamicQuery(QObject):
                     # logger.debug(f"{publishedfileid}: {metadata}")
                     # If the mod is no longer published
                     if metadata["result"] != 1:
-                        if not result["database"].get(
+                        if not result[
+                            "database"
+                        ].get(
                             publishedfileid
                         ):  # If we don't already have a ["database"] entry for this pfid
                             result["database"][publishedfileid] = {}
@@ -475,18 +514,26 @@ class DynamicQuery(QObject):
                         # This case is mostly intended for any missing_children passed back thru
                         # If this is part of an AppIDQuery, then it is useful for population of
                         # child_name and/or child_url below as part of the dependency data being collected
-                        if not result["database"].get(
+                        if not result[
+                            "database"
+                        ].get(
                             publishedfileid
                         ):  # If we don't already have a ["database"] entry for this pfid
-                            result["database"][publishedfileid] = {}  # Add in skeleton data
+                            result["database"][
+                                publishedfileid
+                            ] = {}  # Add in skeleton data
                         # We populate the data
-                        result["database"][publishedfileid]["steamName"] = metadata["title"]
+                        result["database"][publishedfileid]["steamName"] = metadata[
+                            "title"
+                        ]
                         result["database"][publishedfileid]["url"] = (
                             f"https://steamcommunity.com/sharedfiles/filedetails/?id={publishedfileid}"
                         )
                         # Save tags information
                         if metadata.get("tags"):
-                            result["database"][publishedfileid]["tags"] = metadata["tags"]
+                            result["database"][publishedfileid]["tags"] = metadata[
+                                "tags"
+                            ]
                         # Track time publishing created
                         # result["database"][publishedfileid][
                         #     "external_time_created"
@@ -498,23 +545,37 @@ class DynamicQuery(QObject):
                         result["database"][publishedfileid]["dependencies"] = {}
                         # If the publishing has listed mod dependencies
                         if metadata.get("children"):
-                            for children in metadata["children"]:  # Check if children present in database
+                            for children in metadata[
+                                "children"
+                            ]:  # Check if children present in database
                                 child_pfid = children["publishedfileid"]
-                                if result["database"].get(child_pfid):  # If we have data for this child already cached
+                                if result["database"].get(
+                                    child_pfid
+                                ):  # If we have data for this child already cached
                                     if not result["database"][child_pfid].get(
                                         "unpublished"
                                     ):  # ... and the mod is published, populate it
                                         if result["database"][child_pfid].get(
                                             "name"
                                         ):  # Use local name over Steam name if possible
-                                            child_name = result["database"][child_pfid]["name"]
-                                        elif result["database"][child_pfid].get("steamName"):
-                                            child_name = result["database"][child_pfid]["steamName"]
+                                            child_name = result["database"][child_pfid][
+                                                "name"
+                                            ]
+                                        elif result["database"][child_pfid].get(
+                                            "steamName"
+                                        ):
+                                            child_name = result["database"][child_pfid][
+                                                "steamName"
+                                            ]
                                         else:  # This is a stub value used in-memory only (hopefully)
                                             # and is intended for AppIdQuery first pass
                                             child_name = "UNKNOWN"
-                                        child_url = result["database"][child_pfid]["url"]
-                                        result["database"][publishedfileid]["dependencies"][child_pfid] = [
+                                        child_url = result["database"][child_pfid][
+                                            "url"
+                                        ]
+                                        result["database"][publishedfileid][
+                                            "dependencies"
+                                        ][child_pfid] = [
                                             child_name,
                                             child_url,
                                         ]
@@ -526,13 +587,19 @@ class DynamicQuery(QObject):
                                         missing_children.append(child_pfid)
             except Exception:
                 stacktrace = traceback.format_exc()
-                stacktrace = re.sub(r"([?&])key=[^&\s\"']+", r"\1key=[REDACTED]", stacktrace)
+                stacktrace = re.sub(
+                    r"([?&])key=[^&\s\"']+", r"\1key=[REDACTED]", stacktrace
+                )
                 logger.error(
                     f"IPublishedFileService/GetDetails errored querying batch [{chunks_processed}/{total}]: {stacktrace}"
                 )
-            self._emit_message(f"IPublishedFileService/GetDetails chunk [{chunks_processed}/{total}]")
+            self._emit_message(
+                f"IPublishedFileService/GetDetails chunk [{chunks_processed}/{total}]"
+            )
         for missing_child in missing_children:
-            if result["database"].get(missing_child) and result["database"][missing_child].get(
+            if result["database"].get(missing_child) and result["database"][
+                missing_child
+            ].get(
                 "unpublished"
             ):  # If there is somehow an unpublished mod in missing_children, remove it
                 missing_children.remove(missing_child)
@@ -558,7 +625,9 @@ class DynamicQuery(QObject):
         WebAPI.call() results that are being are parsing
         """
         if self.api is None:
-            raise Exception("Tried to query files while API was not properly initialized.")  # Exit query
+            raise Exception(
+                "Tried to query files while API was not properly initialized."
+            )  # Exit query
 
         result = self.api.call(
             method_path="IPublishedFileService.QueryFiles",
@@ -603,15 +672,24 @@ class DynamicQuery(QObject):
             admin_query=False,
         )
         # Print total mods found we need to iter through paginations to get info for
-        if self.pagenum and self.total == 0:  # If True, this is initial loop; we properly set them in initial loop
+        if (
+            self.pagenum and self.total == 0
+        ):  # If True, this is initial loop; we properly set them in initial loop
             if result["response"]["total"]:
                 self.pagenum = 1
                 self.total = result["response"]["total"]
-                self.pages = ceil(self.total / len(result["response"]["publishedfiledetails"]))
+                self.pages = ceil(
+                    self.total / len(result["response"]["publishedfiledetails"])
+                )
                 # Since this is only run during the initial loop, we print out the 0
                 # needed for RunnerPanel progress bar calculations
-                self._emit_message("IPublishedFileService/QueryFiles page [0" + f"/{str(self.pages)}]")
-        self._emit_message(f"IPublishedFileService/QueryFiles page [{str(self.pagenum)}" + f"/{str(self.pages)}]")
+                self._emit_message(
+                    "IPublishedFileService/QueryFiles page [0" + f"/{str(self.pages)}]"
+                )
+        self._emit_message(
+            f"IPublishedFileService/QueryFiles page [{str(self.pagenum)}"
+            + f"/{str(self.pages)}]"
+        )
         ids_from_page = []
         for item in result["response"]["publishedfiledetails"]:
             self.publishedfileids.append(item["publishedfileid"])
@@ -619,7 +697,9 @@ class DynamicQuery(QObject):
         self.pagenum += 1
         return result["response"]["next_cursor"]
 
-    def ISteamUGC_GetAppDependencies(self, publishedfileids: list[str], query: Dict[str, Any]) -> None:
+    def ISteamUGC_GetAppDependencies(
+        self, publishedfileids: list[str], query: Dict[str, Any]
+    ) -> None:
         """
         Given a list of PublishedFileIds and a query, return the query after looking up
         and appending DLC dependency data from the Steamworks API.
@@ -698,7 +778,9 @@ def ISteamRemoteStorage_GetCollectionDetails(
     # Construct arguments to pass to the API call
     metadata = []
     for chunk in list(chunks(_list=publishedfileids, limit=5000)):
-        logger.debug(f"Querying details for {len(chunk)} collection(s) via Steam WebAPI")
+        logger.debug(
+            f"Querying details for {len(chunk)} collection(s) via Steam WebAPI"
+        )
         # Construct arguments to pass to the API call
         data = {"collectioncount": f"{str(len(chunk))}"}
         for publishedfileid in chunk:

--- a/app/views/acf_log_reader.py
+++ b/app/views/acf_log_reader.py
@@ -257,7 +257,7 @@ class AcfLogReader(BaseModsPanel):
                 all_rows.append(base_items)
                 row_metadata.append((path, workshop_url))
             except Exception as e:
-                logger.error(f"Failed to prepare ACF entry {pfid}: {e}", exc_info=True)
+                logger.exception(f"Failed to prepare ACF entry {pfid}: {e}")
                 continue
 
         # Track starting row count before adding new rows
@@ -415,7 +415,7 @@ class AcfLogReader(BaseModsPanel):
                 # Just enable sorting, don't change sort order
                 self.editor_table_view.setSortingEnabled(True)
         except Exception as e:
-            logger.error(f"Failed to populate ACF Log Reader: {e}", exc_info=True)
+            logger.exception(f"Failed to populate ACF Log Reader: {e}")
             # Re-enable updates even on error
             self.editor_table_view.setUpdatesEnabled(True)
             self.editor_table_view.setSortingEnabled(True)

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -3336,13 +3336,11 @@ class MainContent(QObject):
             logger.debug("Steam DB Builder: User cancelled selection...")
             return
         for k, v in db_input_a["database"].items():
-            # print(k, v['dependencies'])
             database_b_deps[k] = set()
             if v.get("dependencies"):
                 for dep_key in v["dependencies"]:
                     database_b_deps[k].add(dep_key)
         for k, v in db_input_b["database"].items():
-            # print(k, v['dependencies'])
             if k in database_b_deps:
                 database_a_deps[k] = set()
                 if v.get("dependencies"):

--- a/app/windows/base_mods_panel.py
+++ b/app/windows/base_mods_panel.py
@@ -616,7 +616,7 @@ class BaseModsPanel(QWidget):
                         try:
                             shutil.rmtree(mod_path)
                         except Exception as e:
-                            print(f"Error deleting mod directory {mod_path}: {e}")
+                            logger.error(f"Error deleting mod directory {mod_path}: {e}")
 
     def _configure_button(
         self,

--- a/app/windows/base_mods_panel.py
+++ b/app/windows/base_mods_panel.py
@@ -616,7 +616,9 @@ class BaseModsPanel(QWidget):
                         try:
                             shutil.rmtree(mod_path)
                         except Exception as e:
-                            logger.error(f"Error deleting mod directory {mod_path}: {e}")
+                            logger.error(
+                                f"Error deleting mod directory {mod_path}: {e}"
+                            )
 
     def _configure_button(
         self,

--- a/tests/utils/test_log_config.py
+++ b/tests/utils/test_log_config.py
@@ -121,3 +121,67 @@ def test_formatter_includes_exception(tmp_path: Path) -> None:
     assert "caught error" in content
     assert "ValueError: test error" in content
     assert "Traceback" in content
+
+
+def test_json_sink_produces_valid_jsonl(tmp_path: Path) -> None:
+    """JSON sink produces valid JSON Lines output."""
+    setup_logging(log_dir=tmp_path, debug=True, json_logging=True)
+    logger.info("json test message")
+    logger.complete()
+
+    json_log = tmp_path / "RimSort.json.log"
+    assert json_log.exists()
+    line = json_log.read_text().strip()
+    record = json.loads(line)
+    assert record["message"] == "json test message"
+    assert record["level"] == "INFO"
+    assert "time" in record
+    assert "module" in record
+    assert "name" in record
+
+
+def test_json_sink_obfuscates_message(tmp_path: Path) -> None:
+    """JSON sink obfuscates paths in messages."""
+    setup_logging(log_dir=tmp_path, debug=True, json_logging=True)
+    logger.info("Path is /home/johndoe/mods")
+    logger.complete()
+
+    json_log = tmp_path / "RimSort.json.log"
+    record = json.loads(json_log.read_text().strip())
+    assert "johndoe" not in record["message"]
+    assert "/home/.../" in record["message"]
+
+
+def test_json_sink_obfuscates_exception(tmp_path: Path) -> None:
+    """JSON sink obfuscates paths in exception tracebacks."""
+    setup_logging(log_dir=tmp_path, debug=True, json_logging=True)
+    try:
+        raise ValueError("error at /home/johndoe/file.py")
+    except ValueError:
+        logger.exception("caught")
+    logger.complete()
+
+    json_log = tmp_path / "RimSort.json.log"
+    record = json.loads(json_log.read_text().strip())
+    assert "exception" in record
+    assert "johndoe" not in record["exception"]
+
+
+def test_json_sink_no_exception_field_when_none(tmp_path: Path) -> None:
+    """JSON records without exceptions don't have an exception field."""
+    setup_logging(log_dir=tmp_path, debug=True, json_logging=True)
+    logger.info("no exception here")
+    logger.complete()
+
+    json_log = tmp_path / "RimSort.json.log"
+    record = json.loads(json_log.read_text().strip())
+    assert "exception" not in record
+
+
+def test_json_sink_disabled(tmp_path: Path) -> None:
+    """json_logging=False produces no JSON log file."""
+    setup_logging(log_dir=tmp_path, debug=True, json_logging=False)
+    logger.info("test")
+    logger.complete()
+
+    assert not (tmp_path / "RimSort.json.log").exists()

--- a/tests/utils/test_log_config.py
+++ b/tests/utils/test_log_config.py
@@ -1,7 +1,9 @@
 import json
 from pathlib import Path
 
-from app.utils.log_config import _rotate_session_logs
+from loguru import logger
+
+from app.utils.log_config import _rotate_session_logs, setup_logging
 
 
 def test_rotate_session_logs_no_existing_files(tmp_path: Path) -> None:
@@ -51,3 +53,71 @@ def test_rotate_session_logs_migrates_old_format(tmp_path: Path) -> None:
     assert not (tmp_path / "RimSort.old.log").exists()
     assert (tmp_path / "RimSort.1.log").read_text() == "current"
     assert (tmp_path / "RimSort.2.log").read_text() == "old"
+
+
+def test_setup_logging_creates_human_readable_log(tmp_path: Path) -> None:
+    """setup_logging creates a human-readable log file and writes to it."""
+    setup_logging(log_dir=tmp_path, debug=False, json_logging=False)
+    logger.info("test message")
+    logger.complete()
+
+    log_file = tmp_path / "RimSort.log"
+    assert log_file.exists()
+    content = log_file.read_text()
+    assert "test message" in content
+    assert "[INFO]" in content
+
+
+def test_setup_logging_debug_level(tmp_path: Path) -> None:
+    """debug=True enables DEBUG level in the file sink."""
+    setup_logging(log_dir=tmp_path, debug=True, json_logging=False)
+    logger.debug("debug message")
+    logger.complete()
+
+    content = (tmp_path / "RimSort.log").read_text()
+    assert "debug message" in content
+    assert "[DEBUG]" in content
+
+
+def test_setup_logging_info_level_filters_debug(tmp_path: Path) -> None:
+    """debug=False (INFO level) filters out DEBUG messages."""
+    setup_logging(log_dir=tmp_path, debug=False, json_logging=False)
+    logger.debug("should not appear")
+    logger.info("should appear")
+    logger.complete()
+
+    content = (tmp_path / "RimSort.log").read_text()
+    assert "should not appear" not in content
+    assert "should appear" in content
+
+
+def test_formatter_obfuscates_paths(tmp_path: Path) -> None:
+    """Log messages containing usernames in paths are obfuscated."""
+    setup_logging(log_dir=tmp_path, debug=True, json_logging=False)
+    logger.info("Loading from /home/johndoe/mods/core")
+    logger.info("Loading from /Users/janedoe/mods/core")
+    logger.info("Loading from C:\\Users\\player\\mods\\core")
+    logger.complete()
+
+    content = (tmp_path / "RimSort.log").read_text()
+    assert "johndoe" not in content
+    assert "janedoe" not in content
+    assert "player" not in content
+    assert "/home/.../" in content
+    assert "/Users/.../" in content
+    assert "\\Users\\...\\" in content
+
+
+def test_formatter_includes_exception(tmp_path: Path) -> None:
+    """logger.exception() includes traceback in output."""
+    setup_logging(log_dir=tmp_path, debug=True, json_logging=False)
+    try:
+        raise ValueError("test error")
+    except ValueError:
+        logger.exception("caught error")
+    logger.complete()
+
+    content = (tmp_path / "RimSort.log").read_text()
+    assert "caught error" in content
+    assert "ValueError: test error" in content
+    assert "Traceback" in content

--- a/tests/utils/test_log_config.py
+++ b/tests/utils/test_log_config.py
@@ -1,0 +1,53 @@
+import json
+from pathlib import Path
+
+from app.utils.log_config import _rotate_session_logs
+
+
+def test_rotate_session_logs_no_existing_files(tmp_path: Path) -> None:
+    """Rotation with no existing logs should be a no-op."""
+    _rotate_session_logs(tmp_path, "RimSort.log", session_history=5)
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_rotate_session_logs_single_existing(tmp_path: Path) -> None:
+    """Existing RimSort.log should become RimSort.1.log."""
+    (tmp_path / "RimSort.log").write_text("session 0")
+    _rotate_session_logs(tmp_path, "RimSort.log", session_history=5)
+    assert not (tmp_path / "RimSort.log").exists()
+    assert (tmp_path / "RimSort.1.log").read_text() == "session 0"
+
+
+def test_rotate_session_logs_cascade(tmp_path: Path) -> None:
+    """Multiple existing logs cascade upward."""
+    (tmp_path / "RimSort.log").write_text("session 0")
+    (tmp_path / "RimSort.1.log").write_text("session 1")
+    (tmp_path / "RimSort.2.log").write_text("session 2")
+    _rotate_session_logs(tmp_path, "RimSort.log", session_history=5)
+    assert not (tmp_path / "RimSort.log").exists()
+    assert (tmp_path / "RimSort.1.log").read_text() == "session 0"
+    assert (tmp_path / "RimSort.2.log").read_text() == "session 1"
+    assert (tmp_path / "RimSort.3.log").read_text() == "session 2"
+
+
+def test_rotate_session_logs_exceeds_history(tmp_path: Path) -> None:
+    """Oldest log beyond history limit is deleted."""
+    (tmp_path / "RimSort.log").write_text("session 0")
+    (tmp_path / "RimSort.1.log").write_text("session 1")
+    (tmp_path / "RimSort.2.log").write_text("session 2")
+    _rotate_session_logs(tmp_path, "RimSort.log", session_history=3)
+    assert not (tmp_path / "RimSort.log").exists()
+    assert (tmp_path / "RimSort.1.log").read_text() == "session 0"
+    assert (tmp_path / "RimSort.2.log").read_text() == "session 1"
+    # session 2 was at index 2, pushed to index 3 which equals history limit -> deleted
+    assert not (tmp_path / "RimSort.3.log").exists()
+
+
+def test_rotate_session_logs_migrates_old_format(tmp_path: Path) -> None:
+    """Legacy RimSort.old.log is migrated to RimSort.1.log."""
+    (tmp_path / "RimSort.log").write_text("current")
+    (tmp_path / "RimSort.old.log").write_text("old")
+    _rotate_session_logs(tmp_path, "RimSort.log", session_history=5)
+    assert not (tmp_path / "RimSort.old.log").exists()
+    assert (tmp_path / "RimSort.1.log").read_text() == "current"
+    assert (tmp_path / "RimSort.2.log").read_text() == "old"

--- a/tests/utils/test_obfuscate_message.py
+++ b/tests/utils/test_obfuscate_message.py
@@ -1,4 +1,8 @@
-from app.utils.obfuscate_message import _anonymize_path
+from app.utils.obfuscate_message import (
+    _anonymize_path,
+    _redact_secrets,
+    obfuscate_message,
+)
 
 
 def test__anonymize_path_windows_path_only() -> None:
@@ -63,3 +67,52 @@ def test__anonymize_path_macos_mixed_message() -> None:
     message = "Error!!! at: /Users/user/Documents/file.txt"
     expected = "Error!!! at: /Users/.../Documents/file.txt"
     assert _anonymize_path(message) == expected
+
+
+class TestRedactSecrets:
+    """Test API key and token redaction."""
+
+    def test_redact_query_param_key(self) -> None:
+        msg = "https://api.steam.com/ISteam?key=ABC123DEF456&format=json"
+        result = _redact_secrets(msg)
+        assert "ABC123DEF456" not in result
+        assert "?key=[REDACTED]" in result
+        assert "&format=json" in result
+
+    def test_redact_ampersand_key(self) -> None:
+        msg = "https://api.steam.com/ISteam?format=json&key=SECRET123"
+        result = _redact_secrets(msg)
+        assert "SECRET123" not in result
+        assert "&key=[REDACTED]" in result
+
+    def test_no_key_unchanged(self) -> None:
+        msg = "Normal error message without any keys"
+        assert _redact_secrets(msg) == msg
+
+    def test_multiple_keys_redacted(self) -> None:
+        msg = "url1?key=AAA and url2&key=BBB"
+        result = _redact_secrets(msg)
+        assert "AAA" not in result
+        assert "BBB" not in result
+
+    def test_obfuscate_message_includes_redaction(self) -> None:
+        msg = "Error at /home/user/app: ?key=SECRET"
+        result = obfuscate_message(msg)
+        assert "SECRET" not in result
+        assert "user" not in result
+        assert "?key=[REDACTED]" in result
+
+    def test_preserves_delimiter(self) -> None:
+        msg = "?key=SECRET"
+        result = _redact_secrets(msg)
+        assert result == "?key=[REDACTED]"
+
+        msg2 = "&key=SECRET"
+        result2 = _redact_secrets(msg2)
+        assert result2 == "&key=[REDACTED]"
+
+    def test_non_url_key_not_redacted(self) -> None:
+        """Strings like 'encryption key=AES256' should NOT be redacted."""
+        msg = "encryption key=AES256"
+        result = _redact_secrets(msg)
+        assert result == msg

--- a/tests/utils/test_obfuscate_message.py
+++ b/tests/utils/test_obfuscate_message.py
@@ -44,3 +44,22 @@ def test__anonymize_path_linux_mixed_message() -> None:
     message = "Error!!! at: /home/user/Documents/file.txt"
     expected = "Error!!! at: /home/.../Documents/file.txt"
     assert _anonymize_path(message) == expected
+
+
+def test__anonymize_path_macos_path_only() -> None:
+    message = "/Users/user/Documents/file.txt"
+    expected = "/Users/.../Documents/file.txt"
+    assert _anonymize_path(message) == expected
+
+    message = "/Users/abc/Documents/file.txt"
+    assert _anonymize_path(message) == expected
+
+
+def test__anonymize_path_macos_mixed_message() -> None:
+    message = "/Users/user/Documents/file.txt: error"
+    expected = "/Users/.../Documents/file.txt: error"
+    assert _anonymize_path(message) == expected
+
+    message = "Error!!! at: /Users/user/Documents/file.txt"
+    expected = "Error!!! at: /Users/.../Documents/file.txt"
+    assert _anonymize_path(message) == expected


### PR DESCRIPTION
Addresses #1624

## Summary

- **Centralized logging module** (`app/utils/log_config.py`): all loguru configuration in one place — formatter, sinks, rotation, third-party logger suppression
- **Dual sinks**: human-readable log file + JSON log file (with obfuscation applied to both messages and exception tracebacks)
- **Session-based rotation**: keeps last 5 sessions with numbered suffixes, migrates legacy `.old.log` format
- **`--debug` CLI flag**: works for both GUI and CLI modes, in addition to existing DEBUG file and settings toggle
- **API key redaction**: replaces fragile `str.find("&key=")` truncation with regex-based `_redact_secrets()` in the loguru pipeline (migrated from #1840)
- **macOS path obfuscation**: `/Users/username/` paths now anonymized (was only Windows/Linux)
- **Fixed silent traceback drops**: `exc_info=` is a no-op in loguru — replaced with `logger.exception()` / `logger.opt(exception=...)` across 5 call sites
- **Replaced bare `print()` calls** with proper `logger.*()` calls in 4 files
- **Thread safety**: all file sinks use `enqueue=True`

## Notes for #1840

This PR absorbs the logging-specific changes from #1840 (secret redaction in `obfuscate_message.py`, `__main__.py`, `steam/webapi/wrapper.py`, `cli/build_db.py`). PR #1840 will need a rebase to remove those overlapping changes — the remaining scope there is settings file permissions (`0o600`) and dialogue-level redaction.

## Test plan

- [x] 28 new tests (15 `test_log_config.py` + 13 `test_obfuscate_message.py`)
- [x] Full test suite: 302 passed, 1 pre-existing failure (unrelated `test_dialogue.py`)
- [x] Linter and formatter clean
- [x] Smoke test: `uv run python -m app --version` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)