### PR TITLE
feat: HTTP-based database syncing as alternative to git

### DIFF
--- a/app/controllers/main_content_controller.py
+++ b/app/controllers/main_content_controller.py
@@ -132,7 +132,7 @@ class MainContentController(QObject):
             event_signal.connect(
                 lambda repo_getter=repo_getter, url_getter=url_getter, source_getter=source_getter, base_path_obj=base_path_obj, display_name=display_name: (
                     self._do_download_database(
-                        base_path=str(base_path_obj),
+                        base_path=base_path_obj,
                         repo_url=repo_getter(),
                         url=url_getter(),
                         source=source_getter(),
@@ -535,7 +535,7 @@ class MainContentController(QObject):
         self.thread_pool.start(worker)
 
     def _do_download_database(
-        self, base_path: str, repo_url: str, url: str, source: str, display_name: str
+        self, base_path: Path, repo_url: str, url: str, source: str, display_name: str
     ) -> None:
         """Dispatch a database download via HTTP or git based on the configured source."""
         if not check_internet_connection():
@@ -549,27 +549,33 @@ class MainContentController(QObject):
             )
             task = DatabaseDownloadTask(
                 url=url,
-                target_dir=Path(base_path),
+                target_dir=base_path,
                 repo_name=repo_name,
                 display_name=display_name,
             )
             self._start_http_download_interactive([task])
         elif source == "Configured git repository" and repo_url:
-            self._do_git_clone(base_path=base_path, repo_url=repo_url)
+            self._do_git_clone(base_path=str(base_path), repo_url=repo_url)
+        else:
+            logger.debug(f"Download not applicable for source type: {source}")
+
+    def _cleanup_http_download_worker(self) -> None:
+        """Disconnect signals, stop, and discard the current HTTP download worker."""
+        if self._http_download_worker is not None:
+            try:
+                self._http_download_worker.download_finished.disconnect()
+                self._http_download_worker.quit()
+                self._http_download_worker.wait()
+            except Exception as e:
+                logger.debug(f"Error during HTTP worker cleanup: {e}")
+            self._http_download_worker = None
 
     def _start_http_download_silent(self, tasks: list[DatabaseDownloadTask]) -> None:
         """Start an HTTP download worker in silent mode (no user dialogs)."""
-        if self._http_download_worker is not None:
-            try:
-                self._http_download_worker.finished.disconnect()
-                self._http_download_worker.quit()
-                self._http_download_worker.wait()
-            except Exception:
-                pass
-            self._http_download_worker = None
+        self._cleanup_http_download_worker()
 
         self._http_download_worker = HttpDownloadWorker(tasks)
-        self._http_download_worker.finished.connect(
+        self._http_download_worker.download_finished.connect(
             self._on_http_download_finished_silent
         )
         self._http_download_worker.progress.connect(
@@ -593,28 +599,16 @@ class MainContentController(QObject):
             logger.warning(
                 f"HTTP DB update: {len(failed)} database(s) failed: {', '.join(failed)}"
             )
-        if self._http_download_worker:
-            try:
-                self._http_download_worker.finished.disconnect()
-            except Exception:
-                pass
-            self._http_download_worker = None
+        self._cleanup_http_download_worker()
 
     def _start_http_download_interactive(
         self, tasks: list[DatabaseDownloadTask]
     ) -> None:
         """Start an HTTP download worker with user-facing result dialogs."""
-        if self._http_download_worker is not None:
-            try:
-                self._http_download_worker.finished.disconnect()
-                self._http_download_worker.quit()
-                self._http_download_worker.wait()
-            except Exception:
-                pass
-            self._http_download_worker = None
+        self._cleanup_http_download_worker()
 
         self._http_download_worker = HttpDownloadWorker(tasks)
-        self._http_download_worker.finished.connect(
+        self._http_download_worker.download_finished.connect(
             self._on_http_download_finished_interactive
         )
         self._http_download_worker.progress.connect(
@@ -658,12 +652,7 @@ class MainContentController(QObject):
                 ),
             ).exec()
 
-        if self._http_download_worker:
-            try:
-                self._http_download_worker.finished.disconnect()
-            except Exception:
-                pass
-            self._http_download_worker = None
+        self._cleanup_http_download_worker()
 
     def _start_git_clone_worker(
         self, repo_url: str, base_path: str, force: bool

--- a/app/controllers/main_content_controller.py
+++ b/app/controllers/main_content_controller.py
@@ -31,6 +31,11 @@ from app.utils.git_worker import (
     GitStageCommitWorker,
     PushConfig,
 )
+from app.utils.http_downloader import (
+    DatabaseDownloadTask,
+    DownloadResult,
+    HttpDownloadWorker,
+)
 from app.views.dialogue import (
     BinaryChoiceDialog,
     InformationBox,
@@ -42,34 +47,63 @@ from app.views.main_content_panel import MainContent
 class MainContentController(QObject):
     """Controller with concurrent checking/updating and improved structure."""
 
-    def __init__(self, view: MainContent, settings_controller: SettingsController) -> None:
+    def __init__(
+        self, view: MainContent, settings_controller: SettingsController
+    ) -> None:
         super().__init__()
         self.view = view
         self.settings_controller = settings_controller
         self._git_clone_worker: Optional[GitCloneWorker] = None
         self._git_push_worker: Optional[GitPushWorker] = None
         self._git_stage_commit_worker: Optional[GitStageCommitWorker] = None
+        self._http_download_worker: Optional[HttpDownloadWorker] = None
 
         # Thread pool for concurrent tasks
         self.thread_pool = QThreadPool.globalInstance()
 
-        # Map download signals to (base_path, url_getter)
+        # Map download signals to (base_path, repo_getter, url_getter, source_getter, display_name)
         self.download_signals = {
             EventBus().do_download_community_rules_db_from_github: (
                 AppInfo().databases_folder,
                 lambda: self.settings_controller.settings.external_community_rules_repo,
+                lambda: self.settings_controller.settings.external_community_rules_url,
+                lambda: (
+                    self.settings_controller.settings.external_community_rules_metadata_source
+                ),
+                "Community Rules",
             ),
             EventBus().do_download_steam_workshop_db_from_github: (
                 AppInfo().databases_folder,
                 lambda: self.settings_controller.settings.external_steam_metadata_repo,
+                lambda: self.settings_controller.settings.external_steam_metadata_url,
+                lambda: (
+                    self.settings_controller.settings.external_steam_metadata_source
+                ),
+                "Steam Workshop",
             ),
             EventBus().do_download_use_this_instead_db_from_github: (
                 AppInfo().databases_folder,
-                lambda: self.settings_controller.settings.external_use_this_instead_repo_path,
+                lambda: (
+                    self.settings_controller.settings.external_use_this_instead_repo_path
+                ),
+                lambda: self.settings_controller.settings.external_use_this_instead_url,
+                lambda: (
+                    self.settings_controller.settings.external_use_this_instead_metadata_source
+                ),
+                "Use This Instead",
             ),
             EventBus().do_download_no_version_warning_db_from_github: (
                 AppInfo().databases_folder,
-                lambda: self.settings_controller.settings.external_no_version_warning_repo_path,
+                lambda: (
+                    self.settings_controller.settings.external_no_version_warning_repo_path
+                ),
+                lambda: (
+                    self.settings_controller.settings.external_no_version_warning_url
+                ),
+                lambda: (
+                    self.settings_controller.settings.external_no_version_warning_metadata_source
+                ),
+                "No Version Warning",
             ),
         }
 
@@ -88,16 +122,31 @@ class MainContentController(QObject):
             signal.connect(self._on_check_updates_requested)
 
         # Bind download signals
-        for event_signal, (base_path_obj, url_getter) in self.download_signals.items():
+        for event_signal, (
+            base_path_obj,
+            repo_getter,
+            url_getter,
+            source_getter,
+            display_name,
+        ) in self.download_signals.items():
             event_signal.connect(
-                lambda url_getter=url_getter, base_path_obj=base_path_obj: self._do_git_clone(
-                    base_path=str(base_path_obj),
-                    repo_url=url_getter(),
+                lambda repo_getter=repo_getter, url_getter=url_getter, source_getter=source_getter, base_path_obj=base_path_obj, display_name=display_name: (
+                    self._do_download_database(
+                        base_path=str(base_path_obj),
+                        repo_url=repo_getter(),
+                        url=url_getter(),
+                        source=source_getter(),
+                        display_name=display_name,
+                    )
                 )
             )
 
-        EventBus().do_upload_steam_workshop_db_to_github.connect(self._on_do_upload_steam_workshop_db_to_github)
-        EventBus().do_upload_community_rules_db_to_github.connect(self._on_do_upload_community_db_to_github)
+        EventBus().do_upload_steam_workshop_db_to_github.connect(
+            self._on_do_upload_steam_workshop_db_to_github
+        )
+        EventBus().do_upload_community_rules_db_to_github.connect(
+            self._on_do_upload_community_db_to_github
+        )
 
     @Slot(list)
     def _on_check_updates_requested(self, repos_paths: List[Path]) -> None:
@@ -109,7 +158,9 @@ class MainContentController(QObject):
                 information=self.tr("Please select at least one repository to check."),
             ).exec()
             return
-        logger.debug(f"Scheduling concurrent check for {len(repos_paths)} repositories.")
+        logger.debug(
+            f"Scheduling concurrent check for {len(repos_paths)} repositories."
+        )
         config = GitOperationConfig(notify_errors=True)
         worker = GitCheckUpdatesWorker(repos_paths, config=config)
         worker.signals.finished.connect(self._handle_check_updates_results)
@@ -134,7 +185,9 @@ class MainContentController(QObject):
             InformationBox(
                 title=self.tr("Errors during update check"),
                 text=self.tr("Some repositories encountered errors."),
-                information=self.tr("Errors occurred while checking for updates:\n{errors}").format(errors=msg),
+                information=self.tr(
+                    "Errors occurred while checking for updates:\n{errors}"
+                ).format(errors=msg),
             ).exec()
             return
 
@@ -155,7 +208,9 @@ class MainContentController(QObject):
 
         binary_diag = BinaryChoiceDialog(
             title=self.tr("Git Updates Found"),
-            text=self.tr("{len} repositories have updates available.").format(len=len(updates)),
+            text=self.tr("{len} repositories have updates available.").format(
+                len=len(updates)
+            ),
             information=self.tr("Would you like to update them now?"),
             details=details_msg,
             positive_text=self.tr("Update All"),
@@ -168,7 +223,9 @@ class MainContentController(QObject):
 
     def _on_update_repos(self, repos_paths: List[Path]) -> None:
         """Schedule concurrent batch pull for multiple repositories."""
-        logger.debug(f"Scheduling concurrent update for {len(repos_paths)} repositories.")
+        logger.debug(
+            f"Scheduling concurrent update for {len(repos_paths)} repositories."
+        )
         config = GitOperationConfig(notify_errors=True)
         worker = GitBatchUpdateWorker(repos_paths, config=config)
         worker.signals.finished.connect(self._handle_batch_update_results)
@@ -185,15 +242,17 @@ class MainContentController(QObject):
             details_msg = ""
             for repo_path in successful:
                 repo_name = Path(repo_path).name
-                commit_info = getattr(results, "commit_info", {}).get(str(repo_path), "No commit info")
+                commit_info = getattr(results, "commit_info", {}).get(
+                    str(repo_path), "No commit info"
+                )
                 details_msg += f"✓ {repo_name}\n  └─ {commit_info}\n\n"
 
             InformationBox(
                 title=self.tr("Updates Completed"),
                 text=self.tr("All repositories updated successfully!"),
-                information=self.tr("{count} repositories were updated with their latest commits:").format(
-                    count=len(successful)
-                ),
+                information=self.tr(
+                    "{count} repositories were updated with their latest commits:"
+                ).format(count=len(successful)),
                 details=details_msg.strip(),
             ).exec()
         elif not successful:
@@ -204,14 +263,18 @@ class MainContentController(QObject):
             InformationBox(
                 title=self.tr("Failed to update repo!"),
                 text=self.tr("All pull operations failed."),
-                information=self.tr("{count} repositories could not be updated.").format(count=len(failed)),
+                information=self.tr(
+                    "{count} repositories could not be updated."
+                ).format(count=len(failed)),
                 details=details_msg,
             ).exec()
         else:
             details_msg = self.tr("Successful updates:\n")
             for repo_path in successful:
                 repo_name = Path(repo_path).name
-                commit_info = getattr(results, "commit_info", {}).get(str(repo_path), "No commit info")
+                commit_info = getattr(results, "commit_info", {}).get(
+                    str(repo_path), "No commit info"
+                )
                 details_msg += f"  ✓ {repo_name}\n    └─ {commit_info}\n"
 
             details_msg += f"\n{self.tr('Failed updates:')}\n"
@@ -221,9 +284,9 @@ class MainContentController(QObject):
             InformationBox(
                 title=self.tr("Partial Updates Completed"),
                 text=self.tr("Some repositories updated successfully."),
-                information=self.tr("{success} succeeded, {failed} failed out of {total}.").format(
-                    success=len(successful), failed=len(failed), total=total
-                ),
+                information=self.tr(
+                    "{success} succeeded, {failed} failed out of {total}."
+                ).format(success=len(successful), failed=len(failed), total=total),
                 details=details_msg,
             ).exec()
 
@@ -243,7 +306,9 @@ class MainContentController(QObject):
         binary_diag = BinaryChoiceDialog(
             title=self.tr("Push Options"),
             text=self.tr("Push changes to remote repositories?"),
-            information=self.tr("This will push local commits to the remote repositories."),
+            information=self.tr(
+                "This will push local commits to the remote repositories."
+            ),
             details="\n".join([str(p) for p in repos_paths]),
             positive_text=self.tr("Push"),
             negative_text=self.tr("Cancel"),
@@ -257,7 +322,9 @@ class MainContentController(QObject):
         force_diag = BinaryChoiceDialog(
             title=self.tr("Force Push"),
             text=self.tr("Use force push?"),
-            information=self.tr("Force push will overwrite remote history. Use with caution!"),
+            information=self.tr(
+                "Force push will overwrite remote history. Use with caution!"
+            ),
             positive_text=self.tr("Force Push"),
             negative_text=self.tr("Normal Push"),
         )
@@ -267,7 +334,9 @@ class MainContentController(QObject):
 
     def _on_push_repos(self, repos_paths: List[Path], force: bool = False) -> None:
         """Schedule concurrent batch push for multiple repositories."""
-        logger.debug(f"Scheduling concurrent push for {len(repos_paths)} repositories (force={force}).")
+        logger.debug(
+            f"Scheduling concurrent push for {len(repos_paths)} repositories (force={force})."
+        )
         config = GitOperationConfig(notify_errors=True)
 
         # Get GitHub authentication from settings
@@ -295,7 +364,9 @@ class MainContentController(QObject):
             InformationBox(
                 title=self.tr("Push Completed"),
                 text=self.tr("All repositories pushed successfully!"),
-                information=self.tr("{count} repositories were pushed.").format(count=len(successful)),
+                information=self.tr("{count} repositories were pushed.").format(
+                    count=len(successful)
+                ),
                 details="\n".join([Path(p).name for p in successful]),
             ).exec()
         elif not successful:
@@ -306,7 +377,9 @@ class MainContentController(QObject):
             InformationBox(
                 title=self.tr("Push Failed"),
                 text=self.tr("All push operations failed."),
-                information=self.tr("{count} repositories could not be pushed.").format(count=len(failed)),
+                information=self.tr("{count} repositories could not be pushed.").format(
+                    count=len(failed)
+                ),
                 details=details_msg,
             ).exec()
         else:
@@ -320,9 +393,9 @@ class MainContentController(QObject):
             InformationBox(
                 title=self.tr("Partial Push Completed"),
                 text=self.tr("Some repositories pushed successfully."),
-                information=self.tr("{success} succeeded, {failed} failed out of {total}.").format(
-                    success=len(successful), failed=len(failed), total=total
-                ),
+                information=self.tr(
+                    "{success} succeeded, {failed} failed out of {total}."
+                ).format(success=len(successful), failed=len(failed), total=total),
                 details=details_msg,
             ).exec()
 
@@ -352,7 +425,9 @@ class MainContentController(QObject):
         if full_repo_path.exists():
             answer = show_dialogue_conditional(
                 title=self.tr("Existing repository found"),
-                text=self.tr("An existing local repo that matches this repository was found:"),
+                text=self.tr(
+                    "An existing local repo that matches this repository was found:"
+                ),
                 information=self.tr(
                     "{repo_folder}<br/>"
                     + "How would you like to handle? Choose option:<br/>"
@@ -373,59 +448,66 @@ class MainContentController(QObject):
     def _update_databases_on_startup_if_enabled_silent(self) -> None:
         """
         Silently update databases on startup if enabled.
-        Directly calls MainContentController methods instead of emitting signals.
+        Dispatches to HTTP or git depending on each database's configured source.
         """
         if not self.settings_controller.settings.update_databases_on_startup:
             logger.info("Update databases on startup is disabled.")
             return
 
-        # Check internet connection before attempting task
         if not check_internet_connection():
             return
 
-        # Community Rules database
-        if (
-            self.settings_controller.settings.external_community_rules_metadata_source == "Configured git repository"
-            and self.settings_controller.settings.external_community_rules_repo
-        ):
-            logger.info("Auto-updating Community Rules database from GitHub.")
-            self._do_auto_database_update(
-                str(AppInfo().databases_folder),
-                self.settings_controller.settings.external_community_rules_repo,
-            )
+        settings = self.settings_controller.settings
+        http_tasks: list[DatabaseDownloadTask] = []
 
-        # Steam Workshop database
-        if (
-            self.settings_controller.settings.external_steam_metadata_source == "Configured git repository"
-            and self.settings_controller.settings.external_steam_metadata_repo
-        ):
-            logger.info("Auto-updating Steam Workshop database from GitHub.")
-            self._do_auto_database_update(
-                str(AppInfo().databases_folder),
-                self.settings_controller.settings.external_steam_metadata_repo,
-            )
+        db_configs = [
+            (
+                settings.external_community_rules_metadata_source,
+                settings.external_community_rules_repo,
+                settings.external_community_rules_url,
+                "Community Rules",
+            ),
+            (
+                settings.external_steam_metadata_source,
+                settings.external_steam_metadata_repo,
+                settings.external_steam_metadata_url,
+                "Steam Workshop",
+            ),
+            (
+                settings.external_no_version_warning_metadata_source,
+                settings.external_no_version_warning_repo_path,
+                settings.external_no_version_warning_url,
+                "No Version Warning",
+            ),
+            (
+                settings.external_use_this_instead_metadata_source,
+                settings.external_use_this_instead_repo_path,
+                settings.external_use_this_instead_url,
+                "Use This Instead",
+            ),
+        ]
 
-        # No Version Warning database
-        if (
-            self.settings_controller.settings.external_no_version_warning_metadata_source == "Configured git repository"
-            and self.settings_controller.settings.external_no_version_warning_repo_path
-        ):
-            logger.info('Auto-updating "No Version Warning" database from GitHub.')
-            self._do_auto_database_update(
-                str(AppInfo().databases_folder),
-                self.settings_controller.settings.external_no_version_warning_repo_path,
-            )
+        for source, repo_url, url, display_name in db_configs:
+            if source == "Configured URL" and url:
+                repo_name = (
+                    extract_git_dir_name(repo_url)
+                    if repo_url
+                    else display_name.replace(" ", "-")
+                )
+                http_tasks.append(
+                    DatabaseDownloadTask(
+                        url=url,
+                        target_dir=AppInfo().databases_folder,
+                        repo_name=repo_name,
+                        display_name=display_name,
+                    )
+                )
+            elif source == "Configured git repository" and repo_url:
+                logger.info(f"Auto-updating {display_name} database via git.")
+                self._do_auto_database_update(str(AppInfo().databases_folder), repo_url)
 
-        # Use This Instead database (Cross Version Databases)
-        if (
-            self.settings_controller.settings.external_use_this_instead_metadata_source == "Configured git repository"
-            and self.settings_controller.settings.external_use_this_instead_repo_path
-        ):
-            logger.info('Auto-updating "Use This Instead" database from GitHub.')
-            self._do_auto_database_update(
-                str(AppInfo().databases_folder),
-                self.settings_controller.settings.external_use_this_instead_repo_path,
-            )
+        if http_tasks:
+            self._start_http_download_silent(http_tasks)
 
     def _do_auto_database_update(self, base_path: str, repo_url: str) -> None:
         """Handle automatic database update: silently update existing or clone new."""
@@ -444,13 +526,148 @@ class MainContentController(QObject):
 
     def _on_update_repos_silent(self, repos_paths: List[Path]) -> None:
         """Schedule concurrent batch pull for multiple repositories silently."""
-        logger.debug(f"Scheduling silent concurrent update for {len(repos_paths)} repositories.")
+        logger.debug(
+            f"Scheduling silent concurrent update for {len(repos_paths)} repositories."
+        )
         config = GitOperationConfig(notify_errors=False)
         worker = GitBatchUpdateWorker(repos_paths, config=config)
         worker.signals.finished.connect(self._handle_batch_update_results_silent)
         self.thread_pool.start(worker)
 
-    def _start_git_clone_worker(self, repo_url: str, base_path: str, force: bool) -> None:
+    def _do_download_database(
+        self, base_path: str, repo_url: str, url: str, source: str, display_name: str
+    ) -> None:
+        """Dispatch a database download via HTTP or git based on the configured source."""
+        if not check_internet_connection():
+            return
+
+        if source == "Configured URL" and url:
+            repo_name = (
+                extract_git_dir_name(repo_url)
+                if repo_url
+                else display_name.replace(" ", "-")
+            )
+            task = DatabaseDownloadTask(
+                url=url,
+                target_dir=Path(base_path),
+                repo_name=repo_name,
+                display_name=display_name,
+            )
+            self._start_http_download_interactive([task])
+        elif source == "Configured git repository" and repo_url:
+            self._do_git_clone(base_path=base_path, repo_url=repo_url)
+
+    def _start_http_download_silent(self, tasks: list[DatabaseDownloadTask]) -> None:
+        """Start an HTTP download worker in silent mode (no user dialogs)."""
+        if self._http_download_worker is not None:
+            try:
+                self._http_download_worker.finished.disconnect()
+                self._http_download_worker.quit()
+                self._http_download_worker.wait()
+            except Exception:
+                pass
+            self._http_download_worker = None
+
+        self._http_download_worker = HttpDownloadWorker(tasks)
+        self._http_download_worker.finished.connect(
+            self._on_http_download_finished_silent
+        )
+        self._http_download_worker.progress.connect(
+            lambda msg: logger.info(f"HTTP DB update: {msg}")
+        )
+        logger.info(f"Starting HTTP download for {len(tasks)} database(s)")
+        self._http_download_worker.start()
+
+    @Slot(dict)
+    def _on_http_download_finished_silent(
+        self, results: dict[str, DownloadResult]
+    ) -> None:
+        """Handle HTTP download completion silently (log only)."""
+        updated = [name for name, r in results.items() if r == DownloadResult.UPDATED]
+        failed = [name for name, r in results.items() if r == DownloadResult.FAILED]
+        if updated:
+            logger.info(
+                f"HTTP DB update: {len(updated)} database(s) updated: {', '.join(updated)}"
+            )
+        if failed:
+            logger.warning(
+                f"HTTP DB update: {len(failed)} database(s) failed: {', '.join(failed)}"
+            )
+        if self._http_download_worker:
+            try:
+                self._http_download_worker.finished.disconnect()
+            except Exception:
+                pass
+            self._http_download_worker = None
+
+    def _start_http_download_interactive(
+        self, tasks: list[DatabaseDownloadTask]
+    ) -> None:
+        """Start an HTTP download worker with user-facing result dialogs."""
+        if self._http_download_worker is not None:
+            try:
+                self._http_download_worker.finished.disconnect()
+                self._http_download_worker.quit()
+                self._http_download_worker.wait()
+            except Exception:
+                pass
+            self._http_download_worker = None
+
+        self._http_download_worker = HttpDownloadWorker(tasks)
+        self._http_download_worker.finished.connect(
+            self._on_http_download_finished_interactive
+        )
+        self._http_download_worker.progress.connect(
+            lambda msg: logger.info(f"HTTP DB download: {msg}")
+        )
+        self._http_download_worker.start()
+
+    @Slot(dict)
+    def _on_http_download_finished_interactive(
+        self, results: dict[str, DownloadResult]
+    ) -> None:
+        """Handle HTTP download completion with user-facing dialogs."""
+        updated = [name for name, r in results.items() if r == DownloadResult.UPDATED]
+        up_to_date = [
+            name for name, r in results.items() if r == DownloadResult.UP_TO_DATE
+        ]
+        failed = [name for name, r in results.items() if r == DownloadResult.FAILED]
+
+        if failed:
+            InformationBox(
+                title=self.tr("Download failed"),
+                text=self.tr("Failed to download database(s): {names}").format(
+                    names=", ".join(failed)
+                ),
+                information=self.tr(
+                    "Please check your internet connection and the configured URL."
+                ),
+            ).exec()
+        elif updated:
+            InformationBox(
+                title=self.tr("Download complete"),
+                text=self.tr("Database(s) downloaded successfully: {names}").format(
+                    names=", ".join(updated)
+                ),
+            ).exec()
+        elif up_to_date:
+            InformationBox(
+                title=self.tr("Already up to date"),
+                text=self.tr("Database(s) are already up to date: {names}").format(
+                    names=", ".join(up_to_date)
+                ),
+            ).exec()
+
+        if self._http_download_worker:
+            try:
+                self._http_download_worker.finished.disconnect()
+            except Exception:
+                pass
+            self._http_download_worker = None
+
+    def _start_git_clone_worker(
+        self, repo_url: str, base_path: str, force: bool
+    ) -> None:
         """Initialize and start GitCloneWorker."""
         if self._git_clone_worker is not None:
             try:
@@ -482,7 +699,9 @@ class MainContentController(QObject):
 
     @Slot(bool, str, str)
     def _on_git_clone_finished(self, success: bool, message: str, path: str) -> None:
-        logger.info(f"Git clone finished: success={success}, message={message}, path={path}")
+        logger.info(
+            f"Git clone finished: success={success}, message={message}, path={path}"
+        )
         if success:
             InformationBox(
                 title=self.tr("Repo retrieved"),
@@ -549,7 +768,9 @@ class MainContentController(QObject):
             InformationBox(
                 title=self.tr("Invalid repository"),
                 text=self.tr("Repository URL is empty or invalid."),
-                information=self.tr("Please configure a valid repository URL in settings."),
+                information=self.tr(
+                    "Please configure a valid repository URL in settings."
+                ),
             ).exec()
             return
 
@@ -573,7 +794,9 @@ class MainContentController(QObject):
             InformationBox(
                 title=self.tr("Invalid repository URL"),
                 text=self.tr("Failed to parse repository information from URL."),
-                information=self.tr("URL: {repo_url}\nError: {error}").format(repo_url=repo_url, error=str(e)),
+                information=self.tr("URL: {repo_url}\nError: {error}").format(
+                    repo_url=repo_url, error=str(e)
+                ),
             ).exec()
             return
 
@@ -584,8 +807,12 @@ class MainContentController(QObject):
         if not github_username or not github_token:
             InformationBox(
                 title=self.tr("GitHub credentials missing"),
-                text=self.tr("GitHub username and token are required for database upload."),
-                information=self.tr("Please configure your GitHub credentials in settings."),
+                text=self.tr(
+                    "GitHub username and token are required for database upload."
+                ),
+                information=self.tr(
+                    "Please configure your GitHub credentials in settings."
+                ),
             ).exec()
             return
 
@@ -611,10 +838,12 @@ class MainContentController(QObject):
         if not file_full_path.exists():
             InformationBox(
                 title=self.tr("File does not exist"),
-                text=self.tr("Please ensure the file exists and then try to upload again!"),
-                information=self.tr("File not found:\n{file_full_path}\nRepository:\n{repo_url}").format(
-                    file_full_path=file_full_path, repo_url=repo_url
+                text=self.tr(
+                    "Please ensure the file exists and then try to upload again!"
                 ),
+                information=self.tr(
+                    "File not found:\n{file_full_path}\nRepository:\n{repo_url}"
+                ).format(file_full_path=file_full_path, repo_url=repo_url),
             ).exec()
             return
 
@@ -624,14 +853,21 @@ class MainContentController(QObject):
                 database = json.loads(f.read())
 
             if database.get("version"):
-                database_version = database["version"] - self.settings_controller.settings.database_expiry
+                database_version = (
+                    database["version"]
+                    - self.settings_controller.settings.database_expiry
+                )
             elif database.get("timestamp"):
                 database_version = database["timestamp"]
             else:
                 InformationBox(
                     title=self.tr("Invalid database"),
-                    text=self.tr("Database file does not contain version or timestamp."),
-                    information=self.tr("File: {file_path}").format(file_path=str(file_full_path)),
+                    text=self.tr(
+                        "Database file does not contain version or timestamp."
+                    ),
+                    information=self.tr("File: {file_path}").format(
+                        file_path=str(file_full_path)
+                    ),
                 ).exec()
                 return
         except (json.JSONDecodeError, IOError) as e:
@@ -644,9 +880,12 @@ class MainContentController(QObject):
             return
 
         # Create human-readable version
-        timezone_abbreviation = datetime.datetime.now(datetime.timezone.utc).astimezone().tzinfo
+        timezone_abbreviation = (
+            datetime.datetime.now(datetime.timezone.utc).astimezone().tzinfo
+        )
         database_version_human_readable = (
-            time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(database_version)) + f" {timezone_abbreviation}"
+            time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(database_version))
+            + f" {timezone_abbreviation}"
         )
         # Initialize GitHub API
         try:
@@ -774,20 +1013,27 @@ class MainContentController(QObject):
 
                 # Step 1: Check if there are uncommitted changes and stash them
                 if git_utils.git_has_uncommitted_changes(repo, config):
-                    logger.info("Uncommitted changes detected, stashing them before pull")
+                    logger.info(
+                        "Uncommitted changes detected, stashing them before pull"
+                    )
                     stash_result = git_utils.git_stash(
                         repo,
                         message="Auto-stash before database upload pull",
                         config=config,
                     )
-                    if stash_result.is_successful() and stash_result == git_utils.GitStashResult.STASHED:
+                    if (
+                        stash_result.is_successful()
+                        and stash_result == git_utils.GitStashResult.STASHED
+                    ):
                         stash_created = True
                         logger.info("Successfully stashed uncommitted changes")
                     elif not stash_result.is_successful():
                         logger.error(f"Failed to stash changes: {stash_result}")
                         InformationBox(
                             title=self.tr("Stash failed"),
-                            text=self.tr("Failed to stash uncommitted changes before pull."),
+                            text=self.tr(
+                                "Failed to stash uncommitted changes before pull."
+                            ),
                             information=str(stash_result),
                         ).exec()
                         return
@@ -808,8 +1054,12 @@ class MainContentController(QObject):
                         logger.error("Merge conflicts detected during pull")
                         InformationBox(
                             title=self.tr("Pull conflict"),
-                            text=self.tr("Merge conflicts encountered during pull operation."),
-                            information=self.tr("Please manually resolve conflicts and try again."),
+                            text=self.tr(
+                                "Merge conflicts encountered during pull operation."
+                            ),
+                            information=self.tr(
+                                "Please manually resolve conflicts and try again."
+                            ),
                         ).exec()
                         return
                     else:
@@ -825,7 +1075,9 @@ class MainContentController(QObject):
                 commit_message = f"DB Update: {database_version_human_readable}"
                 # Step 4: Restore stashed changes with automatic conflict resolution
                 if stash_created:
-                    logger.info("Restoring stashed changes on main branch after successful pull")
+                    logger.info(
+                        "Restoring stashed changes on main branch after successful pull"
+                    )
 
                     # Store current HEAD before attempting stash pop for potential rollback
                     current_head_after_pull = repo.head.target
@@ -837,7 +1089,9 @@ class MainContentController(QObject):
                     )
 
                     if not unstash_result.is_successful():
-                        logger.warning(f"Failed to restore stashed changes: {unstash_result}")
+                        logger.warning(
+                            f"Failed to restore stashed changes: {unstash_result}"
+                        )
 
                         # Check if there are merge conflicts in the working directory
                         conflict_detected = False
@@ -850,23 +1104,31 @@ class MainContentController(QObject):
 
                             if conflict_files:
                                 conflict_detected = True
-                                logger.error(f"Merge conflicts detected in files: {conflict_files}")
+                                logger.error(
+                                    f"Merge conflicts detected in files: {conflict_files}"
+                                )
 
                                 # Automatic conflict resolution: Reset to clean state
                                 logger.info(
                                     "Automatically resolving conflicts by resetting to clean state"
                                 )  # Reset the working directory and index to clean state
-                                repo.reset(current_head_after_pull, pygit2.enums.ResetMode.HARD)
+                                repo.reset(
+                                    current_head_after_pull, pygit2.enums.ResetMode.HARD
+                                )
 
                                 # Clear any remaining conflicted state
                                 repo.state_cleanup()
 
-                                logger.info("Repository reset to clean state after conflicts")
+                                logger.info(
+                                    "Repository reset to clean state after conflicts"
+                                )
 
                                 # Inform user about the automatic resolution
                                 InformationBox(
                                     title=self.tr("Conflicts Auto-Resolved"),
-                                    text=self.tr("Merge conflicts were detected and automatically resolved."),
+                                    text=self.tr(
+                                        "Merge conflicts were detected and automatically resolved."
+                                    ),
                                     information=self.tr(
                                         "Your local changes conflicted with remote changes. "
                                         "The repository has been reset to a clean state with the latest remote changes. "
@@ -879,10 +1141,14 @@ class MainContentController(QObject):
                         # If conflicts were detected and resolved, continue with clean state
                         # If no conflicts but still failed, show warning and continue
                         if not conflict_detected:
-                            logger.warning("Stash pop failed but no conflicts detected, continuing...")
+                            logger.warning(
+                                "Stash pop failed but no conflicts detected, continuing..."
+                            )
                             InformationBox(
                                 title=self.tr("Stash restore warning"),
-                                text=self.tr("Failed to restore stashed changes, but no conflicts detected."),
+                                text=self.tr(
+                                    "Failed to restore stashed changes, but no conflicts detected."
+                                ),
                                 information=self.tr(
                                     "Continuing with current state. Your database changes should still be present."
                                 ),
@@ -909,7 +1175,9 @@ class MainContentController(QObject):
 
                     # IMPORTANT: Don't switch branches yet! Keep the changes in the working directory
                     # We'll switch after committing the changes
-                    logger.info(f"Created branch: {branch_name} (will switch after commit)")
+                    logger.info(
+                        f"Created branch: {branch_name} (will switch after commit)"
+                    )
                 except Exception as e:
                     logger.error(f"Failed to create branch {branch_name}: {e}")
                     InformationBox(
@@ -920,13 +1188,17 @@ class MainContentController(QObject):
                     return
 
                 # Step 6: Verify changes are still present in working directory
-                logger.info("Verifying changes are present in working directory before staging")
+                logger.info(
+                    "Verifying changes are present in working directory before staging"
+                )
 
                 # Quick verification that we have uncommitted changes as expected
                 if git_utils.git_has_uncommitted_changes(repo, config):
                     logger.info("Uncommitted changes confirmed in working directory")
                 else:
-                    logger.warning("No uncommitted changes detected in working directory")
+                    logger.warning(
+                        "No uncommitted changes detected in working directory"
+                    )
                     # Don't return here - let git_stage_commit make the final determination
 
                 # Log the current working tree status before staging
@@ -950,7 +1222,9 @@ class MainContentController(QObject):
                 logger.info(f"Stage and commit result: {stage_commit_result}")
 
                 if stage_commit_result == git_utils.GitStageCommitResult.COMMITTED:
-                    logger.info("Successfully staged and committed changes on main branch")
+                    logger.info(
+                        "Successfully staged and committed changes on main branch"
+                    )
 
                     # Now move the commit to the new branch
                     try:
@@ -967,12 +1241,16 @@ class MainContentController(QObject):
                         main_branch = repo.branches.local["main"]
                         main_branch.set_target(current_commit_oid)
 
-                        logger.info(f"Moved commit to branch: {branch_name} and reset main branch")
+                        logger.info(
+                            f"Moved commit to branch: {branch_name} and reset main branch"
+                        )
                     except Exception as e:
                         logger.error(f"Failed to move commit to new branch: {e}")
                         # If this fails, the commit is still on main, but we can continue
                         # Just switch to the new branch and the commit will be duplicated
-                        repo.head.set_target(branch_ref.target)  # Push to user's fork with the new branch
+                        repo.head.set_target(
+                            branch_ref.target
+                        )  # Push to user's fork with the new branch
                     push_result = git_utils.git_push(
                         repo=repo,
                         branch=branch_name,
@@ -993,8 +1271,12 @@ class MainContentController(QObject):
                             database_version_human_readable=database_version_human_readable,
                             commit_message=commit_message,
                         )
-                    elif push_result == git_utils.GitPushResult.REJECTED_NON_FAST_FORWARD:
-                        logger.warning("Push rejected due to non-fast-forward. Attempting force push.")
+                    elif (
+                        push_result == git_utils.GitPushResult.REJECTED_NON_FAST_FORWARD
+                    ):
+                        logger.warning(
+                            "Push rejected due to non-fast-forward. Attempting force push."
+                        )
 
                         # For a feature branch in a fork, force push is generally safe
                         # since it's a new branch that only we are working on
@@ -1023,7 +1305,9 @@ class MainContentController(QObject):
                             else:
                                 InformationBox(
                                     title=self.tr("Force push failed"),
-                                    text=self.tr("Failed to force push changes to fork."),
+                                    text=self.tr(
+                                        "Failed to force push changes to fork."
+                                    ),
                                     information=str(push_result_force),
                                 ).exec()
 
@@ -1031,7 +1315,9 @@ class MainContentController(QObject):
                             logger.error(f"Error during force push: {e}")
                             InformationBox(
                                 title=self.tr("Force push error"),
-                                text=self.tr("Error occurred while force pushing to remote."),
+                                text=self.tr(
+                                    "Error occurred while force pushing to remote."
+                                ),
                                 information=str(e),
                             ).exec()
                     else:
@@ -1045,7 +1331,9 @@ class MainContentController(QObject):
                     InformationBox(
                         title=self.tr("No changes"),
                         text=self.tr("No changes detected in database file."),
-                        information=self.tr("The database appears to be up to date with the remote repository."),
+                        information=self.tr(
+                            "The database appears to be up to date with the remote repository."
+                        ),
                     ).exec()
                     return
                 # Stop execution here since there's nothing to push or create PR for
@@ -1075,7 +1363,9 @@ class MainContentController(QObject):
                                 repo.checkout(main_branch)
                                 logger.info("Switched back to main branch")
                             else:
-                                logger.warning("Main branch not found, staying on current branch")
+                                logger.warning(
+                                    "Main branch not found, staying on current branch"
+                                )
                         except Exception as e:
                             logger.warning(f"Failed to switch to main branch: {e}")
             except Exception as e:
@@ -1152,8 +1442,12 @@ class MainContentController(QObject):
         """Ask user for confirmation before uploading Steam Workshop database."""
         binary_diag = BinaryChoiceDialog(
             title=self.tr("Upload Steam Workshop Database"),
-            text=self.tr("Are you sure you want to upload the Steam Workshop database to GitHub?"),
-            information=self.tr("This will create a pull request with your local database changes."),
+            text=self.tr(
+                "Are you sure you want to upload the Steam Workshop database to GitHub?"
+            ),
+            information=self.tr(
+                "This will create a pull request with your local database changes."
+            ),
             positive_text=self.tr("Upload"),
             negative_text=self.tr("Cancel"),
         )
@@ -1171,8 +1465,12 @@ class MainContentController(QObject):
         """Ask user for confirmation before uploading Community Rules database."""
         binary_diag = BinaryChoiceDialog(
             title=self.tr("Upload Community Rules Database"),
-            text=self.tr("Are you sure you want to upload the Community Rules database to GitHub?"),
-            information=self.tr("This will create a pull request with your local database changes."),
+            text=self.tr(
+                "Are you sure you want to upload the Community Rules database to GitHub?"
+            ),
+            information=self.tr(
+                "This will create a pull request with your local database changes."
+            ),
             positive_text=self.tr("Upload"),
             negative_text=self.tr("Cancel"),
         )
@@ -1186,13 +1484,19 @@ class MainContentController(QObject):
             logger.debug("User cancelled Community Rules database upload.")
 
     @Slot(object)
-    def _handle_batch_update_results_silent(self, results: GitBatchUpdateResults) -> None:
+    def _handle_batch_update_results_silent(
+        self, results: GitBatchUpdateResults
+    ) -> None:
         """Process results from GitBatchUpdateWorker silently."""
         successful = results.successful
         failed = results.failed
 
         if successful:
-            logger.info(f"Silently updated {len(successful)} database repositories successfully")
+            logger.info(
+                f"Silently updated {len(successful)} database repositories successfully"
+            )
 
         if failed:
-            logger.warning(f"Failed to update {len(failed)} database repositories: {[str(p) for p, e in failed]}")
+            logger.warning(
+                f"Failed to update {len(failed)} database repositories: {[str(p) for p, e in failed]}"
+            )

--- a/app/controllers/main_content_controller.py
+++ b/app/controllers/main_content_controller.py
@@ -47,9 +47,7 @@ from app.views.main_content_panel import MainContent
 class MainContentController(QObject):
     """Controller with concurrent checking/updating and improved structure."""
 
-    def __init__(
-        self, view: MainContent, settings_controller: SettingsController
-    ) -> None:
+    def __init__(self, view: MainContent, settings_controller: SettingsController) -> None:
         super().__init__()
         self.view = view
         self.settings_controller = settings_controller
@@ -67,42 +65,28 @@ class MainContentController(QObject):
                 AppInfo().databases_folder,
                 lambda: self.settings_controller.settings.external_community_rules_repo,
                 lambda: self.settings_controller.settings.external_community_rules_url,
-                lambda: (
-                    self.settings_controller.settings.external_community_rules_metadata_source
-                ),
+                lambda: self.settings_controller.settings.external_community_rules_metadata_source,
                 "Community Rules",
             ),
             EventBus().do_download_steam_workshop_db_from_github: (
                 AppInfo().databases_folder,
                 lambda: self.settings_controller.settings.external_steam_metadata_repo,
                 lambda: self.settings_controller.settings.external_steam_metadata_url,
-                lambda: (
-                    self.settings_controller.settings.external_steam_metadata_source
-                ),
+                lambda: self.settings_controller.settings.external_steam_metadata_source,
                 "Steam Workshop",
             ),
             EventBus().do_download_use_this_instead_db_from_github: (
                 AppInfo().databases_folder,
-                lambda: (
-                    self.settings_controller.settings.external_use_this_instead_repo_path
-                ),
+                lambda: self.settings_controller.settings.external_use_this_instead_repo_path,
                 lambda: self.settings_controller.settings.external_use_this_instead_url,
-                lambda: (
-                    self.settings_controller.settings.external_use_this_instead_metadata_source
-                ),
+                lambda: self.settings_controller.settings.external_use_this_instead_metadata_source,
                 "Use This Instead",
             ),
             EventBus().do_download_no_version_warning_db_from_github: (
                 AppInfo().databases_folder,
-                lambda: (
-                    self.settings_controller.settings.external_no_version_warning_repo_path
-                ),
-                lambda: (
-                    self.settings_controller.settings.external_no_version_warning_url
-                ),
-                lambda: (
-                    self.settings_controller.settings.external_no_version_warning_metadata_source
-                ),
+                lambda: self.settings_controller.settings.external_no_version_warning_repo_path,
+                lambda: self.settings_controller.settings.external_no_version_warning_url,
+                lambda: self.settings_controller.settings.external_no_version_warning_metadata_source,
                 "No Version Warning",
             ),
         }
@@ -141,12 +125,8 @@ class MainContentController(QObject):
                 )
             )
 
-        EventBus().do_upload_steam_workshop_db_to_github.connect(
-            self._on_do_upload_steam_workshop_db_to_github
-        )
-        EventBus().do_upload_community_rules_db_to_github.connect(
-            self._on_do_upload_community_db_to_github
-        )
+        EventBus().do_upload_steam_workshop_db_to_github.connect(self._on_do_upload_steam_workshop_db_to_github)
+        EventBus().do_upload_community_rules_db_to_github.connect(self._on_do_upload_community_db_to_github)
 
     @Slot(list)
     def _on_check_updates_requested(self, repos_paths: List[Path]) -> None:
@@ -158,9 +138,7 @@ class MainContentController(QObject):
                 information=self.tr("Please select at least one repository to check."),
             ).exec()
             return
-        logger.debug(
-            f"Scheduling concurrent check for {len(repos_paths)} repositories."
-        )
+        logger.debug(f"Scheduling concurrent check for {len(repos_paths)} repositories.")
         config = GitOperationConfig(notify_errors=True)
         worker = GitCheckUpdatesWorker(repos_paths, config=config)
         worker.signals.finished.connect(self._handle_check_updates_results)
@@ -185,9 +163,7 @@ class MainContentController(QObject):
             InformationBox(
                 title=self.tr("Errors during update check"),
                 text=self.tr("Some repositories encountered errors."),
-                information=self.tr(
-                    "Errors occurred while checking for updates:\n{errors}"
-                ).format(errors=msg),
+                information=self.tr("Errors occurred while checking for updates:\n{errors}").format(errors=msg),
             ).exec()
             return
 
@@ -208,9 +184,7 @@ class MainContentController(QObject):
 
         binary_diag = BinaryChoiceDialog(
             title=self.tr("Git Updates Found"),
-            text=self.tr("{len} repositories have updates available.").format(
-                len=len(updates)
-            ),
+            text=self.tr("{len} repositories have updates available.").format(len=len(updates)),
             information=self.tr("Would you like to update them now?"),
             details=details_msg,
             positive_text=self.tr("Update All"),
@@ -223,9 +197,7 @@ class MainContentController(QObject):
 
     def _on_update_repos(self, repos_paths: List[Path]) -> None:
         """Schedule concurrent batch pull for multiple repositories."""
-        logger.debug(
-            f"Scheduling concurrent update for {len(repos_paths)} repositories."
-        )
+        logger.debug(f"Scheduling concurrent update for {len(repos_paths)} repositories.")
         config = GitOperationConfig(notify_errors=True)
         worker = GitBatchUpdateWorker(repos_paths, config=config)
         worker.signals.finished.connect(self._handle_batch_update_results)
@@ -242,17 +214,15 @@ class MainContentController(QObject):
             details_msg = ""
             for repo_path in successful:
                 repo_name = Path(repo_path).name
-                commit_info = getattr(results, "commit_info", {}).get(
-                    str(repo_path), "No commit info"
-                )
+                commit_info = getattr(results, "commit_info", {}).get(str(repo_path), "No commit info")
                 details_msg += f"✓ {repo_name}\n  └─ {commit_info}\n\n"
 
             InformationBox(
                 title=self.tr("Updates Completed"),
                 text=self.tr("All repositories updated successfully!"),
-                information=self.tr(
-                    "{count} repositories were updated with their latest commits:"
-                ).format(count=len(successful)),
+                information=self.tr("{count} repositories were updated with their latest commits:").format(
+                    count=len(successful)
+                ),
                 details=details_msg.strip(),
             ).exec()
         elif not successful:
@@ -263,18 +233,14 @@ class MainContentController(QObject):
             InformationBox(
                 title=self.tr("Failed to update repo!"),
                 text=self.tr("All pull operations failed."),
-                information=self.tr(
-                    "{count} repositories could not be updated."
-                ).format(count=len(failed)),
+                information=self.tr("{count} repositories could not be updated.").format(count=len(failed)),
                 details=details_msg,
             ).exec()
         else:
             details_msg = self.tr("Successful updates:\n")
             for repo_path in successful:
                 repo_name = Path(repo_path).name
-                commit_info = getattr(results, "commit_info", {}).get(
-                    str(repo_path), "No commit info"
-                )
+                commit_info = getattr(results, "commit_info", {}).get(str(repo_path), "No commit info")
                 details_msg += f"  ✓ {repo_name}\n    └─ {commit_info}\n"
 
             details_msg += f"\n{self.tr('Failed updates:')}\n"
@@ -284,9 +250,9 @@ class MainContentController(QObject):
             InformationBox(
                 title=self.tr("Partial Updates Completed"),
                 text=self.tr("Some repositories updated successfully."),
-                information=self.tr(
-                    "{success} succeeded, {failed} failed out of {total}."
-                ).format(success=len(successful), failed=len(failed), total=total),
+                information=self.tr("{success} succeeded, {failed} failed out of {total}.").format(
+                    success=len(successful), failed=len(failed), total=total
+                ),
                 details=details_msg,
             ).exec()
 
@@ -306,9 +272,7 @@ class MainContentController(QObject):
         binary_diag = BinaryChoiceDialog(
             title=self.tr("Push Options"),
             text=self.tr("Push changes to remote repositories?"),
-            information=self.tr(
-                "This will push local commits to the remote repositories."
-            ),
+            information=self.tr("This will push local commits to the remote repositories."),
             details="\n".join([str(p) for p in repos_paths]),
             positive_text=self.tr("Push"),
             negative_text=self.tr("Cancel"),
@@ -322,9 +286,7 @@ class MainContentController(QObject):
         force_diag = BinaryChoiceDialog(
             title=self.tr("Force Push"),
             text=self.tr("Use force push?"),
-            information=self.tr(
-                "Force push will overwrite remote history. Use with caution!"
-            ),
+            information=self.tr("Force push will overwrite remote history. Use with caution!"),
             positive_text=self.tr("Force Push"),
             negative_text=self.tr("Normal Push"),
         )
@@ -334,9 +296,7 @@ class MainContentController(QObject):
 
     def _on_push_repos(self, repos_paths: List[Path], force: bool = False) -> None:
         """Schedule concurrent batch push for multiple repositories."""
-        logger.debug(
-            f"Scheduling concurrent push for {len(repos_paths)} repositories (force={force})."
-        )
+        logger.debug(f"Scheduling concurrent push for {len(repos_paths)} repositories (force={force}).")
         config = GitOperationConfig(notify_errors=True)
 
         # Get GitHub authentication from settings
@@ -364,9 +324,7 @@ class MainContentController(QObject):
             InformationBox(
                 title=self.tr("Push Completed"),
                 text=self.tr("All repositories pushed successfully!"),
-                information=self.tr("{count} repositories were pushed.").format(
-                    count=len(successful)
-                ),
+                information=self.tr("{count} repositories were pushed.").format(count=len(successful)),
                 details="\n".join([Path(p).name for p in successful]),
             ).exec()
         elif not successful:
@@ -377,9 +335,7 @@ class MainContentController(QObject):
             InformationBox(
                 title=self.tr("Push Failed"),
                 text=self.tr("All push operations failed."),
-                information=self.tr("{count} repositories could not be pushed.").format(
-                    count=len(failed)
-                ),
+                information=self.tr("{count} repositories could not be pushed.").format(count=len(failed)),
                 details=details_msg,
             ).exec()
         else:
@@ -393,9 +349,9 @@ class MainContentController(QObject):
             InformationBox(
                 title=self.tr("Partial Push Completed"),
                 text=self.tr("Some repositories pushed successfully."),
-                information=self.tr(
-                    "{success} succeeded, {failed} failed out of {total}."
-                ).format(success=len(successful), failed=len(failed), total=total),
+                information=self.tr("{success} succeeded, {failed} failed out of {total}.").format(
+                    success=len(successful), failed=len(failed), total=total
+                ),
                 details=details_msg,
             ).exec()
 
@@ -425,9 +381,7 @@ class MainContentController(QObject):
         if full_repo_path.exists():
             answer = show_dialogue_conditional(
                 title=self.tr("Existing repository found"),
-                text=self.tr(
-                    "An existing local repo that matches this repository was found:"
-                ),
+                text=self.tr("An existing local repo that matches this repository was found:"),
                 information=self.tr(
                     "{repo_folder}<br/>"
                     + "How would you like to handle? Choose option:<br/>"
@@ -489,11 +443,7 @@ class MainContentController(QObject):
 
         for source, repo_url, url, display_name in db_configs:
             if source == "Configured URL" and url:
-                repo_name = (
-                    extract_git_dir_name(repo_url)
-                    if repo_url
-                    else display_name.replace(" ", "-")
-                )
+                repo_name = extract_git_dir_name(repo_url) if repo_url else display_name.replace(" ", "-")
                 http_tasks.append(
                     DatabaseDownloadTask(
                         url=url,
@@ -526,27 +476,19 @@ class MainContentController(QObject):
 
     def _on_update_repos_silent(self, repos_paths: List[Path]) -> None:
         """Schedule concurrent batch pull for multiple repositories silently."""
-        logger.debug(
-            f"Scheduling silent concurrent update for {len(repos_paths)} repositories."
-        )
+        logger.debug(f"Scheduling silent concurrent update for {len(repos_paths)} repositories.")
         config = GitOperationConfig(notify_errors=False)
         worker = GitBatchUpdateWorker(repos_paths, config=config)
         worker.signals.finished.connect(self._handle_batch_update_results_silent)
         self.thread_pool.start(worker)
 
-    def _do_download_database(
-        self, base_path: Path, repo_url: str, url: str, source: str, display_name: str
-    ) -> None:
+    def _do_download_database(self, base_path: Path, repo_url: str, url: str, source: str, display_name: str) -> None:
         """Dispatch a database download via HTTP or git based on the configured source."""
         if not check_internet_connection():
             return
 
         if source == "Configured URL" and url:
-            repo_name = (
-                extract_git_dir_name(repo_url)
-                if repo_url
-                else display_name.replace(" ", "-")
-            )
+            repo_name = extract_git_dir_name(repo_url) if repo_url else display_name.replace(" ", "-")
             task = DatabaseDownloadTask(
                 url=url,
                 target_dir=base_path,
@@ -575,88 +517,58 @@ class MainContentController(QObject):
         self._cleanup_http_download_worker()
 
         self._http_download_worker = HttpDownloadWorker(tasks)
-        self._http_download_worker.download_finished.connect(
-            self._on_http_download_finished_silent
-        )
-        self._http_download_worker.progress.connect(
-            lambda msg: logger.info(f"HTTP DB update: {msg}")
-        )
+        self._http_download_worker.download_finished.connect(self._on_http_download_finished_silent)
+        self._http_download_worker.progress.connect(lambda msg: logger.info(f"HTTP DB update: {msg}"))
         logger.info(f"Starting HTTP download for {len(tasks)} database(s)")
         self._http_download_worker.start()
 
     @Slot(dict)
-    def _on_http_download_finished_silent(
-        self, results: dict[str, DownloadResult]
-    ) -> None:
+    def _on_http_download_finished_silent(self, results: dict[str, DownloadResult]) -> None:
         """Handle HTTP download completion silently (log only)."""
         updated = [name for name, r in results.items() if r == DownloadResult.UPDATED]
         failed = [name for name, r in results.items() if r == DownloadResult.FAILED]
         if updated:
-            logger.info(
-                f"HTTP DB update: {len(updated)} database(s) updated: {', '.join(updated)}"
-            )
+            logger.info(f"HTTP DB update: {len(updated)} database(s) updated: {', '.join(updated)}")
         if failed:
-            logger.warning(
-                f"HTTP DB update: {len(failed)} database(s) failed: {', '.join(failed)}"
-            )
+            logger.warning(f"HTTP DB update: {len(failed)} database(s) failed: {', '.join(failed)}")
         self._cleanup_http_download_worker()
 
-    def _start_http_download_interactive(
-        self, tasks: list[DatabaseDownloadTask]
-    ) -> None:
+    def _start_http_download_interactive(self, tasks: list[DatabaseDownloadTask]) -> None:
         """Start an HTTP download worker with user-facing result dialogs."""
         self._cleanup_http_download_worker()
 
         self._http_download_worker = HttpDownloadWorker(tasks)
-        self._http_download_worker.download_finished.connect(
-            self._on_http_download_finished_interactive
-        )
-        self._http_download_worker.progress.connect(
-            lambda msg: logger.info(f"HTTP DB download: {msg}")
-        )
+        self._http_download_worker.download_finished.connect(self._on_http_download_finished_interactive)
+        self._http_download_worker.progress.connect(lambda msg: logger.info(f"HTTP DB download: {msg}"))
         self._http_download_worker.start()
 
     @Slot(dict)
-    def _on_http_download_finished_interactive(
-        self, results: dict[str, DownloadResult]
-    ) -> None:
+    def _on_http_download_finished_interactive(self, results: dict[str, DownloadResult]) -> None:
         """Handle HTTP download completion with user-facing dialogs."""
         updated = [name for name, r in results.items() if r == DownloadResult.UPDATED]
-        up_to_date = [
-            name for name, r in results.items() if r == DownloadResult.UP_TO_DATE
-        ]
+        up_to_date = [name for name, r in results.items() if r == DownloadResult.UP_TO_DATE]
         failed = [name for name, r in results.items() if r == DownloadResult.FAILED]
 
         if failed:
             InformationBox(
                 title=self.tr("Download failed"),
-                text=self.tr("Failed to download database(s): {names}").format(
-                    names=", ".join(failed)
-                ),
-                information=self.tr(
-                    "Please check your internet connection and the configured URL."
-                ),
+                text=self.tr("Failed to download database(s): {names}").format(names=", ".join(failed)),
+                information=self.tr("Please check your internet connection and the configured URL."),
             ).exec()
         elif updated:
             InformationBox(
                 title=self.tr("Download complete"),
-                text=self.tr("Database(s) downloaded successfully: {names}").format(
-                    names=", ".join(updated)
-                ),
+                text=self.tr("Database(s) downloaded successfully: {names}").format(names=", ".join(updated)),
             ).exec()
         elif up_to_date:
             InformationBox(
                 title=self.tr("Already up to date"),
-                text=self.tr("Database(s) are already up to date: {names}").format(
-                    names=", ".join(up_to_date)
-                ),
+                text=self.tr("Database(s) are already up to date: {names}").format(names=", ".join(up_to_date)),
             ).exec()
 
         self._cleanup_http_download_worker()
 
-    def _start_git_clone_worker(
-        self, repo_url: str, base_path: str, force: bool
-    ) -> None:
+    def _start_git_clone_worker(self, repo_url: str, base_path: str, force: bool) -> None:
         """Initialize and start GitCloneWorker."""
         if self._git_clone_worker is not None:
             try:
@@ -688,9 +600,7 @@ class MainContentController(QObject):
 
     @Slot(bool, str, str)
     def _on_git_clone_finished(self, success: bool, message: str, path: str) -> None:
-        logger.info(
-            f"Git clone finished: success={success}, message={message}, path={path}"
-        )
+        logger.info(f"Git clone finished: success={success}, message={message}, path={path}")
         if success:
             InformationBox(
                 title=self.tr("Repo retrieved"),
@@ -757,9 +667,7 @@ class MainContentController(QObject):
             InformationBox(
                 title=self.tr("Invalid repository"),
                 text=self.tr("Repository URL is empty or invalid."),
-                information=self.tr(
-                    "Please configure a valid repository URL in settings."
-                ),
+                information=self.tr("Please configure a valid repository URL in settings."),
             ).exec()
             return
 
@@ -783,9 +691,7 @@ class MainContentController(QObject):
             InformationBox(
                 title=self.tr("Invalid repository URL"),
                 text=self.tr("Failed to parse repository information from URL."),
-                information=self.tr("URL: {repo_url}\nError: {error}").format(
-                    repo_url=repo_url, error=str(e)
-                ),
+                information=self.tr("URL: {repo_url}\nError: {error}").format(repo_url=repo_url, error=str(e)),
             ).exec()
             return
 
@@ -796,12 +702,8 @@ class MainContentController(QObject):
         if not github_username or not github_token:
             InformationBox(
                 title=self.tr("GitHub credentials missing"),
-                text=self.tr(
-                    "GitHub username and token are required for database upload."
-                ),
-                information=self.tr(
-                    "Please configure your GitHub credentials in settings."
-                ),
+                text=self.tr("GitHub username and token are required for database upload."),
+                information=self.tr("Please configure your GitHub credentials in settings."),
             ).exec()
             return
 
@@ -827,12 +729,10 @@ class MainContentController(QObject):
         if not file_full_path.exists():
             InformationBox(
                 title=self.tr("File does not exist"),
-                text=self.tr(
-                    "Please ensure the file exists and then try to upload again!"
+                text=self.tr("Please ensure the file exists and then try to upload again!"),
+                information=self.tr("File not found:\n{file_full_path}\nRepository:\n{repo_url}").format(
+                    file_full_path=file_full_path, repo_url=repo_url
                 ),
-                information=self.tr(
-                    "File not found:\n{file_full_path}\nRepository:\n{repo_url}"
-                ).format(file_full_path=file_full_path, repo_url=repo_url),
             ).exec()
             return
 
@@ -842,21 +742,14 @@ class MainContentController(QObject):
                 database = json.loads(f.read())
 
             if database.get("version"):
-                database_version = (
-                    database["version"]
-                    - self.settings_controller.settings.database_expiry
-                )
+                database_version = database["version"] - self.settings_controller.settings.database_expiry
             elif database.get("timestamp"):
                 database_version = database["timestamp"]
             else:
                 InformationBox(
                     title=self.tr("Invalid database"),
-                    text=self.tr(
-                        "Database file does not contain version or timestamp."
-                    ),
-                    information=self.tr("File: {file_path}").format(
-                        file_path=str(file_full_path)
-                    ),
+                    text=self.tr("Database file does not contain version or timestamp."),
+                    information=self.tr("File: {file_path}").format(file_path=str(file_full_path)),
                 ).exec()
                 return
         except (json.JSONDecodeError, IOError) as e:
@@ -869,12 +762,9 @@ class MainContentController(QObject):
             return
 
         # Create human-readable version
-        timezone_abbreviation = (
-            datetime.datetime.now(datetime.timezone.utc).astimezone().tzinfo
-        )
+        timezone_abbreviation = datetime.datetime.now(datetime.timezone.utc).astimezone().tzinfo
         database_version_human_readable = (
-            time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(database_version))
-            + f" {timezone_abbreviation}"
+            time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(database_version)) + f" {timezone_abbreviation}"
         )
         # Initialize GitHub API
         try:
@@ -1002,27 +892,20 @@ class MainContentController(QObject):
 
                 # Step 1: Check if there are uncommitted changes and stash them
                 if git_utils.git_has_uncommitted_changes(repo, config):
-                    logger.info(
-                        "Uncommitted changes detected, stashing them before pull"
-                    )
+                    logger.info("Uncommitted changes detected, stashing them before pull")
                     stash_result = git_utils.git_stash(
                         repo,
                         message="Auto-stash before database upload pull",
                         config=config,
                     )
-                    if (
-                        stash_result.is_successful()
-                        and stash_result == git_utils.GitStashResult.STASHED
-                    ):
+                    if stash_result.is_successful() and stash_result == git_utils.GitStashResult.STASHED:
                         stash_created = True
                         logger.info("Successfully stashed uncommitted changes")
                     elif not stash_result.is_successful():
                         logger.error(f"Failed to stash changes: {stash_result}")
                         InformationBox(
                             title=self.tr("Stash failed"),
-                            text=self.tr(
-                                "Failed to stash uncommitted changes before pull."
-                            ),
+                            text=self.tr("Failed to stash uncommitted changes before pull."),
                             information=str(stash_result),
                         ).exec()
                         return
@@ -1043,12 +926,8 @@ class MainContentController(QObject):
                         logger.error("Merge conflicts detected during pull")
                         InformationBox(
                             title=self.tr("Pull conflict"),
-                            text=self.tr(
-                                "Merge conflicts encountered during pull operation."
-                            ),
-                            information=self.tr(
-                                "Please manually resolve conflicts and try again."
-                            ),
+                            text=self.tr("Merge conflicts encountered during pull operation."),
+                            information=self.tr("Please manually resolve conflicts and try again."),
                         ).exec()
                         return
                     else:
@@ -1064,9 +943,7 @@ class MainContentController(QObject):
                 commit_message = f"DB Update: {database_version_human_readable}"
                 # Step 4: Restore stashed changes with automatic conflict resolution
                 if stash_created:
-                    logger.info(
-                        "Restoring stashed changes on main branch after successful pull"
-                    )
+                    logger.info("Restoring stashed changes on main branch after successful pull")
 
                     # Store current HEAD before attempting stash pop for potential rollback
                     current_head_after_pull = repo.head.target
@@ -1078,9 +955,7 @@ class MainContentController(QObject):
                     )
 
                     if not unstash_result.is_successful():
-                        logger.warning(
-                            f"Failed to restore stashed changes: {unstash_result}"
-                        )
+                        logger.warning(f"Failed to restore stashed changes: {unstash_result}")
 
                         # Check if there are merge conflicts in the working directory
                         conflict_detected = False
@@ -1093,31 +968,23 @@ class MainContentController(QObject):
 
                             if conflict_files:
                                 conflict_detected = True
-                                logger.error(
-                                    f"Merge conflicts detected in files: {conflict_files}"
-                                )
+                                logger.error(f"Merge conflicts detected in files: {conflict_files}")
 
                                 # Automatic conflict resolution: Reset to clean state
                                 logger.info(
                                     "Automatically resolving conflicts by resetting to clean state"
                                 )  # Reset the working directory and index to clean state
-                                repo.reset(
-                                    current_head_after_pull, pygit2.enums.ResetMode.HARD
-                                )
+                                repo.reset(current_head_after_pull, pygit2.enums.ResetMode.HARD)
 
                                 # Clear any remaining conflicted state
                                 repo.state_cleanup()
 
-                                logger.info(
-                                    "Repository reset to clean state after conflicts"
-                                )
+                                logger.info("Repository reset to clean state after conflicts")
 
                                 # Inform user about the automatic resolution
                                 InformationBox(
                                     title=self.tr("Conflicts Auto-Resolved"),
-                                    text=self.tr(
-                                        "Merge conflicts were detected and automatically resolved."
-                                    ),
+                                    text=self.tr("Merge conflicts were detected and automatically resolved."),
                                     information=self.tr(
                                         "Your local changes conflicted with remote changes. "
                                         "The repository has been reset to a clean state with the latest remote changes. "
@@ -1130,14 +997,10 @@ class MainContentController(QObject):
                         # If conflicts were detected and resolved, continue with clean state
                         # If no conflicts but still failed, show warning and continue
                         if not conflict_detected:
-                            logger.warning(
-                                "Stash pop failed but no conflicts detected, continuing..."
-                            )
+                            logger.warning("Stash pop failed but no conflicts detected, continuing...")
                             InformationBox(
                                 title=self.tr("Stash restore warning"),
-                                text=self.tr(
-                                    "Failed to restore stashed changes, but no conflicts detected."
-                                ),
+                                text=self.tr("Failed to restore stashed changes, but no conflicts detected."),
                                 information=self.tr(
                                     "Continuing with current state. Your database changes should still be present."
                                 ),
@@ -1164,9 +1027,7 @@ class MainContentController(QObject):
 
                     # IMPORTANT: Don't switch branches yet! Keep the changes in the working directory
                     # We'll switch after committing the changes
-                    logger.info(
-                        f"Created branch: {branch_name} (will switch after commit)"
-                    )
+                    logger.info(f"Created branch: {branch_name} (will switch after commit)")
                 except Exception as e:
                     logger.error(f"Failed to create branch {branch_name}: {e}")
                     InformationBox(
@@ -1177,17 +1038,13 @@ class MainContentController(QObject):
                     return
 
                 # Step 6: Verify changes are still present in working directory
-                logger.info(
-                    "Verifying changes are present in working directory before staging"
-                )
+                logger.info("Verifying changes are present in working directory before staging")
 
                 # Quick verification that we have uncommitted changes as expected
                 if git_utils.git_has_uncommitted_changes(repo, config):
                     logger.info("Uncommitted changes confirmed in working directory")
                 else:
-                    logger.warning(
-                        "No uncommitted changes detected in working directory"
-                    )
+                    logger.warning("No uncommitted changes detected in working directory")
                     # Don't return here - let git_stage_commit make the final determination
 
                 # Log the current working tree status before staging
@@ -1211,9 +1068,7 @@ class MainContentController(QObject):
                 logger.info(f"Stage and commit result: {stage_commit_result}")
 
                 if stage_commit_result == git_utils.GitStageCommitResult.COMMITTED:
-                    logger.info(
-                        "Successfully staged and committed changes on main branch"
-                    )
+                    logger.info("Successfully staged and committed changes on main branch")
 
                     # Now move the commit to the new branch
                     try:
@@ -1230,16 +1085,12 @@ class MainContentController(QObject):
                         main_branch = repo.branches.local["main"]
                         main_branch.set_target(current_commit_oid)
 
-                        logger.info(
-                            f"Moved commit to branch: {branch_name} and reset main branch"
-                        )
+                        logger.info(f"Moved commit to branch: {branch_name} and reset main branch")
                     except Exception as e:
                         logger.error(f"Failed to move commit to new branch: {e}")
                         # If this fails, the commit is still on main, but we can continue
                         # Just switch to the new branch and the commit will be duplicated
-                        repo.head.set_target(
-                            branch_ref.target
-                        )  # Push to user's fork with the new branch
+                        repo.head.set_target(branch_ref.target)  # Push to user's fork with the new branch
                     push_result = git_utils.git_push(
                         repo=repo,
                         branch=branch_name,
@@ -1260,12 +1111,8 @@ class MainContentController(QObject):
                             database_version_human_readable=database_version_human_readable,
                             commit_message=commit_message,
                         )
-                    elif (
-                        push_result == git_utils.GitPushResult.REJECTED_NON_FAST_FORWARD
-                    ):
-                        logger.warning(
-                            "Push rejected due to non-fast-forward. Attempting force push."
-                        )
+                    elif push_result == git_utils.GitPushResult.REJECTED_NON_FAST_FORWARD:
+                        logger.warning("Push rejected due to non-fast-forward. Attempting force push.")
 
                         # For a feature branch in a fork, force push is generally safe
                         # since it's a new branch that only we are working on
@@ -1294,9 +1141,7 @@ class MainContentController(QObject):
                             else:
                                 InformationBox(
                                     title=self.tr("Force push failed"),
-                                    text=self.tr(
-                                        "Failed to force push changes to fork."
-                                    ),
+                                    text=self.tr("Failed to force push changes to fork."),
                                     information=str(push_result_force),
                                 ).exec()
 
@@ -1304,9 +1149,7 @@ class MainContentController(QObject):
                             logger.error(f"Error during force push: {e}")
                             InformationBox(
                                 title=self.tr("Force push error"),
-                                text=self.tr(
-                                    "Error occurred while force pushing to remote."
-                                ),
+                                text=self.tr("Error occurred while force pushing to remote."),
                                 information=str(e),
                             ).exec()
                     else:
@@ -1320,9 +1163,7 @@ class MainContentController(QObject):
                     InformationBox(
                         title=self.tr("No changes"),
                         text=self.tr("No changes detected in database file."),
-                        information=self.tr(
-                            "The database appears to be up to date with the remote repository."
-                        ),
+                        information=self.tr("The database appears to be up to date with the remote repository."),
                     ).exec()
                     return
                 # Stop execution here since there's nothing to push or create PR for
@@ -1352,9 +1193,7 @@ class MainContentController(QObject):
                                 repo.checkout(main_branch)
                                 logger.info("Switched back to main branch")
                             else:
-                                logger.warning(
-                                    "Main branch not found, staying on current branch"
-                                )
+                                logger.warning("Main branch not found, staying on current branch")
                         except Exception as e:
                             logger.warning(f"Failed to switch to main branch: {e}")
             except Exception as e:
@@ -1431,12 +1270,8 @@ class MainContentController(QObject):
         """Ask user for confirmation before uploading Steam Workshop database."""
         binary_diag = BinaryChoiceDialog(
             title=self.tr("Upload Steam Workshop Database"),
-            text=self.tr(
-                "Are you sure you want to upload the Steam Workshop database to GitHub?"
-            ),
-            information=self.tr(
-                "This will create a pull request with your local database changes."
-            ),
+            text=self.tr("Are you sure you want to upload the Steam Workshop database to GitHub?"),
+            information=self.tr("This will create a pull request with your local database changes."),
             positive_text=self.tr("Upload"),
             negative_text=self.tr("Cancel"),
         )
@@ -1454,12 +1289,8 @@ class MainContentController(QObject):
         """Ask user for confirmation before uploading Community Rules database."""
         binary_diag = BinaryChoiceDialog(
             title=self.tr("Upload Community Rules Database"),
-            text=self.tr(
-                "Are you sure you want to upload the Community Rules database to GitHub?"
-            ),
-            information=self.tr(
-                "This will create a pull request with your local database changes."
-            ),
+            text=self.tr("Are you sure you want to upload the Community Rules database to GitHub?"),
+            information=self.tr("This will create a pull request with your local database changes."),
             positive_text=self.tr("Upload"),
             negative_text=self.tr("Cancel"),
         )
@@ -1473,19 +1304,13 @@ class MainContentController(QObject):
             logger.debug("User cancelled Community Rules database upload.")
 
     @Slot(object)
-    def _handle_batch_update_results_silent(
-        self, results: GitBatchUpdateResults
-    ) -> None:
+    def _handle_batch_update_results_silent(self, results: GitBatchUpdateResults) -> None:
         """Process results from GitBatchUpdateWorker silently."""
         successful = results.successful
         failed = results.failed
 
         if successful:
-            logger.info(
-                f"Silently updated {len(successful)} database repositories successfully"
-            )
+            logger.info(f"Silently updated {len(successful)} database repositories successfully")
 
         if failed:
-            logger.warning(
-                f"Failed to update {len(failed)} database repositories: {[str(p) for p, e in failed]}"
-            )
+            logger.warning(f"Failed to update {len(failed)} database repositories: {[str(p) for p, e in failed]}")

--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -84,9 +84,13 @@ class SettingsController(QObject):
             self._on_global_reset_to_defaults_button_clicked
         )
 
-        self.settings_dialog.global_cancel_button.clicked.connect(self._on_global_cancel_button_clicked)
+        self.settings_dialog.global_cancel_button.clicked.connect(
+            self._on_global_cancel_button_clicked
+        )
 
-        self.settings_dialog.global_ok_button.clicked.connect(self._on_global_ok_button_clicked)
+        self.settings_dialog.global_ok_button.clicked.connect(
+            self._on_global_ok_button_clicked
+        )
 
         # Connect launch state radio buttons to update spinbox enabled/disabled state
         # Main Window
@@ -128,12 +132,22 @@ class SettingsController(QObject):
         )
 
         # Locations tab
-        self.settings_dialog.game_location.textChanged.connect(self._on_game_location_text_changed)
-        self.settings_dialog.game_location_open_button.clicked.connect(self._on_game_location_open_button_clicked)
-        self.settings_dialog.game_location_choose_button.clicked.connect(self._on_game_location_choose_button_clicked)
-        self.settings_dialog.game_location_clear_button.clicked.connect(self._on_game_location_clear_button_clicked)
+        self.settings_dialog.game_location.textChanged.connect(
+            self._on_game_location_text_changed
+        )
+        self.settings_dialog.game_location_open_button.clicked.connect(
+            self._on_game_location_open_button_clicked
+        )
+        self.settings_dialog.game_location_choose_button.clicked.connect(
+            self._on_game_location_choose_button_clicked
+        )
+        self.settings_dialog.game_location_clear_button.clicked.connect(
+            self._on_game_location_clear_button_clicked
+        )
 
-        self.settings_dialog.config_folder_location.textChanged.connect(self._on_config_folder_location_text_changed)
+        self.settings_dialog.config_folder_location.textChanged.connect(
+            self._on_config_folder_location_text_changed
+        )
         self.settings_dialog.config_folder_location_open_button.clicked.connect(
             self._on_config_folder_location_open_button_clicked
         )
@@ -182,17 +196,30 @@ class SettingsController(QObject):
             # Buttons may not exist if UI hasn't been updated yet
             pass
 
-        self.settings_dialog.locations_clear_button.clicked.connect(self._on_locations_clear_button_clicked)
+        self.settings_dialog.locations_clear_button.clicked.connect(
+            self._on_locations_clear_button_clicked
+        )
 
-        self.settings_dialog.locations_autodetect_button.clicked.connect(self._on_locations_autodetect_button_clicked)
+        self.settings_dialog.locations_autodetect_button.clicked.connect(
+            self._on_locations_autodetect_button_clicked
+        )
 
         # Game Launch tab
-        self.settings_dialog.run_args.textChanged.connect(self._on_run_args_text_changed)
+        self.settings_dialog.run_args.textChanged.connect(
+            self._on_run_args_text_changed
+        )
 
         # Wire up the Databases tab buttons
 
-        self.settings_dialog.community_rules_db_none_radio.clicked.connect(self._on_community_rules_db_radio_clicked)
-        self.settings_dialog.community_rules_db_github_radio.clicked.connect(self._on_community_rules_db_radio_clicked)
+        self.settings_dialog.community_rules_db_none_radio.clicked.connect(
+            self._on_community_rules_db_radio_clicked
+        )
+        self.settings_dialog.community_rules_db_github_radio.clicked.connect(
+            self._on_community_rules_db_radio_clicked
+        )
+        self.settings_dialog.community_rules_db_url_radio.clicked.connect(
+            self._on_community_rules_db_radio_clicked
+        )
         self.settings_dialog.community_rules_db_local_file_radio.clicked.connect(
             self._on_community_rules_db_radio_clicked
         )
@@ -206,9 +233,19 @@ class SettingsController(QObject):
         self.settings_dialog.community_rules_db_github_download_button.clicked.connect(
             EventBus().do_download_community_rules_db_from_github
         )
+        self.settings_dialog.community_rules_db_url_download_button.clicked.connect(
+            EventBus().do_download_community_rules_db_from_github
+        )
 
-        self.settings_dialog.steam_workshop_db_none_radio.clicked.connect(self._on_steam_workshop_db_radio_clicked)
-        self.settings_dialog.steam_workshop_db_github_radio.clicked.connect(self._on_steam_workshop_db_radio_clicked)
+        self.settings_dialog.steam_workshop_db_none_radio.clicked.connect(
+            self._on_steam_workshop_db_radio_clicked
+        )
+        self.settings_dialog.steam_workshop_db_github_radio.clicked.connect(
+            self._on_steam_workshop_db_radio_clicked
+        )
+        self.settings_dialog.steam_workshop_db_url_radio.clicked.connect(
+            self._on_steam_workshop_db_radio_clicked
+        )
         self.settings_dialog.steam_workshop_db_local_file_radio.clicked.connect(
             self._on_steam_workshop_db_radio_clicked
         )
@@ -222,12 +259,18 @@ class SettingsController(QObject):
         self.settings_dialog.steam_workshop_db_github_download_button.clicked.connect(
             EventBus().do_download_steam_workshop_db_from_github
         )
+        self.settings_dialog.steam_workshop_db_url_download_button.clicked.connect(
+            EventBus().do_download_steam_workshop_db_from_github
+        )
 
         # Cross Version DB tab
         self.settings_dialog.no_version_warning_db_none_radio.clicked.connect(
             self._on_no_version_warning_db_radio_clicked
         )
         self.settings_dialog.no_version_warning_db_github_radio.clicked.connect(
+            self._on_no_version_warning_db_radio_clicked
+        )
+        self.settings_dialog.no_version_warning_db_url_radio.clicked.connect(
             self._on_no_version_warning_db_radio_clicked
         )
         self.settings_dialog.no_version_warning_db_local_file_radio.clicked.connect(
@@ -243,9 +286,17 @@ class SettingsController(QObject):
         self.settings_dialog.no_version_warning_db_github_download_button.clicked.connect(
             EventBus().do_download_no_version_warning_db_from_github
         )
+        self.settings_dialog.no_version_warning_db_url_download_button.clicked.connect(
+            EventBus().do_download_no_version_warning_db_from_github
+        )
 
-        self.settings_dialog.use_this_instead_db_none_radio.clicked.connect(self._on_use_this_instead_db_radio_clicked)
+        self.settings_dialog.use_this_instead_db_none_radio.clicked.connect(
+            self._on_use_this_instead_db_radio_clicked
+        )
         self.settings_dialog.use_this_instead_db_github_radio.clicked.connect(
+            self._on_use_this_instead_db_radio_clicked
+        )
+        self.settings_dialog.use_this_instead_db_url_radio.clicked.connect(
             self._on_use_this_instead_db_radio_clicked
         )
         self.settings_dialog.use_this_instead_db_local_file_radio.clicked.connect(
@@ -259,6 +310,9 @@ class SettingsController(QObject):
             EventBus().do_upload_use_this_instead_db_to_github
         )
         self.settings_dialog.use_this_instead_db_github_download_button.clicked.connect(
+            EventBus().do_download_use_this_instead_db_from_github
+        )
+        self.settings_dialog.use_this_instead_db_url_download_button.clicked.connect(
             EventBus().do_download_use_this_instead_db_from_github
         )
 
@@ -286,9 +340,15 @@ class SettingsController(QObject):
         self.settings_dialog.steamcmd_clear_depot_cache_button.clicked.connect(
             self._on_steamcmd_clear_depot_cache_button_clicked
         )
-        self.settings_dialog.steamcmd_import_acf_button.clicked.connect(self._on_steamcmd_import_acf_button_clicked)
-        self.settings_dialog.steamcmd_delete_acf_button.clicked.connect(self._on_steamcmd_delete_acf_button_clicked)
-        self.settings_dialog.steamcmd_install_button.clicked.connect(self._on_steamcmd_install_button_clicked)
+        self.settings_dialog.steamcmd_import_acf_button.clicked.connect(
+            self._on_steamcmd_import_acf_button_clicked
+        )
+        self.settings_dialog.steamcmd_delete_acf_button.clicked.connect(
+            self._on_steamcmd_delete_acf_button_clicked
+        )
+        self.settings_dialog.steamcmd_install_button.clicked.connect(
+            self._on_steamcmd_install_button_clicked
+        )
 
         # Other External Tools Tab
         self.settings_dialog.text_editor_location_choose_button.clicked.connect(
@@ -296,7 +356,9 @@ class SettingsController(QObject):
         )
 
         # Theme tab
-        self.settings_dialog.theme_location_open_button.clicked.connect(self._on_theme_location_open_button_clicked)
+        self.settings_dialog.theme_location_open_button.clicked.connect(
+            self._on_theme_location_open_button_clicked
+        )
 
         # Advanced tab
         self.settings_dialog.color_background_instead_of_text_checkbox.stateChanged.connect(
@@ -330,9 +392,24 @@ class SettingsController(QObject):
         Get the mod paths for the current instance. Return the Default instance if the current instance is not found.
         """
         return [
-            str(Path(self.settings.instances[self.settings.current_instance].game_folder) / "Data"),
-            str(Path(self.settings.instances[self.settings.current_instance].local_folder)),
-            str(Path(self.settings.instances[self.settings.current_instance].workshop_folder)),
+            str(
+                Path(
+                    self.settings.instances[self.settings.current_instance].game_folder
+                )
+                / "Data"
+            ),
+            str(
+                Path(
+                    self.settings.instances[self.settings.current_instance].local_folder
+                )
+            ),
+            str(
+                Path(
+                    self.settings.instances[
+                        self.settings.current_instance
+                    ].workshop_folder
+                )
+            ),
         ]
 
     def resolve_data_source(self, path: str) -> str | None:
@@ -342,9 +419,16 @@ class SettingsController(QObject):
         # Pathlib the provided path string
         sanitized_path = Path(path)
         # Grab paths from Settings
-        expansions_path = Path(self.settings.instances[self.settings.current_instance].game_folder) / "Data"
-        local_path = Path(self.settings.instances[self.settings.current_instance].local_folder)
-        workshop_path = Path(self.settings.instances[self.settings.current_instance].workshop_folder)
+        expansions_path = (
+            Path(self.settings.instances[self.settings.current_instance].game_folder)
+            / "Data"
+        )
+        local_path = Path(
+            self.settings.instances[self.settings.current_instance].local_folder
+        )
+        workshop_path = Path(
+            self.settings.instances[self.settings.current_instance].workshop_folder
+        )
         # Validate data source, then emit if path is valid and not mapped
         if sanitized_path.parent == expansions_path:
             return "expansion"
@@ -433,7 +517,9 @@ class SettingsController(QObject):
             str(self.settings.instances[self.settings.current_instance].game_folder)
         )
         self.settings_dialog.game_location.setCursorPosition(0)
-        self.settings_dialog.game_location_open_button.setEnabled(self.settings_dialog.game_location.text() != "")
+        self.settings_dialog.game_location_open_button.setEnabled(
+            self.settings_dialog.game_location.text() != ""
+        )
         self.settings_dialog.config_folder_location.setText(
             str(self.settings.instances[self.settings.current_instance].config_folder)
         )
@@ -456,102 +542,255 @@ class SettingsController(QObject):
             self.settings_dialog.local_mods_folder_location.text() != ""
         )
         self.settings_dialog.steam_client_integration_checkbox.setChecked(
-            self.settings.instances[self.settings.current_instance].steam_client_integration
+            self.settings.instances[
+                self.settings.current_instance
+            ].steam_client_integration
         )
         # Enable/disable Steam mods location fields based on checkbox state
         checked = self.settings_dialog.steam_client_integration_checkbox.isChecked()
         self.settings_dialog.steam_mods_folder_location.setEnabled(checked)
         self.settings_dialog.steam_mods_folder_location_open_button.setEnabled(checked)
-        self.settings_dialog.steam_mods_folder_location_choose_button.setEnabled(checked)
+        self.settings_dialog.steam_mods_folder_location_choose_button.setEnabled(
+            checked
+        )
         self.settings_dialog.steam_mods_folder_location_clear_button.setEnabled(checked)
 
         # Load Steam protocol launch option
         self.settings_dialog.launch_via_steam_protocol_checkbox.setChecked(
-            self.settings.instances[self.settings.current_instance].launch_via_steam_protocol
+            self.settings.instances[
+                self.settings.current_instance
+            ].launch_via_steam_protocol
         )
         # Update run_args group enabled state based on Steam protocol setting
-        launch_via_steam_protocol = self.settings.instances[self.settings.current_instance].launch_via_steam_protocol
+        launch_via_steam_protocol = self.settings.instances[
+            self.settings.current_instance
+        ].launch_via_steam_protocol
         self.settings_dialog.run_args_group.setEnabled(not launch_via_steam_protocol)
 
         # Instance folder location (custom override)
         # Only enable for Default instance
         is_default_instance = self.settings.current_instance == DEFAULT_INSTANCE_NAME
         self.settings_dialog.instance_folder_location.setText(
-            self.settings.instances[self.settings.current_instance].instance_folder_override
+            self.settings.instances[
+                self.settings.current_instance
+            ].instance_folder_override
         )
         self.settings_dialog.instance_folder_location.setCursorPosition(0)
         self.settings_dialog.instance_folder_location.setEnabled(is_default_instance)
-        self.settings_dialog.instance_folder_location_choose_button.setEnabled(is_default_instance)
-        self.settings_dialog.instance_folder_location_clear_button.setEnabled(is_default_instance)
+        self.settings_dialog.instance_folder_location_choose_button.setEnabled(
+            is_default_instance
+        )
+        self.settings_dialog.instance_folder_location_clear_button.setEnabled(
+            is_default_instance
+        )
 
         # Databases tab
         if self.settings.external_community_rules_metadata_source == "None":
             self.settings_dialog.community_rules_db_none_radio.setChecked(True)
             self.settings_dialog.community_rules_db_github_url.setEnabled(False)
-            self.settings_dialog.community_rules_db_github_download_button.setEnabled(False)
+            self.settings_dialog.community_rules_db_github_download_button.setEnabled(
+                False
+            )
+            self.settings_dialog.community_rules_db_url_input.setEnabled(False)
+            self.settings_dialog.community_rules_db_url_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.community_rules_db_local_file.setEnabled(False)
-            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(False)
-        elif self.settings.external_community_rules_metadata_source == "Configured git repository":
+            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(
+                False
+            )
+        elif (
+            self.settings.external_community_rules_metadata_source
+            == "Configured git repository"
+        ):
             self.settings_dialog.community_rules_db_github_radio.setChecked(True)
             self.settings_dialog.community_rules_db_github_url.setEnabled(True)
-            self.settings_dialog.community_rules_db_github_download_button.setEnabled(True)
+            self.settings_dialog.community_rules_db_github_download_button.setEnabled(
+                True
+            )
+            self.settings_dialog.community_rules_db_url_input.setEnabled(False)
+            self.settings_dialog.community_rules_db_url_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.community_rules_db_local_file.setEnabled(False)
-            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(False)
-        elif self.settings.external_community_rules_metadata_source == "Configured file path":
+            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(
+                False
+            )
+        elif self.settings.external_community_rules_metadata_source == "Configured URL":
+            self.settings_dialog.community_rules_db_url_radio.setChecked(True)
+            self.settings_dialog.community_rules_db_url_input.setEnabled(True)
+            self.settings_dialog.community_rules_db_url_download_button.setEnabled(True)
+            self.settings_dialog.community_rules_db_github_url.setEnabled(False)
+            self.settings_dialog.community_rules_db_github_download_button.setEnabled(
+                False
+            )
+            self.settings_dialog.community_rules_db_local_file.setEnabled(False)
+            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(
+                False
+            )
+        elif (
+            self.settings.external_community_rules_metadata_source
+            == "Configured file path"
+        ):
             self.settings_dialog.community_rules_db_local_file_radio.setChecked(True)
             self.settings_dialog.community_rules_db_github_url.setEnabled(False)
-            self.settings_dialog.community_rules_db_github_download_button.setEnabled(False)
+            self.settings_dialog.community_rules_db_github_download_button.setEnabled(
+                False
+            )
+            self.settings_dialog.community_rules_db_url_input.setEnabled(False)
+            self.settings_dialog.community_rules_db_url_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.community_rules_db_local_file.setEnabled(True)
-            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(True)
-        self.settings_dialog.community_rules_db_local_file.setText(self.settings.external_community_rules_file_path)
+            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(
+                True
+            )
+        self.settings_dialog.community_rules_db_local_file.setText(
+            self.settings.external_community_rules_file_path
+        )
         self.settings_dialog.community_rules_db_local_file.setCursorPosition(0)
-        self.settings_dialog.community_rules_db_github_url.setText(self.settings.external_community_rules_repo)
+        self.settings_dialog.community_rules_db_github_url.setText(
+            self.settings.external_community_rules_repo
+        )
+        self.settings_dialog.community_rules_db_url_input.setText(
+            self.settings.external_community_rules_url
+        )
 
         if self.settings.external_steam_metadata_source == "None":
             self.settings_dialog.steam_workshop_db_none_radio.setChecked(True)
             self.settings_dialog.steam_workshop_db_github_url.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(False)
+            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(
+                False
+            )
+            self.settings_dialog.steam_workshop_db_url_input.setEnabled(False)
+            self.settings_dialog.steam_workshop_db_url_download_button.setEnabled(False)
             self.settings_dialog.steam_workshop_db_local_file.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(False)
-        elif self.settings.external_steam_metadata_source == "Configured git repository":
+            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(
+                False
+            )
+        elif (
+            self.settings.external_steam_metadata_source == "Configured git repository"
+        ):
             self.settings_dialog.steam_workshop_db_github_radio.setChecked(True)
             self.settings_dialog.steam_workshop_db_github_url.setEnabled(True)
-            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(True)
+            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(
+                True
+            )
+            self.settings_dialog.steam_workshop_db_url_input.setEnabled(False)
+            self.settings_dialog.steam_workshop_db_url_download_button.setEnabled(False)
             self.settings_dialog.steam_workshop_db_local_file.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(False)
+            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(
+                False
+            )
+        elif self.settings.external_steam_metadata_source == "Configured URL":
+            self.settings_dialog.steam_workshop_db_url_radio.setChecked(True)
+            self.settings_dialog.steam_workshop_db_url_input.setEnabled(True)
+            self.settings_dialog.steam_workshop_db_url_download_button.setEnabled(True)
+            self.settings_dialog.steam_workshop_db_github_url.setEnabled(False)
+            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(
+                False
+            )
+            self.settings_dialog.steam_workshop_db_local_file.setEnabled(False)
+            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(
+                False
+            )
         elif self.settings.external_steam_metadata_source == "Configured file path":
             self.settings_dialog.steam_workshop_db_local_file_radio.setChecked(True)
             self.settings_dialog.steam_workshop_db_github_url.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(False)
+            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(
+                False
+            )
+            self.settings_dialog.steam_workshop_db_url_input.setEnabled(False)
+            self.settings_dialog.steam_workshop_db_url_download_button.setEnabled(False)
             self.settings_dialog.steam_workshop_db_local_file.setEnabled(True)
-            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(True)
-        self.settings_dialog.steam_workshop_db_local_file.setText(self.settings.external_steam_metadata_file_path)
+            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(
+                True
+            )
+        self.settings_dialog.steam_workshop_db_local_file.setText(
+            self.settings.external_steam_metadata_file_path
+        )
         self.settings_dialog.steam_workshop_db_local_file.setCursorPosition(0)
-        self.settings_dialog.steam_workshop_db_github_url.setText(self.settings.external_steam_metadata_repo)
+        self.settings_dialog.steam_workshop_db_github_url.setText(
+            self.settings.external_steam_metadata_repo
+        )
         self.settings_dialog.steam_workshop_db_github_url.setCursorPosition(0)
+        self.settings_dialog.steam_workshop_db_url_input.setText(
+            self.settings.external_steam_metadata_url
+        )
         self.settings_dialog.database_expiry.setText(str(self.settings.database_expiry))
-        self.settings_dialog.aux_db_time_limit.setText(str(self.settings.aux_db_time_limit))
-        self.settings_dialog.aux_db_time_limit.setEnabled(self.settings.enable_aux_db_behavior_editing)
+        self.settings_dialog.aux_db_time_limit.setText(
+            str(self.settings.aux_db_time_limit)
+        )
+        self.settings_dialog.aux_db_time_limit.setEnabled(
+            self.settings.enable_aux_db_behavior_editing
+        )
 
         # Cross Version DB Tab
         if self.settings.external_no_version_warning_metadata_source == "None":
             self.settings_dialog.no_version_warning_db_none_radio.setChecked(True)
             self.settings_dialog.no_version_warning_db_github_url.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(False)
+            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(
+                False
+            )
+            self.settings_dialog.no_version_warning_db_url_input.setEnabled(False)
+            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.no_version_warning_db_local_file.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(False)
-        elif self.settings.external_no_version_warning_metadata_source == "Configured git repository":
+            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(
+                False
+            )
+        elif (
+            self.settings.external_no_version_warning_metadata_source
+            == "Configured git repository"
+        ):
             self.settings_dialog.no_version_warning_db_github_radio.setChecked(True)
             self.settings_dialog.no_version_warning_db_github_url.setEnabled(True)
-            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(True)
+            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(
+                True
+            )
+            self.settings_dialog.no_version_warning_db_url_input.setEnabled(False)
+            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.no_version_warning_db_local_file.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(False)
-        elif self.settings.external_no_version_warning_metadata_source == "Configured file path":
+            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(
+                False
+            )
+        elif (
+            self.settings.external_no_version_warning_metadata_source
+            == "Configured URL"
+        ):
+            self.settings_dialog.no_version_warning_db_url_radio.setChecked(True)
+            self.settings_dialog.no_version_warning_db_url_input.setEnabled(True)
+            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(
+                True
+            )
+            self.settings_dialog.no_version_warning_db_github_url.setEnabled(False)
+            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(
+                False
+            )
+            self.settings_dialog.no_version_warning_db_local_file.setEnabled(False)
+            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(
+                False
+            )
+        elif (
+            self.settings.external_no_version_warning_metadata_source
+            == "Configured file path"
+        ):
             self.settings_dialog.no_version_warning_db_local_file_radio.setChecked(True)
             self.settings_dialog.no_version_warning_db_github_url.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(False)
+            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(
+                False
+            )
+            self.settings_dialog.no_version_warning_db_url_input.setEnabled(False)
+            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.no_version_warning_db_local_file.setEnabled(True)
-            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(True)
+            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(
+                True
+            )
         self.settings_dialog.no_version_warning_db_local_file.setText(
             self.settings.external_no_version_warning_file_path
         )
@@ -560,29 +799,85 @@ class SettingsController(QObject):
             self.settings.external_no_version_warning_repo_path
         )
         self.settings_dialog.no_version_warning_db_github_url.setCursorPosition(0)
+        self.settings_dialog.no_version_warning_db_url_input.setText(
+            self.settings.external_no_version_warning_url
+        )
 
         if self.settings.external_use_this_instead_metadata_source == "None":
             self.settings_dialog.use_this_instead_db_none_radio.setChecked(True)
             self.settings_dialog.use_this_instead_db_github_url.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(False)
+            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(
+                False
+            )
+            self.settings_dialog.use_this_instead_db_url_input.setEnabled(False)
+            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.use_this_instead_db_local_file.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(False)
-        elif self.settings.external_use_this_instead_metadata_source == "Configured git repository":
+            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(
+                False
+            )
+        elif (
+            self.settings.external_use_this_instead_metadata_source
+            == "Configured git repository"
+        ):
             self.settings_dialog.use_this_instead_db_github_radio.setChecked(True)
             self.settings_dialog.use_this_instead_db_github_url.setEnabled(True)
-            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(True)
+            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(
+                True
+            )
+            self.settings_dialog.use_this_instead_db_url_input.setEnabled(False)
+            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.use_this_instead_db_local_file.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(False)
-        elif self.settings.external_use_this_instead_metadata_source == "Configured file path":
+            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(
+                False
+            )
+        elif (
+            self.settings.external_use_this_instead_metadata_source == "Configured URL"
+        ):
+            self.settings_dialog.use_this_instead_db_url_radio.setChecked(True)
+            self.settings_dialog.use_this_instead_db_url_input.setEnabled(True)
+            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(
+                True
+            )
+            self.settings_dialog.use_this_instead_db_github_url.setEnabled(False)
+            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(
+                False
+            )
+            self.settings_dialog.use_this_instead_db_local_file.setEnabled(False)
+            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(
+                False
+            )
+        elif (
+            self.settings.external_use_this_instead_metadata_source
+            == "Configured file path"
+        ):
             self.settings_dialog.use_this_instead_db_local_file_radio.setChecked(True)
             self.settings_dialog.use_this_instead_db_github_url.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(False)
+            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(
+                False
+            )
+            self.settings_dialog.use_this_instead_db_url_input.setEnabled(False)
+            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.use_this_instead_db_local_file.setEnabled(True)
-            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(True)
-        self.settings_dialog.use_this_instead_db_local_file.setText(self.settings.external_use_this_instead_file_path)
+            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(
+                True
+            )
+        self.settings_dialog.use_this_instead_db_local_file.setText(
+            self.settings.external_use_this_instead_file_path
+        )
         self.settings_dialog.use_this_instead_db_local_file.setCursorPosition(0)
-        self.settings_dialog.use_this_instead_db_github_url.setText(self.settings.external_use_this_instead_repo_path)
+        self.settings_dialog.use_this_instead_db_github_url.setText(
+            self.settings.external_use_this_instead_repo_path
+        )
         self.settings_dialog.use_this_instead_db_github_url.setCursorPosition(0)
+        self.settings_dialog.use_this_instead_db_url_input.setText(
+            self.settings.external_use_this_instead_url
+        )
 
         # Sorting tab
         if self.settings.sorting_algorithm == SortMethod.ALPHABETICAL:
@@ -591,29 +886,47 @@ class SettingsController(QObject):
             self.settings_dialog.sorting_topological_radio.setChecked(True)
         # Use dependencies for sorting checkbox
         if self.settings.use_moddependencies_as_loadTheseBefore:
-            (self.settings_dialog.use_moddependencies_as_loadTheseBefore.setChecked(True))
+            (
+                self.settings_dialog.use_moddependencies_as_loadTheseBefore.setChecked(
+                    True
+                )
+            )
         # Use alternativePackageIds as satisfying dependencies
         if self.settings.use_alternative_package_ids_as_satisfying_dependencies:
-            self.settings_dialog.use_alternative_package_ids_as_satisfying_dependencies_checkbox.setChecked(True)
+            self.settings_dialog.use_alternative_package_ids_as_satisfying_dependencies_checkbox.setChecked(
+                True
+            )
         # Set dependencies checkbox
-        self.settings_dialog.check_deps_checkbox.setChecked(self.settings.check_dependencies_on_sort)
+        self.settings_dialog.check_deps_checkbox.setChecked(
+            self.settings.check_dependencies_on_sort
+        )
         # Prefer versioned About.xml tags over base tags
         if self.settings.prefer_versioned_about_tags:
             self.settings_dialog.prefer_versioned_about_tags_checkbox.setChecked(True)
         # Download missing mods checkbox
-        self.settings_dialog.download_missing_mods_checkbox.setChecked(self.settings.try_download_missing_mods)
+        self.settings_dialog.download_missing_mods_checkbox.setChecked(
+            self.settings.try_download_missing_mods
+        )
         # Duplicate mod notification checkbox
-        self.settings_dialog.show_duplicate_mods_warning_checkbox.setChecked(self.settings.duplicate_mods_warning)
+        self.settings_dialog.show_duplicate_mods_warning_checkbox.setChecked(
+            self.settings.duplicate_mods_warning
+        )
         # Mod type filter checkbox
-        self.settings_dialog.mod_type_filter_checkbox.setChecked(self.settings.mod_type_filter)
+        self.settings_dialog.mod_type_filter_checkbox.setChecked(
+            self.settings.mod_type_filter
+        )
         # Hide invalid mod filtering checkbox
         self.settings_dialog.hide_invalid_mods_when_filtering_checkbox.setChecked(
             self.settings.hide_invalid_mods_when_filtering
         )
         # Inactive mods sorting options checkbox
-        self.settings_dialog.enable_inactive_mods_sorting_checkbox.setChecked(self.settings.inactive_mods_sorting)
+        self.settings_dialog.enable_inactive_mods_sorting_checkbox.setChecked(
+            self.settings.inactive_mods_sorting
+        )
         # Enable/disable the inactive mods sorting group box based on the checkbox state
-        self.settings_dialog.inactive_mods_sorting_group_box.setEnabled(self.settings.inactive_mods_sorting)
+        self.settings_dialog.inactive_mods_sorting_group_box.setEnabled(
+            self.settings.inactive_mods_sorting
+        )
         # Save inactive mods sort state
         self.settings_dialog.save_inactive_mods_sort_state_checkbox.setChecked(
             self.settings.save_inactive_mods_sort_state
@@ -624,22 +937,34 @@ class SettingsController(QObject):
             self.settings_dialog.db_builder_include_all_radio.setChecked(True)
         elif self.settings.db_builder_include == "no_local":
             self.settings_dialog.db_builder_include_no_local_radio.setChecked(True)
-        self.settings_dialog.db_builder_query_dlc_checkbox.setChecked(self.settings.build_steam_database_dlc_data)
+        self.settings_dialog.db_builder_query_dlc_checkbox.setChecked(
+            self.settings.build_steam_database_dlc_data
+        )
         self.settings_dialog.db_builder_update_instead_of_overwriting_checkbox.setChecked(
             self.settings.build_steam_database_update_toggle
         )
-        self.settings_dialog.db_builder_steam_api_key.setText(self.settings.steam_apikey)
+        self.settings_dialog.db_builder_steam_api_key.setText(
+            self.settings.steam_apikey
+        )
 
         # SteamCMD tab
-        self.settings_dialog.steamcmd_validate_downloads_checkbox.setChecked(self.settings.steamcmd_validate_downloads)
+        self.settings_dialog.steamcmd_validate_downloads_checkbox.setChecked(
+            self.settings.steamcmd_validate_downloads
+        )
         self.settings_dialog.steamcmd_auto_clear_depot_cache_checkbox.setChecked(
-            self.settings.instances[self.settings.current_instance].steamcmd_auto_clear_depot_cache
+            self.settings.instances[
+                self.settings.current_instance
+            ].steamcmd_auto_clear_depot_cache
         )
         self.settings_dialog.steamcmd_delete_before_update_checkbox.setChecked(
             self.settings.steamcmd_delete_before_update
         )
         self.settings_dialog.steamcmd_install_location.setText(
-            str(self.settings.instances[self.settings.current_instance].steamcmd_install_path)
+            str(
+                self.settings.instances[
+                    self.settings.current_instance
+                ].steamcmd_install_path
+            )
         )
 
         # todds tab
@@ -656,26 +981,48 @@ class SettingsController(QObject):
             self.settings_dialog.todds_active_mods_only_radio.setChecked(True)
         else:
             self.settings_dialog.todds_all_mods_radio.setChecked(True)
-        self.settings_dialog.todds_dry_run_checkbox.setChecked(self.settings.todds_dry_run)
-        self.settings_dialog.todds_overwrite_checkbox.setChecked(self.settings.todds_overwrite)
-        self.settings_dialog.todds_custom_command_lineedit.setText(self.settings.todds_custom_command)
-        self.settings_dialog.auto_delete_orphaned_dds_checkbox.setChecked(self.settings.auto_delete_orphaned_dds)
+        self.settings_dialog.todds_dry_run_checkbox.setChecked(
+            self.settings.todds_dry_run
+        )
+        self.settings_dialog.todds_overwrite_checkbox.setChecked(
+            self.settings.todds_overwrite
+        )
+        self.settings_dialog.todds_custom_command_lineedit.setText(
+            self.settings.todds_custom_command
+        )
+        self.settings_dialog.auto_delete_orphaned_dds_checkbox.setChecked(
+            self.settings.auto_delete_orphaned_dds
+        )
         self.settings_dialog.auto_run_todds_before_launch_checkbox.setChecked(
             self.settings.auto_run_todds_before_launch
         )
 
         # External Tools Tab
-        self.settings_dialog.text_editor_location.setText(self.settings.text_editor_location)
-        self.settings_dialog.text_editor_folder_arg.setText(self.settings.text_editor_folder_arg)
-        self.settings_dialog.text_editor_file_arg.setText(self.settings.text_editor_file_arg)
+        self.settings_dialog.text_editor_location.setText(
+            self.settings.text_editor_location
+        )
+        self.settings_dialog.text_editor_folder_arg.setText(
+            self.settings.text_editor_folder_arg
+        )
+        self.settings_dialog.text_editor_file_arg.setText(
+            self.settings.text_editor_file_arg
+        )
 
         # Themes tab
-        self.settings_dialog.enable_themes_checkbox.setChecked(self.settings.enable_themes)
-        self.theme_controller.populate_themes_combobox(self.settings_dialog.themes_combobox)
+        self.settings_dialog.enable_themes_checkbox.setChecked(
+            self.settings.enable_themes
+        )
+        self.theme_controller.populate_themes_combobox(
+            self.settings_dialog.themes_combobox
+        )
         self.theme_controller.setup_theme_dialog(self.settings_dialog, self.settings)
 
-        self.language_controller.populate_languages_combobox(self.settings_dialog.language_combobox)
-        self.language_controller.setup_language_dialog(self.settings_dialog, self.settings)
+        self.language_controller.populate_languages_combobox(
+            self.settings_dialog.language_combobox
+        )
+        self.language_controller.setup_language_dialog(
+            self.settings_dialog, self.settings
+        )
 
         # Advanced tab values
         try:
@@ -740,30 +1087,54 @@ class SettingsController(QObject):
             self.settings_dialog.browser_launch_maximized_radio.setChecked(True)
 
         # Settings Window (only custom option)
-        self.settings_dialog.settings_custom_width_spinbox.setValue(self.settings.settings_window_custom_width)
-        self.settings_dialog.settings_custom_height_spinbox.setValue(self.settings.settings_window_custom_height)
+        self.settings_dialog.settings_custom_width_spinbox.setValue(
+            self.settings.settings_window_custom_width
+        )
+        self.settings_dialog.settings_custom_height_spinbox.setValue(
+            self.settings.settings_window_custom_height
+        )
 
         # Advanced tab
-        self.settings_dialog.debug_logging_checkbox.setChecked(self.settings.debug_logging_enabled)
+        self.settings_dialog.debug_logging_checkbox.setChecked(
+            self.settings.debug_logging_enabled
+        )
         self.settings_dialog.watchdog_checkbox.setChecked(self.settings.watchdog_toggle)
-        self.settings_dialog.backup_saves_on_launch_checkbox.setChecked(self.settings.backup_saves_on_launch)
-        self.settings_dialog.auto_backup_retention_count_spinbox.setValue(self.settings.auto_backup_retention_count)
-        self.settings_dialog.auto_backup_compression_count_spinbox.setValue(self.settings.auto_backup_compression_count)
+        self.settings_dialog.backup_saves_on_launch_checkbox.setChecked(
+            self.settings.backup_saves_on_launch
+        )
+        self.settings_dialog.auto_backup_retention_count_spinbox.setValue(
+            self.settings.auto_backup_retention_count
+        )
+        self.settings_dialog.auto_backup_compression_count_spinbox.setValue(
+            self.settings.auto_backup_compression_count
+        )
         self.settings_dialog.color_background_instead_of_text_checkbox.setChecked(
             self.settings.color_background_instead_of_text_toggle
         )
         # Clear button behavior
-        self.settings_dialog.clear_moves_dlc_checkbox.setChecked(self.settings.clear_moves_dlc)
-        self.settings_dialog.show_mod_updates_checkbox.setChecked(self.settings.steam_mods_update_check)
-        self.settings_dialog.render_unity_rich_text_checkbox.setChecked(self.settings.render_unity_rich_text)
-        self.settings_dialog.update_databases_on_startup_checkbox.setChecked(self.settings.update_databases_on_startup)
+        self.settings_dialog.clear_moves_dlc_checkbox.setChecked(
+            self.settings.clear_moves_dlc
+        )
+        self.settings_dialog.show_mod_updates_checkbox.setChecked(
+            self.settings.steam_mods_update_check
+        )
+        self.settings_dialog.render_unity_rich_text_checkbox.setChecked(
+            self.settings.render_unity_rich_text
+        )
+        self.settings_dialog.update_databases_on_startup_checkbox.setChecked(
+            self.settings.update_databases_on_startup
+        )
         self.settings_dialog.include_mod_notes_in_mod_name_filter_checkbox.setChecked(
             self.settings.include_mod_notes_in_mod_name_filter
         )
 
-        self.settings_dialog.enable_backup_before_update_checkbox.setChecked(self.settings.enable_backup_before_update)
+        self.settings_dialog.enable_backup_before_update_checkbox.setChecked(
+            self.settings.enable_backup_before_update
+        )
         self.settings_dialog.max_backups_spinbox.setValue(self.settings.max_backups)
-        self.settings_dialog.enable_aux_db_behavior_editing.setChecked(self.settings.enable_aux_db_behavior_editing)
+        self.settings_dialog.enable_aux_db_behavior_editing.setChecked(
+            self.settings.enable_aux_db_behavior_editing
+        )
         self.settings_dialog.rentry_auth_code.setText(self.settings.rentry_auth_code)
         self.settings_dialog.rentry_auth_code.setCursorPosition(0)
         self.settings_dialog.github_username.setText(self.settings.github_username)
@@ -772,10 +1143,17 @@ class SettingsController(QObject):
         self.settings_dialog.github_token.setCursorPosition(0)
 
         # Migrate old comma-separated format to new space-separated format if needed
-        run_args_list = self._migrate_run_args(self.settings.instances[self.settings.current_instance].run_args)
+        run_args_list = self._migrate_run_args(
+            self.settings.instances[self.settings.current_instance].run_args
+        )
         # Save migrated format back to settings
-        if run_args_list != self.settings.instances[self.settings.current_instance].run_args:
-            self.settings.instances[self.settings.current_instance].run_args = run_args_list
+        if (
+            run_args_list
+            != self.settings.instances[self.settings.current_instance].run_args
+        ):
+            self.settings.instances[
+                self.settings.current_instance
+            ].run_args = run_args_list
             self.settings.save()
             logger.info(f"Saved migrated run_args: {run_args_list}")
 
@@ -790,7 +1168,9 @@ class SettingsController(QObject):
         """
 
         # Locations tab
-        self.settings.instances[self.settings.current_instance].game_folder = self.settings_dialog.game_location.text()
+        self.settings.instances[
+            self.settings.current_instance
+        ].game_folder = self.settings_dialog.game_location.text()
         self.settings.instances[
             self.settings.current_instance
         ].config_folder = self.settings_dialog.config_folder_location.text()
@@ -802,56 +1182,106 @@ class SettingsController(QObject):
         ].local_folder = self.settings_dialog.local_mods_folder_location.text()
         self.settings.instances[
             self.settings.current_instance
-        ].steam_client_integration = self.settings_dialog.steam_client_integration_checkbox.isChecked()
+        ].steam_client_integration = (
+            self.settings_dialog.steam_client_integration_checkbox.isChecked()
+        )
 
         # Save Steam protocol launch option
         self.settings.instances[
             self.settings.current_instance
-        ].launch_via_steam_protocol = self.settings_dialog.launch_via_steam_protocol_checkbox.isChecked()
+        ].launch_via_steam_protocol = (
+            self.settings_dialog.launch_via_steam_protocol_checkbox.isChecked()
+        )
 
         # Databases tab
         if self.settings_dialog.community_rules_db_none_radio.isChecked():
             self.settings.external_community_rules_metadata_source = "None"
         elif self.settings_dialog.community_rules_db_local_file_radio.isChecked():
-            self.settings.external_community_rules_metadata_source = "Configured file path"
+            self.settings.external_community_rules_metadata_source = (
+                "Configured file path"
+            )
         elif self.settings_dialog.community_rules_db_github_radio.isChecked():
-            self.settings.external_community_rules_metadata_source = "Configured git repository"
-        self.settings.external_community_rules_file_path = self.settings_dialog.community_rules_db_local_file.text()
-        self.settings.external_community_rules_repo = self.settings_dialog.community_rules_db_github_url.text()
+            self.settings.external_community_rules_metadata_source = (
+                "Configured git repository"
+            )
+        elif self.settings_dialog.community_rules_db_url_radio.isChecked():
+            self.settings.external_community_rules_metadata_source = "Configured URL"
+        self.settings.external_community_rules_file_path = (
+            self.settings_dialog.community_rules_db_local_file.text()
+        )
+        self.settings.external_community_rules_repo = (
+            self.settings_dialog.community_rules_db_github_url.text()
+        )
+        self.settings.external_community_rules_url = (
+            self.settings_dialog.community_rules_db_url_input.text()
+        )
         if self.settings_dialog.steam_workshop_db_none_radio.isChecked():
             self.settings.external_steam_metadata_source = "None"
         elif self.settings_dialog.steam_workshop_db_local_file_radio.isChecked():
             self.settings.external_steam_metadata_source = "Configured file path"
         elif self.settings_dialog.steam_workshop_db_github_radio.isChecked():
             self.settings.external_steam_metadata_source = "Configured git repository"
-        self.settings.external_steam_metadata_repo = self.settings_dialog.steam_workshop_db_github_url.text()
-        self.settings.external_steam_metadata_file_path = self.settings_dialog.steam_workshop_db_local_file.text()
+        elif self.settings_dialog.steam_workshop_db_url_radio.isChecked():
+            self.settings.external_steam_metadata_source = "Configured URL"
+        self.settings.external_steam_metadata_repo = (
+            self.settings_dialog.steam_workshop_db_github_url.text()
+        )
+        self.settings.external_steam_metadata_file_path = (
+            self.settings_dialog.steam_workshop_db_local_file.text()
+        )
+        self.settings.external_steam_metadata_url = (
+            self.settings_dialog.steam_workshop_db_url_input.text()
+        )
         self.settings.database_expiry = int(self.settings_dialog.database_expiry.text())
 
         # Cross Version Databases Tab
         if self.settings_dialog.no_version_warning_db_none_radio.isChecked():
             self.settings.external_no_version_warning_metadata_source = "None"
         elif self.settings_dialog.no_version_warning_db_local_file_radio.isChecked():
-            self.settings.external_no_version_warning_metadata_source = "Configured file path"
+            self.settings.external_no_version_warning_metadata_source = (
+                "Configured file path"
+            )
         elif self.settings_dialog.no_version_warning_db_github_radio.isChecked():
-            self.settings.external_no_version_warning_metadata_source = "Configured git repository"
+            self.settings.external_no_version_warning_metadata_source = (
+                "Configured git repository"
+            )
+        elif self.settings_dialog.no_version_warning_db_url_radio.isChecked():
+            self.settings.external_no_version_warning_metadata_source = "Configured URL"
         self.settings.external_no_version_warning_file_path = (
             self.settings_dialog.no_version_warning_db_local_file.text()
         )
         self.settings.external_no_version_warning_repo_path = (
             self.settings_dialog.no_version_warning_db_github_url.text()
         )
+        self.settings.external_no_version_warning_url = (
+            self.settings_dialog.no_version_warning_db_url_input.text()
+        )
 
         if self.settings_dialog.use_this_instead_db_none_radio.isChecked():
             self.settings.external_use_this_instead_metadata_source = "None"
         elif self.settings_dialog.use_this_instead_db_local_file_radio.isChecked():
-            self.settings.external_use_this_instead_metadata_source = "Configured file path"
+            self.settings.external_use_this_instead_metadata_source = (
+                "Configured file path"
+            )
         elif self.settings_dialog.use_this_instead_db_github_radio.isChecked():
-            self.settings.external_use_this_instead_metadata_source = "Configured git repository"
-        self.settings.external_use_this_instead_file_path = self.settings_dialog.use_this_instead_db_local_file.text()
-        self.settings.external_use_this_instead_repo_path = self.settings_dialog.use_this_instead_db_github_url.text()
+            self.settings.external_use_this_instead_metadata_source = (
+                "Configured git repository"
+            )
+        elif self.settings_dialog.use_this_instead_db_url_radio.isChecked():
+            self.settings.external_use_this_instead_metadata_source = "Configured URL"
+        self.settings.external_use_this_instead_file_path = (
+            self.settings_dialog.use_this_instead_db_local_file.text()
+        )
+        self.settings.external_use_this_instead_repo_path = (
+            self.settings_dialog.use_this_instead_db_github_url.text()
+        )
+        self.settings.external_use_this_instead_url = (
+            self.settings_dialog.use_this_instead_db_url_input.text()
+        )
         try:
-            self.settings.aux_db_time_limit = int(self.settings_dialog.aux_db_time_limit.text())
+            self.settings.aux_db_time_limit = int(
+                self.settings_dialog.aux_db_time_limit.text()
+            )
         except Exception:
             logger.warning("Failed setting Aux DB time limit, falling back to -1")
             self.settings.aux_db_time_limit = -1
@@ -867,27 +1297,35 @@ class SettingsController(QObject):
             self.settings_dialog.use_moddependencies_as_loadTheseBefore.isChecked()
         )
         # Use alternativePackageIds as satisfying dependencies
-        self.settings.use_alternative_package_ids_as_satisfying_dependencies = (
-            self.settings_dialog.use_alternative_package_ids_as_satisfying_dependencies_checkbox.isChecked()
-        )
+        self.settings.use_alternative_package_ids_as_satisfying_dependencies = self.settings_dialog.use_alternative_package_ids_as_satisfying_dependencies_checkbox.isChecked()
         # Set dependencies checkbox
-        self.settings.check_dependencies_on_sort = self.settings_dialog.check_deps_checkbox.isChecked()
+        self.settings.check_dependencies_on_sort = (
+            self.settings_dialog.check_deps_checkbox.isChecked()
+        )
         # Prefer versioned About.xml tags over base tags
         self.settings.prefer_versioned_about_tags = (
             self.settings_dialog.prefer_versioned_about_tags_checkbox.isChecked()
         )
         # Download missing mods checkbox
-        self.settings.try_download_missing_mods = self.settings_dialog.download_missing_mods_checkbox.isChecked()
+        self.settings.try_download_missing_mods = (
+            self.settings_dialog.download_missing_mods_checkbox.isChecked()
+        )
         # Duplicate mod notification checkbox
-        self.settings.duplicate_mods_warning = self.settings_dialog.show_duplicate_mods_warning_checkbox.isChecked()
+        self.settings.duplicate_mods_warning = (
+            self.settings_dialog.show_duplicate_mods_warning_checkbox.isChecked()
+        )
         # Mod type filter checkbox
-        self.settings.mod_type_filter = self.settings_dialog.mod_type_filter_checkbox.isChecked()
+        self.settings.mod_type_filter = (
+            self.settings_dialog.mod_type_filter_checkbox.isChecked()
+        )
         # Hide invalid mod filtering checkbox
         self.settings.hide_invalid_mods_when_filtering = (
             self.settings_dialog.hide_invalid_mods_when_filtering_checkbox.isChecked()
         )
         # Inactive mods sorting options checkbox
-        self.settings.inactive_mods_sorting = self.settings_dialog.enable_inactive_mods_sorting_checkbox.isChecked()
+        self.settings.inactive_mods_sorting = (
+            self.settings_dialog.enable_inactive_mods_sorting_checkbox.isChecked()
+        )
         # Save inactive mods sort state
         self.settings.save_inactive_mods_sort_state = (
             self.settings_dialog.save_inactive_mods_sort_state_checkbox.isChecked()
@@ -898,11 +1336,13 @@ class SettingsController(QObject):
             self.settings.db_builder_include = "all_mods"
         elif self.settings_dialog.db_builder_include_no_local_radio.isChecked():
             self.settings.db_builder_include = "no_local"
-        self.settings.build_steam_database_dlc_data = self.settings_dialog.db_builder_query_dlc_checkbox.isChecked()
-        self.settings.build_steam_database_update_toggle = (
-            self.settings_dialog.db_builder_update_instead_of_overwriting_checkbox.isChecked()
+        self.settings.build_steam_database_dlc_data = (
+            self.settings_dialog.db_builder_query_dlc_checkbox.isChecked()
         )
-        self.settings.steam_apikey = self.settings_dialog.db_builder_steam_api_key.text()
+        self.settings.build_steam_database_update_toggle = self.settings_dialog.db_builder_update_instead_of_overwriting_checkbox.isChecked()
+        self.settings.steam_apikey = (
+            self.settings_dialog.db_builder_steam_api_key.text()
+        )
 
         # SteamCMD tab
         self.settings.steamcmd_validate_downloads = (
@@ -913,7 +1353,9 @@ class SettingsController(QObject):
         )
         self.settings.instances[
             self.settings.current_instance
-        ].steamcmd_auto_clear_depot_cache = self.settings_dialog.steamcmd_auto_clear_depot_cache_checkbox.isChecked()
+        ].steamcmd_auto_clear_depot_cache = (
+            self.settings_dialog.steamcmd_auto_clear_depot_cache_checkbox.isChecked()
+        )
         self.settings.instances[
             self.settings.current_instance
         ].steamcmd_install_path = self.settings_dialog.steamcmd_install_location.text()
@@ -923,38 +1365,54 @@ class SettingsController(QObject):
             self.settings.todds_preset = "optimized"
         if self.settings_dialog.todds_preset_custom_radio.isChecked():
             self.settings.todds_preset = "custom"
-            self.settings.todds_custom_command = self.settings_dialog.todds_custom_command_lineedit.text()
+            self.settings.todds_custom_command = (
+                self.settings_dialog.todds_custom_command_lineedit.text()
+            )
         else:
             self.settings.todds_preset = "optimized"
         if self.settings_dialog.todds_active_mods_only_radio.isChecked():
             self.settings.todds_active_mods_target = True
         elif self.settings_dialog.todds_all_mods_radio.isChecked():
             self.settings.todds_active_mods_target = False
-        self.settings.todds_dry_run = self.settings_dialog.todds_dry_run_checkbox.isChecked()
-        self.settings.todds_overwrite = self.settings_dialog.todds_overwrite_checkbox.isChecked()
-        self.settings.auto_delete_orphaned_dds = self.settings_dialog.auto_delete_orphaned_dds_checkbox.isChecked()
+        self.settings.todds_dry_run = (
+            self.settings_dialog.todds_dry_run_checkbox.isChecked()
+        )
+        self.settings.todds_overwrite = (
+            self.settings_dialog.todds_overwrite_checkbox.isChecked()
+        )
+        self.settings.auto_delete_orphaned_dds = (
+            self.settings_dialog.auto_delete_orphaned_dds_checkbox.isChecked()
+        )
         self.settings.auto_run_todds_before_launch = (
             self.settings_dialog.auto_run_todds_before_launch_checkbox.isChecked()
         )
 
         # Other External Tools Tab
-        self.settings.text_editor_location = self.settings_dialog.text_editor_location.text()
-        self.settings.text_editor_folder_arg = self.settings_dialog.text_editor_folder_arg.text()
-        self.settings.text_editor_file_arg = self.settings_dialog.text_editor_file_arg.text()
+        self.settings.text_editor_location = (
+            self.settings_dialog.text_editor_location.text()
+        )
+        self.settings.text_editor_folder_arg = (
+            self.settings_dialog.text_editor_folder_arg.text()
+        )
+        self.settings.text_editor_file_arg = (
+            self.settings_dialog.text_editor_file_arg.text()
+        )
 
         # Themes tab
-        self.settings.enable_themes = self.settings_dialog.enable_themes_checkbox.isChecked()
+        self.settings.enable_themes = (
+            self.settings_dialog.enable_themes_checkbox.isChecked()
+        )
         self.settings.theme_name = self.settings_dialog.themes_combobox.currentText()
 
-        self.settings.font_family = self.settings_dialog.font_family_combobox.currentText()
+        self.settings.font_family = (
+            self.settings_dialog.font_family_combobox.currentText()
+        )
         self.settings.font_size = self.settings_dialog.font_size_spinbox.value()
         self.settings.language = self.settings_dialog.language_combobox.currentData()
 
         # Launch State tab
         # Dialogue positioning
-        self.settings.constrain_dialogues_to_main_window_monitor = (
-            self.settings_dialog.constrain_dialogues_to_main_window_monitor_checkbox.isChecked()
-        )
+        self.settings.constrain_dialogues_to_main_window_monitor = self.settings_dialog.constrain_dialogues_to_main_window_monitor_checkbox.isChecked()
 
         # Windows launch state
         # Main Window
@@ -964,8 +1422,12 @@ class SettingsController(QObject):
             self.settings.main_window_launch_state = "normal"
         elif self.settings_dialog.main_launch_custom_radio.isChecked():
             self.settings.main_window_launch_state = "custom"
-            self.settings.main_window_custom_width = self.settings_dialog.main_custom_width_spinbox.value()
-            self.settings.main_window_custom_height = self.settings_dialog.main_custom_height_spinbox.value()
+            self.settings.main_window_custom_width = (
+                self.settings_dialog.main_custom_width_spinbox.value()
+            )
+            self.settings.main_window_custom_height = (
+                self.settings_dialog.main_custom_height_spinbox.value()
+            )
         else:
             self.settings.main_window_launch_state = "maximized"
         # Browser Window
@@ -975,45 +1437,71 @@ class SettingsController(QObject):
             self.settings.browser_window_launch_state = "normal"
         elif self.settings_dialog.browser_launch_custom_radio.isChecked():
             self.settings.browser_window_launch_state = "custom"
-            self.settings.browser_window_custom_width = self.settings_dialog.browser_custom_width_spinbox.value()
-            self.settings.browser_window_custom_height = self.settings_dialog.browser_custom_height_spinbox.value()
+            self.settings.browser_window_custom_width = (
+                self.settings_dialog.browser_custom_width_spinbox.value()
+            )
+            self.settings.browser_window_custom_height = (
+                self.settings_dialog.browser_custom_height_spinbox.value()
+            )
         else:
             self.settings.browser_window_launch_state = "maximized"
 
         # Settings Window (only custom option)
-        self.settings.settings_window_custom_width = self.settings_dialog.settings_custom_width_spinbox.value()
-        self.settings.settings_window_custom_height = self.settings_dialog.settings_custom_height_spinbox.value()
+        self.settings.settings_window_custom_width = (
+            self.settings_dialog.settings_custom_width_spinbox.value()
+        )
+        self.settings.settings_window_custom_height = (
+            self.settings_dialog.settings_custom_height_spinbox.value()
+        )
 
         # Advanced tab
-        self.settings.debug_logging_enabled = self.settings_dialog.debug_logging_checkbox.isChecked()
-        self.settings.watchdog_toggle = self.settings_dialog.watchdog_checkbox.isChecked()
-        self.settings.backup_saves_on_launch = self.settings_dialog.backup_saves_on_launch_checkbox.isChecked()
-        self.settings.auto_backup_retention_count = self.settings_dialog.auto_backup_retention_count_spinbox.value()
-        self.settings.auto_backup_compression_count = self.settings_dialog.auto_backup_compression_count_spinbox.value()
+        self.settings.debug_logging_enabled = (
+            self.settings_dialog.debug_logging_checkbox.isChecked()
+        )
+        self.settings.watchdog_toggle = (
+            self.settings_dialog.watchdog_checkbox.isChecked()
+        )
+        self.settings.backup_saves_on_launch = (
+            self.settings_dialog.backup_saves_on_launch_checkbox.isChecked()
+        )
+        self.settings.auto_backup_retention_count = (
+            self.settings_dialog.auto_backup_retention_count_spinbox.value()
+        )
+        self.settings.auto_backup_compression_count = (
+            self.settings_dialog.auto_backup_compression_count_spinbox.value()
+        )
         self.settings.color_background_instead_of_text_toggle = (
             self.settings_dialog.color_background_instead_of_text_checkbox.isChecked()
         )
         # Clear button behavior
-        self.settings.clear_moves_dlc = self.settings_dialog.clear_moves_dlc_checkbox.isChecked()
-        self.settings.steam_mods_update_check = self.settings_dialog.show_mod_updates_checkbox.isChecked()
-        self.settings.render_unity_rich_text = self.settings_dialog.render_unity_rich_text_checkbox.isChecked()
+        self.settings.clear_moves_dlc = (
+            self.settings_dialog.clear_moves_dlc_checkbox.isChecked()
+        )
+        self.settings.steam_mods_update_check = (
+            self.settings_dialog.show_mod_updates_checkbox.isChecked()
+        )
+        self.settings.render_unity_rich_text = (
+            self.settings_dialog.render_unity_rich_text_checkbox.isChecked()
+        )
         self.settings.update_databases_on_startup = (
             self.settings_dialog.update_databases_on_startup_checkbox.isChecked()
         )
-        self.settings.include_mod_notes_in_mod_name_filter = (
-            self.settings_dialog.include_mod_notes_in_mod_name_filter_checkbox.isChecked()
-        )
+        self.settings.include_mod_notes_in_mod_name_filter = self.settings_dialog.include_mod_notes_in_mod_name_filter_checkbox.isChecked()
 
         self.settings.enable_backup_before_update = (
             self.settings_dialog.enable_backup_before_update_checkbox.isChecked()
         )
         self.settings.max_backups = self.settings_dialog.max_backups_spinbox.value()
-        self.settings.enable_aux_db_behavior_editing = self.settings_dialog.enable_aux_db_behavior_editing.isChecked()
+        self.settings.enable_aux_db_behavior_editing = (
+            self.settings_dialog.enable_aux_db_behavior_editing.isChecked()
+        )
         self.settings.rentry_auth_code = self.settings_dialog.rentry_auth_code.text()
         self.settings.github_username = self.settings_dialog.github_username.text()
         self.settings.github_token = self.settings_dialog.github_token.text()
         # Migrate and extract command string from single-element list
-        run_args_list = self._migrate_run_args(self.settings.instances[self.settings.current_instance].run_args)
+        run_args_list = self._migrate_run_args(
+            self.settings.instances[self.settings.current_instance].run_args
+        )
         run_args_str = run_args_list[0] if run_args_list else ""
         self.settings_dialog.run_args.setText(run_args_str)
 
@@ -1024,7 +1512,9 @@ class SettingsController(QObject):
         """
         answer = BinaryChoiceDialog(
             title=self.tr("Reset to defaults"),
-            text=self.tr("Are you sure you want to reset all settings to their default values?"),
+            text=self.tr(
+                "Are you sure you want to reset all settings to their default values?"
+            ),
         )
         if not answer.exec_is_positive():
             return
@@ -1076,7 +1566,9 @@ class SettingsController(QObject):
             return False
         return True
 
-    def _check_steam_integration_validity(self, steam_client_integration: bool, steam_mods_location: str) -> bool:
+    def _check_steam_integration_validity(
+        self, steam_client_integration: bool, steam_mods_location: str
+    ) -> bool:
         """
         Check if Steam client integration and Steam mods location are valid.
 
@@ -1122,8 +1614,12 @@ class SettingsController(QObject):
 
         :return: True if valid configuration, False if invalid.
         """
-        steam_client_integration = self.settings_dialog.steam_client_integration_checkbox.isChecked()
-        steam_mods_location = self.settings_dialog.steam_mods_folder_location.text().strip()
+        steam_client_integration = (
+            self.settings_dialog.steam_client_integration_checkbox.isChecked()
+        )
+        steam_mods_location = (
+            self.settings_dialog.steam_mods_folder_location.text().strip()
+        )
 
         # Handle user explicitly disabling Steam integration
         if not steam_client_integration:
@@ -1139,7 +1635,9 @@ class SettingsController(QObject):
             self.settings_dialog.launch_via_steam_protocol_checkbox.setChecked(False)
 
         # Validate Steam integration configuration
-        is_valid = self._check_steam_integration_validity(steam_client_integration, steam_mods_location)
+        is_valid = self._check_steam_integration_validity(
+            steam_client_integration, steam_mods_location
+        )
 
         if not is_valid:
             # Disable all Steam integration settings if validation fails
@@ -1155,7 +1653,9 @@ class SettingsController(QObject):
                         "Steam client integration, Steam mods location, and Steam protocol launch have been disabled."
                     ),
                 )
-            elif steam_mods_location and not validate_acf_file_exists(steam_mods_location):
+            elif steam_mods_location and not validate_acf_file_exists(
+                steam_mods_location
+            ):
                 QMessageBox.warning(
                     self.settings_dialog,
                     self.tr("Steam Workshop File Not Found"),
@@ -1180,7 +1680,9 @@ class SettingsController(QObject):
 
         # Validate config folder if set
         config_folder_text = self.settings_dialog.config_folder_location.text().strip()
-        if config_folder_text and not self._validate_config_folder_location(config_folder_text):
+        if config_folder_text and not self._validate_config_folder_location(
+            config_folder_text
+        ):
             return
 
         # Validate Steam integration if enabled
@@ -1204,7 +1706,9 @@ class SettingsController(QObject):
 
     @Slot()
     def _on_game_location_text_changed(self) -> None:
-        self.settings_dialog.game_location_open_button.setEnabled(self.settings_dialog.game_location.text() != "")
+        self.settings_dialog.game_location_open_button.setEnabled(
+            self.settings_dialog.game_location.text() != ""
+        )
 
     @Slot()
     def _on_game_location_open_button_clicked(self) -> None:
@@ -1225,7 +1729,9 @@ class SettingsController(QObject):
         if not self._validate_game_location(str(game_location)):
             return
         self.settings_dialog.game_location.setText(str(game_location))
-        self.settings_dialog.local_mods_folder_location.setText(str(game_location / "Mods"))
+        self.settings_dialog.local_mods_folder_location.setText(
+            str(game_location / "Mods")
+        )
         self._last_file_dialog_path = str(game_location)
 
     def _on_game_location_choose_button_clicked_macos(self) -> Path | None:
@@ -1317,7 +1823,9 @@ class SettingsController(QObject):
         if not steam_mods_folder_location:
             return
 
-        self.settings_dialog.steam_mods_folder_location.setText(steam_mods_folder_location)
+        self.settings_dialog.steam_mods_folder_location.setText(
+            steam_mods_folder_location
+        )
         self._last_file_dialog_path = str(Path(steam_mods_folder_location).parent)
 
     @Slot()
@@ -1337,7 +1845,9 @@ class SettingsController(QObject):
         if not local_mods_folder_location:
             return
 
-        self.settings_dialog.local_mods_folder_location.setText(local_mods_folder_location)
+        self.settings_dialog.local_mods_folder_location.setText(
+            local_mods_folder_location
+        )
         self._last_file_dialog_path = str(Path(local_mods_folder_location).parent)
 
     @Slot()
@@ -1355,7 +1865,9 @@ class SettingsController(QObject):
         self.settings_dialog.local_mods_folder_location.setText("")
 
     @Slot()
-    def _on_locations_clear_button_clicked(self, skip_confirmation: bool = False) -> None:
+    def _on_locations_clear_button_clicked(
+        self, skip_confirmation: bool = False
+    ) -> None:
         """
         Clear the settings dialog's location fields.
         """
@@ -1402,7 +1914,9 @@ class SettingsController(QObject):
 
         path_groups = [
             _PathGroup(os_paths[0], self.settings_dialog.game_location, "game"),
-            _PathGroup(os_paths[1], self.settings_dialog.config_folder_location, "config"),
+            _PathGroup(
+                os_paths[1], self.settings_dialog.config_folder_location, "config"
+            ),
             _PathGroup(
                 os_paths[2],
                 self.settings_dialog.steam_mods_folder_location,
@@ -1417,14 +1931,20 @@ class SettingsController(QObject):
 
         for group in path_groups:
             if group.folder.exists():
-                logger.info(f"Auto-detected {group.name} folder path exists: {group.folder}")
+                logger.info(
+                    f"Auto-detected {group.name} folder path exists: {group.folder}"
+                )
                 if not group.settings_line.text():
-                    logger.info(f"No value set currently for {group.name} folder. Overwriting with auto-detected path")
+                    logger.info(
+                        f"No value set currently for {group.name} folder. Overwriting with auto-detected path"
+                    )
                     group.settings_line.setText(str(group.folder))
                 else:
                     logger.info(f"Value already set for {group.name} folder. Passing")
             else:
-                logger.warning(f"Auto-detected {group.name} folder path does not exist: {group.folder}")
+                logger.warning(
+                    f"Auto-detected {group.name} folder path does not exist: {group.folder}"
+                )
 
     def __get_darwin_paths(self) -> tuple[Path, Path, Path]:
         """
@@ -1434,9 +1954,15 @@ class SettingsController(QObject):
             tuple[Path, Path, Path]: game_folder, config_folder, steam_mods_folder
         """
         user_home = Path.home()
-        game_folder = Path(f"/{user_home}/Library/Application Support/Steam/steamapps/common/Rimworld/RimworldMac.app")
-        config_folder = Path(f"/{user_home}/Library/Application Support/Rimworld/Config")
-        steam_mods_folder = Path(f"/{user_home}/Library/Application Support/Steam/steamapps/workshop/content/294100")
+        game_folder = Path(
+            f"/{user_home}/Library/Application Support/Steam/steamapps/common/Rimworld/RimworldMac.app"
+        )
+        config_folder = Path(
+            f"/{user_home}/Library/Application Support/Rimworld/Config"
+        )
+        steam_mods_folder = Path(
+            f"/{user_home}/Library/Application Support/Steam/steamapps/workshop/content/294100"
+        )
 
         return game_folder, config_folder, steam_mods_folder
 
@@ -1453,7 +1979,10 @@ class SettingsController(QObject):
             steam_path = user_home / ".steam/steam"
             debian_path = steam_path / "steamapps/common/RimWorld"
         game_folder = debian_path / "steamapps/common/RimWorld"
-        config_folder = user_home / ".config/unity3d/Ludeon Studios/RimWorld by Ludeon Studios/Config"
+        config_folder = (
+            user_home
+            / ".config/unity3d/Ludeon Studios/RimWorld by Ludeon Studios/Config"
+        )
         steam_mods_folder = debian_path / "steamapps/workshop/content/294100"
 
         return game_folder, config_folder, steam_mods_folder
@@ -1472,7 +2001,9 @@ class SettingsController(QObject):
             steam_folder, found = find_steam_folder()
 
             if not found:
-                logger.error("[win32] Could not find Steam folder. Using fallback assumptions")
+                logger.error(
+                    "[win32] Could not find Steam folder. Using fallback assumptions"
+                )
                 steam_folder = "C:/Program Files (x86)/Steam"
 
             game_folder: str | Path = find_steam_rimworld(steam_folder)
@@ -1482,12 +2013,18 @@ class SettingsController(QObject):
                 game_folder = f"{steam_folder}/steamapps/common/RimWorld"
             game_folder = Path(game_folder)
 
-            config_folder = Path(f"{user_home}/AppData/LocalLow/Ludeon Studios/RimWorld by Ludeon Studios/Config")
+            config_folder = Path(
+                f"{user_home}/AppData/LocalLow/Ludeon Studios/RimWorld by Ludeon Studios/Config"
+            )
 
-            steam_mods_folder = get_path_up_to_string(game_folder, "common", exclude=True)
+            steam_mods_folder = get_path_up_to_string(
+                game_folder, "common", exclude=True
+            )
             if steam_mods_folder == "":
                 # Fallback steam mods path
-                steam_mods_folder = Path(f"{steam_folder}/steamapps/workshop/content/294100")
+                steam_mods_folder = Path(
+                    f"{steam_folder}/steamapps/workshop/content/294100"
+                )
             else:
                 steam_mods_folder = Path(steam_mods_folder) / "workshop/content/294100"
 
@@ -1501,30 +2038,80 @@ class SettingsController(QObject):
         This function handles the community rules db radio buttons. Clicking one button
         enables the associated widgets and disables the other widgets.
         """
-        if self.sender() == self.settings_dialog.community_rules_db_none_radio and checked:
+        if (
+            self.sender() == self.settings_dialog.community_rules_db_none_radio
+            and checked
+        ):
             self.settings_dialog.community_rules_db_github_url.setEnabled(False)
-            self.settings_dialog.community_rules_db_github_download_button.setEnabled(False)
+            self.settings_dialog.community_rules_db_github_download_button.setEnabled(
+                False
+            )
+            self.settings_dialog.community_rules_db_url_input.setEnabled(False)
+            self.settings_dialog.community_rules_db_url_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.community_rules_db_local_file.setEnabled(False)
-            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(False)
+            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(
+                False
+            )
             if isinstance(self.app_instance, QApplication):
                 focused_widget = self.app_instance.focusWidget()
                 if focused_widget is not None:
                     focused_widget.clearFocus()
             return
 
-        if self.sender() == self.settings_dialog.community_rules_db_github_radio and checked:
+        if (
+            self.sender() == self.settings_dialog.community_rules_db_github_radio
+            and checked
+        ):
             self.settings_dialog.community_rules_db_github_url.setEnabled(True)
-            self.settings_dialog.community_rules_db_github_download_button.setEnabled(True)
+            self.settings_dialog.community_rules_db_github_download_button.setEnabled(
+                True
+            )
+            self.settings_dialog.community_rules_db_url_input.setEnabled(False)
+            self.settings_dialog.community_rules_db_url_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.community_rules_db_local_file.setEnabled(False)
-            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(False)
+            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(
+                False
+            )
             self.settings_dialog.community_rules_db_github_url.setFocus()
             return
 
-        if self.sender() == self.settings_dialog.community_rules_db_local_file_radio and checked:
+        if (
+            self.sender() == self.settings_dialog.community_rules_db_url_radio
+            and checked
+        ):
+            self.settings_dialog.community_rules_db_url_input.setEnabled(True)
+            self.settings_dialog.community_rules_db_url_download_button.setEnabled(True)
             self.settings_dialog.community_rules_db_github_url.setEnabled(False)
-            self.settings_dialog.community_rules_db_github_download_button.setEnabled(False)
+            self.settings_dialog.community_rules_db_github_download_button.setEnabled(
+                False
+            )
+            self.settings_dialog.community_rules_db_local_file.setEnabled(False)
+            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(
+                False
+            )
+            self.settings_dialog.community_rules_db_url_input.setFocus()
+            return
+
+        if (
+            self.sender() == self.settings_dialog.community_rules_db_local_file_radio
+            and checked
+        ):
+            self.settings_dialog.community_rules_db_github_url.setEnabled(False)
+            self.settings_dialog.community_rules_db_github_download_button.setEnabled(
+                False
+            )
+            self.settings_dialog.community_rules_db_url_input.setEnabled(False)
+            self.settings_dialog.community_rules_db_url_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.community_rules_db_local_file.setEnabled(True)
-            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(True)
+            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(
+                True
+            )
             self.settings_dialog.community_rules_db_local_file.setFocus()
             return
 
@@ -1541,7 +2128,9 @@ class SettingsController(QObject):
         if not community_rules_db_location:
             return
 
-        self.settings_dialog.community_rules_db_local_file.setText(community_rules_db_location)
+        self.settings_dialog.community_rules_db_local_file.setText(
+            community_rules_db_location
+        )
         self._last_file_dialog_path = str(Path(community_rules_db_location).parent)
 
     @Slot(bool)
@@ -1550,30 +2139,74 @@ class SettingsController(QObject):
         This function handles the Steam workshop db radio buttons. Clicking one button
         enables the associated widgets and disables the other widgets.
         """
-        if self.sender() == self.settings_dialog.steam_workshop_db_none_radio and checked:
+        if (
+            self.sender() == self.settings_dialog.steam_workshop_db_none_radio
+            and checked
+        ):
             self.settings_dialog.steam_workshop_db_github_url.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(False)
+            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(
+                False
+            )
+            self.settings_dialog.steam_workshop_db_url_input.setEnabled(False)
+            self.settings_dialog.steam_workshop_db_url_download_button.setEnabled(False)
             self.settings_dialog.steam_workshop_db_local_file.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(False)
+            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(
+                False
+            )
             if isinstance(self.app_instance, QApplication):
                 focused_widget = self.app_instance.focusWidget()
                 if focused_widget is not None:
                     focused_widget.clearFocus()
             return
 
-        if self.sender() == self.settings_dialog.steam_workshop_db_github_radio and checked:
+        if (
+            self.sender() == self.settings_dialog.steam_workshop_db_github_radio
+            and checked
+        ):
             self.settings_dialog.steam_workshop_db_github_url.setEnabled(True)
-            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(True)
+            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(
+                True
+            )
+            self.settings_dialog.steam_workshop_db_url_input.setEnabled(False)
+            self.settings_dialog.steam_workshop_db_url_download_button.setEnabled(False)
             self.settings_dialog.steam_workshop_db_local_file.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(False)
+            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(
+                False
+            )
             self.settings_dialog.steam_workshop_db_github_url.setFocus()
             return
 
-        if self.sender() == self.settings_dialog.steam_workshop_db_local_file_radio and checked:
+        if (
+            self.sender() == self.settings_dialog.steam_workshop_db_url_radio
+            and checked
+        ):
+            self.settings_dialog.steam_workshop_db_url_input.setEnabled(True)
+            self.settings_dialog.steam_workshop_db_url_download_button.setEnabled(True)
             self.settings_dialog.steam_workshop_db_github_url.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(False)
+            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(
+                False
+            )
+            self.settings_dialog.steam_workshop_db_local_file.setEnabled(False)
+            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(
+                False
+            )
+            self.settings_dialog.steam_workshop_db_url_input.setFocus()
+            return
+
+        if (
+            self.sender() == self.settings_dialog.steam_workshop_db_local_file_radio
+            and checked
+        ):
+            self.settings_dialog.steam_workshop_db_github_url.setEnabled(False)
+            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(
+                False
+            )
+            self.settings_dialog.steam_workshop_db_url_input.setEnabled(False)
+            self.settings_dialog.steam_workshop_db_url_download_button.setEnabled(False)
             self.settings_dialog.steam_workshop_db_local_file.setEnabled(True)
-            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(True)
+            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(
+                True
+            )
             self.settings_dialog.steam_workshop_db_local_file.setFocus()
             return
 
@@ -1590,7 +2223,9 @@ class SettingsController(QObject):
         if not steam_workshop_db_location:
             return
 
-        self.settings_dialog.steam_workshop_db_local_file.setText(steam_workshop_db_location)
+        self.settings_dialog.steam_workshop_db_local_file.setText(
+            steam_workshop_db_location
+        )
         self._last_file_dialog_path = str(Path(steam_workshop_db_location).parent)
 
     @Slot(bool)
@@ -1599,11 +2234,22 @@ class SettingsController(QObject):
         This function handles the "No Version Warning" db radio buttons. Clicking one button
         enables the associated widgets and disables the other widgets.
         """
-        if self.sender() == self.settings_dialog.no_version_warning_db_none_radio and checked:
+        if (
+            self.sender() == self.settings_dialog.no_version_warning_db_none_radio
+            and checked
+        ):
             self.settings_dialog.no_version_warning_db_github_url.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(False)
+            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(
+                False
+            )
+            self.settings_dialog.no_version_warning_db_url_input.setEnabled(False)
+            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.no_version_warning_db_local_file.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(False)
+            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(
+                False
+            )
             app_instance = QApplication.instance()
             if isinstance(app_instance, QApplication):
                 focused_widget = app_instance.focusWidget()
@@ -1611,19 +2257,60 @@ class SettingsController(QObject):
                     focused_widget.clearFocus()
             return
 
-        if self.sender() == self.settings_dialog.no_version_warning_db_github_radio and checked:
+        if (
+            self.sender() == self.settings_dialog.no_version_warning_db_github_radio
+            and checked
+        ):
             self.settings_dialog.no_version_warning_db_github_url.setEnabled(True)
-            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(True)
+            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(
+                True
+            )
+            self.settings_dialog.no_version_warning_db_url_input.setEnabled(False)
+            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.no_version_warning_db_local_file.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(False)
+            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(
+                False
+            )
             self.settings_dialog.no_version_warning_db_github_url.setFocus()
             return
 
-        if self.sender() == self.settings_dialog.no_version_warning_db_local_file_radio and checked:
+        if (
+            self.sender() == self.settings_dialog.no_version_warning_db_url_radio
+            and checked
+        ):
+            self.settings_dialog.no_version_warning_db_url_input.setEnabled(True)
+            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(
+                True
+            )
             self.settings_dialog.no_version_warning_db_github_url.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(False)
+            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(
+                False
+            )
+            self.settings_dialog.no_version_warning_db_local_file.setEnabled(False)
+            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(
+                False
+            )
+            self.settings_dialog.no_version_warning_db_url_input.setFocus()
+            return
+
+        if (
+            self.sender() == self.settings_dialog.no_version_warning_db_local_file_radio
+            and checked
+        ):
+            self.settings_dialog.no_version_warning_db_github_url.setEnabled(False)
+            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(
+                False
+            )
+            self.settings_dialog.no_version_warning_db_url_input.setEnabled(False)
+            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.no_version_warning_db_local_file.setEnabled(True)
-            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(True)
+            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(
+                True
+            )
             self.settings_dialog.no_version_warning_db_local_file.setFocus()
             return
 
@@ -1640,7 +2327,9 @@ class SettingsController(QObject):
         if not no_version_warning_db_location:
             return
 
-        self.settings_dialog.no_version_warning_db_local_file.setText(no_version_warning_db_location)
+        self.settings_dialog.no_version_warning_db_local_file.setText(
+            no_version_warning_db_location
+        )
         self._last_file_dialog_path = str(Path(no_version_warning_db_location).parent)
 
     @Slot(bool)
@@ -1649,11 +2338,22 @@ class SettingsController(QObject):
         This function handles the "Use This Instead" db radio buttons. Clicking one button
         enables the associated widgets and disables the other widgets.
         """
-        if self.sender() == self.settings_dialog.use_this_instead_db_none_radio and checked:
+        if (
+            self.sender() == self.settings_dialog.use_this_instead_db_none_radio
+            and checked
+        ):
             self.settings_dialog.use_this_instead_db_github_url.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(False)
+            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(
+                False
+            )
+            self.settings_dialog.use_this_instead_db_url_input.setEnabled(False)
+            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.use_this_instead_db_local_file.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(False)
+            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(
+                False
+            )
             app_instance = QApplication.instance()
             if isinstance(app_instance, QApplication):
                 focused_widget = app_instance.focusWidget()
@@ -1661,19 +2361,60 @@ class SettingsController(QObject):
                     focused_widget.clearFocus()
             return
 
-        if self.sender() == self.settings_dialog.use_this_instead_db_github_radio and checked:
+        if (
+            self.sender() == self.settings_dialog.use_this_instead_db_github_radio
+            and checked
+        ):
             self.settings_dialog.use_this_instead_db_github_url.setEnabled(True)
-            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(True)
+            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(
+                True
+            )
+            self.settings_dialog.use_this_instead_db_url_input.setEnabled(False)
+            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.use_this_instead_db_local_file.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(False)
+            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(
+                False
+            )
             self.settings_dialog.use_this_instead_db_github_url.setFocus()
             return
 
-        if self.sender() == self.settings_dialog.use_this_instead_db_local_file_radio and checked:
+        if (
+            self.sender() == self.settings_dialog.use_this_instead_db_url_radio
+            and checked
+        ):
+            self.settings_dialog.use_this_instead_db_url_input.setEnabled(True)
+            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(
+                True
+            )
             self.settings_dialog.use_this_instead_db_github_url.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(False)
+            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(
+                False
+            )
+            self.settings_dialog.use_this_instead_db_local_file.setEnabled(False)
+            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(
+                False
+            )
+            self.settings_dialog.use_this_instead_db_url_input.setFocus()
+            return
+
+        if (
+            self.sender() == self.settings_dialog.use_this_instead_db_local_file_radio
+            and checked
+        ):
+            self.settings_dialog.use_this_instead_db_github_url.setEnabled(False)
+            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(
+                False
+            )
+            self.settings_dialog.use_this_instead_db_url_input.setEnabled(False)
+            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.use_this_instead_db_local_file.setEnabled(True)
-            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(True)
+            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(
+                True
+            )
             self.settings_dialog.use_this_instead_db_local_file.setFocus()
             return
 
@@ -1691,7 +2432,9 @@ class SettingsController(QObject):
         if not use_this_instead_db_location:
             return
 
-        self.settings_dialog.use_this_instead_db_local_file.setText(use_this_instead_db_location)
+        self.settings_dialog.use_this_instead_db_local_file.setText(
+            use_this_instead_db_location
+        )
         self._last_file_dialog_path = str(Path(use_this_instead_db_location).parent)
 
     @Slot()
@@ -1707,7 +2450,9 @@ class SettingsController(QObject):
         if not steamcmd_install_location:
             return
 
-        self.settings_dialog.steamcmd_install_location.setText(steamcmd_install_location)
+        self.settings_dialog.steamcmd_install_location.setText(
+            steamcmd_install_location
+        )
         self._last_file_dialog_path = str(Path(steamcmd_install_location).parent)
 
     @Slot()
@@ -1905,7 +2650,9 @@ class SettingsController(QObject):
 
         # Validate the path before setting it
 
-        test_controller = InstanceController(self.settings.instances[self.settings.current_instance])
+        test_controller = InstanceController(
+            self.settings.instances[self.settings.current_instance]
+        )
         test_controller.instance.instance_folder_override = instance_folder_location
         is_valid, error_msg = test_controller.validate_instance_folder_override()
 
@@ -1918,7 +2665,9 @@ class SettingsController(QObject):
             return
 
         # Update the instance and UI
-        self.settings.instances[self.settings.current_instance].instance_folder_override = instance_folder_location
+        self.settings.instances[
+            self.settings.current_instance
+        ].instance_folder_override = instance_folder_location
         self.settings_dialog.instance_folder_location.setText(instance_folder_location)
         self._last_file_dialog_path = str(Path(instance_folder_location).parent)
         self.settings.save()
@@ -1935,7 +2684,9 @@ class SettingsController(QObject):
             )
             return
 
-        self.settings.instances[self.settings.current_instance].instance_folder_override = ""
+        self.settings.instances[
+            self.settings.current_instance
+        ].instance_folder_override = ""
         self.settings_dialog.instance_folder_location.setText("")
         self.settings.save()
 
@@ -1952,12 +2703,16 @@ class SettingsController(QObject):
         """
         selected_theme_name = self.settings_dialog.themes_combobox.currentText()
         logger.info(f"Opening theme location: {selected_theme_name}")
-        stylesheet_path = self.theme_controller.get_theme_stylesheet_path(selected_theme_name)
+        stylesheet_path = self.theme_controller.get_theme_stylesheet_path(
+            selected_theme_name
+        )
 
         if stylesheet_path and stylesheet_path.exists():
             platform_specific_open(stylesheet_path.parent)
         else:
-            logger.warning(f"Failed to open theme location: {stylesheet_path} not found or does not exist")
+            logger.warning(
+                f"Failed to open theme location: {stylesheet_path} not found or does not exist"
+            )
 
     @Slot()
     def _on_use_background_coloring_checkbox_changed(self) -> None:
@@ -1965,9 +2720,7 @@ class SettingsController(QObject):
 
     @Slot()
     def _on_include_mod_notes_in_mod_name_filter_changed(self) -> None:
-        self.settings.include_mod_notes_in_mod_name_filter = (
-            self.settings_dialog.include_mod_notes_in_mod_name_filter_checkbox.isChecked()
-        )
+        self.settings.include_mod_notes_in_mod_name_filter = self.settings_dialog.include_mod_notes_in_mod_name_filter_checkbox.isChecked()
 
     @Slot()
     def _handle_mod_coloring_mode_changed(self) -> None:

--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -12,13 +12,20 @@ from app.controllers.language_controller import LanguageController
 from app.controllers.theme_controller import ThemeController
 from app.models.settings import Instance, Settings
 from app.utils.acf_utils import validate_acf_file_exists
+from app.utils.app_info import AppInfo
 from app.utils.constants import DEFAULT_INSTANCE_NAME, SortMethod
 from app.utils.event_bus import EventBus
 from app.utils.generic import (
+    extract_git_dir_name,
     find_steam_rimworld,
     get_path_up_to_string,
     platform_specific_open,
     validate_game_executable,
+)
+from app.utils.http_downloader import (
+    DatabaseDownloadTask,
+    DownloadResult,
+    HttpDownloadWorker,
 )
 from app.utils.system_info import SystemInfo
 from app.views.dialogue import (
@@ -73,6 +80,8 @@ class SettingsController(QObject):
         self.app_instance = QApplication.instance()
 
         self.change_mod_coloring_mode = False
+
+        self._http_download_worker: HttpDownloadWorker | None = None
 
         # Initialize the settings dialog from the settings model
 
@@ -234,7 +243,11 @@ class SettingsController(QObject):
             EventBus().do_download_community_rules_db_from_github
         )
         self.settings_dialog.community_rules_db_url_download_button.clicked.connect(
-            EventBus().do_download_community_rules_db_from_github
+            lambda: self._do_http_download_from_dialog(
+                self.settings_dialog.community_rules_db_url_input.text(),
+                self.settings.external_community_rules_repo,
+                "Community Rules",
+            )
         )
 
         self.settings_dialog.steam_workshop_db_none_radio.clicked.connect(
@@ -260,7 +273,11 @@ class SettingsController(QObject):
             EventBus().do_download_steam_workshop_db_from_github
         )
         self.settings_dialog.steam_workshop_db_url_download_button.clicked.connect(
-            EventBus().do_download_steam_workshop_db_from_github
+            lambda: self._do_http_download_from_dialog(
+                self.settings_dialog.steam_workshop_db_url_input.text(),
+                self.settings.external_steam_metadata_repo,
+                "Steam Workshop",
+            )
         )
 
         # Cross Version DB tab
@@ -287,7 +304,11 @@ class SettingsController(QObject):
             EventBus().do_download_no_version_warning_db_from_github
         )
         self.settings_dialog.no_version_warning_db_url_download_button.clicked.connect(
-            EventBus().do_download_no_version_warning_db_from_github
+            lambda: self._do_http_download_from_dialog(
+                self.settings_dialog.no_version_warning_db_url_input.text(),
+                self.settings.external_no_version_warning_repo_path,
+                "No Version Warning",
+            )
         )
 
         self.settings_dialog.use_this_instead_db_none_radio.clicked.connect(
@@ -313,7 +334,11 @@ class SettingsController(QObject):
             EventBus().do_download_use_this_instead_db_from_github
         )
         self.settings_dialog.use_this_instead_db_url_download_button.clicked.connect(
-            EventBus().do_download_use_this_instead_db_from_github
+            lambda: self._do_http_download_from_dialog(
+                self.settings_dialog.use_this_instead_db_url_input.text(),
+                self.settings.external_use_this_instead_repo_path,
+                "Use This Instead",
+            )
         )
 
         # Build DB tab
@@ -2033,6 +2058,79 @@ class SettingsController(QObject):
             raise ValueError("This function should only be called on Windows")
 
     @Slot(bool)
+    def _do_http_download_from_dialog(
+        self, url: str, repo_url: str, display_name: str
+    ) -> None:
+        """Download a database via HTTP using the URL currently in the settings dialog."""
+        if not url:
+            show_warning(
+                title="No URL configured",
+                text=f"No URL is configured for {display_name}.",
+                information="Please enter a URL in the text field.",
+            )
+            return
+
+        repo_name = (
+            extract_git_dir_name(repo_url)
+            if repo_url
+            else display_name.replace(" ", "-")
+        )
+        task = DatabaseDownloadTask(
+            url=url,
+            target_dir=AppInfo().databases_folder,
+            repo_name=repo_name,
+            display_name=display_name,
+        )
+
+        if self._http_download_worker is not None:
+            try:
+                self._http_download_worker.download_finished.disconnect()
+                self._http_download_worker.quit()
+                self._http_download_worker.wait()
+            except Exception as e:
+                logger.debug(f"Error during HTTP worker cleanup: {e}")
+            self._http_download_worker = None
+
+        self._http_download_worker = HttpDownloadWorker([task])
+        self._http_download_worker.download_finished.connect(
+            self._on_http_download_from_dialog_finished
+        )
+        self._http_download_worker.start()
+
+    @Slot(dict)
+    def _on_http_download_from_dialog_finished(
+        self, results: dict[str, DownloadResult]
+    ) -> None:
+        updated = [name for name, r in results.items() if r == DownloadResult.UPDATED]
+        up_to_date = [
+            name for name, r in results.items() if r == DownloadResult.UP_TO_DATE
+        ]
+        failed = [name for name, r in results.items() if r == DownloadResult.FAILED]
+
+        if failed:
+            show_warning(
+                title="Download failed",
+                text=f"Failed to download: {', '.join(failed)}",
+                information="Please check your internet connection and the configured URL.",
+            )
+        elif updated:
+            show_warning(
+                title="Download complete",
+                text=f"Downloaded successfully: {', '.join(updated)}",
+            )
+        elif up_to_date:
+            show_warning(
+                title="Already up to date",
+                text=f"Already up to date: {', '.join(up_to_date)}",
+            )
+
+        if self._http_download_worker:
+            try:
+                self._http_download_worker.download_finished.disconnect()
+            except Exception as e:
+                logger.debug(f"Error during HTTP worker cleanup: {e}")
+            self._http_download_worker = None
+
     def _on_community_rules_db_radio_clicked(self, checked: bool = True) -> None:
         """
         This function handles the community rules db radio buttons. Clicking one button

--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -93,13 +93,9 @@ class SettingsController(QObject):
             self._on_global_reset_to_defaults_button_clicked
         )
 
-        self.settings_dialog.global_cancel_button.clicked.connect(
-            self._on_global_cancel_button_clicked
-        )
+        self.settings_dialog.global_cancel_button.clicked.connect(self._on_global_cancel_button_clicked)
 
-        self.settings_dialog.global_ok_button.clicked.connect(
-            self._on_global_ok_button_clicked
-        )
+        self.settings_dialog.global_ok_button.clicked.connect(self._on_global_ok_button_clicked)
 
         # Connect launch state radio buttons to update spinbox enabled/disabled state
         # Main Window
@@ -141,22 +137,12 @@ class SettingsController(QObject):
         )
 
         # Locations tab
-        self.settings_dialog.game_location.textChanged.connect(
-            self._on_game_location_text_changed
-        )
-        self.settings_dialog.game_location_open_button.clicked.connect(
-            self._on_game_location_open_button_clicked
-        )
-        self.settings_dialog.game_location_choose_button.clicked.connect(
-            self._on_game_location_choose_button_clicked
-        )
-        self.settings_dialog.game_location_clear_button.clicked.connect(
-            self._on_game_location_clear_button_clicked
-        )
+        self.settings_dialog.game_location.textChanged.connect(self._on_game_location_text_changed)
+        self.settings_dialog.game_location_open_button.clicked.connect(self._on_game_location_open_button_clicked)
+        self.settings_dialog.game_location_choose_button.clicked.connect(self._on_game_location_choose_button_clicked)
+        self.settings_dialog.game_location_clear_button.clicked.connect(self._on_game_location_clear_button_clicked)
 
-        self.settings_dialog.config_folder_location.textChanged.connect(
-            self._on_config_folder_location_text_changed
-        )
+        self.settings_dialog.config_folder_location.textChanged.connect(self._on_config_folder_location_text_changed)
         self.settings_dialog.config_folder_location_open_button.clicked.connect(
             self._on_config_folder_location_open_button_clicked
         )
@@ -205,30 +191,18 @@ class SettingsController(QObject):
             # Buttons may not exist if UI hasn't been updated yet
             pass
 
-        self.settings_dialog.locations_clear_button.clicked.connect(
-            self._on_locations_clear_button_clicked
-        )
+        self.settings_dialog.locations_clear_button.clicked.connect(self._on_locations_clear_button_clicked)
 
-        self.settings_dialog.locations_autodetect_button.clicked.connect(
-            self._on_locations_autodetect_button_clicked
-        )
+        self.settings_dialog.locations_autodetect_button.clicked.connect(self._on_locations_autodetect_button_clicked)
 
         # Game Launch tab
-        self.settings_dialog.run_args.textChanged.connect(
-            self._on_run_args_text_changed
-        )
+        self.settings_dialog.run_args.textChanged.connect(self._on_run_args_text_changed)
 
         # Wire up the Databases tab buttons
 
-        self.settings_dialog.community_rules_db_none_radio.clicked.connect(
-            self._on_community_rules_db_radio_clicked
-        )
-        self.settings_dialog.community_rules_db_github_radio.clicked.connect(
-            self._on_community_rules_db_radio_clicked
-        )
-        self.settings_dialog.community_rules_db_url_radio.clicked.connect(
-            self._on_community_rules_db_radio_clicked
-        )
+        self.settings_dialog.community_rules_db_none_radio.clicked.connect(self._on_community_rules_db_radio_clicked)
+        self.settings_dialog.community_rules_db_github_radio.clicked.connect(self._on_community_rules_db_radio_clicked)
+        self.settings_dialog.community_rules_db_url_radio.clicked.connect(self._on_community_rules_db_radio_clicked)
         self.settings_dialog.community_rules_db_local_file_radio.clicked.connect(
             self._on_community_rules_db_radio_clicked
         )
@@ -250,15 +224,9 @@ class SettingsController(QObject):
             )
         )
 
-        self.settings_dialog.steam_workshop_db_none_radio.clicked.connect(
-            self._on_steam_workshop_db_radio_clicked
-        )
-        self.settings_dialog.steam_workshop_db_github_radio.clicked.connect(
-            self._on_steam_workshop_db_radio_clicked
-        )
-        self.settings_dialog.steam_workshop_db_url_radio.clicked.connect(
-            self._on_steam_workshop_db_radio_clicked
-        )
+        self.settings_dialog.steam_workshop_db_none_radio.clicked.connect(self._on_steam_workshop_db_radio_clicked)
+        self.settings_dialog.steam_workshop_db_github_radio.clicked.connect(self._on_steam_workshop_db_radio_clicked)
+        self.settings_dialog.steam_workshop_db_url_radio.clicked.connect(self._on_steam_workshop_db_radio_clicked)
         self.settings_dialog.steam_workshop_db_local_file_radio.clicked.connect(
             self._on_steam_workshop_db_radio_clicked
         )
@@ -311,15 +279,11 @@ class SettingsController(QObject):
             )
         )
 
-        self.settings_dialog.use_this_instead_db_none_radio.clicked.connect(
-            self._on_use_this_instead_db_radio_clicked
-        )
+        self.settings_dialog.use_this_instead_db_none_radio.clicked.connect(self._on_use_this_instead_db_radio_clicked)
         self.settings_dialog.use_this_instead_db_github_radio.clicked.connect(
             self._on_use_this_instead_db_radio_clicked
         )
-        self.settings_dialog.use_this_instead_db_url_radio.clicked.connect(
-            self._on_use_this_instead_db_radio_clicked
-        )
+        self.settings_dialog.use_this_instead_db_url_radio.clicked.connect(self._on_use_this_instead_db_radio_clicked)
         self.settings_dialog.use_this_instead_db_local_file_radio.clicked.connect(
             self._on_use_this_instead_db_radio_clicked
         )
@@ -365,15 +329,9 @@ class SettingsController(QObject):
         self.settings_dialog.steamcmd_clear_depot_cache_button.clicked.connect(
             self._on_steamcmd_clear_depot_cache_button_clicked
         )
-        self.settings_dialog.steamcmd_import_acf_button.clicked.connect(
-            self._on_steamcmd_import_acf_button_clicked
-        )
-        self.settings_dialog.steamcmd_delete_acf_button.clicked.connect(
-            self._on_steamcmd_delete_acf_button_clicked
-        )
-        self.settings_dialog.steamcmd_install_button.clicked.connect(
-            self._on_steamcmd_install_button_clicked
-        )
+        self.settings_dialog.steamcmd_import_acf_button.clicked.connect(self._on_steamcmd_import_acf_button_clicked)
+        self.settings_dialog.steamcmd_delete_acf_button.clicked.connect(self._on_steamcmd_delete_acf_button_clicked)
+        self.settings_dialog.steamcmd_install_button.clicked.connect(self._on_steamcmd_install_button_clicked)
 
         # Other External Tools Tab
         self.settings_dialog.text_editor_location_choose_button.clicked.connect(
@@ -381,9 +339,7 @@ class SettingsController(QObject):
         )
 
         # Theme tab
-        self.settings_dialog.theme_location_open_button.clicked.connect(
-            self._on_theme_location_open_button_clicked
-        )
+        self.settings_dialog.theme_location_open_button.clicked.connect(self._on_theme_location_open_button_clicked)
 
         # Advanced tab
         self.settings_dialog.color_background_instead_of_text_checkbox.stateChanged.connect(
@@ -417,24 +373,9 @@ class SettingsController(QObject):
         Get the mod paths for the current instance. Return the Default instance if the current instance is not found.
         """
         return [
-            str(
-                Path(
-                    self.settings.instances[self.settings.current_instance].game_folder
-                )
-                / "Data"
-            ),
-            str(
-                Path(
-                    self.settings.instances[self.settings.current_instance].local_folder
-                )
-            ),
-            str(
-                Path(
-                    self.settings.instances[
-                        self.settings.current_instance
-                    ].workshop_folder
-                )
-            ),
+            str(Path(self.settings.instances[self.settings.current_instance].game_folder) / "Data"),
+            str(Path(self.settings.instances[self.settings.current_instance].local_folder)),
+            str(Path(self.settings.instances[self.settings.current_instance].workshop_folder)),
         ]
 
     def resolve_data_source(self, path: str) -> str | None:
@@ -444,16 +385,9 @@ class SettingsController(QObject):
         # Pathlib the provided path string
         sanitized_path = Path(path)
         # Grab paths from Settings
-        expansions_path = (
-            Path(self.settings.instances[self.settings.current_instance].game_folder)
-            / "Data"
-        )
-        local_path = Path(
-            self.settings.instances[self.settings.current_instance].local_folder
-        )
-        workshop_path = Path(
-            self.settings.instances[self.settings.current_instance].workshop_folder
-        )
+        expansions_path = Path(self.settings.instances[self.settings.current_instance].game_folder) / "Data"
+        local_path = Path(self.settings.instances[self.settings.current_instance].local_folder)
+        workshop_path = Path(self.settings.instances[self.settings.current_instance].workshop_folder)
         # Validate data source, then emit if path is valid and not mapped
         if sanitized_path.parent == expansions_path:
             return "expansion"
@@ -542,9 +476,7 @@ class SettingsController(QObject):
             str(self.settings.instances[self.settings.current_instance].game_folder)
         )
         self.settings_dialog.game_location.setCursorPosition(0)
-        self.settings_dialog.game_location_open_button.setEnabled(
-            self.settings_dialog.game_location.text() != ""
-        )
+        self.settings_dialog.game_location_open_button.setEnabled(self.settings_dialog.game_location.text() != "")
         self.settings_dialog.config_folder_location.setText(
             str(self.settings.instances[self.settings.current_instance].config_folder)
         )
@@ -567,255 +499,146 @@ class SettingsController(QObject):
             self.settings_dialog.local_mods_folder_location.text() != ""
         )
         self.settings_dialog.steam_client_integration_checkbox.setChecked(
-            self.settings.instances[
-                self.settings.current_instance
-            ].steam_client_integration
+            self.settings.instances[self.settings.current_instance].steam_client_integration
         )
         # Enable/disable Steam mods location fields based on checkbox state
         checked = self.settings_dialog.steam_client_integration_checkbox.isChecked()
         self.settings_dialog.steam_mods_folder_location.setEnabled(checked)
         self.settings_dialog.steam_mods_folder_location_open_button.setEnabled(checked)
-        self.settings_dialog.steam_mods_folder_location_choose_button.setEnabled(
-            checked
-        )
+        self.settings_dialog.steam_mods_folder_location_choose_button.setEnabled(checked)
         self.settings_dialog.steam_mods_folder_location_clear_button.setEnabled(checked)
 
         # Load Steam protocol launch option
         self.settings_dialog.launch_via_steam_protocol_checkbox.setChecked(
-            self.settings.instances[
-                self.settings.current_instance
-            ].launch_via_steam_protocol
+            self.settings.instances[self.settings.current_instance].launch_via_steam_protocol
         )
         # Update run_args group enabled state based on Steam protocol setting
-        launch_via_steam_protocol = self.settings.instances[
-            self.settings.current_instance
-        ].launch_via_steam_protocol
+        launch_via_steam_protocol = self.settings.instances[self.settings.current_instance].launch_via_steam_protocol
         self.settings_dialog.run_args_group.setEnabled(not launch_via_steam_protocol)
 
         # Instance folder location (custom override)
         # Only enable for Default instance
         is_default_instance = self.settings.current_instance == DEFAULT_INSTANCE_NAME
         self.settings_dialog.instance_folder_location.setText(
-            self.settings.instances[
-                self.settings.current_instance
-            ].instance_folder_override
+            self.settings.instances[self.settings.current_instance].instance_folder_override
         )
         self.settings_dialog.instance_folder_location.setCursorPosition(0)
         self.settings_dialog.instance_folder_location.setEnabled(is_default_instance)
-        self.settings_dialog.instance_folder_location_choose_button.setEnabled(
-            is_default_instance
-        )
-        self.settings_dialog.instance_folder_location_clear_button.setEnabled(
-            is_default_instance
-        )
+        self.settings_dialog.instance_folder_location_choose_button.setEnabled(is_default_instance)
+        self.settings_dialog.instance_folder_location_clear_button.setEnabled(is_default_instance)
 
         # Databases tab
         if self.settings.external_community_rules_metadata_source == "None":
             self.settings_dialog.community_rules_db_none_radio.setChecked(True)
             self.settings_dialog.community_rules_db_github_url.setEnabled(False)
-            self.settings_dialog.community_rules_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.community_rules_db_github_download_button.setEnabled(False)
             self.settings_dialog.community_rules_db_url_input.setEnabled(False)
-            self.settings_dialog.community_rules_db_url_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.community_rules_db_url_download_button.setEnabled(False)
             self.settings_dialog.community_rules_db_local_file.setEnabled(False)
-            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(
-                False
-            )
-        elif (
-            self.settings.external_community_rules_metadata_source
-            == "Configured git repository"
-        ):
+            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(False)
+        elif self.settings.external_community_rules_metadata_source == "Configured git repository":
             self.settings_dialog.community_rules_db_github_radio.setChecked(True)
             self.settings_dialog.community_rules_db_github_url.setEnabled(True)
-            self.settings_dialog.community_rules_db_github_download_button.setEnabled(
-                True
-            )
+            self.settings_dialog.community_rules_db_github_download_button.setEnabled(True)
             self.settings_dialog.community_rules_db_url_input.setEnabled(False)
-            self.settings_dialog.community_rules_db_url_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.community_rules_db_url_download_button.setEnabled(False)
             self.settings_dialog.community_rules_db_local_file.setEnabled(False)
-            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(
-                False
-            )
+            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(False)
         elif self.settings.external_community_rules_metadata_source == "Configured URL":
             self.settings_dialog.community_rules_db_url_radio.setChecked(True)
             self.settings_dialog.community_rules_db_url_input.setEnabled(True)
             self.settings_dialog.community_rules_db_url_download_button.setEnabled(True)
             self.settings_dialog.community_rules_db_github_url.setEnabled(False)
-            self.settings_dialog.community_rules_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.community_rules_db_github_download_button.setEnabled(False)
             self.settings_dialog.community_rules_db_local_file.setEnabled(False)
-            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(
-                False
-            )
-        elif (
-            self.settings.external_community_rules_metadata_source
-            == "Configured file path"
-        ):
+            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(False)
+        elif self.settings.external_community_rules_metadata_source == "Configured file path":
             self.settings_dialog.community_rules_db_local_file_radio.setChecked(True)
             self.settings_dialog.community_rules_db_github_url.setEnabled(False)
-            self.settings_dialog.community_rules_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.community_rules_db_github_download_button.setEnabled(False)
             self.settings_dialog.community_rules_db_url_input.setEnabled(False)
-            self.settings_dialog.community_rules_db_url_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.community_rules_db_url_download_button.setEnabled(False)
             self.settings_dialog.community_rules_db_local_file.setEnabled(True)
-            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(
-                True
-            )
-        self.settings_dialog.community_rules_db_local_file.setText(
-            self.settings.external_community_rules_file_path
-        )
+            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(True)
+        self.settings_dialog.community_rules_db_local_file.setText(self.settings.external_community_rules_file_path)
         self.settings_dialog.community_rules_db_local_file.setCursorPosition(0)
-        self.settings_dialog.community_rules_db_github_url.setText(
-            self.settings.external_community_rules_repo
-        )
-        self.settings_dialog.community_rules_db_url_input.setText(
-            self.settings.external_community_rules_url
-        )
+        self.settings_dialog.community_rules_db_github_url.setText(self.settings.external_community_rules_repo)
+        self.settings_dialog.community_rules_db_url_input.setText(self.settings.external_community_rules_url)
 
         if self.settings.external_steam_metadata_source == "None":
             self.settings_dialog.steam_workshop_db_none_radio.setChecked(True)
             self.settings_dialog.steam_workshop_db_github_url.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(False)
             self.settings_dialog.steam_workshop_db_url_input.setEnabled(False)
             self.settings_dialog.steam_workshop_db_url_download_button.setEnabled(False)
             self.settings_dialog.steam_workshop_db_local_file.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(
-                False
-            )
-        elif (
-            self.settings.external_steam_metadata_source == "Configured git repository"
-        ):
+            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(False)
+        elif self.settings.external_steam_metadata_source == "Configured git repository":
             self.settings_dialog.steam_workshop_db_github_radio.setChecked(True)
             self.settings_dialog.steam_workshop_db_github_url.setEnabled(True)
-            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(
-                True
-            )
+            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(True)
             self.settings_dialog.steam_workshop_db_url_input.setEnabled(False)
             self.settings_dialog.steam_workshop_db_url_download_button.setEnabled(False)
             self.settings_dialog.steam_workshop_db_local_file.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(
-                False
-            )
+            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(False)
         elif self.settings.external_steam_metadata_source == "Configured URL":
             self.settings_dialog.steam_workshop_db_url_radio.setChecked(True)
             self.settings_dialog.steam_workshop_db_url_input.setEnabled(True)
             self.settings_dialog.steam_workshop_db_url_download_button.setEnabled(True)
             self.settings_dialog.steam_workshop_db_github_url.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(False)
             self.settings_dialog.steam_workshop_db_local_file.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(
-                False
-            )
+            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(False)
         elif self.settings.external_steam_metadata_source == "Configured file path":
             self.settings_dialog.steam_workshop_db_local_file_radio.setChecked(True)
             self.settings_dialog.steam_workshop_db_github_url.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(False)
             self.settings_dialog.steam_workshop_db_url_input.setEnabled(False)
             self.settings_dialog.steam_workshop_db_url_download_button.setEnabled(False)
             self.settings_dialog.steam_workshop_db_local_file.setEnabled(True)
-            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(
-                True
-            )
-        self.settings_dialog.steam_workshop_db_local_file.setText(
-            self.settings.external_steam_metadata_file_path
-        )
+            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(True)
+        self.settings_dialog.steam_workshop_db_local_file.setText(self.settings.external_steam_metadata_file_path)
         self.settings_dialog.steam_workshop_db_local_file.setCursorPosition(0)
-        self.settings_dialog.steam_workshop_db_github_url.setText(
-            self.settings.external_steam_metadata_repo
-        )
+        self.settings_dialog.steam_workshop_db_github_url.setText(self.settings.external_steam_metadata_repo)
         self.settings_dialog.steam_workshop_db_github_url.setCursorPosition(0)
-        self.settings_dialog.steam_workshop_db_url_input.setText(
-            self.settings.external_steam_metadata_url
-        )
+        self.settings_dialog.steam_workshop_db_url_input.setText(self.settings.external_steam_metadata_url)
         self.settings_dialog.database_expiry.setText(str(self.settings.database_expiry))
-        self.settings_dialog.aux_db_time_limit.setText(
-            str(self.settings.aux_db_time_limit)
-        )
-        self.settings_dialog.aux_db_time_limit.setEnabled(
-            self.settings.enable_aux_db_behavior_editing
-        )
+        self.settings_dialog.aux_db_time_limit.setText(str(self.settings.aux_db_time_limit))
+        self.settings_dialog.aux_db_time_limit.setEnabled(self.settings.enable_aux_db_behavior_editing)
 
         # Cross Version DB Tab
         if self.settings.external_no_version_warning_metadata_source == "None":
             self.settings_dialog.no_version_warning_db_none_radio.setChecked(True)
             self.settings_dialog.no_version_warning_db_github_url.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(False)
             self.settings_dialog.no_version_warning_db_url_input.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(False)
             self.settings_dialog.no_version_warning_db_local_file.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(
-                False
-            )
-        elif (
-            self.settings.external_no_version_warning_metadata_source
-            == "Configured git repository"
-        ):
+            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(False)
+        elif self.settings.external_no_version_warning_metadata_source == "Configured git repository":
             self.settings_dialog.no_version_warning_db_github_radio.setChecked(True)
             self.settings_dialog.no_version_warning_db_github_url.setEnabled(True)
-            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(
-                True
-            )
+            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(True)
             self.settings_dialog.no_version_warning_db_url_input.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(False)
             self.settings_dialog.no_version_warning_db_local_file.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(
-                False
-            )
-        elif (
-            self.settings.external_no_version_warning_metadata_source
-            == "Configured URL"
-        ):
+            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(False)
+        elif self.settings.external_no_version_warning_metadata_source == "Configured URL":
             self.settings_dialog.no_version_warning_db_url_radio.setChecked(True)
             self.settings_dialog.no_version_warning_db_url_input.setEnabled(True)
-            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(
-                True
-            )
+            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(True)
             self.settings_dialog.no_version_warning_db_github_url.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(False)
             self.settings_dialog.no_version_warning_db_local_file.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(
-                False
-            )
-        elif (
-            self.settings.external_no_version_warning_metadata_source
-            == "Configured file path"
-        ):
+            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(False)
+        elif self.settings.external_no_version_warning_metadata_source == "Configured file path":
             self.settings_dialog.no_version_warning_db_local_file_radio.setChecked(True)
             self.settings_dialog.no_version_warning_db_github_url.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(False)
             self.settings_dialog.no_version_warning_db_url_input.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(False)
             self.settings_dialog.no_version_warning_db_local_file.setEnabled(True)
-            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(
-                True
-            )
+            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(True)
         self.settings_dialog.no_version_warning_db_local_file.setText(
             self.settings.external_no_version_warning_file_path
         )
@@ -824,85 +647,45 @@ class SettingsController(QObject):
             self.settings.external_no_version_warning_repo_path
         )
         self.settings_dialog.no_version_warning_db_github_url.setCursorPosition(0)
-        self.settings_dialog.no_version_warning_db_url_input.setText(
-            self.settings.external_no_version_warning_url
-        )
+        self.settings_dialog.no_version_warning_db_url_input.setText(self.settings.external_no_version_warning_url)
 
         if self.settings.external_use_this_instead_metadata_source == "None":
             self.settings_dialog.use_this_instead_db_none_radio.setChecked(True)
             self.settings_dialog.use_this_instead_db_github_url.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(False)
             self.settings_dialog.use_this_instead_db_url_input.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(False)
             self.settings_dialog.use_this_instead_db_local_file.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(
-                False
-            )
-        elif (
-            self.settings.external_use_this_instead_metadata_source
-            == "Configured git repository"
-        ):
+            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(False)
+        elif self.settings.external_use_this_instead_metadata_source == "Configured git repository":
             self.settings_dialog.use_this_instead_db_github_radio.setChecked(True)
             self.settings_dialog.use_this_instead_db_github_url.setEnabled(True)
-            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(
-                True
-            )
+            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(True)
             self.settings_dialog.use_this_instead_db_url_input.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(False)
             self.settings_dialog.use_this_instead_db_local_file.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(
-                False
-            )
-        elif (
-            self.settings.external_use_this_instead_metadata_source == "Configured URL"
-        ):
+            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(False)
+        elif self.settings.external_use_this_instead_metadata_source == "Configured URL":
             self.settings_dialog.use_this_instead_db_url_radio.setChecked(True)
             self.settings_dialog.use_this_instead_db_url_input.setEnabled(True)
-            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(
-                True
-            )
+            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(True)
             self.settings_dialog.use_this_instead_db_github_url.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(False)
             self.settings_dialog.use_this_instead_db_local_file.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(
-                False
-            )
-        elif (
-            self.settings.external_use_this_instead_metadata_source
-            == "Configured file path"
-        ):
+            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(False)
+        elif self.settings.external_use_this_instead_metadata_source == "Configured file path":
             self.settings_dialog.use_this_instead_db_local_file_radio.setChecked(True)
             self.settings_dialog.use_this_instead_db_github_url.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(False)
             self.settings_dialog.use_this_instead_db_url_input.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(False)
             self.settings_dialog.use_this_instead_db_local_file.setEnabled(True)
-            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(
-                True
-            )
-        self.settings_dialog.use_this_instead_db_local_file.setText(
-            self.settings.external_use_this_instead_file_path
-        )
+            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(True)
+        self.settings_dialog.use_this_instead_db_local_file.setText(self.settings.external_use_this_instead_file_path)
         self.settings_dialog.use_this_instead_db_local_file.setCursorPosition(0)
-        self.settings_dialog.use_this_instead_db_github_url.setText(
-            self.settings.external_use_this_instead_repo_path
-        )
+        self.settings_dialog.use_this_instead_db_github_url.setText(self.settings.external_use_this_instead_repo_path)
         self.settings_dialog.use_this_instead_db_github_url.setCursorPosition(0)
-        self.settings_dialog.use_this_instead_db_url_input.setText(
-            self.settings.external_use_this_instead_url
-        )
+        self.settings_dialog.use_this_instead_db_url_input.setText(self.settings.external_use_this_instead_url)
 
         # Sorting tab
         if self.settings.sorting_algorithm == SortMethod.ALPHABETICAL:
@@ -911,47 +694,29 @@ class SettingsController(QObject):
             self.settings_dialog.sorting_topological_radio.setChecked(True)
         # Use dependencies for sorting checkbox
         if self.settings.use_moddependencies_as_loadTheseBefore:
-            (
-                self.settings_dialog.use_moddependencies_as_loadTheseBefore.setChecked(
-                    True
-                )
-            )
+            (self.settings_dialog.use_moddependencies_as_loadTheseBefore.setChecked(True))
         # Use alternativePackageIds as satisfying dependencies
         if self.settings.use_alternative_package_ids_as_satisfying_dependencies:
-            self.settings_dialog.use_alternative_package_ids_as_satisfying_dependencies_checkbox.setChecked(
-                True
-            )
+            self.settings_dialog.use_alternative_package_ids_as_satisfying_dependencies_checkbox.setChecked(True)
         # Set dependencies checkbox
-        self.settings_dialog.check_deps_checkbox.setChecked(
-            self.settings.check_dependencies_on_sort
-        )
+        self.settings_dialog.check_deps_checkbox.setChecked(self.settings.check_dependencies_on_sort)
         # Prefer versioned About.xml tags over base tags
         if self.settings.prefer_versioned_about_tags:
             self.settings_dialog.prefer_versioned_about_tags_checkbox.setChecked(True)
         # Download missing mods checkbox
-        self.settings_dialog.download_missing_mods_checkbox.setChecked(
-            self.settings.try_download_missing_mods
-        )
+        self.settings_dialog.download_missing_mods_checkbox.setChecked(self.settings.try_download_missing_mods)
         # Duplicate mod notification checkbox
-        self.settings_dialog.show_duplicate_mods_warning_checkbox.setChecked(
-            self.settings.duplicate_mods_warning
-        )
+        self.settings_dialog.show_duplicate_mods_warning_checkbox.setChecked(self.settings.duplicate_mods_warning)
         # Mod type filter checkbox
-        self.settings_dialog.mod_type_filter_checkbox.setChecked(
-            self.settings.mod_type_filter
-        )
+        self.settings_dialog.mod_type_filter_checkbox.setChecked(self.settings.mod_type_filter)
         # Hide invalid mod filtering checkbox
         self.settings_dialog.hide_invalid_mods_when_filtering_checkbox.setChecked(
             self.settings.hide_invalid_mods_when_filtering
         )
         # Inactive mods sorting options checkbox
-        self.settings_dialog.enable_inactive_mods_sorting_checkbox.setChecked(
-            self.settings.inactive_mods_sorting
-        )
+        self.settings_dialog.enable_inactive_mods_sorting_checkbox.setChecked(self.settings.inactive_mods_sorting)
         # Enable/disable the inactive mods sorting group box based on the checkbox state
-        self.settings_dialog.inactive_mods_sorting_group_box.setEnabled(
-            self.settings.inactive_mods_sorting
-        )
+        self.settings_dialog.inactive_mods_sorting_group_box.setEnabled(self.settings.inactive_mods_sorting)
         # Save inactive mods sort state
         self.settings_dialog.save_inactive_mods_sort_state_checkbox.setChecked(
             self.settings.save_inactive_mods_sort_state
@@ -962,34 +727,22 @@ class SettingsController(QObject):
             self.settings_dialog.db_builder_include_all_radio.setChecked(True)
         elif self.settings.db_builder_include == "no_local":
             self.settings_dialog.db_builder_include_no_local_radio.setChecked(True)
-        self.settings_dialog.db_builder_query_dlc_checkbox.setChecked(
-            self.settings.build_steam_database_dlc_data
-        )
+        self.settings_dialog.db_builder_query_dlc_checkbox.setChecked(self.settings.build_steam_database_dlc_data)
         self.settings_dialog.db_builder_update_instead_of_overwriting_checkbox.setChecked(
             self.settings.build_steam_database_update_toggle
         )
-        self.settings_dialog.db_builder_steam_api_key.setText(
-            self.settings.steam_apikey
-        )
+        self.settings_dialog.db_builder_steam_api_key.setText(self.settings.steam_apikey)
 
         # SteamCMD tab
-        self.settings_dialog.steamcmd_validate_downloads_checkbox.setChecked(
-            self.settings.steamcmd_validate_downloads
-        )
+        self.settings_dialog.steamcmd_validate_downloads_checkbox.setChecked(self.settings.steamcmd_validate_downloads)
         self.settings_dialog.steamcmd_auto_clear_depot_cache_checkbox.setChecked(
-            self.settings.instances[
-                self.settings.current_instance
-            ].steamcmd_auto_clear_depot_cache
+            self.settings.instances[self.settings.current_instance].steamcmd_auto_clear_depot_cache
         )
         self.settings_dialog.steamcmd_delete_before_update_checkbox.setChecked(
             self.settings.steamcmd_delete_before_update
         )
         self.settings_dialog.steamcmd_install_location.setText(
-            str(
-                self.settings.instances[
-                    self.settings.current_instance
-                ].steamcmd_install_path
-            )
+            str(self.settings.instances[self.settings.current_instance].steamcmd_install_path)
         )
 
         # todds tab
@@ -1006,48 +759,26 @@ class SettingsController(QObject):
             self.settings_dialog.todds_active_mods_only_radio.setChecked(True)
         else:
             self.settings_dialog.todds_all_mods_radio.setChecked(True)
-        self.settings_dialog.todds_dry_run_checkbox.setChecked(
-            self.settings.todds_dry_run
-        )
-        self.settings_dialog.todds_overwrite_checkbox.setChecked(
-            self.settings.todds_overwrite
-        )
-        self.settings_dialog.todds_custom_command_lineedit.setText(
-            self.settings.todds_custom_command
-        )
-        self.settings_dialog.auto_delete_orphaned_dds_checkbox.setChecked(
-            self.settings.auto_delete_orphaned_dds
-        )
+        self.settings_dialog.todds_dry_run_checkbox.setChecked(self.settings.todds_dry_run)
+        self.settings_dialog.todds_overwrite_checkbox.setChecked(self.settings.todds_overwrite)
+        self.settings_dialog.todds_custom_command_lineedit.setText(self.settings.todds_custom_command)
+        self.settings_dialog.auto_delete_orphaned_dds_checkbox.setChecked(self.settings.auto_delete_orphaned_dds)
         self.settings_dialog.auto_run_todds_before_launch_checkbox.setChecked(
             self.settings.auto_run_todds_before_launch
         )
 
         # External Tools Tab
-        self.settings_dialog.text_editor_location.setText(
-            self.settings.text_editor_location
-        )
-        self.settings_dialog.text_editor_folder_arg.setText(
-            self.settings.text_editor_folder_arg
-        )
-        self.settings_dialog.text_editor_file_arg.setText(
-            self.settings.text_editor_file_arg
-        )
+        self.settings_dialog.text_editor_location.setText(self.settings.text_editor_location)
+        self.settings_dialog.text_editor_folder_arg.setText(self.settings.text_editor_folder_arg)
+        self.settings_dialog.text_editor_file_arg.setText(self.settings.text_editor_file_arg)
 
         # Themes tab
-        self.settings_dialog.enable_themes_checkbox.setChecked(
-            self.settings.enable_themes
-        )
-        self.theme_controller.populate_themes_combobox(
-            self.settings_dialog.themes_combobox
-        )
+        self.settings_dialog.enable_themes_checkbox.setChecked(self.settings.enable_themes)
+        self.theme_controller.populate_themes_combobox(self.settings_dialog.themes_combobox)
         self.theme_controller.setup_theme_dialog(self.settings_dialog, self.settings)
 
-        self.language_controller.populate_languages_combobox(
-            self.settings_dialog.language_combobox
-        )
-        self.language_controller.setup_language_dialog(
-            self.settings_dialog, self.settings
-        )
+        self.language_controller.populate_languages_combobox(self.settings_dialog.language_combobox)
+        self.language_controller.setup_language_dialog(self.settings_dialog, self.settings)
 
         # Advanced tab values
         try:
@@ -1112,54 +843,30 @@ class SettingsController(QObject):
             self.settings_dialog.browser_launch_maximized_radio.setChecked(True)
 
         # Settings Window (only custom option)
-        self.settings_dialog.settings_custom_width_spinbox.setValue(
-            self.settings.settings_window_custom_width
-        )
-        self.settings_dialog.settings_custom_height_spinbox.setValue(
-            self.settings.settings_window_custom_height
-        )
+        self.settings_dialog.settings_custom_width_spinbox.setValue(self.settings.settings_window_custom_width)
+        self.settings_dialog.settings_custom_height_spinbox.setValue(self.settings.settings_window_custom_height)
 
         # Advanced tab
-        self.settings_dialog.debug_logging_checkbox.setChecked(
-            self.settings.debug_logging_enabled
-        )
+        self.settings_dialog.debug_logging_checkbox.setChecked(self.settings.debug_logging_enabled)
         self.settings_dialog.watchdog_checkbox.setChecked(self.settings.watchdog_toggle)
-        self.settings_dialog.backup_saves_on_launch_checkbox.setChecked(
-            self.settings.backup_saves_on_launch
-        )
-        self.settings_dialog.auto_backup_retention_count_spinbox.setValue(
-            self.settings.auto_backup_retention_count
-        )
-        self.settings_dialog.auto_backup_compression_count_spinbox.setValue(
-            self.settings.auto_backup_compression_count
-        )
+        self.settings_dialog.backup_saves_on_launch_checkbox.setChecked(self.settings.backup_saves_on_launch)
+        self.settings_dialog.auto_backup_retention_count_spinbox.setValue(self.settings.auto_backup_retention_count)
+        self.settings_dialog.auto_backup_compression_count_spinbox.setValue(self.settings.auto_backup_compression_count)
         self.settings_dialog.color_background_instead_of_text_checkbox.setChecked(
             self.settings.color_background_instead_of_text_toggle
         )
         # Clear button behavior
-        self.settings_dialog.clear_moves_dlc_checkbox.setChecked(
-            self.settings.clear_moves_dlc
-        )
-        self.settings_dialog.show_mod_updates_checkbox.setChecked(
-            self.settings.steam_mods_update_check
-        )
-        self.settings_dialog.render_unity_rich_text_checkbox.setChecked(
-            self.settings.render_unity_rich_text
-        )
-        self.settings_dialog.update_databases_on_startup_checkbox.setChecked(
-            self.settings.update_databases_on_startup
-        )
+        self.settings_dialog.clear_moves_dlc_checkbox.setChecked(self.settings.clear_moves_dlc)
+        self.settings_dialog.show_mod_updates_checkbox.setChecked(self.settings.steam_mods_update_check)
+        self.settings_dialog.render_unity_rich_text_checkbox.setChecked(self.settings.render_unity_rich_text)
+        self.settings_dialog.update_databases_on_startup_checkbox.setChecked(self.settings.update_databases_on_startup)
         self.settings_dialog.include_mod_notes_in_mod_name_filter_checkbox.setChecked(
             self.settings.include_mod_notes_in_mod_name_filter
         )
 
-        self.settings_dialog.enable_backup_before_update_checkbox.setChecked(
-            self.settings.enable_backup_before_update
-        )
+        self.settings_dialog.enable_backup_before_update_checkbox.setChecked(self.settings.enable_backup_before_update)
         self.settings_dialog.max_backups_spinbox.setValue(self.settings.max_backups)
-        self.settings_dialog.enable_aux_db_behavior_editing.setChecked(
-            self.settings.enable_aux_db_behavior_editing
-        )
+        self.settings_dialog.enable_aux_db_behavior_editing.setChecked(self.settings.enable_aux_db_behavior_editing)
         self.settings_dialog.rentry_auth_code.setText(self.settings.rentry_auth_code)
         self.settings_dialog.rentry_auth_code.setCursorPosition(0)
         self.settings_dialog.github_username.setText(self.settings.github_username)
@@ -1168,17 +875,10 @@ class SettingsController(QObject):
         self.settings_dialog.github_token.setCursorPosition(0)
 
         # Migrate old comma-separated format to new space-separated format if needed
-        run_args_list = self._migrate_run_args(
-            self.settings.instances[self.settings.current_instance].run_args
-        )
+        run_args_list = self._migrate_run_args(self.settings.instances[self.settings.current_instance].run_args)
         # Save migrated format back to settings
-        if (
-            run_args_list
-            != self.settings.instances[self.settings.current_instance].run_args
-        ):
-            self.settings.instances[
-                self.settings.current_instance
-            ].run_args = run_args_list
+        if run_args_list != self.settings.instances[self.settings.current_instance].run_args:
+            self.settings.instances[self.settings.current_instance].run_args = run_args_list
             self.settings.save()
             logger.info(f"Saved migrated run_args: {run_args_list}")
 
@@ -1193,9 +893,7 @@ class SettingsController(QObject):
         """
 
         # Locations tab
-        self.settings.instances[
-            self.settings.current_instance
-        ].game_folder = self.settings_dialog.game_location.text()
+        self.settings.instances[self.settings.current_instance].game_folder = self.settings_dialog.game_location.text()
         self.settings.instances[
             self.settings.current_instance
         ].config_folder = self.settings_dialog.config_folder_location.text()
@@ -1207,39 +905,25 @@ class SettingsController(QObject):
         ].local_folder = self.settings_dialog.local_mods_folder_location.text()
         self.settings.instances[
             self.settings.current_instance
-        ].steam_client_integration = (
-            self.settings_dialog.steam_client_integration_checkbox.isChecked()
-        )
+        ].steam_client_integration = self.settings_dialog.steam_client_integration_checkbox.isChecked()
 
         # Save Steam protocol launch option
         self.settings.instances[
             self.settings.current_instance
-        ].launch_via_steam_protocol = (
-            self.settings_dialog.launch_via_steam_protocol_checkbox.isChecked()
-        )
+        ].launch_via_steam_protocol = self.settings_dialog.launch_via_steam_protocol_checkbox.isChecked()
 
         # Databases tab
         if self.settings_dialog.community_rules_db_none_radio.isChecked():
             self.settings.external_community_rules_metadata_source = "None"
         elif self.settings_dialog.community_rules_db_local_file_radio.isChecked():
-            self.settings.external_community_rules_metadata_source = (
-                "Configured file path"
-            )
+            self.settings.external_community_rules_metadata_source = "Configured file path"
         elif self.settings_dialog.community_rules_db_github_radio.isChecked():
-            self.settings.external_community_rules_metadata_source = (
-                "Configured git repository"
-            )
+            self.settings.external_community_rules_metadata_source = "Configured git repository"
         elif self.settings_dialog.community_rules_db_url_radio.isChecked():
             self.settings.external_community_rules_metadata_source = "Configured URL"
-        self.settings.external_community_rules_file_path = (
-            self.settings_dialog.community_rules_db_local_file.text()
-        )
-        self.settings.external_community_rules_repo = (
-            self.settings_dialog.community_rules_db_github_url.text()
-        )
-        self.settings.external_community_rules_url = (
-            self.settings_dialog.community_rules_db_url_input.text()
-        )
+        self.settings.external_community_rules_file_path = self.settings_dialog.community_rules_db_local_file.text()
+        self.settings.external_community_rules_repo = self.settings_dialog.community_rules_db_github_url.text()
+        self.settings.external_community_rules_url = self.settings_dialog.community_rules_db_url_input.text()
         if self.settings_dialog.steam_workshop_db_none_radio.isChecked():
             self.settings.external_steam_metadata_source = "None"
         elif self.settings_dialog.steam_workshop_db_local_file_radio.isChecked():
@@ -1248,28 +932,18 @@ class SettingsController(QObject):
             self.settings.external_steam_metadata_source = "Configured git repository"
         elif self.settings_dialog.steam_workshop_db_url_radio.isChecked():
             self.settings.external_steam_metadata_source = "Configured URL"
-        self.settings.external_steam_metadata_repo = (
-            self.settings_dialog.steam_workshop_db_github_url.text()
-        )
-        self.settings.external_steam_metadata_file_path = (
-            self.settings_dialog.steam_workshop_db_local_file.text()
-        )
-        self.settings.external_steam_metadata_url = (
-            self.settings_dialog.steam_workshop_db_url_input.text()
-        )
+        self.settings.external_steam_metadata_repo = self.settings_dialog.steam_workshop_db_github_url.text()
+        self.settings.external_steam_metadata_file_path = self.settings_dialog.steam_workshop_db_local_file.text()
+        self.settings.external_steam_metadata_url = self.settings_dialog.steam_workshop_db_url_input.text()
         self.settings.database_expiry = int(self.settings_dialog.database_expiry.text())
 
         # Cross Version Databases Tab
         if self.settings_dialog.no_version_warning_db_none_radio.isChecked():
             self.settings.external_no_version_warning_metadata_source = "None"
         elif self.settings_dialog.no_version_warning_db_local_file_radio.isChecked():
-            self.settings.external_no_version_warning_metadata_source = (
-                "Configured file path"
-            )
+            self.settings.external_no_version_warning_metadata_source = "Configured file path"
         elif self.settings_dialog.no_version_warning_db_github_radio.isChecked():
-            self.settings.external_no_version_warning_metadata_source = (
-                "Configured git repository"
-            )
+            self.settings.external_no_version_warning_metadata_source = "Configured git repository"
         elif self.settings_dialog.no_version_warning_db_url_radio.isChecked():
             self.settings.external_no_version_warning_metadata_source = "Configured URL"
         self.settings.external_no_version_warning_file_path = (
@@ -1278,35 +952,21 @@ class SettingsController(QObject):
         self.settings.external_no_version_warning_repo_path = (
             self.settings_dialog.no_version_warning_db_github_url.text()
         )
-        self.settings.external_no_version_warning_url = (
-            self.settings_dialog.no_version_warning_db_url_input.text()
-        )
+        self.settings.external_no_version_warning_url = self.settings_dialog.no_version_warning_db_url_input.text()
 
         if self.settings_dialog.use_this_instead_db_none_radio.isChecked():
             self.settings.external_use_this_instead_metadata_source = "None"
         elif self.settings_dialog.use_this_instead_db_local_file_radio.isChecked():
-            self.settings.external_use_this_instead_metadata_source = (
-                "Configured file path"
-            )
+            self.settings.external_use_this_instead_metadata_source = "Configured file path"
         elif self.settings_dialog.use_this_instead_db_github_radio.isChecked():
-            self.settings.external_use_this_instead_metadata_source = (
-                "Configured git repository"
-            )
+            self.settings.external_use_this_instead_metadata_source = "Configured git repository"
         elif self.settings_dialog.use_this_instead_db_url_radio.isChecked():
             self.settings.external_use_this_instead_metadata_source = "Configured URL"
-        self.settings.external_use_this_instead_file_path = (
-            self.settings_dialog.use_this_instead_db_local_file.text()
-        )
-        self.settings.external_use_this_instead_repo_path = (
-            self.settings_dialog.use_this_instead_db_github_url.text()
-        )
-        self.settings.external_use_this_instead_url = (
-            self.settings_dialog.use_this_instead_db_url_input.text()
-        )
+        self.settings.external_use_this_instead_file_path = self.settings_dialog.use_this_instead_db_local_file.text()
+        self.settings.external_use_this_instead_repo_path = self.settings_dialog.use_this_instead_db_github_url.text()
+        self.settings.external_use_this_instead_url = self.settings_dialog.use_this_instead_db_url_input.text()
         try:
-            self.settings.aux_db_time_limit = int(
-                self.settings_dialog.aux_db_time_limit.text()
-            )
+            self.settings.aux_db_time_limit = int(self.settings_dialog.aux_db_time_limit.text())
         except Exception:
             logger.warning("Failed setting Aux DB time limit, falling back to -1")
             self.settings.aux_db_time_limit = -1
@@ -1322,35 +982,27 @@ class SettingsController(QObject):
             self.settings_dialog.use_moddependencies_as_loadTheseBefore.isChecked()
         )
         # Use alternativePackageIds as satisfying dependencies
-        self.settings.use_alternative_package_ids_as_satisfying_dependencies = self.settings_dialog.use_alternative_package_ids_as_satisfying_dependencies_checkbox.isChecked()
-        # Set dependencies checkbox
-        self.settings.check_dependencies_on_sort = (
-            self.settings_dialog.check_deps_checkbox.isChecked()
+        self.settings.use_alternative_package_ids_as_satisfying_dependencies = (
+            self.settings_dialog.use_alternative_package_ids_as_satisfying_dependencies_checkbox.isChecked()
         )
+        # Set dependencies checkbox
+        self.settings.check_dependencies_on_sort = self.settings_dialog.check_deps_checkbox.isChecked()
         # Prefer versioned About.xml tags over base tags
         self.settings.prefer_versioned_about_tags = (
             self.settings_dialog.prefer_versioned_about_tags_checkbox.isChecked()
         )
         # Download missing mods checkbox
-        self.settings.try_download_missing_mods = (
-            self.settings_dialog.download_missing_mods_checkbox.isChecked()
-        )
+        self.settings.try_download_missing_mods = self.settings_dialog.download_missing_mods_checkbox.isChecked()
         # Duplicate mod notification checkbox
-        self.settings.duplicate_mods_warning = (
-            self.settings_dialog.show_duplicate_mods_warning_checkbox.isChecked()
-        )
+        self.settings.duplicate_mods_warning = self.settings_dialog.show_duplicate_mods_warning_checkbox.isChecked()
         # Mod type filter checkbox
-        self.settings.mod_type_filter = (
-            self.settings_dialog.mod_type_filter_checkbox.isChecked()
-        )
+        self.settings.mod_type_filter = self.settings_dialog.mod_type_filter_checkbox.isChecked()
         # Hide invalid mod filtering checkbox
         self.settings.hide_invalid_mods_when_filtering = (
             self.settings_dialog.hide_invalid_mods_when_filtering_checkbox.isChecked()
         )
         # Inactive mods sorting options checkbox
-        self.settings.inactive_mods_sorting = (
-            self.settings_dialog.enable_inactive_mods_sorting_checkbox.isChecked()
-        )
+        self.settings.inactive_mods_sorting = self.settings_dialog.enable_inactive_mods_sorting_checkbox.isChecked()
         # Save inactive mods sort state
         self.settings.save_inactive_mods_sort_state = (
             self.settings_dialog.save_inactive_mods_sort_state_checkbox.isChecked()
@@ -1361,13 +1013,11 @@ class SettingsController(QObject):
             self.settings.db_builder_include = "all_mods"
         elif self.settings_dialog.db_builder_include_no_local_radio.isChecked():
             self.settings.db_builder_include = "no_local"
-        self.settings.build_steam_database_dlc_data = (
-            self.settings_dialog.db_builder_query_dlc_checkbox.isChecked()
+        self.settings.build_steam_database_dlc_data = self.settings_dialog.db_builder_query_dlc_checkbox.isChecked()
+        self.settings.build_steam_database_update_toggle = (
+            self.settings_dialog.db_builder_update_instead_of_overwriting_checkbox.isChecked()
         )
-        self.settings.build_steam_database_update_toggle = self.settings_dialog.db_builder_update_instead_of_overwriting_checkbox.isChecked()
-        self.settings.steam_apikey = (
-            self.settings_dialog.db_builder_steam_api_key.text()
-        )
+        self.settings.steam_apikey = self.settings_dialog.db_builder_steam_api_key.text()
 
         # SteamCMD tab
         self.settings.steamcmd_validate_downloads = (
@@ -1378,9 +1028,7 @@ class SettingsController(QObject):
         )
         self.settings.instances[
             self.settings.current_instance
-        ].steamcmd_auto_clear_depot_cache = (
-            self.settings_dialog.steamcmd_auto_clear_depot_cache_checkbox.isChecked()
-        )
+        ].steamcmd_auto_clear_depot_cache = self.settings_dialog.steamcmd_auto_clear_depot_cache_checkbox.isChecked()
         self.settings.instances[
             self.settings.current_instance
         ].steamcmd_install_path = self.settings_dialog.steamcmd_install_location.text()
@@ -1390,54 +1038,38 @@ class SettingsController(QObject):
             self.settings.todds_preset = "optimized"
         if self.settings_dialog.todds_preset_custom_radio.isChecked():
             self.settings.todds_preset = "custom"
-            self.settings.todds_custom_command = (
-                self.settings_dialog.todds_custom_command_lineedit.text()
-            )
+            self.settings.todds_custom_command = self.settings_dialog.todds_custom_command_lineedit.text()
         else:
             self.settings.todds_preset = "optimized"
         if self.settings_dialog.todds_active_mods_only_radio.isChecked():
             self.settings.todds_active_mods_target = True
         elif self.settings_dialog.todds_all_mods_radio.isChecked():
             self.settings.todds_active_mods_target = False
-        self.settings.todds_dry_run = (
-            self.settings_dialog.todds_dry_run_checkbox.isChecked()
-        )
-        self.settings.todds_overwrite = (
-            self.settings_dialog.todds_overwrite_checkbox.isChecked()
-        )
-        self.settings.auto_delete_orphaned_dds = (
-            self.settings_dialog.auto_delete_orphaned_dds_checkbox.isChecked()
-        )
+        self.settings.todds_dry_run = self.settings_dialog.todds_dry_run_checkbox.isChecked()
+        self.settings.todds_overwrite = self.settings_dialog.todds_overwrite_checkbox.isChecked()
+        self.settings.auto_delete_orphaned_dds = self.settings_dialog.auto_delete_orphaned_dds_checkbox.isChecked()
         self.settings.auto_run_todds_before_launch = (
             self.settings_dialog.auto_run_todds_before_launch_checkbox.isChecked()
         )
 
         # Other External Tools Tab
-        self.settings.text_editor_location = (
-            self.settings_dialog.text_editor_location.text()
-        )
-        self.settings.text_editor_folder_arg = (
-            self.settings_dialog.text_editor_folder_arg.text()
-        )
-        self.settings.text_editor_file_arg = (
-            self.settings_dialog.text_editor_file_arg.text()
-        )
+        self.settings.text_editor_location = self.settings_dialog.text_editor_location.text()
+        self.settings.text_editor_folder_arg = self.settings_dialog.text_editor_folder_arg.text()
+        self.settings.text_editor_file_arg = self.settings_dialog.text_editor_file_arg.text()
 
         # Themes tab
-        self.settings.enable_themes = (
-            self.settings_dialog.enable_themes_checkbox.isChecked()
-        )
+        self.settings.enable_themes = self.settings_dialog.enable_themes_checkbox.isChecked()
         self.settings.theme_name = self.settings_dialog.themes_combobox.currentText()
 
-        self.settings.font_family = (
-            self.settings_dialog.font_family_combobox.currentText()
-        )
+        self.settings.font_family = self.settings_dialog.font_family_combobox.currentText()
         self.settings.font_size = self.settings_dialog.font_size_spinbox.value()
         self.settings.language = self.settings_dialog.language_combobox.currentData()
 
         # Launch State tab
         # Dialogue positioning
-        self.settings.constrain_dialogues_to_main_window_monitor = self.settings_dialog.constrain_dialogues_to_main_window_monitor_checkbox.isChecked()
+        self.settings.constrain_dialogues_to_main_window_monitor = (
+            self.settings_dialog.constrain_dialogues_to_main_window_monitor_checkbox.isChecked()
+        )
 
         # Windows launch state
         # Main Window
@@ -1447,12 +1079,8 @@ class SettingsController(QObject):
             self.settings.main_window_launch_state = "normal"
         elif self.settings_dialog.main_launch_custom_radio.isChecked():
             self.settings.main_window_launch_state = "custom"
-            self.settings.main_window_custom_width = (
-                self.settings_dialog.main_custom_width_spinbox.value()
-            )
-            self.settings.main_window_custom_height = (
-                self.settings_dialog.main_custom_height_spinbox.value()
-            )
+            self.settings.main_window_custom_width = self.settings_dialog.main_custom_width_spinbox.value()
+            self.settings.main_window_custom_height = self.settings_dialog.main_custom_height_spinbox.value()
         else:
             self.settings.main_window_launch_state = "maximized"
         # Browser Window
@@ -1462,71 +1090,45 @@ class SettingsController(QObject):
             self.settings.browser_window_launch_state = "normal"
         elif self.settings_dialog.browser_launch_custom_radio.isChecked():
             self.settings.browser_window_launch_state = "custom"
-            self.settings.browser_window_custom_width = (
-                self.settings_dialog.browser_custom_width_spinbox.value()
-            )
-            self.settings.browser_window_custom_height = (
-                self.settings_dialog.browser_custom_height_spinbox.value()
-            )
+            self.settings.browser_window_custom_width = self.settings_dialog.browser_custom_width_spinbox.value()
+            self.settings.browser_window_custom_height = self.settings_dialog.browser_custom_height_spinbox.value()
         else:
             self.settings.browser_window_launch_state = "maximized"
 
         # Settings Window (only custom option)
-        self.settings.settings_window_custom_width = (
-            self.settings_dialog.settings_custom_width_spinbox.value()
-        )
-        self.settings.settings_window_custom_height = (
-            self.settings_dialog.settings_custom_height_spinbox.value()
-        )
+        self.settings.settings_window_custom_width = self.settings_dialog.settings_custom_width_spinbox.value()
+        self.settings.settings_window_custom_height = self.settings_dialog.settings_custom_height_spinbox.value()
 
         # Advanced tab
-        self.settings.debug_logging_enabled = (
-            self.settings_dialog.debug_logging_checkbox.isChecked()
-        )
-        self.settings.watchdog_toggle = (
-            self.settings_dialog.watchdog_checkbox.isChecked()
-        )
-        self.settings.backup_saves_on_launch = (
-            self.settings_dialog.backup_saves_on_launch_checkbox.isChecked()
-        )
-        self.settings.auto_backup_retention_count = (
-            self.settings_dialog.auto_backup_retention_count_spinbox.value()
-        )
-        self.settings.auto_backup_compression_count = (
-            self.settings_dialog.auto_backup_compression_count_spinbox.value()
-        )
+        self.settings.debug_logging_enabled = self.settings_dialog.debug_logging_checkbox.isChecked()
+        self.settings.watchdog_toggle = self.settings_dialog.watchdog_checkbox.isChecked()
+        self.settings.backup_saves_on_launch = self.settings_dialog.backup_saves_on_launch_checkbox.isChecked()
+        self.settings.auto_backup_retention_count = self.settings_dialog.auto_backup_retention_count_spinbox.value()
+        self.settings.auto_backup_compression_count = self.settings_dialog.auto_backup_compression_count_spinbox.value()
         self.settings.color_background_instead_of_text_toggle = (
             self.settings_dialog.color_background_instead_of_text_checkbox.isChecked()
         )
         # Clear button behavior
-        self.settings.clear_moves_dlc = (
-            self.settings_dialog.clear_moves_dlc_checkbox.isChecked()
-        )
-        self.settings.steam_mods_update_check = (
-            self.settings_dialog.show_mod_updates_checkbox.isChecked()
-        )
-        self.settings.render_unity_rich_text = (
-            self.settings_dialog.render_unity_rich_text_checkbox.isChecked()
-        )
+        self.settings.clear_moves_dlc = self.settings_dialog.clear_moves_dlc_checkbox.isChecked()
+        self.settings.steam_mods_update_check = self.settings_dialog.show_mod_updates_checkbox.isChecked()
+        self.settings.render_unity_rich_text = self.settings_dialog.render_unity_rich_text_checkbox.isChecked()
         self.settings.update_databases_on_startup = (
             self.settings_dialog.update_databases_on_startup_checkbox.isChecked()
         )
-        self.settings.include_mod_notes_in_mod_name_filter = self.settings_dialog.include_mod_notes_in_mod_name_filter_checkbox.isChecked()
+        self.settings.include_mod_notes_in_mod_name_filter = (
+            self.settings_dialog.include_mod_notes_in_mod_name_filter_checkbox.isChecked()
+        )
 
         self.settings.enable_backup_before_update = (
             self.settings_dialog.enable_backup_before_update_checkbox.isChecked()
         )
         self.settings.max_backups = self.settings_dialog.max_backups_spinbox.value()
-        self.settings.enable_aux_db_behavior_editing = (
-            self.settings_dialog.enable_aux_db_behavior_editing.isChecked()
-        )
+        self.settings.enable_aux_db_behavior_editing = self.settings_dialog.enable_aux_db_behavior_editing.isChecked()
         self.settings.rentry_auth_code = self.settings_dialog.rentry_auth_code.text()
         self.settings.github_username = self.settings_dialog.github_username.text()
         self.settings.github_token = self.settings_dialog.github_token.text()
         # Migrate and extract command string from single-element list
-        run_args_list = self._migrate_run_args(
-            self.settings.instances[self.settings.current_instance].run_args
-        )
+        run_args_list = self._migrate_run_args(self.settings.instances[self.settings.current_instance].run_args)
         run_args_str = run_args_list[0] if run_args_list else ""
         self.settings_dialog.run_args.setText(run_args_str)
 
@@ -1537,9 +1139,7 @@ class SettingsController(QObject):
         """
         answer = BinaryChoiceDialog(
             title=self.tr("Reset to defaults"),
-            text=self.tr(
-                "Are you sure you want to reset all settings to their default values?"
-            ),
+            text=self.tr("Are you sure you want to reset all settings to their default values?"),
         )
         if not answer.exec_is_positive():
             return
@@ -1591,9 +1191,7 @@ class SettingsController(QObject):
             return False
         return True
 
-    def _check_steam_integration_validity(
-        self, steam_client_integration: bool, steam_mods_location: str
-    ) -> bool:
+    def _check_steam_integration_validity(self, steam_client_integration: bool, steam_mods_location: str) -> bool:
         """
         Check if Steam client integration and Steam mods location are valid.
 
@@ -1639,12 +1237,8 @@ class SettingsController(QObject):
 
         :return: True if valid configuration, False if invalid.
         """
-        steam_client_integration = (
-            self.settings_dialog.steam_client_integration_checkbox.isChecked()
-        )
-        steam_mods_location = (
-            self.settings_dialog.steam_mods_folder_location.text().strip()
-        )
+        steam_client_integration = self.settings_dialog.steam_client_integration_checkbox.isChecked()
+        steam_mods_location = self.settings_dialog.steam_mods_folder_location.text().strip()
 
         # Handle user explicitly disabling Steam integration
         if not steam_client_integration:
@@ -1660,9 +1254,7 @@ class SettingsController(QObject):
             self.settings_dialog.launch_via_steam_protocol_checkbox.setChecked(False)
 
         # Validate Steam integration configuration
-        is_valid = self._check_steam_integration_validity(
-            steam_client_integration, steam_mods_location
-        )
+        is_valid = self._check_steam_integration_validity(steam_client_integration, steam_mods_location)
 
         if not is_valid:
             # Disable all Steam integration settings if validation fails
@@ -1678,9 +1270,7 @@ class SettingsController(QObject):
                         "Steam client integration, Steam mods location, and Steam protocol launch have been disabled."
                     ),
                 )
-            elif steam_mods_location and not validate_acf_file_exists(
-                steam_mods_location
-            ):
+            elif steam_mods_location and not validate_acf_file_exists(steam_mods_location):
                 QMessageBox.warning(
                     self.settings_dialog,
                     self.tr("Steam Workshop File Not Found"),
@@ -1705,9 +1295,7 @@ class SettingsController(QObject):
 
         # Validate config folder if set
         config_folder_text = self.settings_dialog.config_folder_location.text().strip()
-        if config_folder_text and not self._validate_config_folder_location(
-            config_folder_text
-        ):
+        if config_folder_text and not self._validate_config_folder_location(config_folder_text):
             return
 
         # Validate Steam integration if enabled
@@ -1731,9 +1319,7 @@ class SettingsController(QObject):
 
     @Slot()
     def _on_game_location_text_changed(self) -> None:
-        self.settings_dialog.game_location_open_button.setEnabled(
-            self.settings_dialog.game_location.text() != ""
-        )
+        self.settings_dialog.game_location_open_button.setEnabled(self.settings_dialog.game_location.text() != "")
 
     @Slot()
     def _on_game_location_open_button_clicked(self) -> None:
@@ -1754,9 +1340,7 @@ class SettingsController(QObject):
         if not self._validate_game_location(str(game_location)):
             return
         self.settings_dialog.game_location.setText(str(game_location))
-        self.settings_dialog.local_mods_folder_location.setText(
-            str(game_location / "Mods")
-        )
+        self.settings_dialog.local_mods_folder_location.setText(str(game_location / "Mods"))
         self._last_file_dialog_path = str(game_location)
 
     def _on_game_location_choose_button_clicked_macos(self) -> Path | None:
@@ -1848,9 +1432,7 @@ class SettingsController(QObject):
         if not steam_mods_folder_location:
             return
 
-        self.settings_dialog.steam_mods_folder_location.setText(
-            steam_mods_folder_location
-        )
+        self.settings_dialog.steam_mods_folder_location.setText(steam_mods_folder_location)
         self._last_file_dialog_path = str(Path(steam_mods_folder_location).parent)
 
     @Slot()
@@ -1870,9 +1452,7 @@ class SettingsController(QObject):
         if not local_mods_folder_location:
             return
 
-        self.settings_dialog.local_mods_folder_location.setText(
-            local_mods_folder_location
-        )
+        self.settings_dialog.local_mods_folder_location.setText(local_mods_folder_location)
         self._last_file_dialog_path = str(Path(local_mods_folder_location).parent)
 
     @Slot()
@@ -1890,9 +1470,7 @@ class SettingsController(QObject):
         self.settings_dialog.local_mods_folder_location.setText("")
 
     @Slot()
-    def _on_locations_clear_button_clicked(
-        self, skip_confirmation: bool = False
-    ) -> None:
+    def _on_locations_clear_button_clicked(self, skip_confirmation: bool = False) -> None:
         """
         Clear the settings dialog's location fields.
         """
@@ -1939,9 +1517,7 @@ class SettingsController(QObject):
 
         path_groups = [
             _PathGroup(os_paths[0], self.settings_dialog.game_location, "game"),
-            _PathGroup(
-                os_paths[1], self.settings_dialog.config_folder_location, "config"
-            ),
+            _PathGroup(os_paths[1], self.settings_dialog.config_folder_location, "config"),
             _PathGroup(
                 os_paths[2],
                 self.settings_dialog.steam_mods_folder_location,
@@ -1956,20 +1532,14 @@ class SettingsController(QObject):
 
         for group in path_groups:
             if group.folder.exists():
-                logger.info(
-                    f"Auto-detected {group.name} folder path exists: {group.folder}"
-                )
+                logger.info(f"Auto-detected {group.name} folder path exists: {group.folder}")
                 if not group.settings_line.text():
-                    logger.info(
-                        f"No value set currently for {group.name} folder. Overwriting with auto-detected path"
-                    )
+                    logger.info(f"No value set currently for {group.name} folder. Overwriting with auto-detected path")
                     group.settings_line.setText(str(group.folder))
                 else:
                     logger.info(f"Value already set for {group.name} folder. Passing")
             else:
-                logger.warning(
-                    f"Auto-detected {group.name} folder path does not exist: {group.folder}"
-                )
+                logger.warning(f"Auto-detected {group.name} folder path does not exist: {group.folder}")
 
     def __get_darwin_paths(self) -> tuple[Path, Path, Path]:
         """
@@ -1979,15 +1549,9 @@ class SettingsController(QObject):
             tuple[Path, Path, Path]: game_folder, config_folder, steam_mods_folder
         """
         user_home = Path.home()
-        game_folder = Path(
-            f"/{user_home}/Library/Application Support/Steam/steamapps/common/Rimworld/RimworldMac.app"
-        )
-        config_folder = Path(
-            f"/{user_home}/Library/Application Support/Rimworld/Config"
-        )
-        steam_mods_folder = Path(
-            f"/{user_home}/Library/Application Support/Steam/steamapps/workshop/content/294100"
-        )
+        game_folder = Path(f"/{user_home}/Library/Application Support/Steam/steamapps/common/Rimworld/RimworldMac.app")
+        config_folder = Path(f"/{user_home}/Library/Application Support/Rimworld/Config")
+        steam_mods_folder = Path(f"/{user_home}/Library/Application Support/Steam/steamapps/workshop/content/294100")
 
         return game_folder, config_folder, steam_mods_folder
 
@@ -2004,10 +1568,7 @@ class SettingsController(QObject):
             steam_path = user_home / ".steam/steam"
             debian_path = steam_path / "steamapps/common/RimWorld"
         game_folder = debian_path / "steamapps/common/RimWorld"
-        config_folder = (
-            user_home
-            / ".config/unity3d/Ludeon Studios/RimWorld by Ludeon Studios/Config"
-        )
+        config_folder = user_home / ".config/unity3d/Ludeon Studios/RimWorld by Ludeon Studios/Config"
         steam_mods_folder = debian_path / "steamapps/workshop/content/294100"
 
         return game_folder, config_folder, steam_mods_folder
@@ -2026,9 +1587,7 @@ class SettingsController(QObject):
             steam_folder, found = find_steam_folder()
 
             if not found:
-                logger.error(
-                    "[win32] Could not find Steam folder. Using fallback assumptions"
-                )
+                logger.error("[win32] Could not find Steam folder. Using fallback assumptions")
                 steam_folder = "C:/Program Files (x86)/Steam"
 
             game_folder: str | Path = find_steam_rimworld(steam_folder)
@@ -2038,18 +1597,12 @@ class SettingsController(QObject):
                 game_folder = f"{steam_folder}/steamapps/common/RimWorld"
             game_folder = Path(game_folder)
 
-            config_folder = Path(
-                f"{user_home}/AppData/LocalLow/Ludeon Studios/RimWorld by Ludeon Studios/Config"
-            )
+            config_folder = Path(f"{user_home}/AppData/LocalLow/Ludeon Studios/RimWorld by Ludeon Studios/Config")
 
-            steam_mods_folder = get_path_up_to_string(
-                game_folder, "common", exclude=True
-            )
+            steam_mods_folder = get_path_up_to_string(game_folder, "common", exclude=True)
             if steam_mods_folder == "":
                 # Fallback steam mods path
-                steam_mods_folder = Path(
-                    f"{steam_folder}/steamapps/workshop/content/294100"
-                )
+                steam_mods_folder = Path(f"{steam_folder}/steamapps/workshop/content/294100")
             else:
                 steam_mods_folder = Path(steam_mods_folder) / "workshop/content/294100"
 
@@ -2058,9 +1611,7 @@ class SettingsController(QObject):
             raise ValueError("This function should only be called on Windows")
 
     @Slot(bool)
-    def _do_http_download_from_dialog(
-        self, url: str, repo_url: str, display_name: str
-    ) -> None:
+    def _do_http_download_from_dialog(self, url: str, repo_url: str, display_name: str) -> None:
         """Download a database via HTTP using the URL currently in the settings dialog."""
         if not url:
             show_warning(
@@ -2070,11 +1621,7 @@ class SettingsController(QObject):
             )
             return
 
-        repo_name = (
-            extract_git_dir_name(repo_url)
-            if repo_url
-            else display_name.replace(" ", "-")
-        )
+        repo_name = extract_git_dir_name(repo_url) if repo_url else display_name.replace(" ", "-")
         task = DatabaseDownloadTask(
             url=url,
             target_dir=AppInfo().databases_folder,
@@ -2092,19 +1639,13 @@ class SettingsController(QObject):
             self._http_download_worker = None
 
         self._http_download_worker = HttpDownloadWorker([task])
-        self._http_download_worker.download_finished.connect(
-            self._on_http_download_from_dialog_finished
-        )
+        self._http_download_worker.download_finished.connect(self._on_http_download_from_dialog_finished)
         self._http_download_worker.start()
 
     @Slot(dict)
-    def _on_http_download_from_dialog_finished(
-        self, results: dict[str, DownloadResult]
-    ) -> None:
+    def _on_http_download_from_dialog_finished(self, results: dict[str, DownloadResult]) -> None:
         updated = [name for name, r in results.items() if r == DownloadResult.UPDATED]
-        up_to_date = [
-            name for name, r in results.items() if r == DownloadResult.UP_TO_DATE
-        ]
+        up_to_date = [name for name, r in results.items() if r == DownloadResult.UP_TO_DATE]
         failed = [name for name, r in results.items() if r == DownloadResult.FAILED]
 
         if failed:
@@ -2136,80 +1677,46 @@ class SettingsController(QObject):
         This function handles the community rules db radio buttons. Clicking one button
         enables the associated widgets and disables the other widgets.
         """
-        if (
-            self.sender() == self.settings_dialog.community_rules_db_none_radio
-            and checked
-        ):
+        if self.sender() == self.settings_dialog.community_rules_db_none_radio and checked:
             self.settings_dialog.community_rules_db_github_url.setEnabled(False)
-            self.settings_dialog.community_rules_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.community_rules_db_github_download_button.setEnabled(False)
             self.settings_dialog.community_rules_db_url_input.setEnabled(False)
-            self.settings_dialog.community_rules_db_url_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.community_rules_db_url_download_button.setEnabled(False)
             self.settings_dialog.community_rules_db_local_file.setEnabled(False)
-            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(
-                False
-            )
+            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(False)
             if isinstance(self.app_instance, QApplication):
                 focused_widget = self.app_instance.focusWidget()
                 if focused_widget is not None:
                     focused_widget.clearFocus()
             return
 
-        if (
-            self.sender() == self.settings_dialog.community_rules_db_github_radio
-            and checked
-        ):
+        if self.sender() == self.settings_dialog.community_rules_db_github_radio and checked:
             self.settings_dialog.community_rules_db_github_url.setEnabled(True)
-            self.settings_dialog.community_rules_db_github_download_button.setEnabled(
-                True
-            )
+            self.settings_dialog.community_rules_db_github_download_button.setEnabled(True)
             self.settings_dialog.community_rules_db_url_input.setEnabled(False)
-            self.settings_dialog.community_rules_db_url_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.community_rules_db_url_download_button.setEnabled(False)
             self.settings_dialog.community_rules_db_local_file.setEnabled(False)
-            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(
-                False
-            )
+            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(False)
             self.settings_dialog.community_rules_db_github_url.setFocus()
             return
 
-        if (
-            self.sender() == self.settings_dialog.community_rules_db_url_radio
-            and checked
-        ):
+        if self.sender() == self.settings_dialog.community_rules_db_url_radio and checked:
             self.settings_dialog.community_rules_db_url_input.setEnabled(True)
             self.settings_dialog.community_rules_db_url_download_button.setEnabled(True)
             self.settings_dialog.community_rules_db_github_url.setEnabled(False)
-            self.settings_dialog.community_rules_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.community_rules_db_github_download_button.setEnabled(False)
             self.settings_dialog.community_rules_db_local_file.setEnabled(False)
-            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(
-                False
-            )
+            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(False)
             self.settings_dialog.community_rules_db_url_input.setFocus()
             return
 
-        if (
-            self.sender() == self.settings_dialog.community_rules_db_local_file_radio
-            and checked
-        ):
+        if self.sender() == self.settings_dialog.community_rules_db_local_file_radio and checked:
             self.settings_dialog.community_rules_db_github_url.setEnabled(False)
-            self.settings_dialog.community_rules_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.community_rules_db_github_download_button.setEnabled(False)
             self.settings_dialog.community_rules_db_url_input.setEnabled(False)
-            self.settings_dialog.community_rules_db_url_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.community_rules_db_url_download_button.setEnabled(False)
             self.settings_dialog.community_rules_db_local_file.setEnabled(True)
-            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(
-                True
-            )
+            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(True)
             self.settings_dialog.community_rules_db_local_file.setFocus()
             return
 
@@ -2226,9 +1733,7 @@ class SettingsController(QObject):
         if not community_rules_db_location:
             return
 
-        self.settings_dialog.community_rules_db_local_file.setText(
-            community_rules_db_location
-        )
+        self.settings_dialog.community_rules_db_local_file.setText(community_rules_db_location)
         self._last_file_dialog_path = str(Path(community_rules_db_location).parent)
 
     @Slot(bool)
@@ -2237,74 +1742,46 @@ class SettingsController(QObject):
         This function handles the Steam workshop db radio buttons. Clicking one button
         enables the associated widgets and disables the other widgets.
         """
-        if (
-            self.sender() == self.settings_dialog.steam_workshop_db_none_radio
-            and checked
-        ):
+        if self.sender() == self.settings_dialog.steam_workshop_db_none_radio and checked:
             self.settings_dialog.steam_workshop_db_github_url.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(False)
             self.settings_dialog.steam_workshop_db_url_input.setEnabled(False)
             self.settings_dialog.steam_workshop_db_url_download_button.setEnabled(False)
             self.settings_dialog.steam_workshop_db_local_file.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(
-                False
-            )
+            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(False)
             if isinstance(self.app_instance, QApplication):
                 focused_widget = self.app_instance.focusWidget()
                 if focused_widget is not None:
                     focused_widget.clearFocus()
             return
 
-        if (
-            self.sender() == self.settings_dialog.steam_workshop_db_github_radio
-            and checked
-        ):
+        if self.sender() == self.settings_dialog.steam_workshop_db_github_radio and checked:
             self.settings_dialog.steam_workshop_db_github_url.setEnabled(True)
-            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(
-                True
-            )
+            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(True)
             self.settings_dialog.steam_workshop_db_url_input.setEnabled(False)
             self.settings_dialog.steam_workshop_db_url_download_button.setEnabled(False)
             self.settings_dialog.steam_workshop_db_local_file.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(
-                False
-            )
+            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(False)
             self.settings_dialog.steam_workshop_db_github_url.setFocus()
             return
 
-        if (
-            self.sender() == self.settings_dialog.steam_workshop_db_url_radio
-            and checked
-        ):
+        if self.sender() == self.settings_dialog.steam_workshop_db_url_radio and checked:
             self.settings_dialog.steam_workshop_db_url_input.setEnabled(True)
             self.settings_dialog.steam_workshop_db_url_download_button.setEnabled(True)
             self.settings_dialog.steam_workshop_db_github_url.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(False)
             self.settings_dialog.steam_workshop_db_local_file.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(
-                False
-            )
+            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(False)
             self.settings_dialog.steam_workshop_db_url_input.setFocus()
             return
 
-        if (
-            self.sender() == self.settings_dialog.steam_workshop_db_local_file_radio
-            and checked
-        ):
+        if self.sender() == self.settings_dialog.steam_workshop_db_local_file_radio and checked:
             self.settings_dialog.steam_workshop_db_github_url.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(False)
             self.settings_dialog.steam_workshop_db_url_input.setEnabled(False)
             self.settings_dialog.steam_workshop_db_url_download_button.setEnabled(False)
             self.settings_dialog.steam_workshop_db_local_file.setEnabled(True)
-            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(
-                True
-            )
+            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(True)
             self.settings_dialog.steam_workshop_db_local_file.setFocus()
             return
 
@@ -2321,9 +1798,7 @@ class SettingsController(QObject):
         if not steam_workshop_db_location:
             return
 
-        self.settings_dialog.steam_workshop_db_local_file.setText(
-            steam_workshop_db_location
-        )
+        self.settings_dialog.steam_workshop_db_local_file.setText(steam_workshop_db_location)
         self._last_file_dialog_path = str(Path(steam_workshop_db_location).parent)
 
     @Slot(bool)
@@ -2332,22 +1807,13 @@ class SettingsController(QObject):
         This function handles the "No Version Warning" db radio buttons. Clicking one button
         enables the associated widgets and disables the other widgets.
         """
-        if (
-            self.sender() == self.settings_dialog.no_version_warning_db_none_radio
-            and checked
-        ):
+        if self.sender() == self.settings_dialog.no_version_warning_db_none_radio and checked:
             self.settings_dialog.no_version_warning_db_github_url.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(False)
             self.settings_dialog.no_version_warning_db_url_input.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(False)
             self.settings_dialog.no_version_warning_db_local_file.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(
-                False
-            )
+            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(False)
             app_instance = QApplication.instance()
             if isinstance(app_instance, QApplication):
                 focused_widget = app_instance.focusWidget()
@@ -2355,60 +1821,33 @@ class SettingsController(QObject):
                     focused_widget.clearFocus()
             return
 
-        if (
-            self.sender() == self.settings_dialog.no_version_warning_db_github_radio
-            and checked
-        ):
+        if self.sender() == self.settings_dialog.no_version_warning_db_github_radio and checked:
             self.settings_dialog.no_version_warning_db_github_url.setEnabled(True)
-            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(
-                True
-            )
+            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(True)
             self.settings_dialog.no_version_warning_db_url_input.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(False)
             self.settings_dialog.no_version_warning_db_local_file.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(
-                False
-            )
+            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(False)
             self.settings_dialog.no_version_warning_db_github_url.setFocus()
             return
 
-        if (
-            self.sender() == self.settings_dialog.no_version_warning_db_url_radio
-            and checked
-        ):
+        if self.sender() == self.settings_dialog.no_version_warning_db_url_radio and checked:
             self.settings_dialog.no_version_warning_db_url_input.setEnabled(True)
-            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(
-                True
-            )
+            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(True)
             self.settings_dialog.no_version_warning_db_github_url.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(False)
             self.settings_dialog.no_version_warning_db_local_file.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(
-                False
-            )
+            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(False)
             self.settings_dialog.no_version_warning_db_url_input.setFocus()
             return
 
-        if (
-            self.sender() == self.settings_dialog.no_version_warning_db_local_file_radio
-            and checked
-        ):
+        if self.sender() == self.settings_dialog.no_version_warning_db_local_file_radio and checked:
             self.settings_dialog.no_version_warning_db_github_url.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(False)
             self.settings_dialog.no_version_warning_db_url_input.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(False)
             self.settings_dialog.no_version_warning_db_local_file.setEnabled(True)
-            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(
-                True
-            )
+            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(True)
             self.settings_dialog.no_version_warning_db_local_file.setFocus()
             return
 
@@ -2425,9 +1864,7 @@ class SettingsController(QObject):
         if not no_version_warning_db_location:
             return
 
-        self.settings_dialog.no_version_warning_db_local_file.setText(
-            no_version_warning_db_location
-        )
+        self.settings_dialog.no_version_warning_db_local_file.setText(no_version_warning_db_location)
         self._last_file_dialog_path = str(Path(no_version_warning_db_location).parent)
 
     @Slot(bool)
@@ -2436,22 +1873,13 @@ class SettingsController(QObject):
         This function handles the "Use This Instead" db radio buttons. Clicking one button
         enables the associated widgets and disables the other widgets.
         """
-        if (
-            self.sender() == self.settings_dialog.use_this_instead_db_none_radio
-            and checked
-        ):
+        if self.sender() == self.settings_dialog.use_this_instead_db_none_radio and checked:
             self.settings_dialog.use_this_instead_db_github_url.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(False)
             self.settings_dialog.use_this_instead_db_url_input.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(False)
             self.settings_dialog.use_this_instead_db_local_file.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(
-                False
-            )
+            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(False)
             app_instance = QApplication.instance()
             if isinstance(app_instance, QApplication):
                 focused_widget = app_instance.focusWidget()
@@ -2459,60 +1887,33 @@ class SettingsController(QObject):
                     focused_widget.clearFocus()
             return
 
-        if (
-            self.sender() == self.settings_dialog.use_this_instead_db_github_radio
-            and checked
-        ):
+        if self.sender() == self.settings_dialog.use_this_instead_db_github_radio and checked:
             self.settings_dialog.use_this_instead_db_github_url.setEnabled(True)
-            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(
-                True
-            )
+            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(True)
             self.settings_dialog.use_this_instead_db_url_input.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(False)
             self.settings_dialog.use_this_instead_db_local_file.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(
-                False
-            )
+            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(False)
             self.settings_dialog.use_this_instead_db_github_url.setFocus()
             return
 
-        if (
-            self.sender() == self.settings_dialog.use_this_instead_db_url_radio
-            and checked
-        ):
+        if self.sender() == self.settings_dialog.use_this_instead_db_url_radio and checked:
             self.settings_dialog.use_this_instead_db_url_input.setEnabled(True)
-            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(
-                True
-            )
+            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(True)
             self.settings_dialog.use_this_instead_db_github_url.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(False)
             self.settings_dialog.use_this_instead_db_local_file.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(
-                False
-            )
+            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(False)
             self.settings_dialog.use_this_instead_db_url_input.setFocus()
             return
 
-        if (
-            self.sender() == self.settings_dialog.use_this_instead_db_local_file_radio
-            and checked
-        ):
+        if self.sender() == self.settings_dialog.use_this_instead_db_local_file_radio and checked:
             self.settings_dialog.use_this_instead_db_github_url.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(False)
             self.settings_dialog.use_this_instead_db_url_input.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(False)
             self.settings_dialog.use_this_instead_db_local_file.setEnabled(True)
-            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(
-                True
-            )
+            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(True)
             self.settings_dialog.use_this_instead_db_local_file.setFocus()
             return
 
@@ -2530,9 +1931,7 @@ class SettingsController(QObject):
         if not use_this_instead_db_location:
             return
 
-        self.settings_dialog.use_this_instead_db_local_file.setText(
-            use_this_instead_db_location
-        )
+        self.settings_dialog.use_this_instead_db_local_file.setText(use_this_instead_db_location)
         self._last_file_dialog_path = str(Path(use_this_instead_db_location).parent)
 
     @Slot()
@@ -2548,9 +1947,7 @@ class SettingsController(QObject):
         if not steamcmd_install_location:
             return
 
-        self.settings_dialog.steamcmd_install_location.setText(
-            steamcmd_install_location
-        )
+        self.settings_dialog.steamcmd_install_location.setText(steamcmd_install_location)
         self._last_file_dialog_path = str(Path(steamcmd_install_location).parent)
 
     @Slot()
@@ -2748,9 +2145,7 @@ class SettingsController(QObject):
 
         # Validate the path before setting it
 
-        test_controller = InstanceController(
-            self.settings.instances[self.settings.current_instance]
-        )
+        test_controller = InstanceController(self.settings.instances[self.settings.current_instance])
         test_controller.instance.instance_folder_override = instance_folder_location
         is_valid, error_msg = test_controller.validate_instance_folder_override()
 
@@ -2763,9 +2158,7 @@ class SettingsController(QObject):
             return
 
         # Update the instance and UI
-        self.settings.instances[
-            self.settings.current_instance
-        ].instance_folder_override = instance_folder_location
+        self.settings.instances[self.settings.current_instance].instance_folder_override = instance_folder_location
         self.settings_dialog.instance_folder_location.setText(instance_folder_location)
         self._last_file_dialog_path = str(Path(instance_folder_location).parent)
         self.settings.save()
@@ -2782,9 +2175,7 @@ class SettingsController(QObject):
             )
             return
 
-        self.settings.instances[
-            self.settings.current_instance
-        ].instance_folder_override = ""
+        self.settings.instances[self.settings.current_instance].instance_folder_override = ""
         self.settings_dialog.instance_folder_location.setText("")
         self.settings.save()
 
@@ -2801,16 +2192,12 @@ class SettingsController(QObject):
         """
         selected_theme_name = self.settings_dialog.themes_combobox.currentText()
         logger.info(f"Opening theme location: {selected_theme_name}")
-        stylesheet_path = self.theme_controller.get_theme_stylesheet_path(
-            selected_theme_name
-        )
+        stylesheet_path = self.theme_controller.get_theme_stylesheet_path(selected_theme_name)
 
         if stylesheet_path and stylesheet_path.exists():
             platform_specific_open(stylesheet_path.parent)
         else:
-            logger.warning(
-                f"Failed to open theme location: {stylesheet_path} not found or does not exist"
-            )
+            logger.warning(f"Failed to open theme location: {stylesheet_path} not found or does not exist")
 
     @Slot()
     def _on_use_background_coloring_checkbox_changed(self) -> None:
@@ -2818,7 +2205,9 @@ class SettingsController(QObject):
 
     @Slot()
     def _on_include_mod_notes_in_mod_name_filter_changed(self) -> None:
-        self.settings.include_mod_notes_in_mod_name_filter = self.settings_dialog.include_mod_notes_in_mod_name_filter_checkbox.isChecked()
+        self.settings.include_mod_notes_in_mod_name_filter = (
+            self.settings_dialog.include_mod_notes_in_mod_name_filter_checkbox.isChecked()
+        )
 
     @Slot()
     def _handle_mod_coloring_mode_changed(self) -> None:

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -54,22 +54,18 @@ class Settings(QObject):
 
         # Databases
         self.external_steam_metadata_source: str = "Configured URL"
-        self.external_steam_metadata_file_path: str = str(
-            AppInfo().app_storage_folder / "steamDB.json"
+        self.external_steam_metadata_file_path: str = str(AppInfo().app_storage_folder / "steamDB.json")
+        self.external_steam_metadata_repo: str = "https://github.com/RimSort/Steam-Workshop-Database"
+        self.external_steam_metadata_url: str = (
+            "https://github.com/RimSort/Steam-Workshop-Database/archive/refs/heads/main.zip"
         )
-        self.external_steam_metadata_repo: str = (
-            "https://github.com/RimSort/Steam-Workshop-Database"
-        )
-        self.external_steam_metadata_url: str = "https://github.com/RimSort/Steam-Workshop-Database/archive/refs/heads/main.zip"
 
         self.external_community_rules_metadata_source: str = "Configured URL"
-        self.external_community_rules_file_path: str = str(
-            AppInfo().app_storage_folder / "communityRules.json"
+        self.external_community_rules_file_path: str = str(AppInfo().app_storage_folder / "communityRules.json")
+        self.external_community_rules_repo: str = "https://github.com/RimSort/Community-Rules-Database"
+        self.external_community_rules_url: str = (
+            "https://github.com/RimSort/Community-Rules-Database/archive/refs/heads/main.zip"
         )
-        self.external_community_rules_repo: str = (
-            "https://github.com/RimSort/Community-Rules-Database"
-        )
-        self.external_community_rules_url: str = "https://github.com/RimSort/Community-Rules-Database/archive/refs/heads/main.zip"
 
         # Disable by default previously this was 7 days "604800"
         self.database_expiry: int = 0
@@ -77,12 +73,8 @@ class Settings(QObject):
         self.aux_db_time_limit: int = -1
 
         self.external_no_version_warning_metadata_source: str = "Configured URL"
-        self.external_no_version_warning_file_path: str = str(
-            AppInfo().app_storage_folder / "ModIdsToFix.xml"
-        )
-        self.external_no_version_warning_repo_path: str = (
-            "https://github.com/emipa606/NoVersionWarning"
-        )
+        self.external_no_version_warning_file_path: str = str(AppInfo().app_storage_folder / "ModIdsToFix.xml")
+        self.external_no_version_warning_repo_path: str = "https://github.com/emipa606/NoVersionWarning"
         self.external_no_version_warning_url: str = (
             "https://github.com/emipa606/NoVersionWarning/archive/refs/heads/master.zip"
         )
@@ -91,9 +83,7 @@ class Settings(QObject):
         self.external_use_this_instead_file_path: str = str(
             AppInfo().app_storage_folder / "UseThisInstead" / "replacements.json.gz"
         )
-        self.external_use_this_instead_repo_path: str = (
-            "https://github.com/emipa606/UseThisInstead"
-        )
+        self.external_use_this_instead_repo_path: str = "https://github.com/emipa606/UseThisInstead"
         self.external_use_this_instead_url: str = (
             "https://github.com/emipa606/UseThisInstead/archive/refs/heads/master.zip"
         )
@@ -218,9 +208,7 @@ class Settings(QObject):
         # Instances
         self.current_instance: str = DEFAULT_INSTANCE_NAME
         self.current_instance_path: str = str(
-            Path(AppInfo().app_storage_folder)
-            / INSTANCE_FOLDER_NAME
-            / self.current_instance
+            Path(AppInfo().app_storage_folder) / INSTANCE_FOLDER_NAME / self.current_instance
         )
         self.instances: dict[str, Instance] = {DEFAULT_INSTANCE_NAME: Instance()}
 
@@ -235,14 +223,8 @@ class Settings(QObject):
 
         instance = self.instances[self.current_instance]
         # Default instance never uses override
-        override = (
-            ""
-            if self.current_instance == DEFAULT_INSTANCE_NAME
-            else instance.instance_folder_override
-        )
-        instance_path = InstanceController.get_instance_folder_path(
-            self.current_instance, override
-        )
+        override = "" if self.current_instance == DEFAULT_INSTANCE_NAME else instance.instance_folder_override
+        instance_path = InstanceController.get_instance_folder_path(self.current_instance, override)
         return instance_path / "aux_metadata.db"
 
     def __setattr__(self, key: str, value: Any) -> None:
@@ -269,15 +251,9 @@ class Settings(QObject):
                 mitigations = True
                 # Mitigate issues when "instances" key is not parsed, but the old path attributes are present
                 if not data.get("instances"):
-                    logger.debug(
-                        "Instances key not found in settings.json. Performing mitigation."
-                    )
+                    logger.debug("Instances key not found in settings.json. Performing mitigation.")
                     steamcmd_prefix_default_instance_path = str(
-                        Path(
-                            AppInfo().app_storage_folder
-                            / INSTANCE_FOLDER_NAME
-                            / DEFAULT_INSTANCE_NAME
-                        )
+                        Path(AppInfo().app_storage_folder / INSTANCE_FOLDER_NAME / DEFAULT_INSTANCE_NAME)
                     )
                     # Create Default instance
                     data["instances"] = {
@@ -293,25 +269,17 @@ class Settings(QObject):
                         )
                     }
                     steamcmd_prefix_to_mitigate = data.get("steamcmd_install_path", "")
-                    steamcmd_path_to_mitigate = str(
-                        Path(steamcmd_prefix_to_mitigate) / STEAMCMD_FOLDER_NAME
-                    )
-                    steam_path_to_mitigate = str(
-                        Path(steamcmd_prefix_to_mitigate) / STEAM_FOLDER_NAME
-                    )
-                    if steamcmd_prefix_to_mitigate and path.exists(
-                        steamcmd_prefix_to_mitigate
-                    ):
+                    steamcmd_path_to_mitigate = str(Path(steamcmd_prefix_to_mitigate) / STEAMCMD_FOLDER_NAME)
+                    steam_path_to_mitigate = str(Path(steamcmd_prefix_to_mitigate) / STEAM_FOLDER_NAME)
+                    if steamcmd_prefix_to_mitigate and path.exists(steamcmd_prefix_to_mitigate):
                         logger.debug(
                             "Configured SteamCMD install path found. Attempting to migrate it to the Default instance path..."
                         )
                         steamcmd_prefix_steamcmd_path = str(
-                            Path(steamcmd_prefix_default_instance_path)
-                            / STEAMCMD_FOLDER_NAME
+                            Path(steamcmd_prefix_default_instance_path) / STEAMCMD_FOLDER_NAME
                         )
                         steamcmd_prefix_steam_path = str(
-                            Path(steamcmd_prefix_default_instance_path)
-                            / STEAM_FOLDER_NAME
+                            Path(steamcmd_prefix_default_instance_path) / STEAM_FOLDER_NAME
                         )
                         try:
                             if path.exists(steamcmd_prefix_steamcmd_path):
@@ -334,9 +302,7 @@ class Settings(QObject):
                                 steamcmd_prefix_steamcmd_path,
                                 symlinks=True,
                             )
-                            logger.info(
-                                f"Deleting old SteamCMD install path at {steamcmd_path_to_mitigate}..."
-                            )
+                            logger.info(f"Deleting old SteamCMD install path at {steamcmd_path_to_mitigate}...")
                             rmtree(
                                 steamcmd_path_to_mitigate,
                                 ignore_errors=False,
@@ -350,39 +316,22 @@ class Settings(QObject):
                                 steamcmd_prefix_steam_path,
                                 symlinks=True,
                             )
-                            logger.info(
-                                f"Deleting old SteamCMD data path at {steam_path_to_mitigate}..."
-                            )
+                            logger.info(f"Deleting old SteamCMD data path at {steam_path_to_mitigate}...")
                             rmtree(
                                 steam_path_to_mitigate,
                                 ignore_errors=False,
                                 onerror=handle_remove_read_only,
                             )
                         except Exception as e:
-                            logger.error(
-                                f"Failed to migrate SteamCMD install path. Error: {e}"
-                            )
-                elif (
-                    not data.get("current_instance")
-                    or data["current_instance"] not in data["instances"]
-                ):
-                    logger.debug(
-                        "Current instance not found in settings.json. Performing mitigation."
-                    )
+                            logger.error(f"Failed to migrate SteamCMD install path. Error: {e}")
+                elif not data.get("current_instance") or data["current_instance"] not in data["instances"]:
+                    logger.debug("Current instance not found in settings.json. Performing mitigation.")
                     data["current_instance"] = DEFAULT_INSTANCE_NAME
 
-                    new_path = str(
-                        Path(AppInfo().app_storage_folder)
-                        / "instances"
-                        / data.get("current_instance")
-                    )
+                    new_path = str(Path(AppInfo().app_storage_folder) / "instances" / data.get("current_instance"))
                     data["current_instance_path"] = new_path
                 elif not data.get("current_instance_path"):
-                    new_path = str(
-                        Path(AppInfo().app_storage_folder)
-                        / "instances"
-                        / data.get("current_instance")
-                    )
+                    new_path = str(Path(AppInfo().app_storage_folder) / "instances" / data.get("current_instance"))
                     data["current_instance_path"] = new_path
                 else:
                     # There was nothing to mitigate, so don't save the model to the file
@@ -516,9 +465,7 @@ class Settings(QObject):
                 elif isinstance(instance_data, dict):
                     instances[instance_name] = msgspec.convert(instance_data, Instance)
                 else:
-                    logger.warning(
-                        f"Instance data for {instance_name} is not a valid type: {type(instance_data)}"
-                    )
+                    logger.warning(f"Instance data for {instance_name} is not a valid type: {type(instance_data)}")
             self.instances = instances
 
     def _to_dict(self, skip_private: bool = True) -> Dict[str, Any]:
@@ -539,9 +486,7 @@ class Settings(QObject):
         # Serialize instances using msgspec
         instances_dict = {}
         for name, instance in self.instances.items():
-            instances_dict[name] = msgspec.json.decode(
-                msgspec.json.encode(instance), type=dict
-            )
+            instances_dict[name] = msgspec.json.decode(msgspec.json.encode(instance), type=dict)
         data["instances"] = instances_dict
         return data
 
@@ -565,26 +510,18 @@ class Settings(QObject):
         launch_via_steam_protocol = active_instance.launch_via_steam_protocol
 
         # If neither is enabled, no validation needed
-        if (
-            not steam_client_integration
-            and not workshop_folder
-            and not launch_via_steam_protocol
-        ):
+        if not steam_client_integration and not workshop_folder and not launch_via_steam_protocol:
             return False
 
         # If launch_via_steam_protocol is enabled but steam_client_integration is not, disable it
         if launch_via_steam_protocol and not steam_client_integration:
-            logger.warning(
-                "Steam protocol launch is enabled but Steam client integration is disabled. Disabling..."
-            )
+            logger.warning("Steam protocol launch is enabled but Steam client integration is disabled. Disabling...")
             active_instance.launch_via_steam_protocol = False
             return True
 
         # If steam_client_integration is enabled but workshop_folder is not set, disable it
         if steam_client_integration and not workshop_folder:
-            logger.warning(
-                "Steam client integration is enabled but workshop folder is not configured. Disabling..."
-            )
+            logger.warning("Steam client integration is enabled but workshop folder is not configured. Disabling...")
             active_instance.steam_client_integration = False
             return True
 

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -53,28 +53,50 @@ class Settings(QObject):
         self.check_for_update_startup: bool = True
 
         # Databases
-        self.external_steam_metadata_source: str = "None"
-        self.external_steam_metadata_file_path: str = str(AppInfo().app_storage_folder / "steamDB.json")
-        self.external_steam_metadata_repo: str = "https://github.com/RimSort/Steam-Workshop-Database"
+        self.external_steam_metadata_source: str = "Configured URL"
+        self.external_steam_metadata_file_path: str = str(
+            AppInfo().app_storage_folder / "steamDB.json"
+        )
+        self.external_steam_metadata_repo: str = (
+            "https://github.com/RimSort/Steam-Workshop-Database"
+        )
+        self.external_steam_metadata_url: str = "https://github.com/RimSort/Steam-Workshop-Database/archive/refs/heads/main.zip"
 
-        self.external_community_rules_metadata_source: str = "None"
-        self.external_community_rules_file_path: str = str(AppInfo().app_storage_folder / "communityRules.json")
-        self.external_community_rules_repo: str = "https://github.com/RimSort/Community-Rules-Database"
+        self.external_community_rules_metadata_source: str = "Configured URL"
+        self.external_community_rules_file_path: str = str(
+            AppInfo().app_storage_folder / "communityRules.json"
+        )
+        self.external_community_rules_repo: str = (
+            "https://github.com/RimSort/Community-Rules-Database"
+        )
+        self.external_community_rules_url: str = "https://github.com/RimSort/Community-Rules-Database/archive/refs/heads/main.zip"
 
         # Disable by default previously this was 7 days "604800"
         self.database_expiry: int = 0
         # Default (-1) means do not delete data from Aux Metadata DB
         self.aux_db_time_limit: int = -1
 
-        self.external_no_version_warning_metadata_source: str = "None"
-        self.external_no_version_warning_file_path: str = str(AppInfo().app_storage_folder / "ModIdsToFix.xml")
-        self.external_no_version_warning_repo_path: str = "https://github.com/emipa606/NoVersionWarning"
+        self.external_no_version_warning_metadata_source: str = "Configured URL"
+        self.external_no_version_warning_file_path: str = str(
+            AppInfo().app_storage_folder / "ModIdsToFix.xml"
+        )
+        self.external_no_version_warning_repo_path: str = (
+            "https://github.com/emipa606/NoVersionWarning"
+        )
+        self.external_no_version_warning_url: str = (
+            "https://github.com/emipa606/NoVersionWarning/archive/refs/heads/master.zip"
+        )
 
-        self.external_use_this_instead_metadata_source: str = "None"
+        self.external_use_this_instead_metadata_source: str = "Configured URL"
         self.external_use_this_instead_file_path: str = str(
             AppInfo().app_storage_folder / "UseThisInstead" / "replacements.json.gz"
         )
-        self.external_use_this_instead_repo_path: str = "https://github.com/emipa606/UseThisInstead"
+        self.external_use_this_instead_repo_path: str = (
+            "https://github.com/emipa606/UseThisInstead"
+        )
+        self.external_use_this_instead_url: str = (
+            "https://github.com/emipa606/UseThisInstead/archive/refs/heads/master.zip"
+        )
 
         # Sorting
         self.sorting_algorithm: SortMethod = SortMethod.TOPOLOGICAL
@@ -196,7 +218,9 @@ class Settings(QObject):
         # Instances
         self.current_instance: str = DEFAULT_INSTANCE_NAME
         self.current_instance_path: str = str(
-            Path(AppInfo().app_storage_folder) / INSTANCE_FOLDER_NAME / self.current_instance
+            Path(AppInfo().app_storage_folder)
+            / INSTANCE_FOLDER_NAME
+            / self.current_instance
         )
         self.instances: dict[str, Instance] = {DEFAULT_INSTANCE_NAME: Instance()}
 
@@ -211,8 +235,14 @@ class Settings(QObject):
 
         instance = self.instances[self.current_instance]
         # Default instance never uses override
-        override = "" if self.current_instance == DEFAULT_INSTANCE_NAME else instance.instance_folder_override
-        instance_path = InstanceController.get_instance_folder_path(self.current_instance, override)
+        override = (
+            ""
+            if self.current_instance == DEFAULT_INSTANCE_NAME
+            else instance.instance_folder_override
+        )
+        instance_path = InstanceController.get_instance_folder_path(
+            self.current_instance, override
+        )
         return instance_path / "aux_metadata.db"
 
     def __setattr__(self, key: str, value: Any) -> None:
@@ -239,9 +269,15 @@ class Settings(QObject):
                 mitigations = True
                 # Mitigate issues when "instances" key is not parsed, but the old path attributes are present
                 if not data.get("instances"):
-                    logger.debug("Instances key not found in settings.json. Performing mitigation.")
+                    logger.debug(
+                        "Instances key not found in settings.json. Performing mitigation."
+                    )
                     steamcmd_prefix_default_instance_path = str(
-                        Path(AppInfo().app_storage_folder / INSTANCE_FOLDER_NAME / DEFAULT_INSTANCE_NAME)
+                        Path(
+                            AppInfo().app_storage_folder
+                            / INSTANCE_FOLDER_NAME
+                            / DEFAULT_INSTANCE_NAME
+                        )
                     )
                     # Create Default instance
                     data["instances"] = {
@@ -257,17 +293,25 @@ class Settings(QObject):
                         )
                     }
                     steamcmd_prefix_to_mitigate = data.get("steamcmd_install_path", "")
-                    steamcmd_path_to_mitigate = str(Path(steamcmd_prefix_to_mitigate) / STEAMCMD_FOLDER_NAME)
-                    steam_path_to_mitigate = str(Path(steamcmd_prefix_to_mitigate) / STEAM_FOLDER_NAME)
-                    if steamcmd_prefix_to_mitigate and path.exists(steamcmd_prefix_to_mitigate):
+                    steamcmd_path_to_mitigate = str(
+                        Path(steamcmd_prefix_to_mitigate) / STEAMCMD_FOLDER_NAME
+                    )
+                    steam_path_to_mitigate = str(
+                        Path(steamcmd_prefix_to_mitigate) / STEAM_FOLDER_NAME
+                    )
+                    if steamcmd_prefix_to_mitigate and path.exists(
+                        steamcmd_prefix_to_mitigate
+                    ):
                         logger.debug(
                             "Configured SteamCMD install path found. Attempting to migrate it to the Default instance path..."
                         )
                         steamcmd_prefix_steamcmd_path = str(
-                            Path(steamcmd_prefix_default_instance_path) / STEAMCMD_FOLDER_NAME
+                            Path(steamcmd_prefix_default_instance_path)
+                            / STEAMCMD_FOLDER_NAME
                         )
                         steamcmd_prefix_steam_path = str(
-                            Path(steamcmd_prefix_default_instance_path) / STEAM_FOLDER_NAME
+                            Path(steamcmd_prefix_default_instance_path)
+                            / STEAM_FOLDER_NAME
                         )
                         try:
                             if path.exists(steamcmd_prefix_steamcmd_path):
@@ -290,7 +334,9 @@ class Settings(QObject):
                                 steamcmd_prefix_steamcmd_path,
                                 symlinks=True,
                             )
-                            logger.info(f"Deleting old SteamCMD install path at {steamcmd_path_to_mitigate}...")
+                            logger.info(
+                                f"Deleting old SteamCMD install path at {steamcmd_path_to_mitigate}..."
+                            )
                             rmtree(
                                 steamcmd_path_to_mitigate,
                                 ignore_errors=False,
@@ -304,22 +350,39 @@ class Settings(QObject):
                                 steamcmd_prefix_steam_path,
                                 symlinks=True,
                             )
-                            logger.info(f"Deleting old SteamCMD data path at {steam_path_to_mitigate}...")
+                            logger.info(
+                                f"Deleting old SteamCMD data path at {steam_path_to_mitigate}..."
+                            )
                             rmtree(
                                 steam_path_to_mitigate,
                                 ignore_errors=False,
                                 onerror=handle_remove_read_only,
                             )
                         except Exception as e:
-                            logger.error(f"Failed to migrate SteamCMD install path. Error: {e}")
-                elif not data.get("current_instance") or data["current_instance"] not in data["instances"]:
-                    logger.debug("Current instance not found in settings.json. Performing mitigation.")
+                            logger.error(
+                                f"Failed to migrate SteamCMD install path. Error: {e}"
+                            )
+                elif (
+                    not data.get("current_instance")
+                    or data["current_instance"] not in data["instances"]
+                ):
+                    logger.debug(
+                        "Current instance not found in settings.json. Performing mitigation."
+                    )
                     data["current_instance"] = DEFAULT_INSTANCE_NAME
 
-                    new_path = str(Path(AppInfo().app_storage_folder) / "instances" / data.get("current_instance"))
+                    new_path = str(
+                        Path(AppInfo().app_storage_folder)
+                        / "instances"
+                        / data.get("current_instance")
+                    )
                     data["current_instance_path"] = new_path
                 elif not data.get("current_instance_path"):
-                    new_path = str(Path(AppInfo().app_storage_folder) / "instances" / data.get("current_instance"))
+                    new_path = str(
+                        Path(AppInfo().app_storage_folder)
+                        / "instances"
+                        / data.get("current_instance")
+                    )
                     data["current_instance_path"] = new_path
                 else:
                     # There was nothing to mitigate, so don't save the model to the file
@@ -453,7 +516,9 @@ class Settings(QObject):
                 elif isinstance(instance_data, dict):
                     instances[instance_name] = msgspec.convert(instance_data, Instance)
                 else:
-                    logger.warning(f"Instance data for {instance_name} is not a valid type: {type(instance_data)}")
+                    logger.warning(
+                        f"Instance data for {instance_name} is not a valid type: {type(instance_data)}"
+                    )
             self.instances = instances
 
     def _to_dict(self, skip_private: bool = True) -> Dict[str, Any]:
@@ -474,7 +539,9 @@ class Settings(QObject):
         # Serialize instances using msgspec
         instances_dict = {}
         for name, instance in self.instances.items():
-            instances_dict[name] = msgspec.json.decode(msgspec.json.encode(instance), type=dict)
+            instances_dict[name] = msgspec.json.decode(
+                msgspec.json.encode(instance), type=dict
+            )
         data["instances"] = instances_dict
         return data
 
@@ -498,18 +565,26 @@ class Settings(QObject):
         launch_via_steam_protocol = active_instance.launch_via_steam_protocol
 
         # If neither is enabled, no validation needed
-        if not steam_client_integration and not workshop_folder and not launch_via_steam_protocol:
+        if (
+            not steam_client_integration
+            and not workshop_folder
+            and not launch_via_steam_protocol
+        ):
             return False
 
         # If launch_via_steam_protocol is enabled but steam_client_integration is not, disable it
         if launch_via_steam_protocol and not steam_client_integration:
-            logger.warning("Steam protocol launch is enabled but Steam client integration is disabled. Disabling...")
+            logger.warning(
+                "Steam protocol launch is enabled but Steam client integration is disabled. Disabling..."
+            )
             active_instance.launch_via_steam_protocol = False
             return True
 
         # If steam_client_integration is enabled but workshop_folder is not set, disable it
         if steam_client_integration and not workshop_folder:
-            logger.warning("Steam client integration is enabled but workshop folder is not configured. Disabling...")
+            logger.warning(
+                "Steam client integration is enabled but workshop folder is not configured. Disabling..."
+            )
             active_instance.steam_client_integration = False
             return True
 

--- a/app/utils/external_metadata_loaders.py
+++ b/app/utils/external_metadata_loaders.py
@@ -13,6 +13,7 @@ from app.utils.xml import xml_path_to_json
 # Metadata loader source constants
 SOURCE_FILE_PATH = "Configured file path"
 SOURCE_GIT_REPO = "Configured git repository"
+SOURCE_URL = "Configured URL"
 SOURCE_DISABLED = "Disabled"
 
 # Metadata file names
@@ -35,7 +36,9 @@ class ExternalMetadataLoader:
             path,
         )
 
-    def _validate_db_path(self, path: str, db_type: str, expect_directory: bool = False) -> bool:
+    def _validate_db_path(
+        self, path: str, db_type: str, expect_directory: bool = False
+    ) -> bool:
         """Validate that a database path exists and matches expected type."""
         if not os.path.exists(path):
             self._emit_db_error(
@@ -101,22 +104,22 @@ class ExternalMetadataLoader:
         getter_func: Callable[[str], tuple[Any, str | None]],
         subdir: str = "",
     ) -> tuple[Any, str | None]:
-        """Load metadata from either file path or git repository.
+        """Load metadata from either file path, git repository, or HTTP URL.
 
         Args:
-            source: SOURCE_FILE_PATH, SOURCE_GIT_REPO, or SOURCE_DISABLED
+            source: SOURCE_FILE_PATH, SOURCE_GIT_REPO, SOURCE_URL, or SOURCE_DISABLED
             file_path: Path to file when using SOURCE_FILE_PATH
-            repo_path: Path to git repo when using SOURCE_GIT_REPO
+            repo_path: Path to git repo/URL when using SOURCE_GIT_REPO or SOURCE_URL
             file_name: Name of the file to load (e.g., 'steamDB.json')
             getter_func: Callable that loads and validates the file at given path
-            subdir: Optional subdirectory within git repo path
+            subdir: Optional subdirectory within git repo/URL path
 
         Returns:
             Tuple of (loaded_data, path_used) or (None, None) if disabled
         """
         if source == SOURCE_FILE_PATH:
             return getter_func(file_path)
-        elif source == SOURCE_GIT_REPO:
+        elif source in (SOURCE_GIT_REPO, SOURCE_URL):
             path = self._get_repo_path(repo_path, file_name, subdir)
             return getter_func(path)
         else:
@@ -140,12 +143,22 @@ class ExternalMetadataLoader:
                 self.manager.external_user_rules = rules
             else:
                 self.manager.external_user_rules = None
-            total_entries = len(self.manager.external_user_rules) if self.manager.external_user_rules else 0
+            total_entries = (
+                len(self.manager.external_user_rules)
+                if self.manager.external_user_rules
+                else 0
+            )
             if self.manager.external_user_rules is None:
-                logger.warning("Unable to load userRules.json. 'rules' is None or not a dict")
-            logger.info(f"Loaded {total_entries} additional sorting rules from User Rules")
+                logger.warning(
+                    "Unable to load userRules.json. 'rules' is None or not a dict"
+                )
+            logger.info(
+                f"Loaded {total_entries} additional sorting rules from User Rules"
+            )
 
-    def _load_steam_db(self, life: int, path: str) -> tuple[dict[str, Any] | None, str | None]:
+    def _load_steam_db(
+        self, life: int, path: str
+    ) -> tuple[dict[str, Any] | None, str | None]:
         """Load and validate Steam database with expiry checking.
 
         NOTE: Steam DB has special handling for expired data - it will still be loaded
@@ -191,7 +204,9 @@ class ExternalMetadataLoader:
 
         db_json_data = db_data.get("database", {})
         total_entries = len(db_json_data)
-        logger.info(f"Loaded metadata for {total_entries} Steam Workshop mods from Steam DB")
+        logger.info(
+            f"Loaded metadata for {total_entries} Steam Workshop mods from Steam DB"
+        )
 
         # Build packageid to name mapping for faster lookups
         self.manager.steamdb_packageid_to_name = {
@@ -220,7 +235,9 @@ class ExternalMetadataLoader:
             else (None, None)
         )
 
-    def _load_community_rules_db(self, path: str) -> tuple[dict[str, Any] | None, str | None]:
+    def _load_community_rules_db(
+        self, path: str
+    ) -> tuple[dict[str, Any] | None, str | None]:
         """Load and validate Community Rules database."""
         logger.info(f"Checking for Community Rules DB at: {path}")
         if not self._validate_db_path(path, "Community Rules"):
@@ -233,7 +250,9 @@ class ExternalMetadataLoader:
 
         community_rules_json_data = rule_data.get("rules", {})
         total_entries = len(community_rules_json_data)
-        logger.info(f"Loaded {total_entries} additional sorting rules from Community Rules")
+        logger.info(
+            f"Loaded {total_entries} additional sorting rules from Community Rules"
+        )
         return community_rules_json_data, path
 
     def _load_community_rules_metadata(self, settings: Any) -> None:
@@ -254,7 +273,9 @@ class ExternalMetadataLoader:
             else (None, None)
         )
 
-    def _load_no_version_warning_db(self, path: str) -> tuple[list[str] | None, str | None]:
+    def _load_no_version_warning_db(
+        self, path: str
+    ) -> tuple[list[str] | None, str | None]:
         """Load and validate No Version Warning database."""
         logger.info(f'Checking for "No Version Warning" DB at: {path}')
         if not self._validate_db_path(path, "No Version Warning"):
@@ -263,7 +284,9 @@ class ExternalMetadataLoader:
         logger.info("No Version Warning DB exists, loading")
         no_version_warning_json_data = xml_path_to_json(path)
         total_entries = len(no_version_warning_json_data)
-        logger.info(f'Loaded {total_entries} compatibility version overrides from "No Version Warning"')
+        logger.info(
+            f'Loaded {total_entries} compatibility version overrides from "No Version Warning"'
+        )
         return list(
             map(
                 str.lower,
@@ -290,7 +313,9 @@ class ExternalMetadataLoader:
             else (None, None)
         )
 
-    def _load_use_this_instead_db(self, path: str) -> tuple[dict[str, Any] | None, str | None]:
+    def _load_use_this_instead_db(
+        self, path: str
+    ) -> tuple[dict[str, Any] | None, str | None]:
         """Load and validate Use This Instead database."""
         logger.info(f"Checking for Use This Instead DB at: {path}")
         if not self._validate_db_path(path, "Use This Instead"):
@@ -302,7 +327,9 @@ class ExternalMetadataLoader:
             return None, None
 
         total_entries = len(db_data)
-        logger.info(f"Loaded metadata for {total_entries} mod replacements from Use This Instead DB")
+        logger.info(
+            f"Loaded metadata for {total_entries} mod replacements from Use This Instead DB"
+        )
         return db_data, path
 
     def _load_use_this_instead_metadata(self, settings: Any) -> None:

--- a/app/utils/external_metadata_loaders.py
+++ b/app/utils/external_metadata_loaders.py
@@ -36,9 +36,7 @@ class ExternalMetadataLoader:
             path,
         )
 
-    def _validate_db_path(
-        self, path: str, db_type: str, expect_directory: bool = False
-    ) -> bool:
+    def _validate_db_path(self, path: str, db_type: str, expect_directory: bool = False) -> bool:
         """Validate that a database path exists and matches expected type."""
         if not os.path.exists(path):
             self._emit_db_error(
@@ -143,22 +141,12 @@ class ExternalMetadataLoader:
                 self.manager.external_user_rules = rules
             else:
                 self.manager.external_user_rules = None
-            total_entries = (
-                len(self.manager.external_user_rules)
-                if self.manager.external_user_rules
-                else 0
-            )
+            total_entries = len(self.manager.external_user_rules) if self.manager.external_user_rules else 0
             if self.manager.external_user_rules is None:
-                logger.warning(
-                    "Unable to load userRules.json. 'rules' is None or not a dict"
-                )
-            logger.info(
-                f"Loaded {total_entries} additional sorting rules from User Rules"
-            )
+                logger.warning("Unable to load userRules.json. 'rules' is None or not a dict")
+            logger.info(f"Loaded {total_entries} additional sorting rules from User Rules")
 
-    def _load_steam_db(
-        self, life: int, path: str
-    ) -> tuple[dict[str, Any] | None, str | None]:
+    def _load_steam_db(self, life: int, path: str) -> tuple[dict[str, Any] | None, str | None]:
         """Load and validate Steam database with expiry checking.
 
         NOTE: Steam DB has special handling for expired data - it will still be loaded
@@ -204,9 +192,7 @@ class ExternalMetadataLoader:
 
         db_json_data = db_data.get("database", {})
         total_entries = len(db_json_data)
-        logger.info(
-            f"Loaded metadata for {total_entries} Steam Workshop mods from Steam DB"
-        )
+        logger.info(f"Loaded metadata for {total_entries} Steam Workshop mods from Steam DB")
 
         # Build packageid to name mapping for faster lookups
         self.manager.steamdb_packageid_to_name = {
@@ -235,9 +221,7 @@ class ExternalMetadataLoader:
             else (None, None)
         )
 
-    def _load_community_rules_db(
-        self, path: str
-    ) -> tuple[dict[str, Any] | None, str | None]:
+    def _load_community_rules_db(self, path: str) -> tuple[dict[str, Any] | None, str | None]:
         """Load and validate Community Rules database."""
         logger.info(f"Checking for Community Rules DB at: {path}")
         if not self._validate_db_path(path, "Community Rules"):
@@ -250,9 +234,7 @@ class ExternalMetadataLoader:
 
         community_rules_json_data = rule_data.get("rules", {})
         total_entries = len(community_rules_json_data)
-        logger.info(
-            f"Loaded {total_entries} additional sorting rules from Community Rules"
-        )
+        logger.info(f"Loaded {total_entries} additional sorting rules from Community Rules")
         return community_rules_json_data, path
 
     def _load_community_rules_metadata(self, settings: Any) -> None:
@@ -273,9 +255,7 @@ class ExternalMetadataLoader:
             else (None, None)
         )
 
-    def _load_no_version_warning_db(
-        self, path: str
-    ) -> tuple[list[str] | None, str | None]:
+    def _load_no_version_warning_db(self, path: str) -> tuple[list[str] | None, str | None]:
         """Load and validate No Version Warning database."""
         logger.info(f'Checking for "No Version Warning" DB at: {path}')
         if not self._validate_db_path(path, "No Version Warning"):
@@ -284,9 +264,7 @@ class ExternalMetadataLoader:
         logger.info("No Version Warning DB exists, loading")
         no_version_warning_json_data = xml_path_to_json(path)
         total_entries = len(no_version_warning_json_data)
-        logger.info(
-            f'Loaded {total_entries} compatibility version overrides from "No Version Warning"'
-        )
+        logger.info(f'Loaded {total_entries} compatibility version overrides from "No Version Warning"')
         return list(
             map(
                 str.lower,
@@ -313,9 +291,7 @@ class ExternalMetadataLoader:
             else (None, None)
         )
 
-    def _load_use_this_instead_db(
-        self, path: str
-    ) -> tuple[dict[str, Any] | None, str | None]:
+    def _load_use_this_instead_db(self, path: str) -> tuple[dict[str, Any] | None, str | None]:
         """Load and validate Use This Instead database."""
         logger.info(f"Checking for Use This Instead DB at: {path}")
         if not self._validate_db_path(path, "Use This Instead"):
@@ -327,9 +303,7 @@ class ExternalMetadataLoader:
             return None, None
 
         total_entries = len(db_data)
-        logger.info(
-            f"Loaded metadata for {total_entries} mod replacements from Use This Instead DB"
-        )
+        logger.info(f"Loaded metadata for {total_entries} mod replacements from Use This Instead DB")
         return db_data, path
 
     def _load_use_this_instead_metadata(self, settings: Any) -> None:

--- a/app/utils/http_downloader.py
+++ b/app/utils/http_downloader.py
@@ -59,9 +59,7 @@ class HttpDatabaseDownloader:
             logger.debug(f"Could not read HTTP cache metadata: {e}")
             return {}
 
-    def _write_cache_metadata(
-        self, repo_dir: Path, etag: str | None, last_modified: str | None
-    ) -> None:
+    def _write_cache_metadata(self, repo_dir: Path, etag: str | None, last_modified: str | None) -> None:
         """Write ETag/Last-Modified to the sidecar cache file.
 
         :param repo_dir: Directory to write the cache sidecar into
@@ -91,9 +89,7 @@ class HttpDatabaseDownloader:
             headers["If-Modified-Since"] = cache["last_modified"]
         return headers
 
-    def _extract_zip_to_dir(
-        self, zip_path: Path, target_dir: Path, repo_name: str
-    ) -> Path:
+    def _extract_zip_to_dir(self, zip_path: Path, target_dir: Path, repo_name: str) -> Path:
         """Extract a zip archive into the target directory.
 
         GitHub zips contain a single top-level ``<repo>-<branch>/`` directory.
@@ -183,9 +179,7 @@ class HttpDatabaseDownloader:
             total_size = int(total_size_str) if total_size_str else None
 
             target_dir.mkdir(parents=True, exist_ok=True)
-            temp_fd = tempfile.NamedTemporaryFile(
-                dir=str(target_dir), suffix=".zip", delete=False
-            )
+            temp_fd = tempfile.NamedTemporaryFile(dir=str(target_dir), suffix=".zip", delete=False)
             temp_path = Path(temp_fd.name)
 
             try:

--- a/app/utils/http_downloader.py
+++ b/app/utils/http_downloader.py
@@ -151,6 +151,7 @@ class HttpDatabaseDownloader:
         target_dir: Path,
         repo_name: str,
         progress_callback: Callable[[int, int | None], None] | None = None,
+        cancel_check: Callable[[], bool] | None = None,
     ) -> tuple[DownloadResult, str | None]:
         """Download and extract a zip archive from a URL.
 
@@ -163,6 +164,7 @@ class HttpDatabaseDownloader:
         :param target_dir: Parent directory where ``repo_name/`` will be created
         :param repo_name: Subdirectory name for the extracted content
         :param progress_callback: Optional ``(downloaded_bytes, total_bytes)`` callback
+        :param cancel_check: Optional callable returning True to abort the download
         :return: Tuple of (result, error_message_or_none)
         """
         repo_dir = target_dir / repo_name
@@ -189,6 +191,8 @@ class HttpDatabaseDownloader:
             try:
                 downloaded = 0
                 for chunk in response.iter_content(chunk_size=DOWNLOAD_CHUNK_SIZE):
+                    if cancel_check and cancel_check():
+                        raise _DownloadCancelled()
                     if chunk:
                         temp_fd.write(chunk)
                         downloaded += len(chunk)
@@ -212,6 +216,9 @@ class HttpDatabaseDownloader:
                     except OSError:
                         pass
 
+        except _DownloadCancelled:
+            logger.info(f"{repo_name}: download cancelled")
+            return DownloadResult.FAILED, "Download cancelled"
         except requests.RequestException as e:
             error_msg = f"Failed to download {repo_name}: {e}"
             logger.warning(error_msg)
@@ -224,32 +231,47 @@ class HttpDatabaseDownloader:
 
 @dataclass
 class DatabaseDownloadTask:
+    """Describes a single database archive to download and extract."""
+
     url: str
     target_dir: Path
     repo_name: str
     display_name: str
 
 
+class _DownloadCancelled(Exception):
+    """Raised internally when a download is cancelled via the worker's cancel flag."""
+
+
 class HttpDownloadWorker(QThread):
     progress = Signal(str)
-    finished = Signal(dict)
-    error = Signal(str)
+    download_finished = Signal(dict)
 
     def __init__(self, tasks: list[DatabaseDownloadTask]) -> None:
         super().__init__()
         self._tasks = tasks
         self._downloader = HttpDatabaseDownloader()
+        self._cancelled = False
+
+    def cancel(self) -> None:
+        """Request cancellation of the current download batch."""
+        self._cancelled = True
 
     def run(self) -> None:
         results: dict[str, DownloadResult] = {}
 
         for task in self._tasks:
+            if self._cancelled:
+                results[task.repo_name] = DownloadResult.FAILED
+                continue
+
             self.progress.emit(f"Downloading {task.display_name}...")
             result, error_msg = self._downloader.download(
                 url=task.url,
                 target_dir=task.target_dir,
                 repo_name=task.repo_name,
                 progress_callback=None,
+                cancel_check=lambda: self._cancelled,
             )
             results[task.repo_name] = result
 
@@ -260,4 +282,4 @@ class HttpDownloadWorker(QThread):
             elif result == DownloadResult.FAILED:
                 self.progress.emit(f"{task.display_name}: failed — {error_msg}")
 
-        self.finished.emit(results)
+        self.download_finished.emit(results)

--- a/app/utils/http_downloader.py
+++ b/app/utils/http_downloader.py
@@ -1,0 +1,220 @@
+"""HTTP-based database downloader with conditional requests and zip extraction.
+
+Downloads zip archives from HTTP URLs (e.g. GitHub release/archive endpoints),
+extracts them to a target directory, and caches ETag/Last-Modified headers for
+conditional GET requests on subsequent runs.
+"""
+
+import json
+import shutil
+import tempfile
+import zipfile
+from datetime import datetime, timezone
+from enum import Enum, auto
+from pathlib import Path
+from typing import Callable
+
+import requests
+from loguru import logger
+
+from app.utils import http
+
+DOWNLOAD_CHUNK_SIZE = 131072  # 128KB
+HTTP_CACHE_FILENAME = ".http_cache.json"
+
+
+class DownloadResult(Enum):
+    """Outcome of an HTTP database download attempt."""
+
+    UPDATED = auto()
+    UP_TO_DATE = auto()
+    FAILED = auto()
+
+
+class HttpDatabaseDownloader:
+    """Downloads and extracts zip archives with conditional HTTP caching.
+
+    Stores ETag/Last-Modified metadata in a sidecar JSON file so subsequent
+    downloads can use conditional GET headers (``If-None-Match`` /
+    ``If-Modified-Since``) to avoid re-downloading unchanged content.
+
+    GitHub zip archives extract to ``<repo>-<branch>/`` — the extractor
+    automatically unwraps this single top-level directory.
+    """
+
+    def _read_cache_metadata(self, repo_dir: Path) -> dict[str, str]:
+        """Read cached ETag/Last-Modified from the sidecar file.
+
+        :param repo_dir: Directory containing the cache sidecar
+        :return: Cached metadata dict, or empty dict if missing/corrupt
+        """
+        cache_file = repo_dir / HTTP_CACHE_FILENAME
+        if not cache_file.exists():
+            return {}
+        try:
+            return json.loads(cache_file.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as e:
+            logger.debug(f"Could not read HTTP cache metadata: {e}")
+            return {}
+
+    def _write_cache_metadata(
+        self, repo_dir: Path, etag: str | None, last_modified: str | None
+    ) -> None:
+        """Write ETag/Last-Modified to the sidecar cache file.
+
+        :param repo_dir: Directory to write the cache sidecar into
+        :param etag: ETag header value from the server response
+        :param last_modified: Last-Modified header value from the server response
+        """
+        cache_data: dict[str, str] = {
+            "downloaded_at": datetime.now(timezone.utc).isoformat(),
+        }
+        if etag:
+            cache_data["etag"] = etag
+        if last_modified:
+            cache_data["last_modified"] = last_modified
+        cache_file = repo_dir / HTTP_CACHE_FILENAME
+        cache_file.write_text(json.dumps(cache_data, indent=2), encoding="utf-8")
+
+    def _build_conditional_headers(self, cache: dict[str, str]) -> dict[str, str]:
+        """Build conditional GET headers from cached metadata.
+
+        :param cache: Previously cached metadata dict
+        :return: Headers dict with If-None-Match/If-Modified-Since as available
+        """
+        headers: dict[str, str] = {}
+        if "etag" in cache:
+            headers["If-None-Match"] = cache["etag"]
+        if "last_modified" in cache:
+            headers["If-Modified-Since"] = cache["last_modified"]
+        return headers
+
+    def _extract_zip_to_dir(
+        self, zip_path: Path, target_dir: Path, repo_name: str
+    ) -> Path:
+        """Extract a zip archive into the target directory.
+
+        GitHub zips contain a single top-level ``<repo>-<branch>/`` directory.
+        This method detects that pattern and unwraps it so extracted files land
+        directly in ``target_dir/repo_name/``.
+
+        Replacement is atomic-ish: the old directory is renamed to ``.bak``,
+        the new one is moved in, then the backup is deleted.
+
+        :param zip_path: Path to the downloaded zip file
+        :param target_dir: Parent directory for extraction
+        :param repo_name: Name of the subdirectory to create/replace
+        :return: Path to the final extracted directory
+        """
+        extracted_dir = target_dir / repo_name
+        temp_extract = target_dir / f".{repo_name}_extracting"
+
+        if temp_extract.exists():
+            shutil.rmtree(temp_extract)
+        temp_extract.mkdir(parents=True)
+
+        with zipfile.ZipFile(zip_path, "r") as zf:
+            zf.extractall(temp_extract)
+
+        # GitHub zips extract to <repo>-<branch>/ — unwrap if single top-level dir
+        children = list(temp_extract.iterdir())
+        final_dir = target_dir / f".{repo_name}_new"
+        if final_dir.exists():
+            shutil.rmtree(final_dir)
+
+        if len(children) == 1 and children[0].is_dir():
+            children[0].rename(final_dir)
+            shutil.rmtree(temp_extract)
+        else:
+            temp_extract.rename(final_dir)
+
+        # Atomic-ish replacement: old -> .bak, new -> target, delete .bak
+        backup_dir = target_dir / f"{repo_name}.bak"
+        if backup_dir.exists():
+            shutil.rmtree(backup_dir)
+        if extracted_dir.exists():
+            extracted_dir.rename(backup_dir)
+        final_dir.rename(extracted_dir)
+        if backup_dir.exists():
+            try:
+                shutil.rmtree(backup_dir)
+            except OSError as e:
+                logger.warning(f"Failed to remove backup dir {backup_dir}: {e}")
+
+        return extracted_dir
+
+    def download(
+        self,
+        url: str,
+        target_dir: Path,
+        repo_name: str,
+        progress_callback: Callable[[int, int | None], None] | None = None,
+    ) -> tuple[DownloadResult, str | None]:
+        """Download and extract a zip archive from a URL.
+
+        Uses conditional GET headers when cached metadata exists. On a 304
+        response the existing files are left untouched. On a 200 response the
+        zip is streamed to a temp file, extracted, and the target directory is
+        replaced atomically.
+
+        :param url: URL of the zip archive to download
+        :param target_dir: Parent directory where ``repo_name/`` will be created
+        :param repo_name: Subdirectory name for the extracted content
+        :param progress_callback: Optional ``(downloaded_bytes, total_bytes)`` callback
+        :return: Tuple of (result, error_message_or_none)
+        """
+        repo_dir = target_dir / repo_name
+        cache = self._read_cache_metadata(repo_dir) if repo_dir.exists() else {}
+        headers = self._build_conditional_headers(cache)
+
+        try:
+            response = http.get(url, headers=headers, stream=True, timeout=30)
+            response.raise_for_status()
+
+            if response.status_code == 304:
+                logger.info(f"{repo_name}: already up to date (304)")
+                return DownloadResult.UP_TO_DATE, None
+
+            total_size_str = response.headers.get("Content-Length")
+            total_size = int(total_size_str) if total_size_str else None
+
+            target_dir.mkdir(parents=True, exist_ok=True)
+            temp_fd = tempfile.NamedTemporaryFile(
+                dir=str(target_dir), suffix=".zip", delete=False
+            )
+            temp_path = Path(temp_fd.name)
+
+            try:
+                downloaded = 0
+                for chunk in response.iter_content(chunk_size=DOWNLOAD_CHUNK_SIZE):
+                    if chunk:
+                        temp_fd.write(chunk)
+                        downloaded += len(chunk)
+                        if progress_callback:
+                            progress_callback(downloaded, total_size)
+                temp_fd.close()
+
+                extracted = self._extract_zip_to_dir(temp_path, target_dir, repo_name)
+
+                new_etag = response.headers.get("ETag")
+                new_last_modified = response.headers.get("Last-Modified")
+                self._write_cache_metadata(extracted, new_etag, new_last_modified)
+
+                logger.info(f"{repo_name}: downloaded and extracted successfully")
+                return DownloadResult.UPDATED, None
+
+            finally:
+                if temp_path.exists():
+                    try:
+                        temp_path.unlink()
+                    except OSError:
+                        pass
+
+        except requests.RequestException as e:
+            error_msg = f"Failed to download {repo_name}: {e}"
+            logger.warning(error_msg)
+            return DownloadResult.FAILED, error_msg
+        except (zipfile.BadZipFile, OSError) as e:
+            error_msg = f"Failed to extract {repo_name}: {e}"
+            logger.warning(error_msg)
+            return DownloadResult.FAILED, error_msg

--- a/app/utils/http_downloader.py
+++ b/app/utils/http_downloader.py
@@ -9,6 +9,7 @@ import json
 import shutil
 import tempfile
 import zipfile
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum, auto
 from pathlib import Path
@@ -16,6 +17,7 @@ from typing import Callable
 
 import requests
 from loguru import logger
+from PySide6.QtCore import QThread, Signal
 
 from app.utils import http
 
@@ -218,3 +220,44 @@ class HttpDatabaseDownloader:
             error_msg = f"Failed to extract {repo_name}: {e}"
             logger.warning(error_msg)
             return DownloadResult.FAILED, error_msg
+
+
+@dataclass
+class DatabaseDownloadTask:
+    url: str
+    target_dir: Path
+    repo_name: str
+    display_name: str
+
+
+class HttpDownloadWorker(QThread):
+    progress = Signal(str)
+    finished = Signal(dict)
+    error = Signal(str)
+
+    def __init__(self, tasks: list[DatabaseDownloadTask]) -> None:
+        super().__init__()
+        self._tasks = tasks
+        self._downloader = HttpDatabaseDownloader()
+
+    def run(self) -> None:
+        results: dict[str, DownloadResult] = {}
+
+        for task in self._tasks:
+            self.progress.emit(f"Downloading {task.display_name}...")
+            result, error_msg = self._downloader.download(
+                url=task.url,
+                target_dir=task.target_dir,
+                repo_name=task.repo_name,
+                progress_callback=None,
+            )
+            results[task.repo_name] = result
+
+            if result == DownloadResult.UPDATED:
+                self.progress.emit(f"{task.display_name}: updated")
+            elif result == DownloadResult.UP_TO_DATE:
+                self.progress.emit(f"{task.display_name}: already up to date")
+            elif result == DownloadResult.FAILED:
+                self.progress.emit(f"{task.display_name}: failed — {error_msg}")
+
+        self.finished.emit(results)

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -52,7 +52,9 @@ class SettingsDialog(QDialog):
         main_layout.addLayout(button_layout)
 
         # Reset to defaults button
-        self.global_reset_to_defaults_button = QPushButton(self.tr("Reset to Defaults"), self)
+        self.global_reset_to_defaults_button = QPushButton(
+            self.tr("Reset to Defaults"), self
+        )
         button_layout.addWidget(self.global_reset_to_defaults_button)
 
         button_layout.addStretch()
@@ -100,7 +102,9 @@ class SettingsDialog(QDialog):
         # "Game location" → "Config location" → "Steam mods location" → "Local mods location"
         self.setTabOrder(self.game_location, self.config_folder_location)
         self.setTabOrder(self.config_folder_location, self.steam_mods_folder_location)
-        self.setTabOrder(self.steam_mods_folder_location, self.local_mods_folder_location)
+        self.setTabOrder(
+            self.steam_mods_folder_location, self.local_mods_folder_location
+        )
 
         # Push the buttons to the bottom
         tab_layout.addStretch()
@@ -147,7 +151,9 @@ class SettingsDialog(QDialog):
 
         self.game_location = QLineEdit()
         self.game_location.setPlaceholderText(
-            self.tr(r"Should be like: C:\Program Files (x86)\Steam\steamapps\common\RimWorld")
+            self.tr(
+                r"Should be like: C:\Program Files (x86)\Steam\steamapps\common\RimWorld"
+            )
         )
         self.game_location.setTextMargins(GUIInfo().text_field_margins)
         self.game_location.setFixedHeight(GUIInfo().default_font_line_height * 2)
@@ -185,7 +191,9 @@ class SettingsDialog(QDialog):
             )
         )
         self.config_folder_location.setTextMargins(GUIInfo().text_field_margins)
-        self.config_folder_location.setFixedHeight(GUIInfo().default_font_line_height * 2)
+        self.config_folder_location.setFixedHeight(
+            GUIInfo().default_font_line_height * 2
+        )
         group_layout.addWidget(self.config_folder_location)
 
     def _do_steam_mods_folder_location_area(self, tab_layout: QVBoxLayout) -> None:
@@ -197,10 +205,14 @@ class SettingsDialog(QDialog):
         header_layout = QHBoxLayout()
         group_layout.addLayout(header_layout)
 
-        self.steam_client_integration_checkbox = QCheckBox(self.tr("Enable Steam client integration"))
+        self.steam_client_integration_checkbox = QCheckBox(
+            self.tr("Enable Steam client integration")
+        )
         group_layout.addWidget(self.steam_client_integration_checkbox)
 
-        self.steam_client_integration_checkbox.stateChanged.connect(self._on_steam_integration_toggled)
+        self.steam_client_integration_checkbox.stateChanged.connect(
+            self._on_steam_integration_toggled
+        )
 
         section_label = QLabel(self.tr("Steam mods location"))
         section_label.setFont(GUIInfo().emphasis_font)
@@ -225,7 +237,9 @@ class SettingsDialog(QDialog):
             )
         )
         self.steam_mods_folder_location.setTextMargins(GUIInfo().text_field_margins)
-        self.steam_mods_folder_location.setFixedHeight(GUIInfo().default_font_line_height * 2)
+        self.steam_mods_folder_location.setFixedHeight(
+            GUIInfo().default_font_line_height * 2
+        )
         group_layout.addWidget(self.steam_mods_folder_location)
 
     def _do_local_mods_folder_location_area(self, tab_layout: QVBoxLayout) -> None:
@@ -255,10 +269,14 @@ class SettingsDialog(QDialog):
 
         self.local_mods_folder_location = QLineEdit()
         self.local_mods_folder_location.setPlaceholderText(
-            self.tr(r"should be like: C:\Program Files (x86)\Steam\steamapps\common\Rimworld\Mods")
+            self.tr(
+                r"should be like: C:\Program Files (x86)\Steam\steamapps\common\Rimworld\Mods"
+            )
         )
         self.local_mods_folder_location.setTextMargins(GUIInfo().text_field_margins)
-        self.local_mods_folder_location.setFixedHeight(GUIInfo().default_font_line_height * 2)
+        self.local_mods_folder_location.setFixedHeight(
+            GUIInfo().default_font_line_height * 2
+        )
         group_layout.addWidget(self.local_mods_folder_location)
 
     def _do_instance_folder_location_area(self, tab_layout: QVBoxLayout) -> None:
@@ -285,9 +303,13 @@ class SettingsDialog(QDialog):
 
         self.instance_folder_location = QLineEdit()
         self.instance_folder_location.setReadOnly(True)
-        self.instance_folder_location.setPlaceholderText(self.tr("Leave empty to use default location"))
+        self.instance_folder_location.setPlaceholderText(
+            self.tr("Leave empty to use default location")
+        )
         self.instance_folder_location.setTextMargins(GUIInfo().text_field_margins)
-        self.instance_folder_location.setFixedHeight(GUIInfo().default_font_line_height * 2)
+        self.instance_folder_location.setFixedHeight(
+            GUIInfo().default_font_line_height * 2
+        )
         group_layout.addWidget(self.instance_folder_location)
 
     def _do_game_launch_tab(self) -> None:
@@ -314,7 +336,9 @@ class SettingsDialog(QDialog):
             )
         )
         # Connect checkbox to disable/enable run_args group
-        self.launch_via_steam_protocol_checkbox.stateChanged.connect(self._on_steam_protocol_toggled)
+        self.launch_via_steam_protocol_checkbox.stateChanged.connect(
+            self._on_steam_protocol_toggled
+        )
         steam_protocol_layout.addWidget(self.launch_via_steam_protocol_checkbox)
 
         # Game arguments group
@@ -347,7 +371,9 @@ class SettingsDialog(QDialog):
         run_args_layout.addLayout(run_args_info_layout, 0, 0, 1, 2)
 
         run_args_label = QLabel(self.tr("Edit Game Run Arguments:"))
-        run_args_layout.addWidget(run_args_label, 1, 0, alignment=Qt.AlignmentFlag.AlignRight)
+        run_args_layout.addWidget(
+            run_args_label, 1, 0, alignment=Qt.AlignmentFlag.AlignRight
+        )
 
         self.run_args = QLineEdit()
         self.run_args.setTextMargins(GUIInfo().text_field_margins)
@@ -398,9 +424,13 @@ class SettingsDialog(QDialog):
         backup_group_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         tab_layout.addWidget(backup_group_label)
 
-        self.backup_saves_on_launch_checkbox = QCheckBox(self.tr("Automatically backup saves on first daily launch"))
+        self.backup_saves_on_launch_checkbox = QCheckBox(
+            self.tr("Automatically backup saves on first daily launch")
+        )
         self.backup_saves_on_launch_checkbox.setToolTip(
-            self.tr("If enabled, RimSort will automatically backup saves on the first daily launch.")
+            self.tr(
+                "If enabled, RimSort will automatically backup saves on the first daily launch."
+            )
         )
         tab_layout.addWidget(self.backup_saves_on_launch_checkbox)
 
@@ -408,13 +438,17 @@ class SettingsDialog(QDialog):
         retention_layout = QHBoxLayout()
         retention_label = QLabel(self.tr("Number of backups to keep:"))
         retention_label.setToolTip(
-            self.tr("The number of backups to keep. Set to -1 to keep all backups, 0 to delete all.")
+            self.tr(
+                "The number of backups to keep. Set to -1 to keep all backups, 0 to delete all."
+            )
         )
         retention_layout.addWidget(retention_label)
 
         self.auto_backup_retention_count_spinbox = QSpinBox()
         self.auto_backup_retention_count_spinbox.setRange(-1, 999)
-        self.auto_backup_retention_count_spinbox.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        self.auto_backup_retention_count_spinbox.setSizePolicy(
+            QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed
+        )
         retention_layout.addWidget(self.auto_backup_retention_count_spinbox)
         tab_layout.addLayout(retention_layout)
 
@@ -429,7 +463,9 @@ class SettingsDialog(QDialog):
         )
         self.auto_backup_compression_count_spinbox = QSpinBox()
         self.auto_backup_compression_count_spinbox.setRange(-1, 999)
-        self.auto_backup_compression_count_spinbox.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        self.auto_backup_compression_count_spinbox.setSizePolicy(
+            QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed
+        )
         compression_layout.addWidget(self.auto_backup_compression_count_spinbox)
         tab_layout.addLayout(compression_layout)
 
@@ -458,6 +494,9 @@ class SettingsDialog(QDialog):
         QRadioButton,
         QLineEdit,
         QToolButton,
+        QRadioButton,
+        QLineEdit,
+        QToolButton,
     ]:
         group = QGroupBox()
         tab_layout.addWidget(group, stretch=1)
@@ -468,7 +507,9 @@ class SettingsDialog(QDialog):
 
         section_label = QLabel(section_lbl)
         section_label.setFont(GUIInfo().emphasis_font)
-        section_label.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
+        section_label.setSizePolicy(
+            QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed
+        )
         group_layout.addWidget(section_label)
 
         section_layout = QVBoxLayout()
@@ -519,6 +560,32 @@ class SettingsDialog(QDialog):
 
         item_layout = QHBoxLayout()
         section_layout.addLayout(item_layout, stretch=1)
+
+        url_radio = QRadioButton(self.tr("URL"))
+        url_radio.setMinimumSize(0, GUIInfo().default_font_line_height * 2)
+        item_layout.addWidget(url_radio, stretch=2)
+
+        row_layout = QHBoxLayout()
+        row_layout.setSpacing(8)
+        item_layout.addLayout(row_layout, stretch=8)
+
+        url_input = QLineEdit()
+        url_input.setFixedHeight(GUIInfo().default_font_line_height * 2)
+        url_input.setTextMargins(GUIInfo().text_field_margins)
+        url_input.setClearButtonEnabled(True)
+        url_input.setEnabled(False)
+        url_input.setPlaceholderText(
+            self.tr("https://github.com/.../archive/refs/heads/main.zip")
+        )
+        row_layout.addWidget(url_input)
+
+        url_download_button = QToolButton()
+        url_download_button.setText(self.tr("Download…"))
+        url_download_button.setEnabled(False)
+        row_layout.addWidget(url_download_button)
+
+        item_layout = QHBoxLayout()
+        section_layout.addLayout(item_layout, stretch=1)
         local_file_radio = QRadioButton(self.tr("Local File"))
         local_file_radio.setMinimumSize(0, GUIInfo().default_font_line_height * 2)
         item_layout.addWidget(local_file_radio, stretch=2)
@@ -537,7 +604,9 @@ class SettingsDialog(QDialog):
         local_file_choose_button = QToolButton()
         local_file_choose_button.setText(self.tr("Choose…"))
         local_file_choose_button.setEnabled(False)
-        local_file_choose_button.setFixedWidth(github_download_button.sizeHint().width())
+        local_file_choose_button.setFixedWidth(
+            github_download_button.sizeHint().width()
+        )
         row_layout.addWidget(local_file_choose_button)
 
         section_layout.addStretch(1)
@@ -556,6 +625,9 @@ class SettingsDialog(QDialog):
             github_url,
             github_upload_button,
             github_download_button,
+            url_radio,
+            url_input,
+            url_download_button,
             local_file_radio,
             local_file,
             local_file_choose_button,
@@ -572,6 +644,9 @@ class SettingsDialog(QDialog):
             self.community_rules_db_github_url,
             self.community_rules_db_github_upload_button,
             self.community_rules_db_github_download_button,
+            self.community_rules_db_url_radio,
+            self.community_rules_db_url_input,
+            self.community_rules_db_url_download_button,
             self.community_rules_db_local_file_radio,
             self.community_rules_db_local_file,
             self.community_rules_db_local_file_choose_button,
@@ -588,12 +663,17 @@ class SettingsDialog(QDialog):
             self.steam_workshop_db_github_url,
             self.steam_workshop_db_github_upload_button,
             self.steam_workshop_db_github_download_button,
+            self.steam_workshop_db_url_radio,
+            self.steam_workshop_db_url_input,
+            self.steam_workshop_db_url_download_button,
             self.steam_workshop_db_local_file_radio,
             self.steam_workshop_db_local_file,
             self.steam_workshop_db_local_file_choose_button,
         ) = self.__create_db_group(section_lbl, none_lbl, tab_layout)
         database_expiry_label = QLabel(
-            self.tr("Database expiry in seconds for example, 604800 for 7 days. and 0 for no expiry.")
+            self.tr(
+                "Database expiry in seconds for example, 604800 for 7 days. and 0 for no expiry."
+            )
         )
         database_expiry_label.setFont(GUIInfo().emphasis_font)
         group_layout.addWidget(database_expiry_label)
@@ -613,6 +693,9 @@ class SettingsDialog(QDialog):
             self.no_version_warning_db_github_url,
             self.no_version_warning_db_github_upload_button,
             self.no_version_warning_db_github_download_button,
+            self.no_version_warning_db_url_radio,
+            self.no_version_warning_db_url_input,
+            self.no_version_warning_db_url_download_button,
             self.no_version_warning_db_local_file_radio,
             self.no_version_warning_db_local_file,
             self.no_version_warning_db_local_file_choose_button,
@@ -628,6 +711,9 @@ class SettingsDialog(QDialog):
             self.use_this_instead_db_github_url,
             self.use_this_instead_db_github_upload_button,
             self.use_this_instead_db_github_download_button,
+            self.use_this_instead_db_url_radio,
+            self.use_this_instead_db_url_input,
+            self.use_this_instead_db_url_download_button,
             self.use_this_instead_db_local_file_radio,
             self.use_this_instead_db_local_file,
             self.use_this_instead_db_local_file_choose_button,
@@ -635,7 +721,9 @@ class SettingsDialog(QDialog):
 
     def _do_aux_db_time_limit_group(self, tab_layout: QBoxLayout) -> None:
         self.aux_db_time_limit_label = QLabel(
-            self.tr("Auxiliary Metadata DB deletion time limit in seconds. (Delete instantly 0, Never Delete -1)")
+            self.tr(
+                "Auxiliary Metadata DB deletion time limit in seconds. (Delete instantly 0, Never Delete -1)"
+            )
         )
         aux_db_tooltip = self.tr("""To enable editing of this time limit, enable the checkbox (Enable editing) on the right.
 After a mod is deleted, this is the time we wait until this mod item is deleted from the Auxiliary Metadata DB. 
@@ -652,9 +740,13 @@ This basically preserves your mod coloring, user notes etc. for this many second
         self.aux_db_time_limit.setFixedHeight(GUIInfo().default_font_line_height * 2)
 
         self.enable_aux_db_behavior_editing = QCheckBox(self.tr("Enable editing"))
-        self.enable_aux_db_behavior_editing.stateChanged.connect(self.enable_aux_db_time_limit_line_edit)
+        self.enable_aux_db_behavior_editing.stateChanged.connect(
+            self.enable_aux_db_time_limit_line_edit
+        )
         self.enable_aux_db_behavior_editing.setToolTip(
-            self.tr("This enables the editing of the time limit for Aux Metadata DB data deletion.")
+            self.tr(
+                "This enables the editing of the time limit for Aux Metadata DB data deletion."
+            )
         )
 
         label_layout = QHBoxLayout()
@@ -701,7 +793,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         deps_group_box_layout.addWidget(deps_label)
 
         # Use dependencies for sorting checkbox
-        self.use_moddependencies_as_loadTheseBefore = QCheckBox(self.tr("Use dependency rules for sorting."))
+        self.use_moddependencies_as_loadTheseBefore = QCheckBox(
+            self.tr("Use dependency rules for sorting.")
+        )
         self.use_moddependencies_as_loadTheseBefore.setToolTip(
             self.tr(
                 "If enabled, also uses moddependencies as loadTheseBefore, and mods will be sorted such that dependencies are loaded before the dependent mod."
@@ -710,8 +804,8 @@ This basically preserves your mod coloring, user notes etc. for this many second
         deps_group_box_layout.addWidget(self.use_moddependencies_as_loadTheseBefore)
 
         # Use alternativePackageIds as satisfying dependencies
-        self.use_alternative_package_ids_as_satisfying_dependencies_checkbox = QCheckBox(
-            self.tr("Use alternativePackageIds as satisfying dependencies")
+        self.use_alternative_package_ids_as_satisfying_dependencies_checkbox = (
+            QCheckBox(self.tr("Use alternativePackageIds as satisfying dependencies"))
         )
         self.use_alternative_package_ids_as_satisfying_dependencies_checkbox.setToolTip(
             self.tr(
@@ -719,9 +813,13 @@ This basically preserves your mod coloring, user notes etc. for this many second
                 "E.g., 'oels.vehiclemapframework', alternatives: 'oels.vehiclemapframework.dev'"
             )
         )
-        deps_group_box_layout.addWidget(self.use_alternative_package_ids_as_satisfying_dependencies_checkbox)
+        deps_group_box_layout.addWidget(
+            self.use_alternative_package_ids_as_satisfying_dependencies_checkbox
+        )
 
-        self.check_deps_checkbox = QCheckBox(self.tr("Prompt user to download dependencies when click in Sort"))
+        self.check_deps_checkbox = QCheckBox(
+            self.tr("Prompt user to download dependencies when click in Sort")
+        )
         deps_group_box_layout.addWidget(self.check_deps_checkbox)
 
         # XML parsing behavior group
@@ -735,7 +833,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         xml_parsing_explanatory_label = QLabel(self.tr("XML Parsing Behavior"))
         xml_parsing_explanatory_label.setFont(GUIInfo().emphasis_font)
         xml_parsing_group_box_layout.addWidget(xml_parsing_explanatory_label)
-        self.prefer_versioned_about_tags_checkbox = QCheckBox(self.tr("Prefer versioned About.xml tags over base tags"))
+        self.prefer_versioned_about_tags_checkbox = QCheckBox(
+            self.tr("Prefer versioned About.xml tags over base tags")
+        )
         self.prefer_versioned_about_tags_checkbox.setToolTip(
             self.tr(
                 "When enabled, *ByVersion tags take precedence over the base tags, \n"
@@ -744,7 +844,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
             )
         )
 
-        xml_parsing_group_box_layout.addWidget(self.prefer_versioned_about_tags_checkbox)
+        xml_parsing_group_box_layout.addWidget(
+            self.prefer_versioned_about_tags_checkbox
+        )
 
         # Mod list options group
         modlist_option_group_box = QGroupBox()
@@ -758,56 +860,80 @@ This basically preserves your mod coloring, user notes etc. for this many second
         modlist_option_group_box_layout.addWidget(modlist_option_label)
 
         # Download missing mods checkbox
-        self.download_missing_mods_checkbox = QCheckBox(self.tr("Download missing mods automatically"))
+        self.download_missing_mods_checkbox = QCheckBox(
+            self.tr("Download missing mods automatically")
+        )
         self.download_missing_mods_checkbox.setToolTip(
-            self.tr("Notifies to download mods that may be missing in the active modlist")
+            self.tr(
+                "Notifies to download mods that may be missing in the active modlist"
+            )
         )
         modlist_option_group_box_layout.addWidget(self.download_missing_mods_checkbox)
 
         # Duplicate mod notification checkbox
-        self.show_duplicate_mods_warning_checkbox = QCheckBox(self.tr("Show duplicate mods warning"))
+        self.show_duplicate_mods_warning_checkbox = QCheckBox(
+            self.tr("Show duplicate mods warning")
+        )
         self.show_duplicate_mods_warning_checkbox.setToolTip(
             self.tr("Notifies and displays the mods that have the same packageid")
         )
-        modlist_option_group_box_layout.addWidget(self.show_duplicate_mods_warning_checkbox)
+        modlist_option_group_box_layout.addWidget(
+            self.show_duplicate_mods_warning_checkbox
+        )
 
         # Mod type filter checkbox
         self.mod_type_filter_checkbox = QCheckBox(self.tr("Enable mod type filter"))
         self.mod_type_filter_checkbox.setToolTip(
-            self.tr("Add icons and filtering options for easy mods identification and grouping")
+            self.tr(
+                "Add icons and filtering options for easy mods identification and grouping"
+            )
         )
         modlist_option_group_box_layout.addWidget(self.mod_type_filter_checkbox)
 
         # Hide invalid mod filtering checkbox
-        self.hide_invalid_mods_when_filtering_checkbox = QCheckBox(self.tr("Hide invalid mods when filtering"))
+        self.hide_invalid_mods_when_filtering_checkbox = QCheckBox(
+            self.tr("Hide invalid mods when filtering")
+        )
         self.hide_invalid_mods_when_filtering_checkbox.setToolTip(
             self.tr("Hides invalid mods, not recommended to enable")
         )
-        modlist_option_group_box_layout.addWidget(self.hide_invalid_mods_when_filtering_checkbox)
+        modlist_option_group_box_layout.addWidget(
+            self.hide_invalid_mods_when_filtering_checkbox
+        )
 
         # Inactive mods sorting group
         self.inactive_mods_sorting_group_box = QGroupBox()
         tab_layout.addWidget(self.inactive_mods_sorting_group_box)
 
         inactive_mods_sorting_group_box_layout = QVBoxLayout()
-        self.inactive_mods_sorting_group_box.setLayout(inactive_mods_sorting_group_box_layout)
+        self.inactive_mods_sorting_group_box.setLayout(
+            inactive_mods_sorting_group_box_layout
+        )
 
         inactive_mods_sorting_label = QLabel(self.tr("Inactive Mods Sorting"))
         inactive_mods_sorting_label.setFont(GUIInfo().emphasis_font)
         inactive_mods_sorting_group_box_layout.addWidget(inactive_mods_sorting_label)
 
         # Inactive mods sorting options checkbox
-        self.enable_inactive_mods_sorting_checkbox = QCheckBox(self.tr("Enable inactive mods sorting"))
+        self.enable_inactive_mods_sorting_checkbox = QCheckBox(
+            self.tr("Enable inactive mods sorting")
+        )
         self.enable_inactive_mods_sorting_checkbox.setToolTip(
             self.tr(
                 "Additional options like name, author, folder size, modified date will be available in the mods panel for sorting inactive mods \n"
                 "Disabling this can improve performance by avoiding heavy calculations."
             )
         )
-        inactive_mods_sorting_group_box_layout.addWidget(self.enable_inactive_mods_sorting_checkbox)
+        inactive_mods_sorting_group_box_layout.addWidget(
+            self.enable_inactive_mods_sorting_checkbox
+        )
 
-        self.save_inactive_mods_sort_state_checkbox = QCheckBox(self.tr("Save inactive mods sort state"))
-        inactive_mods_sorting_group_box_layout.addWidget(self.save_inactive_mods_sort_state_checkbox)
+        self.save_inactive_mods_sort_state_checkbox = QCheckBox(
+            self.tr("Save inactive mods sort state")
+        )
+        inactive_mods_sorting_group_box_layout.addWidget(
+            self.save_inactive_mods_sort_state_checkbox
+        )
 
         tab_layout.addStretch()
 
@@ -829,7 +955,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         when_building_database_label.setFont(GUIInfo().emphasis_font)
         group_layout.addWidget(when_building_database_label)
 
-        self.db_builder_include_all_radio = QRadioButton(self.tr("Get PublishedFileIDs from locally installed mods."))
+        self.db_builder_include_all_radio = QRadioButton(
+            self.tr("Get PublishedFileIDs from locally installed mods.")
+        )
         group_layout.addWidget(self.db_builder_include_all_radio)
 
         explanatory_label = QLabel(
@@ -840,7 +968,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         )
         group_layout.addWidget(explanatory_label)
 
-        self.db_builder_include_no_local_radio = QRadioButton(self.tr("Get PublishedFileIDs from the Steam Workshop."))
+        self.db_builder_include_no_local_radio = QRadioButton(
+            self.tr("Get PublishedFileIDs from the Steam Workshop.")
+        )
         group_layout.addWidget(self.db_builder_include_no_local_radio)
 
         explanatory_label = QLabel(
@@ -858,7 +988,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         group_layout = QVBoxLayout()
         group_box.setLayout(group_layout)
 
-        self.db_builder_query_dlc_checkbox = QCheckBox(self.tr("Query DLC dependency data with Steamworks API"))
+        self.db_builder_query_dlc_checkbox = QCheckBox(
+            self.tr("Query DLC dependency data with Steamworks API")
+        )
         group_layout.addWidget(self.db_builder_query_dlc_checkbox)
 
         self.db_builder_update_instead_of_overwriting_checkbox = QCheckBox(
@@ -879,7 +1011,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         self.db_builder_steam_api_key = QLineEdit()
         self.db_builder_steam_api_key.setEchoMode(QLineEdit.EchoMode.Password)
         self.db_builder_steam_api_key.setTextMargins(GUIInfo().text_field_margins)
-        self.db_builder_steam_api_key.setFixedHeight(GUIInfo().default_font_line_height * 2)
+        self.db_builder_steam_api_key.setFixedHeight(
+            GUIInfo().default_font_line_height * 2
+        )
         grid_group_layout.addWidget(self.db_builder_steam_api_key, 1, 1)
 
         grid_group_layout.setColumnStretch(0, 0)
@@ -896,10 +1030,14 @@ This basically preserves your mod coloring, user notes etc. for this many second
         item_label = QLabel(self.tr("Download all published Workshop mods via:"))
         item_layout.addWidget(item_label)
 
-        self.db_builder_download_all_mods_via_steamcmd_button = QPushButton(self.tr("SteamCMD"))
+        self.db_builder_download_all_mods_via_steamcmd_button = QPushButton(
+            self.tr("SteamCMD")
+        )
         item_layout.addWidget(self.db_builder_download_all_mods_via_steamcmd_button)
 
-        self.db_builder_download_all_mods_via_steam_button = QPushButton(self.tr("Steam"))
+        self.db_builder_download_all_mods_via_steam_button = QPushButton(
+            self.tr("Steam")
+        )
         self.db_builder_download_all_mods_via_steam_button.setFixedWidth(
             self.db_builder_download_all_mods_via_steamcmd_button.sizeHint().width()
         )
@@ -911,7 +1049,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
 
         item_layout.addStretch()
 
-        self.db_builder_compare_databases_button = QPushButton(self.tr("Compare Databases"))
+        self.db_builder_compare_databases_button = QPushButton(
+            self.tr("Compare Databases")
+        )
         item_layout.addWidget(self.db_builder_compare_databases_button)
 
         self.db_builder_merge_databases_button = QPushButton(self.tr("Merge Databases"))
@@ -921,7 +1061,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         item_layout.addWidget(self.db_builder_merge_databases_button)
 
         self.db_builder_build_database_button = QPushButton(self.tr("Build Database"))
-        self.db_builder_build_database_button.setFixedWidth(self.db_builder_compare_databases_button.sizeHint().width())
+        self.db_builder_build_database_button.setFixedWidth(
+            self.db_builder_compare_databases_button.sizeHint().width()
+        )
         item_layout.addWidget(self.db_builder_build_database_button)
 
     def _do_steamcmd_tab(self) -> None:
@@ -937,10 +1079,14 @@ This basically preserves your mod coloring, user notes etc. for this many second
         group_layout = QVBoxLayout()
         group_box.setLayout(group_layout)
 
-        self.steamcmd_validate_downloads_checkbox = QCheckBox(self.tr("Validate downloaded mods"))
+        self.steamcmd_validate_downloads_checkbox = QCheckBox(
+            self.tr("Validate downloaded mods")
+        )
         group_layout.addWidget(self.steamcmd_validate_downloads_checkbox)
 
-        self.steamcmd_auto_clear_depot_cache_checkbox = QCheckBox(self.tr("Automatically clear depot cache"))
+        self.steamcmd_auto_clear_depot_cache_checkbox = QCheckBox(
+            self.tr("Automatically clear depot cache")
+        )
         self.steamcmd_auto_clear_depot_cache_checkbox.setToolTip(
             (
                 self.tr(
@@ -951,7 +1097,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         )
         group_layout.addWidget(self.steamcmd_auto_clear_depot_cache_checkbox)
 
-        self.steamcmd_delete_before_update_checkbox = QCheckBox(self.tr("Delete before update"))
+        self.steamcmd_delete_before_update_checkbox = QCheckBox(
+            self.tr("Delete before update")
+        )
         self.steamcmd_delete_before_update_checkbox.setToolTip(
             self.tr("This is useful if you want to ensure clean mod updates.")
         )
@@ -976,7 +1124,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
 
         self.steamcmd_install_location = QLineEdit()
         self.steamcmd_install_location.setTextMargins(GUIInfo().text_field_margins)
-        self.steamcmd_install_location.setFixedHeight(GUIInfo().default_font_line_height * 2)
+        self.steamcmd_install_location.setFixedHeight(
+            GUIInfo().default_font_line_height * 2
+        )
         group_layout.addWidget(self.steamcmd_install_location)
 
         tab_layout.addStretch()
@@ -986,7 +1136,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
 
         button_layout.addStretch()
 
-        self.steamcmd_clear_depot_cache_button = QPushButton(self.tr("Clear depot cache"))
+        self.steamcmd_clear_depot_cache_button = QPushButton(
+            self.tr("Clear depot cache")
+        )
         self.steamcmd_clear_depot_cache_button.setToolTip(
             self.tr(
                 "Clear the depot cache manually. This may be useful if you encounter issues with downloading mods through SteamCMD."
@@ -1020,25 +1172,33 @@ This basically preserves your mod coloring, user notes etc. for this many second
         quality_preset_label.setFont(GUIInfo().emphasis_font)
         group_layout.addWidget(quality_preset_label)
 
-        self.todds_preset_optimized_radio = QRadioButton(self.tr("Optimized - Recommended for RimWorld"))
+        self.todds_preset_optimized_radio = QRadioButton(
+            self.tr("Optimized - Recommended for RimWorld")
+        )
         group_layout.addWidget(self.todds_preset_optimized_radio)
 
         self.todds_preset_custom_radio = QRadioButton(self.tr("Custom todds command"))
         group_layout.addWidget(self.todds_preset_custom_radio)
 
         custom_command_label = QLabel(
-            self.tr("If -p as in path is not specified, path from current active or all mods selection will be used.")
+            self.tr(
+                "If -p as in path is not specified, path from current active or all mods selection will be used."
+            )
         )
         custom_command_label.setFont(GUIInfo().emphasis_font)
         group_layout.addWidget(custom_command_label)
 
         self.todds_custom_command_lineedit = QLineEdit()
-        todds_example = '-f BC1 -af BC7 -on -vf -fs -r Textures -t -p "D:\\Games\\RimWorld\\Mods"'
+        todds_example = (
+            '-f BC1 -af BC7 -on -vf -fs -r Textures -t -p "D:\\Games\\RimWorld\\Mods"'
+        )
         self.todds_custom_command_lineedit.setPlaceholderText(
             self.tr("eg: {todds_example}").format(todds_example=todds_example)
         )
         self.todds_custom_command_lineedit.setTextMargins(GUIInfo().text_field_margins)
-        self.todds_custom_command_lineedit.setFixedHeight(GUIInfo().default_font_line_height * 2)
+        self.todds_custom_command_lineedit.setFixedHeight(
+            GUIInfo().default_font_line_height * 2
+        )
         group_layout.addWidget(self.todds_custom_command_lineedit)
 
         group_box = QGroupBox()
@@ -1051,7 +1211,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         when_optimizing_label.setFont(GUIInfo().emphasis_font)
         group_layout.addWidget(when_optimizing_label)
 
-        self.todds_active_mods_only_radio = QRadioButton(self.tr("Optimize active mods only"))
+        self.todds_active_mods_only_radio = QRadioButton(
+            self.tr("Optimize active mods only")
+        )
         group_layout.addWidget(self.todds_active_mods_only_radio)
 
         self.todds_all_mods_radio = QRadioButton(self.tr("Optimize all mods"))
@@ -1066,11 +1228,15 @@ This basically preserves your mod coloring, user notes etc. for this many second
         self.todds_dry_run_checkbox = QCheckBox(self.tr("Enable dry-run mode"))
         group_layout.addWidget(self.todds_dry_run_checkbox)
 
-        self.todds_overwrite_checkbox = QCheckBox(self.tr("Overwrite existing optimized textures"))
+        self.todds_overwrite_checkbox = QCheckBox(
+            self.tr("Overwrite existing optimized textures")
+        )
         group_layout.addWidget(self.todds_overwrite_checkbox)
 
         self.auto_delete_orphaned_dds_checkbox = QCheckBox(
-            self.tr("Automatically delete .dds files if no corresponding .png file exists")
+            self.tr(
+                "Automatically delete .dds files if no corresponding .png file exists"
+            )
         )
         self.auto_delete_orphaned_dds_checkbox.setToolTip(
             self.tr(
@@ -1122,7 +1288,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         group_layout.addWidget(folder_arg_label)
         self.text_editor_folder_arg = QLineEdit()
         self.text_editor_folder_arg.setTextMargins(GUIInfo().text_field_margins)
-        self.text_editor_folder_arg.setFixedHeight(GUIInfo().default_font_line_height * 2)
+        self.text_editor_folder_arg.setFixedHeight(
+            GUIInfo().default_font_line_height * 2
+        )
         group_layout.addWidget(self.text_editor_folder_arg)
 
         file_arg_label = QLabel(self.tr("Additional Arguments (Opening Single File)"))
@@ -1169,7 +1337,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         theme_layout = QHBoxLayout()
         theme_group_box.setLayout(theme_layout)
 
-        self.enable_themes_checkbox = QCheckBox(self.tr("Enable to use theme / stylesheet instead of system Theme"))
+        self.enable_themes_checkbox = QCheckBox(
+            self.tr("Enable to use theme / stylesheet instead of system Theme")
+        )
         self.enable_themes_checkbox.setToolTip(
             self.tr(
                 "To add your own theme / stylesheet \n\n"
@@ -1185,7 +1355,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         theme_layout.addWidget(self.enable_themes_checkbox)
 
         self.themes_combobox = QComboBox()
-        self.themes_combobox.setSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred)
+        self.themes_combobox.setSizePolicy(
+            QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred
+        )
         theme_layout.addWidget(self.themes_combobox)
 
         self.theme_location_open_button = QToolButton()
@@ -1209,7 +1381,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         font_family_layout.addWidget(font_family_label)
 
         self.font_family_combobox = QFontComboBox()
-        self.font_family_combobox.setSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred)
+        self.font_family_combobox.setSizePolicy(
+            QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred
+        )
         font_family_layout.addWidget(self.font_family_combobox)
 
         font_size_layout = QHBoxLayout()
@@ -1221,11 +1395,15 @@ This basically preserves your mod coloring, user notes etc. for this many second
         self.font_size_spinbox = QSpinBox()
         self.font_size_spinbox.setRange(8, 20)
         self.font_size_spinbox.setValue(12)
-        self.font_size_spinbox.setSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred)
+        self.font_size_spinbox.setSizePolicy(
+            QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred
+        )
         font_size_layout.addWidget(self.font_size_spinbox)
 
         reset_button = QPushButton(self.tr("Reset"))
-        reset_button.setSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred)
+        reset_button.setSizePolicy(
+            QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred
+        )
 
         reset_button_layout = QHBoxLayout()
         reset_button_layout.addStretch(1)
@@ -1234,7 +1412,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         reset_button.clicked.connect(self.reset_font_settings)
 
         if self.enable_themes_checkbox.isChecked():
-            self.enable_themes_checkbox.stateChanged.connect(self.connect_populate_themes_combobox)
+            self.enable_themes_checkbox.stateChanged.connect(
+                self.connect_populate_themes_combobox
+            )
         else:
             self.themes_combobox.clear()
 
@@ -1249,11 +1429,15 @@ This basically preserves your mod coloring, user notes etc. for this many second
         language_group_layout = QHBoxLayout()
         language_group_box.setLayout(language_group_layout)
 
-        language_label = QLabel(self.tr("Select Language (Restart required to apply changes)"))
+        language_label = QLabel(
+            self.tr("Select Language (Restart required to apply changes)")
+        )
         language_group_layout.addWidget(language_label)
 
         self.language_combobox = QComboBox()
-        self.language_combobox.setSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred)
+        self.language_combobox.setSizePolicy(
+            QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred
+        )
 
         language_group_layout.addWidget(self.language_combobox)
 
@@ -1316,9 +1500,15 @@ This basically preserves your mod coloring, user notes etc. for this many second
         group_layout.addWidget(self.main_window_group)
 
         # Connect main window radio buttons to enable/disable custom size spinboxes dynamically
-        self.main_launch_maximized_radio.toggled.connect(self.disable_main_custom_size_spinboxes)
-        self.main_launch_normal_radio.toggled.connect(self.disable_main_custom_size_spinboxes)
-        self.main_launch_custom_radio.toggled.connect(self.enable_main_custom_size_spinboxes)
+        self.main_launch_maximized_radio.toggled.connect(
+            self.disable_main_custom_size_spinboxes
+        )
+        self.main_launch_normal_radio.toggled.connect(
+            self.disable_main_custom_size_spinboxes
+        )
+        self.main_launch_custom_radio.toggled.connect(
+            self.enable_main_custom_size_spinboxes
+        )
 
         # Browser Window
         (
@@ -1344,9 +1534,15 @@ This basically preserves your mod coloring, user notes etc. for this many second
         group_layout.addWidget(self.browser_window_group)
 
         # Connect browser window radio buttons to enable/disable custom size spinboxes dynamically
-        self.browser_launch_maximized_radio.toggled.connect(self.disable_browser_custom_size_spinboxes)
-        self.browser_launch_normal_radio.toggled.connect(self.disable_browser_custom_size_spinboxes)
-        self.browser_launch_custom_radio.toggled.connect(self.enable_browser_custom_size_spinboxes)
+        self.browser_launch_maximized_radio.toggled.connect(
+            self.disable_browser_custom_size_spinboxes
+        )
+        self.browser_launch_normal_radio.toggled.connect(
+            self.disable_browser_custom_size_spinboxes
+        )
+        self.browser_launch_custom_radio.toggled.connect(
+            self.enable_browser_custom_size_spinboxes
+        )
 
         # Settings Window (only custom option)
         settings_window_title_label = QLabel(self.tr("Settings Window Launch State"))
@@ -1358,7 +1554,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         settings_window_group.setLayout(settings_window_layout)
 
         self.settings_custom_width_spinbox = QSpinBox()
-        self.settings_custom_width_spinbox.setRange(Settings.MIN_SIZE, Settings.MAX_SIZE)
+        self.settings_custom_width_spinbox.setRange(
+            Settings.MIN_SIZE, Settings.MAX_SIZE
+        )
         self.settings_custom_width_spinbox.setValue(Settings.DEFAULT_WIDTH)
         self.settings_custom_width_spinbox.setSuffix(" px")
         self.settings_custom_width_spinbox.setFixedWidth(100)
@@ -1368,7 +1566,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         settings_window_layout.addWidget(self.settings_custom_width_spinbox)
 
         self.settings_custom_height_spinbox = QSpinBox()
-        self.settings_custom_height_spinbox.setRange(Settings.MIN_SIZE, Settings.MAX_SIZE)
+        self.settings_custom_height_spinbox.setRange(
+            Settings.MIN_SIZE, Settings.MAX_SIZE
+        )
         self.settings_custom_height_spinbox.setValue(Settings.DEFAULT_HEIGHT)
         self.settings_custom_height_spinbox.setSuffix(" px")
         self.settings_custom_height_spinbox.setFixedWidth(100)
@@ -1439,12 +1639,16 @@ This basically preserves your mod coloring, user notes etc. for this many second
         auth_group.setLayout(auth_group_layout)
 
         rentry_auth_label = QLabel(self.tr("Rentry Auth:"))
-        auth_group_layout.addWidget(rentry_auth_label, 0, 0, alignment=Qt.AlignmentFlag.AlignRight)
+        auth_group_layout.addWidget(
+            rentry_auth_label, 0, 0, alignment=Qt.AlignmentFlag.AlignRight
+        )
 
         self.rentry_auth_code = QLineEdit()
         self.rentry_auth_code.setTextMargins(GUIInfo().text_field_margins)
         self.rentry_auth_code.setFixedHeight(GUIInfo().default_font_line_height * 2)
-        self.rentry_auth_code.setPlaceholderText(self.tr("Obtain rentry auth code by emailing: support@rentry.co"))
+        self.rentry_auth_code.setPlaceholderText(
+            self.tr("Obtain rentry auth code by emailing: support@rentry.co")
+        )
         # TODO: If we add a rentry auth code with builds, we should change placeholder to clarify this code will be used instead of the provided one
         auth_group_layout.addWidget(self.rentry_auth_code, 0, 1)
 
@@ -1455,7 +1659,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         github_identity_group.setLayout(github_identity_layout)
 
         github_username_label = QLabel(self.tr("GitHub username:"))
-        github_identity_layout.addWidget(github_username_label, 0, 0, alignment=Qt.AlignmentFlag.AlignRight)
+        github_identity_layout.addWidget(
+            github_username_label, 0, 0, alignment=Qt.AlignmentFlag.AlignRight
+        )
 
         self.github_username = QLineEdit()
         self.github_username.setTextMargins(GUIInfo().text_field_margins)
@@ -1463,7 +1669,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         github_identity_layout.addWidget(self.github_username, 0, 1)
 
         github_token_label = QLabel(self.tr("GitHub personal access token:"))
-        github_identity_layout.addWidget(github_token_label, 1, 0, alignment=Qt.AlignmentFlag.AlignRight)
+        github_identity_layout.addWidget(
+            github_token_label, 1, 0, alignment=Qt.AlignmentFlag.AlignRight
+        )
 
         self.github_token = QLineEdit()
         self.github_token.setEchoMode(QLineEdit.EchoMode.Password)
@@ -1499,27 +1707,37 @@ This basically preserves your mod coloring, user notes etc. for this many second
         self.debug_logging_checkbox = QCheckBox(self.tr("Enable debug logging"))
         group_layout.addWidget(self.debug_logging_checkbox)
 
-        self.watchdog_checkbox = QCheckBox(self.tr("Enable watchdog file monitor daemon"))
+        self.watchdog_checkbox = QCheckBox(
+            self.tr("Enable watchdog file monitor daemon")
+        )
         group_layout.addWidget(self.watchdog_checkbox)
 
         # Clear button behavior
         self.clear_moves_dlc_checkbox = QCheckBox(self.tr("Clear also moves DLC"))
         group_layout.addWidget(self.clear_moves_dlc_checkbox)
 
-        self.show_mod_updates_checkbox = QCheckBox(self.tr("Check for mod updates on refresh"))
+        self.show_mod_updates_checkbox = QCheckBox(
+            self.tr("Check for mod updates on refresh")
+        )
         group_layout.addWidget(self.show_mod_updates_checkbox)
 
-        self.render_unity_rich_text_checkbox = QCheckBox(self.tr("Render Unity Rich Text in mod descriptions"))
+        self.render_unity_rich_text_checkbox = QCheckBox(
+            self.tr("Render Unity Rich Text in mod descriptions")
+        )
         self.color_background_instead_of_text_checkbox = QCheckBox(
             self.tr("Apply mod coloring to background instead of text")
         )
         group_layout.addWidget(self.color_background_instead_of_text_checkbox)
         self.render_unity_rich_text_checkbox.setToolTip(
-            self.tr("Enable this option to render Unity Rich Text in mod descriptions. Images will not be displayed.")
+            self.tr(
+                "Enable this option to render Unity Rich Text in mod descriptions. Images will not be displayed."
+            )
         )
         group_layout.addWidget(self.render_unity_rich_text_checkbox)
 
-        self.update_databases_on_startup_checkbox = QCheckBox(self.tr("Update databases on startup"))
+        self.update_databases_on_startup_checkbox = QCheckBox(
+            self.tr("Update databases on startup")
+        )
         self.update_databases_on_startup_checkbox.setToolTip(
             self.tr(
                 "Enable this option to automatically update enabled databases when RimSort starts. "
@@ -1532,13 +1750,17 @@ This basically preserves your mod coloring, user notes etc. for this many second
             self.tr("Include mod notes in mod name search filter")
         )
         self.include_mod_notes_in_mod_name_filter_checkbox.setToolTip(
-            self.tr("This option will include searching mod notes when searching by mod name.")
+            self.tr(
+                "This option will include searching mod notes when searching by mod name."
+            )
         )
         group_layout.addWidget(self.include_mod_notes_in_mod_name_filter_checkbox)
 
         # Put checkbox, label and spinbox on the same horizontal line
         backup_layout = QHBoxLayout()
-        self.enable_backup_before_update_checkbox = QCheckBox(self.tr("Create backup before RimSort update"))
+        self.enable_backup_before_update_checkbox = QCheckBox(
+            self.tr("Create backup before RimSort update")
+        )
         self.enable_backup_before_update_checkbox.setToolTip(
             self.tr(
                 "Recommended to keep this enabled as it creates a backup before updating RimSort, "

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -52,9 +52,7 @@ class SettingsDialog(QDialog):
         main_layout.addLayout(button_layout)
 
         # Reset to defaults button
-        self.global_reset_to_defaults_button = QPushButton(
-            self.tr("Reset to Defaults"), self
-        )
+        self.global_reset_to_defaults_button = QPushButton(self.tr("Reset to Defaults"), self)
         button_layout.addWidget(self.global_reset_to_defaults_button)
 
         button_layout.addStretch()
@@ -102,9 +100,7 @@ class SettingsDialog(QDialog):
         # "Game location" → "Config location" → "Steam mods location" → "Local mods location"
         self.setTabOrder(self.game_location, self.config_folder_location)
         self.setTabOrder(self.config_folder_location, self.steam_mods_folder_location)
-        self.setTabOrder(
-            self.steam_mods_folder_location, self.local_mods_folder_location
-        )
+        self.setTabOrder(self.steam_mods_folder_location, self.local_mods_folder_location)
 
         # Push the buttons to the bottom
         tab_layout.addStretch()
@@ -151,9 +147,7 @@ class SettingsDialog(QDialog):
 
         self.game_location = QLineEdit()
         self.game_location.setPlaceholderText(
-            self.tr(
-                r"Should be like: C:\Program Files (x86)\Steam\steamapps\common\RimWorld"
-            )
+            self.tr(r"Should be like: C:\Program Files (x86)\Steam\steamapps\common\RimWorld")
         )
         self.game_location.setTextMargins(GUIInfo().text_field_margins)
         self.game_location.setFixedHeight(GUIInfo().default_font_line_height * 2)
@@ -191,9 +185,7 @@ class SettingsDialog(QDialog):
             )
         )
         self.config_folder_location.setTextMargins(GUIInfo().text_field_margins)
-        self.config_folder_location.setFixedHeight(
-            GUIInfo().default_font_line_height * 2
-        )
+        self.config_folder_location.setFixedHeight(GUIInfo().default_font_line_height * 2)
         group_layout.addWidget(self.config_folder_location)
 
     def _do_steam_mods_folder_location_area(self, tab_layout: QVBoxLayout) -> None:
@@ -205,14 +197,10 @@ class SettingsDialog(QDialog):
         header_layout = QHBoxLayout()
         group_layout.addLayout(header_layout)
 
-        self.steam_client_integration_checkbox = QCheckBox(
-            self.tr("Enable Steam client integration")
-        )
+        self.steam_client_integration_checkbox = QCheckBox(self.tr("Enable Steam client integration"))
         group_layout.addWidget(self.steam_client_integration_checkbox)
 
-        self.steam_client_integration_checkbox.stateChanged.connect(
-            self._on_steam_integration_toggled
-        )
+        self.steam_client_integration_checkbox.stateChanged.connect(self._on_steam_integration_toggled)
 
         section_label = QLabel(self.tr("Steam mods location"))
         section_label.setFont(GUIInfo().emphasis_font)
@@ -237,9 +225,7 @@ class SettingsDialog(QDialog):
             )
         )
         self.steam_mods_folder_location.setTextMargins(GUIInfo().text_field_margins)
-        self.steam_mods_folder_location.setFixedHeight(
-            GUIInfo().default_font_line_height * 2
-        )
+        self.steam_mods_folder_location.setFixedHeight(GUIInfo().default_font_line_height * 2)
         group_layout.addWidget(self.steam_mods_folder_location)
 
     def _do_local_mods_folder_location_area(self, tab_layout: QVBoxLayout) -> None:
@@ -269,14 +255,10 @@ class SettingsDialog(QDialog):
 
         self.local_mods_folder_location = QLineEdit()
         self.local_mods_folder_location.setPlaceholderText(
-            self.tr(
-                r"should be like: C:\Program Files (x86)\Steam\steamapps\common\Rimworld\Mods"
-            )
+            self.tr(r"should be like: C:\Program Files (x86)\Steam\steamapps\common\Rimworld\Mods")
         )
         self.local_mods_folder_location.setTextMargins(GUIInfo().text_field_margins)
-        self.local_mods_folder_location.setFixedHeight(
-            GUIInfo().default_font_line_height * 2
-        )
+        self.local_mods_folder_location.setFixedHeight(GUIInfo().default_font_line_height * 2)
         group_layout.addWidget(self.local_mods_folder_location)
 
     def _do_instance_folder_location_area(self, tab_layout: QVBoxLayout) -> None:
@@ -303,13 +285,9 @@ class SettingsDialog(QDialog):
 
         self.instance_folder_location = QLineEdit()
         self.instance_folder_location.setReadOnly(True)
-        self.instance_folder_location.setPlaceholderText(
-            self.tr("Leave empty to use default location")
-        )
+        self.instance_folder_location.setPlaceholderText(self.tr("Leave empty to use default location"))
         self.instance_folder_location.setTextMargins(GUIInfo().text_field_margins)
-        self.instance_folder_location.setFixedHeight(
-            GUIInfo().default_font_line_height * 2
-        )
+        self.instance_folder_location.setFixedHeight(GUIInfo().default_font_line_height * 2)
         group_layout.addWidget(self.instance_folder_location)
 
     def _do_game_launch_tab(self) -> None:
@@ -336,9 +314,7 @@ class SettingsDialog(QDialog):
             )
         )
         # Connect checkbox to disable/enable run_args group
-        self.launch_via_steam_protocol_checkbox.stateChanged.connect(
-            self._on_steam_protocol_toggled
-        )
+        self.launch_via_steam_protocol_checkbox.stateChanged.connect(self._on_steam_protocol_toggled)
         steam_protocol_layout.addWidget(self.launch_via_steam_protocol_checkbox)
 
         # Game arguments group
@@ -371,9 +347,7 @@ class SettingsDialog(QDialog):
         run_args_layout.addLayout(run_args_info_layout, 0, 0, 1, 2)
 
         run_args_label = QLabel(self.tr("Edit Game Run Arguments:"))
-        run_args_layout.addWidget(
-            run_args_label, 1, 0, alignment=Qt.AlignmentFlag.AlignRight
-        )
+        run_args_layout.addWidget(run_args_label, 1, 0, alignment=Qt.AlignmentFlag.AlignRight)
 
         self.run_args = QLineEdit()
         self.run_args.setTextMargins(GUIInfo().text_field_margins)
@@ -424,13 +398,9 @@ class SettingsDialog(QDialog):
         backup_group_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         tab_layout.addWidget(backup_group_label)
 
-        self.backup_saves_on_launch_checkbox = QCheckBox(
-            self.tr("Automatically backup saves on first daily launch")
-        )
+        self.backup_saves_on_launch_checkbox = QCheckBox(self.tr("Automatically backup saves on first daily launch"))
         self.backup_saves_on_launch_checkbox.setToolTip(
-            self.tr(
-                "If enabled, RimSort will automatically backup saves on the first daily launch."
-            )
+            self.tr("If enabled, RimSort will automatically backup saves on the first daily launch.")
         )
         tab_layout.addWidget(self.backup_saves_on_launch_checkbox)
 
@@ -438,17 +408,13 @@ class SettingsDialog(QDialog):
         retention_layout = QHBoxLayout()
         retention_label = QLabel(self.tr("Number of backups to keep:"))
         retention_label.setToolTip(
-            self.tr(
-                "The number of backups to keep. Set to -1 to keep all backups, 0 to delete all."
-            )
+            self.tr("The number of backups to keep. Set to -1 to keep all backups, 0 to delete all.")
         )
         retention_layout.addWidget(retention_label)
 
         self.auto_backup_retention_count_spinbox = QSpinBox()
         self.auto_backup_retention_count_spinbox.setRange(-1, 999)
-        self.auto_backup_retention_count_spinbox.setSizePolicy(
-            QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed
-        )
+        self.auto_backup_retention_count_spinbox.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         retention_layout.addWidget(self.auto_backup_retention_count_spinbox)
         tab_layout.addLayout(retention_layout)
 
@@ -463,9 +429,7 @@ class SettingsDialog(QDialog):
         )
         self.auto_backup_compression_count_spinbox = QSpinBox()
         self.auto_backup_compression_count_spinbox.setRange(-1, 999)
-        self.auto_backup_compression_count_spinbox.setSizePolicy(
-            QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed
-        )
+        self.auto_backup_compression_count_spinbox.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         compression_layout.addWidget(self.auto_backup_compression_count_spinbox)
         tab_layout.addLayout(compression_layout)
 
@@ -507,9 +471,7 @@ class SettingsDialog(QDialog):
 
         section_label = QLabel(section_lbl)
         section_label.setFont(GUIInfo().emphasis_font)
-        section_label.setSizePolicy(
-            QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed
-        )
+        section_label.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
         group_layout.addWidget(section_label)
 
         section_layout = QVBoxLayout()
@@ -574,9 +536,7 @@ class SettingsDialog(QDialog):
         url_input.setTextMargins(GUIInfo().text_field_margins)
         url_input.setClearButtonEnabled(True)
         url_input.setEnabled(False)
-        url_input.setPlaceholderText(
-            self.tr("https://github.com/.../archive/refs/heads/main.zip")
-        )
+        url_input.setPlaceholderText(self.tr("https://github.com/.../archive/refs/heads/main.zip"))
         row_layout.addWidget(url_input)
 
         url_download_button = QToolButton()
@@ -604,9 +564,7 @@ class SettingsDialog(QDialog):
         local_file_choose_button = QToolButton()
         local_file_choose_button.setText(self.tr("Choose…"))
         local_file_choose_button.setEnabled(False)
-        local_file_choose_button.setFixedWidth(
-            github_download_button.sizeHint().width()
-        )
+        local_file_choose_button.setFixedWidth(github_download_button.sizeHint().width())
         row_layout.addWidget(local_file_choose_button)
 
         section_layout.addStretch(1)
@@ -671,9 +629,7 @@ class SettingsDialog(QDialog):
             self.steam_workshop_db_local_file_choose_button,
         ) = self.__create_db_group(section_lbl, none_lbl, tab_layout)
         database_expiry_label = QLabel(
-            self.tr(
-                "Database expiry in seconds for example, 604800 for 7 days. and 0 for no expiry."
-            )
+            self.tr("Database expiry in seconds for example, 604800 for 7 days. and 0 for no expiry.")
         )
         database_expiry_label.setFont(GUIInfo().emphasis_font)
         group_layout.addWidget(database_expiry_label)
@@ -721,9 +677,7 @@ class SettingsDialog(QDialog):
 
     def _do_aux_db_time_limit_group(self, tab_layout: QBoxLayout) -> None:
         self.aux_db_time_limit_label = QLabel(
-            self.tr(
-                "Auxiliary Metadata DB deletion time limit in seconds. (Delete instantly 0, Never Delete -1)"
-            )
+            self.tr("Auxiliary Metadata DB deletion time limit in seconds. (Delete instantly 0, Never Delete -1)")
         )
         aux_db_tooltip = self.tr("""To enable editing of this time limit, enable the checkbox (Enable editing) on the right.
 After a mod is deleted, this is the time we wait until this mod item is deleted from the Auxiliary Metadata DB. 
@@ -740,13 +694,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         self.aux_db_time_limit.setFixedHeight(GUIInfo().default_font_line_height * 2)
 
         self.enable_aux_db_behavior_editing = QCheckBox(self.tr("Enable editing"))
-        self.enable_aux_db_behavior_editing.stateChanged.connect(
-            self.enable_aux_db_time_limit_line_edit
-        )
+        self.enable_aux_db_behavior_editing.stateChanged.connect(self.enable_aux_db_time_limit_line_edit)
         self.enable_aux_db_behavior_editing.setToolTip(
-            self.tr(
-                "This enables the editing of the time limit for Aux Metadata DB data deletion."
-            )
+            self.tr("This enables the editing of the time limit for Aux Metadata DB data deletion.")
         )
 
         label_layout = QHBoxLayout()
@@ -793,9 +743,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
         deps_group_box_layout.addWidget(deps_label)
 
         # Use dependencies for sorting checkbox
-        self.use_moddependencies_as_loadTheseBefore = QCheckBox(
-            self.tr("Use dependency rules for sorting.")
-        )
+        self.use_moddependencies_as_loadTheseBefore = QCheckBox(self.tr("Use dependency rules for sorting."))
         self.use_moddependencies_as_loadTheseBefore.setToolTip(
             self.tr(
                 "If enabled, also uses moddependencies as loadTheseBefore, and mods will be sorted such that dependencies are loaded before the dependent mod."
@@ -804,8 +752,8 @@ This basically preserves your mod coloring, user notes etc. for this many second
         deps_group_box_layout.addWidget(self.use_moddependencies_as_loadTheseBefore)
 
         # Use alternativePackageIds as satisfying dependencies
-        self.use_alternative_package_ids_as_satisfying_dependencies_checkbox = (
-            QCheckBox(self.tr("Use alternativePackageIds as satisfying dependencies"))
+        self.use_alternative_package_ids_as_satisfying_dependencies_checkbox = QCheckBox(
+            self.tr("Use alternativePackageIds as satisfying dependencies")
         )
         self.use_alternative_package_ids_as_satisfying_dependencies_checkbox.setToolTip(
             self.tr(
@@ -813,13 +761,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
                 "E.g., 'oels.vehiclemapframework', alternatives: 'oels.vehiclemapframework.dev'"
             )
         )
-        deps_group_box_layout.addWidget(
-            self.use_alternative_package_ids_as_satisfying_dependencies_checkbox
-        )
+        deps_group_box_layout.addWidget(self.use_alternative_package_ids_as_satisfying_dependencies_checkbox)
 
-        self.check_deps_checkbox = QCheckBox(
-            self.tr("Prompt user to download dependencies when click in Sort")
-        )
+        self.check_deps_checkbox = QCheckBox(self.tr("Prompt user to download dependencies when click in Sort"))
         deps_group_box_layout.addWidget(self.check_deps_checkbox)
 
         # XML parsing behavior group
@@ -833,9 +777,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
         xml_parsing_explanatory_label = QLabel(self.tr("XML Parsing Behavior"))
         xml_parsing_explanatory_label.setFont(GUIInfo().emphasis_font)
         xml_parsing_group_box_layout.addWidget(xml_parsing_explanatory_label)
-        self.prefer_versioned_about_tags_checkbox = QCheckBox(
-            self.tr("Prefer versioned About.xml tags over base tags")
-        )
+        self.prefer_versioned_about_tags_checkbox = QCheckBox(self.tr("Prefer versioned About.xml tags over base tags"))
         self.prefer_versioned_about_tags_checkbox.setToolTip(
             self.tr(
                 "When enabled, *ByVersion tags take precedence over the base tags, \n"
@@ -844,9 +786,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
             )
         )
 
-        xml_parsing_group_box_layout.addWidget(
-            self.prefer_versioned_about_tags_checkbox
-        )
+        xml_parsing_group_box_layout.addWidget(self.prefer_versioned_about_tags_checkbox)
 
         # Mod list options group
         modlist_option_group_box = QGroupBox()
@@ -860,80 +800,56 @@ This basically preserves your mod coloring, user notes etc. for this many second
         modlist_option_group_box_layout.addWidget(modlist_option_label)
 
         # Download missing mods checkbox
-        self.download_missing_mods_checkbox = QCheckBox(
-            self.tr("Download missing mods automatically")
-        )
+        self.download_missing_mods_checkbox = QCheckBox(self.tr("Download missing mods automatically"))
         self.download_missing_mods_checkbox.setToolTip(
-            self.tr(
-                "Notifies to download mods that may be missing in the active modlist"
-            )
+            self.tr("Notifies to download mods that may be missing in the active modlist")
         )
         modlist_option_group_box_layout.addWidget(self.download_missing_mods_checkbox)
 
         # Duplicate mod notification checkbox
-        self.show_duplicate_mods_warning_checkbox = QCheckBox(
-            self.tr("Show duplicate mods warning")
-        )
+        self.show_duplicate_mods_warning_checkbox = QCheckBox(self.tr("Show duplicate mods warning"))
         self.show_duplicate_mods_warning_checkbox.setToolTip(
             self.tr("Notifies and displays the mods that have the same packageid")
         )
-        modlist_option_group_box_layout.addWidget(
-            self.show_duplicate_mods_warning_checkbox
-        )
+        modlist_option_group_box_layout.addWidget(self.show_duplicate_mods_warning_checkbox)
 
         # Mod type filter checkbox
         self.mod_type_filter_checkbox = QCheckBox(self.tr("Enable mod type filter"))
         self.mod_type_filter_checkbox.setToolTip(
-            self.tr(
-                "Add icons and filtering options for easy mods identification and grouping"
-            )
+            self.tr("Add icons and filtering options for easy mods identification and grouping")
         )
         modlist_option_group_box_layout.addWidget(self.mod_type_filter_checkbox)
 
         # Hide invalid mod filtering checkbox
-        self.hide_invalid_mods_when_filtering_checkbox = QCheckBox(
-            self.tr("Hide invalid mods when filtering")
-        )
+        self.hide_invalid_mods_when_filtering_checkbox = QCheckBox(self.tr("Hide invalid mods when filtering"))
         self.hide_invalid_mods_when_filtering_checkbox.setToolTip(
             self.tr("Hides invalid mods, not recommended to enable")
         )
-        modlist_option_group_box_layout.addWidget(
-            self.hide_invalid_mods_when_filtering_checkbox
-        )
+        modlist_option_group_box_layout.addWidget(self.hide_invalid_mods_when_filtering_checkbox)
 
         # Inactive mods sorting group
         self.inactive_mods_sorting_group_box = QGroupBox()
         tab_layout.addWidget(self.inactive_mods_sorting_group_box)
 
         inactive_mods_sorting_group_box_layout = QVBoxLayout()
-        self.inactive_mods_sorting_group_box.setLayout(
-            inactive_mods_sorting_group_box_layout
-        )
+        self.inactive_mods_sorting_group_box.setLayout(inactive_mods_sorting_group_box_layout)
 
         inactive_mods_sorting_label = QLabel(self.tr("Inactive Mods Sorting"))
         inactive_mods_sorting_label.setFont(GUIInfo().emphasis_font)
         inactive_mods_sorting_group_box_layout.addWidget(inactive_mods_sorting_label)
 
         # Inactive mods sorting options checkbox
-        self.enable_inactive_mods_sorting_checkbox = QCheckBox(
-            self.tr("Enable inactive mods sorting")
-        )
+        self.enable_inactive_mods_sorting_checkbox = QCheckBox(self.tr("Enable inactive mods sorting"))
         self.enable_inactive_mods_sorting_checkbox.setToolTip(
             self.tr(
                 "Additional options like name, author, folder size, modified date will be available in the mods panel for sorting inactive mods \n"
                 "Disabling this can improve performance by avoiding heavy calculations."
             )
         )
-        inactive_mods_sorting_group_box_layout.addWidget(
-            self.enable_inactive_mods_sorting_checkbox
-        )
+        inactive_mods_sorting_group_box_layout.addWidget(self.enable_inactive_mods_sorting_checkbox)
 
-        self.save_inactive_mods_sort_state_checkbox = QCheckBox(
-            self.tr("Save inactive mods sort state")
-        )
-        inactive_mods_sorting_group_box_layout.addWidget(
-            self.save_inactive_mods_sort_state_checkbox
-        )
+        self.save_inactive_mods_sort_state_checkbox = QCheckBox(self.tr("Save inactive mods sort state"))
+        inactive_mods_sorting_group_box_layout.addWidget(self.save_inactive_mods_sort_state_checkbox)
 
         tab_layout.addStretch()
 
@@ -955,9 +871,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
         when_building_database_label.setFont(GUIInfo().emphasis_font)
         group_layout.addWidget(when_building_database_label)
 
-        self.db_builder_include_all_radio = QRadioButton(
-            self.tr("Get PublishedFileIDs from locally installed mods.")
-        )
+        self.db_builder_include_all_radio = QRadioButton(self.tr("Get PublishedFileIDs from locally installed mods."))
         group_layout.addWidget(self.db_builder_include_all_radio)
 
         explanatory_label = QLabel(
@@ -968,9 +882,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
         )
         group_layout.addWidget(explanatory_label)
 
-        self.db_builder_include_no_local_radio = QRadioButton(
-            self.tr("Get PublishedFileIDs from the Steam Workshop.")
-        )
+        self.db_builder_include_no_local_radio = QRadioButton(self.tr("Get PublishedFileIDs from the Steam Workshop."))
         group_layout.addWidget(self.db_builder_include_no_local_radio)
 
         explanatory_label = QLabel(
@@ -988,9 +900,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
         group_layout = QVBoxLayout()
         group_box.setLayout(group_layout)
 
-        self.db_builder_query_dlc_checkbox = QCheckBox(
-            self.tr("Query DLC dependency data with Steamworks API")
-        )
+        self.db_builder_query_dlc_checkbox = QCheckBox(self.tr("Query DLC dependency data with Steamworks API"))
         group_layout.addWidget(self.db_builder_query_dlc_checkbox)
 
         self.db_builder_update_instead_of_overwriting_checkbox = QCheckBox(
@@ -1011,9 +921,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
         self.db_builder_steam_api_key = QLineEdit()
         self.db_builder_steam_api_key.setEchoMode(QLineEdit.EchoMode.Password)
         self.db_builder_steam_api_key.setTextMargins(GUIInfo().text_field_margins)
-        self.db_builder_steam_api_key.setFixedHeight(
-            GUIInfo().default_font_line_height * 2
-        )
+        self.db_builder_steam_api_key.setFixedHeight(GUIInfo().default_font_line_height * 2)
         grid_group_layout.addWidget(self.db_builder_steam_api_key, 1, 1)
 
         grid_group_layout.setColumnStretch(0, 0)
@@ -1030,14 +938,10 @@ This basically preserves your mod coloring, user notes etc. for this many second
         item_label = QLabel(self.tr("Download all published Workshop mods via:"))
         item_layout.addWidget(item_label)
 
-        self.db_builder_download_all_mods_via_steamcmd_button = QPushButton(
-            self.tr("SteamCMD")
-        )
+        self.db_builder_download_all_mods_via_steamcmd_button = QPushButton(self.tr("SteamCMD"))
         item_layout.addWidget(self.db_builder_download_all_mods_via_steamcmd_button)
 
-        self.db_builder_download_all_mods_via_steam_button = QPushButton(
-            self.tr("Steam")
-        )
+        self.db_builder_download_all_mods_via_steam_button = QPushButton(self.tr("Steam"))
         self.db_builder_download_all_mods_via_steam_button.setFixedWidth(
             self.db_builder_download_all_mods_via_steamcmd_button.sizeHint().width()
         )
@@ -1049,9 +953,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
 
         item_layout.addStretch()
 
-        self.db_builder_compare_databases_button = QPushButton(
-            self.tr("Compare Databases")
-        )
+        self.db_builder_compare_databases_button = QPushButton(self.tr("Compare Databases"))
         item_layout.addWidget(self.db_builder_compare_databases_button)
 
         self.db_builder_merge_databases_button = QPushButton(self.tr("Merge Databases"))
@@ -1061,9 +963,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
         item_layout.addWidget(self.db_builder_merge_databases_button)
 
         self.db_builder_build_database_button = QPushButton(self.tr("Build Database"))
-        self.db_builder_build_database_button.setFixedWidth(
-            self.db_builder_compare_databases_button.sizeHint().width()
-        )
+        self.db_builder_build_database_button.setFixedWidth(self.db_builder_compare_databases_button.sizeHint().width())
         item_layout.addWidget(self.db_builder_build_database_button)
 
     def _do_steamcmd_tab(self) -> None:
@@ -1079,14 +979,10 @@ This basically preserves your mod coloring, user notes etc. for this many second
         group_layout = QVBoxLayout()
         group_box.setLayout(group_layout)
 
-        self.steamcmd_validate_downloads_checkbox = QCheckBox(
-            self.tr("Validate downloaded mods")
-        )
+        self.steamcmd_validate_downloads_checkbox = QCheckBox(self.tr("Validate downloaded mods"))
         group_layout.addWidget(self.steamcmd_validate_downloads_checkbox)
 
-        self.steamcmd_auto_clear_depot_cache_checkbox = QCheckBox(
-            self.tr("Automatically clear depot cache")
-        )
+        self.steamcmd_auto_clear_depot_cache_checkbox = QCheckBox(self.tr("Automatically clear depot cache"))
         self.steamcmd_auto_clear_depot_cache_checkbox.setToolTip(
             (
                 self.tr(
@@ -1097,9 +993,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
         )
         group_layout.addWidget(self.steamcmd_auto_clear_depot_cache_checkbox)
 
-        self.steamcmd_delete_before_update_checkbox = QCheckBox(
-            self.tr("Delete before update")
-        )
+        self.steamcmd_delete_before_update_checkbox = QCheckBox(self.tr("Delete before update"))
         self.steamcmd_delete_before_update_checkbox.setToolTip(
             self.tr("This is useful if you want to ensure clean mod updates.")
         )
@@ -1124,9 +1018,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
 
         self.steamcmd_install_location = QLineEdit()
         self.steamcmd_install_location.setTextMargins(GUIInfo().text_field_margins)
-        self.steamcmd_install_location.setFixedHeight(
-            GUIInfo().default_font_line_height * 2
-        )
+        self.steamcmd_install_location.setFixedHeight(GUIInfo().default_font_line_height * 2)
         group_layout.addWidget(self.steamcmd_install_location)
 
         tab_layout.addStretch()
@@ -1136,9 +1028,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
 
         button_layout.addStretch()
 
-        self.steamcmd_clear_depot_cache_button = QPushButton(
-            self.tr("Clear depot cache")
-        )
+        self.steamcmd_clear_depot_cache_button = QPushButton(self.tr("Clear depot cache"))
         self.steamcmd_clear_depot_cache_button.setToolTip(
             self.tr(
                 "Clear the depot cache manually. This may be useful if you encounter issues with downloading mods through SteamCMD."
@@ -1172,33 +1062,25 @@ This basically preserves your mod coloring, user notes etc. for this many second
         quality_preset_label.setFont(GUIInfo().emphasis_font)
         group_layout.addWidget(quality_preset_label)
 
-        self.todds_preset_optimized_radio = QRadioButton(
-            self.tr("Optimized - Recommended for RimWorld")
-        )
+        self.todds_preset_optimized_radio = QRadioButton(self.tr("Optimized - Recommended for RimWorld"))
         group_layout.addWidget(self.todds_preset_optimized_radio)
 
         self.todds_preset_custom_radio = QRadioButton(self.tr("Custom todds command"))
         group_layout.addWidget(self.todds_preset_custom_radio)
 
         custom_command_label = QLabel(
-            self.tr(
-                "If -p as in path is not specified, path from current active or all mods selection will be used."
-            )
+            self.tr("If -p as in path is not specified, path from current active or all mods selection will be used.")
         )
         custom_command_label.setFont(GUIInfo().emphasis_font)
         group_layout.addWidget(custom_command_label)
 
         self.todds_custom_command_lineedit = QLineEdit()
-        todds_example = (
-            '-f BC1 -af BC7 -on -vf -fs -r Textures -t -p "D:\\Games\\RimWorld\\Mods"'
-        )
+        todds_example = '-f BC1 -af BC7 -on -vf -fs -r Textures -t -p "D:\\Games\\RimWorld\\Mods"'
         self.todds_custom_command_lineedit.setPlaceholderText(
             self.tr("eg: {todds_example}").format(todds_example=todds_example)
         )
         self.todds_custom_command_lineedit.setTextMargins(GUIInfo().text_field_margins)
-        self.todds_custom_command_lineedit.setFixedHeight(
-            GUIInfo().default_font_line_height * 2
-        )
+        self.todds_custom_command_lineedit.setFixedHeight(GUIInfo().default_font_line_height * 2)
         group_layout.addWidget(self.todds_custom_command_lineedit)
 
         group_box = QGroupBox()
@@ -1211,9 +1093,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
         when_optimizing_label.setFont(GUIInfo().emphasis_font)
         group_layout.addWidget(when_optimizing_label)
 
-        self.todds_active_mods_only_radio = QRadioButton(
-            self.tr("Optimize active mods only")
-        )
+        self.todds_active_mods_only_radio = QRadioButton(self.tr("Optimize active mods only"))
         group_layout.addWidget(self.todds_active_mods_only_radio)
 
         self.todds_all_mods_radio = QRadioButton(self.tr("Optimize all mods"))
@@ -1228,15 +1108,11 @@ This basically preserves your mod coloring, user notes etc. for this many second
         self.todds_dry_run_checkbox = QCheckBox(self.tr("Enable dry-run mode"))
         group_layout.addWidget(self.todds_dry_run_checkbox)
 
-        self.todds_overwrite_checkbox = QCheckBox(
-            self.tr("Overwrite existing optimized textures")
-        )
+        self.todds_overwrite_checkbox = QCheckBox(self.tr("Overwrite existing optimized textures"))
         group_layout.addWidget(self.todds_overwrite_checkbox)
 
         self.auto_delete_orphaned_dds_checkbox = QCheckBox(
-            self.tr(
-                "Automatically delete .dds files if no corresponding .png file exists"
-            )
+            self.tr("Automatically delete .dds files if no corresponding .png file exists")
         )
         self.auto_delete_orphaned_dds_checkbox.setToolTip(
             self.tr(
@@ -1288,9 +1164,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
         group_layout.addWidget(folder_arg_label)
         self.text_editor_folder_arg = QLineEdit()
         self.text_editor_folder_arg.setTextMargins(GUIInfo().text_field_margins)
-        self.text_editor_folder_arg.setFixedHeight(
-            GUIInfo().default_font_line_height * 2
-        )
+        self.text_editor_folder_arg.setFixedHeight(GUIInfo().default_font_line_height * 2)
         group_layout.addWidget(self.text_editor_folder_arg)
 
         file_arg_label = QLabel(self.tr("Additional Arguments (Opening Single File)"))
@@ -1337,9 +1211,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
         theme_layout = QHBoxLayout()
         theme_group_box.setLayout(theme_layout)
 
-        self.enable_themes_checkbox = QCheckBox(
-            self.tr("Enable to use theme / stylesheet instead of system Theme")
-        )
+        self.enable_themes_checkbox = QCheckBox(self.tr("Enable to use theme / stylesheet instead of system Theme"))
         self.enable_themes_checkbox.setToolTip(
             self.tr(
                 "To add your own theme / stylesheet \n\n"
@@ -1355,9 +1227,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
         theme_layout.addWidget(self.enable_themes_checkbox)
 
         self.themes_combobox = QComboBox()
-        self.themes_combobox.setSizePolicy(
-            QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred
-        )
+        self.themes_combobox.setSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred)
         theme_layout.addWidget(self.themes_combobox)
 
         self.theme_location_open_button = QToolButton()
@@ -1381,9 +1251,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
         font_family_layout.addWidget(font_family_label)
 
         self.font_family_combobox = QFontComboBox()
-        self.font_family_combobox.setSizePolicy(
-            QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred
-        )
+        self.font_family_combobox.setSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred)
         font_family_layout.addWidget(self.font_family_combobox)
 
         font_size_layout = QHBoxLayout()
@@ -1395,15 +1263,11 @@ This basically preserves your mod coloring, user notes etc. for this many second
         self.font_size_spinbox = QSpinBox()
         self.font_size_spinbox.setRange(8, 20)
         self.font_size_spinbox.setValue(12)
-        self.font_size_spinbox.setSizePolicy(
-            QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred
-        )
+        self.font_size_spinbox.setSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred)
         font_size_layout.addWidget(self.font_size_spinbox)
 
         reset_button = QPushButton(self.tr("Reset"))
-        reset_button.setSizePolicy(
-            QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred
-        )
+        reset_button.setSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred)
 
         reset_button_layout = QHBoxLayout()
         reset_button_layout.addStretch(1)
@@ -1412,9 +1276,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
         reset_button.clicked.connect(self.reset_font_settings)
 
         if self.enable_themes_checkbox.isChecked():
-            self.enable_themes_checkbox.stateChanged.connect(
-                self.connect_populate_themes_combobox
-            )
+            self.enable_themes_checkbox.stateChanged.connect(self.connect_populate_themes_combobox)
         else:
             self.themes_combobox.clear()
 
@@ -1429,15 +1291,11 @@ This basically preserves your mod coloring, user notes etc. for this many second
         language_group_layout = QHBoxLayout()
         language_group_box.setLayout(language_group_layout)
 
-        language_label = QLabel(
-            self.tr("Select Language (Restart required to apply changes)")
-        )
+        language_label = QLabel(self.tr("Select Language (Restart required to apply changes)"))
         language_group_layout.addWidget(language_label)
 
         self.language_combobox = QComboBox()
-        self.language_combobox.setSizePolicy(
-            QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred
-        )
+        self.language_combobox.setSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred)
 
         language_group_layout.addWidget(self.language_combobox)
 
@@ -1500,15 +1358,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         group_layout.addWidget(self.main_window_group)
 
         # Connect main window radio buttons to enable/disable custom size spinboxes dynamically
-        self.main_launch_maximized_radio.toggled.connect(
-            self.disable_main_custom_size_spinboxes
-        )
-        self.main_launch_normal_radio.toggled.connect(
-            self.disable_main_custom_size_spinboxes
-        )
-        self.main_launch_custom_radio.toggled.connect(
-            self.enable_main_custom_size_spinboxes
-        )
+        self.main_launch_maximized_radio.toggled.connect(self.disable_main_custom_size_spinboxes)
+        self.main_launch_normal_radio.toggled.connect(self.disable_main_custom_size_spinboxes)
+        self.main_launch_custom_radio.toggled.connect(self.enable_main_custom_size_spinboxes)
 
         # Browser Window
         (
@@ -1534,15 +1386,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         group_layout.addWidget(self.browser_window_group)
 
         # Connect browser window radio buttons to enable/disable custom size spinboxes dynamically
-        self.browser_launch_maximized_radio.toggled.connect(
-            self.disable_browser_custom_size_spinboxes
-        )
-        self.browser_launch_normal_radio.toggled.connect(
-            self.disable_browser_custom_size_spinboxes
-        )
-        self.browser_launch_custom_radio.toggled.connect(
-            self.enable_browser_custom_size_spinboxes
-        )
+        self.browser_launch_maximized_radio.toggled.connect(self.disable_browser_custom_size_spinboxes)
+        self.browser_launch_normal_radio.toggled.connect(self.disable_browser_custom_size_spinboxes)
+        self.browser_launch_custom_radio.toggled.connect(self.enable_browser_custom_size_spinboxes)
 
         # Settings Window (only custom option)
         settings_window_title_label = QLabel(self.tr("Settings Window Launch State"))
@@ -1554,9 +1400,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
         settings_window_group.setLayout(settings_window_layout)
 
         self.settings_custom_width_spinbox = QSpinBox()
-        self.settings_custom_width_spinbox.setRange(
-            Settings.MIN_SIZE, Settings.MAX_SIZE
-        )
+        self.settings_custom_width_spinbox.setRange(Settings.MIN_SIZE, Settings.MAX_SIZE)
         self.settings_custom_width_spinbox.setValue(Settings.DEFAULT_WIDTH)
         self.settings_custom_width_spinbox.setSuffix(" px")
         self.settings_custom_width_spinbox.setFixedWidth(100)
@@ -1566,9 +1410,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
         settings_window_layout.addWidget(self.settings_custom_width_spinbox)
 
         self.settings_custom_height_spinbox = QSpinBox()
-        self.settings_custom_height_spinbox.setRange(
-            Settings.MIN_SIZE, Settings.MAX_SIZE
-        )
+        self.settings_custom_height_spinbox.setRange(Settings.MIN_SIZE, Settings.MAX_SIZE)
         self.settings_custom_height_spinbox.setValue(Settings.DEFAULT_HEIGHT)
         self.settings_custom_height_spinbox.setSuffix(" px")
         self.settings_custom_height_spinbox.setFixedWidth(100)
@@ -1639,16 +1481,12 @@ This basically preserves your mod coloring, user notes etc. for this many second
         auth_group.setLayout(auth_group_layout)
 
         rentry_auth_label = QLabel(self.tr("Rentry Auth:"))
-        auth_group_layout.addWidget(
-            rentry_auth_label, 0, 0, alignment=Qt.AlignmentFlag.AlignRight
-        )
+        auth_group_layout.addWidget(rentry_auth_label, 0, 0, alignment=Qt.AlignmentFlag.AlignRight)
 
         self.rentry_auth_code = QLineEdit()
         self.rentry_auth_code.setTextMargins(GUIInfo().text_field_margins)
         self.rentry_auth_code.setFixedHeight(GUIInfo().default_font_line_height * 2)
-        self.rentry_auth_code.setPlaceholderText(
-            self.tr("Obtain rentry auth code by emailing: support@rentry.co")
-        )
+        self.rentry_auth_code.setPlaceholderText(self.tr("Obtain rentry auth code by emailing: support@rentry.co"))
         # TODO: If we add a rentry auth code with builds, we should change placeholder to clarify this code will be used instead of the provided one
         auth_group_layout.addWidget(self.rentry_auth_code, 0, 1)
 
@@ -1659,9 +1497,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
         github_identity_group.setLayout(github_identity_layout)
 
         github_username_label = QLabel(self.tr("GitHub username:"))
-        github_identity_layout.addWidget(
-            github_username_label, 0, 0, alignment=Qt.AlignmentFlag.AlignRight
-        )
+        github_identity_layout.addWidget(github_username_label, 0, 0, alignment=Qt.AlignmentFlag.AlignRight)
 
         self.github_username = QLineEdit()
         self.github_username.setTextMargins(GUIInfo().text_field_margins)
@@ -1669,9 +1505,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
         github_identity_layout.addWidget(self.github_username, 0, 1)
 
         github_token_label = QLabel(self.tr("GitHub personal access token:"))
-        github_identity_layout.addWidget(
-            github_token_label, 1, 0, alignment=Qt.AlignmentFlag.AlignRight
-        )
+        github_identity_layout.addWidget(github_token_label, 1, 0, alignment=Qt.AlignmentFlag.AlignRight)
 
         self.github_token = QLineEdit()
         self.github_token.setEchoMode(QLineEdit.EchoMode.Password)
@@ -1707,37 +1541,27 @@ This basically preserves your mod coloring, user notes etc. for this many second
         self.debug_logging_checkbox = QCheckBox(self.tr("Enable debug logging"))
         group_layout.addWidget(self.debug_logging_checkbox)
 
-        self.watchdog_checkbox = QCheckBox(
-            self.tr("Enable watchdog file monitor daemon")
-        )
+        self.watchdog_checkbox = QCheckBox(self.tr("Enable watchdog file monitor daemon"))
         group_layout.addWidget(self.watchdog_checkbox)
 
         # Clear button behavior
         self.clear_moves_dlc_checkbox = QCheckBox(self.tr("Clear also moves DLC"))
         group_layout.addWidget(self.clear_moves_dlc_checkbox)
 
-        self.show_mod_updates_checkbox = QCheckBox(
-            self.tr("Check for mod updates on refresh")
-        )
+        self.show_mod_updates_checkbox = QCheckBox(self.tr("Check for mod updates on refresh"))
         group_layout.addWidget(self.show_mod_updates_checkbox)
 
-        self.render_unity_rich_text_checkbox = QCheckBox(
-            self.tr("Render Unity Rich Text in mod descriptions")
-        )
+        self.render_unity_rich_text_checkbox = QCheckBox(self.tr("Render Unity Rich Text in mod descriptions"))
         self.color_background_instead_of_text_checkbox = QCheckBox(
             self.tr("Apply mod coloring to background instead of text")
         )
         group_layout.addWidget(self.color_background_instead_of_text_checkbox)
         self.render_unity_rich_text_checkbox.setToolTip(
-            self.tr(
-                "Enable this option to render Unity Rich Text in mod descriptions. Images will not be displayed."
-            )
+            self.tr("Enable this option to render Unity Rich Text in mod descriptions. Images will not be displayed.")
         )
         group_layout.addWidget(self.render_unity_rich_text_checkbox)
 
-        self.update_databases_on_startup_checkbox = QCheckBox(
-            self.tr("Update databases on startup")
-        )
+        self.update_databases_on_startup_checkbox = QCheckBox(self.tr("Update databases on startup"))
         self.update_databases_on_startup_checkbox.setToolTip(
             self.tr(
                 "Enable this option to automatically update enabled databases when RimSort starts. "
@@ -1750,17 +1574,13 @@ This basically preserves your mod coloring, user notes etc. for this many second
             self.tr("Include mod notes in mod name search filter")
         )
         self.include_mod_notes_in_mod_name_filter_checkbox.setToolTip(
-            self.tr(
-                "This option will include searching mod notes when searching by mod name."
-            )
+            self.tr("This option will include searching mod notes when searching by mod name.")
         )
         group_layout.addWidget(self.include_mod_notes_in_mod_name_filter_checkbox)
 
         # Put checkbox, label and spinbox on the same horizontal line
         backup_layout = QHBoxLayout()
-        self.enable_backup_before_update_checkbox = QCheckBox(
-            self.tr("Create backup before RimSort update")
-        )
+        self.enable_backup_before_update_checkbox = QCheckBox(self.tr("Create backup before RimSort update"))
         self.enable_backup_before_update_checkbox.setToolTip(
             self.tr(
                 "Recommended to keep this enabled as it creates a backup before updating RimSort, "

--- a/tests/models/__init__.py
+++ b/tests/models/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for app.models."""

--- a/tests/models/test_settings_defaults.py
+++ b/tests/models/test_settings_defaults.py
@@ -8,9 +8,7 @@ class TestSettingsURLDefaults:
 
     @patch("app.models.settings.QApplication")
     @patch("app.models.settings.AppInfo")
-    def test_new_install_defaults_to_configured_url(
-        self, mock_app_info: MagicMock, mock_qapp: MagicMock
-    ) -> None:
+    def test_new_install_defaults_to_configured_url(self, mock_app_info: MagicMock, mock_qapp: MagicMock) -> None:
         """New installs should default all database sources to 'Configured URL'."""
         mock_qapp.font.return_value.family.return_value = "monospace"
         mock_app_info.return_value.app_storage_folder = MagicMock()
@@ -27,9 +25,7 @@ class TestSettingsURLDefaults:
 
     @patch("app.models.settings.QApplication")
     @patch("app.models.settings.AppInfo")
-    def test_url_fields_have_github_archive_defaults(
-        self, mock_app_info: MagicMock, mock_qapp: MagicMock
-    ) -> None:
+    def test_url_fields_have_github_archive_defaults(self, mock_app_info: MagicMock, mock_qapp: MagicMock) -> None:
         """URL fields should point to GitHub archive ZIP URLs by default."""
         mock_qapp.font.return_value.family.return_value = "monospace"
         mock_app_info.return_value.app_storage_folder = MagicMock()
@@ -39,29 +35,15 @@ class TestSettingsURLDefaults:
 
         settings = Settings()
 
-        assert (
-            "github.com/RimSort/Steam-Workshop-Database"
-            in settings.external_steam_metadata_url
-        )
+        assert "github.com/RimSort/Steam-Workshop-Database" in settings.external_steam_metadata_url
         assert "archive" in settings.external_steam_metadata_url
-        assert (
-            "github.com/RimSort/Community-Rules-Database"
-            in settings.external_community_rules_url
-        )
-        assert (
-            "github.com/emipa606/NoVersionWarning"
-            in settings.external_no_version_warning_url
-        )
-        assert (
-            "github.com/emipa606/UseThisInstead"
-            in settings.external_use_this_instead_url
-        )
+        assert "github.com/RimSort/Community-Rules-Database" in settings.external_community_rules_url
+        assert "github.com/emipa606/NoVersionWarning" in settings.external_no_version_warning_url
+        assert "github.com/emipa606/UseThisInstead" in settings.external_use_this_instead_url
 
     @patch("app.models.settings.QApplication")
     @patch("app.models.settings.AppInfo")
-    def test_git_repo_fields_still_exist(
-        self, mock_app_info: MagicMock, mock_qapp: MagicMock
-    ) -> None:
+    def test_git_repo_fields_still_exist(self, mock_app_info: MagicMock, mock_qapp: MagicMock) -> None:
         """Git repo fields must remain for backward compatibility."""
         mock_qapp.font.return_value.family.return_value = "monospace"
         mock_app_info.return_value.app_storage_folder = MagicMock()

--- a/tests/models/test_settings_defaults.py
+++ b/tests/models/test_settings_defaults.py
@@ -8,7 +8,9 @@ class TestSettingsURLDefaults:
 
     @patch("app.models.settings.QApplication")
     @patch("app.models.settings.AppInfo")
-    def test_new_install_defaults_to_configured_url(self, mock_app_info, mock_qapp):
+    def test_new_install_defaults_to_configured_url(
+        self, mock_app_info: MagicMock, mock_qapp: MagicMock
+    ) -> None:
         """New installs should default all database sources to 'Configured URL'."""
         mock_qapp.font.return_value.family.return_value = "monospace"
         mock_app_info.return_value.app_storage_folder = MagicMock()
@@ -25,7 +27,9 @@ class TestSettingsURLDefaults:
 
     @patch("app.models.settings.QApplication")
     @patch("app.models.settings.AppInfo")
-    def test_url_fields_have_github_archive_defaults(self, mock_app_info, mock_qapp):
+    def test_url_fields_have_github_archive_defaults(
+        self, mock_app_info: MagicMock, mock_qapp: MagicMock
+    ) -> None:
         """URL fields should point to GitHub archive ZIP URLs by default."""
         mock_qapp.font.return_value.family.return_value = "monospace"
         mock_app_info.return_value.app_storage_folder = MagicMock()
@@ -55,7 +59,9 @@ class TestSettingsURLDefaults:
 
     @patch("app.models.settings.QApplication")
     @patch("app.models.settings.AppInfo")
-    def test_git_repo_fields_still_exist(self, mock_app_info, mock_qapp):
+    def test_git_repo_fields_still_exist(
+        self, mock_app_info: MagicMock, mock_qapp: MagicMock
+    ) -> None:
         """Git repo fields must remain for backward compatibility."""
         mock_qapp.font.return_value.family.return_value = "monospace"
         mock_app_info.return_value.app_storage_folder = MagicMock()

--- a/tests/models/test_settings_defaults.py
+++ b/tests/models/test_settings_defaults.py
@@ -1,0 +1,71 @@
+"""Test Settings model default values for HTTP database syncing."""
+
+from unittest.mock import MagicMock, patch
+
+
+class TestSettingsURLDefaults:
+    """Test that new Settings instances have correct HTTP URL defaults."""
+
+    @patch("app.models.settings.QApplication")
+    @patch("app.models.settings.AppInfo")
+    def test_new_install_defaults_to_configured_url(self, mock_app_info, mock_qapp):
+        """New installs should default all database sources to 'Configured URL'."""
+        mock_qapp.font.return_value.family.return_value = "monospace"
+        mock_app_info.return_value.app_storage_folder = MagicMock()
+        mock_app_info.return_value.app_settings_file = MagicMock()
+
+        from app.models.settings import Settings
+
+        settings = Settings()
+
+        assert settings.external_steam_metadata_source == "Configured URL"
+        assert settings.external_community_rules_metadata_source == "Configured URL"
+        assert settings.external_no_version_warning_metadata_source == "Configured URL"
+        assert settings.external_use_this_instead_metadata_source == "Configured URL"
+
+    @patch("app.models.settings.QApplication")
+    @patch("app.models.settings.AppInfo")
+    def test_url_fields_have_github_archive_defaults(self, mock_app_info, mock_qapp):
+        """URL fields should point to GitHub archive ZIP URLs by default."""
+        mock_qapp.font.return_value.family.return_value = "monospace"
+        mock_app_info.return_value.app_storage_folder = MagicMock()
+        mock_app_info.return_value.app_settings_file = MagicMock()
+
+        from app.models.settings import Settings
+
+        settings = Settings()
+
+        assert (
+            "github.com/RimSort/Steam-Workshop-Database"
+            in settings.external_steam_metadata_url
+        )
+        assert "archive" in settings.external_steam_metadata_url
+        assert (
+            "github.com/RimSort/Community-Rules-Database"
+            in settings.external_community_rules_url
+        )
+        assert (
+            "github.com/emipa606/NoVersionWarning"
+            in settings.external_no_version_warning_url
+        )
+        assert (
+            "github.com/emipa606/UseThisInstead"
+            in settings.external_use_this_instead_url
+        )
+
+    @patch("app.models.settings.QApplication")
+    @patch("app.models.settings.AppInfo")
+    def test_git_repo_fields_still_exist(self, mock_app_info, mock_qapp):
+        """Git repo fields must remain for backward compatibility."""
+        mock_qapp.font.return_value.family.return_value = "monospace"
+        mock_app_info.return_value.app_storage_folder = MagicMock()
+        mock_app_info.return_value.app_settings_file = MagicMock()
+
+        from app.models.settings import Settings
+
+        settings = Settings()
+
+        assert hasattr(settings, "external_steam_metadata_repo")
+        assert hasattr(settings, "external_community_rules_repo")
+        assert hasattr(settings, "external_no_version_warning_repo_path")
+        assert hasattr(settings, "external_use_this_instead_repo_path")

--- a/tests/utils/test_external_metadata_loaders.py
+++ b/tests/utils/test_external_metadata_loaders.py
@@ -42,9 +42,7 @@ class TestLoadMetadataBySource:
         """Create an ExternalMetadataLoader instance with mock manager."""
         return ExternalMetadataLoader(manager)
 
-    def test_url_source_resolves_path_like_git_repo(
-        self, loader: ExternalMetadataLoader
-    ) -> None:
+    def test_url_source_resolves_path_like_git_repo(self, loader: ExternalMetadataLoader) -> None:
         """URL source should call getter with same path as git repo source."""
         getter = MagicMock(return_value=({"key": "value"}, "/some/path"))
         file_path = "/custom/file/path.json"
@@ -53,15 +51,11 @@ class TestLoadMetadataBySource:
         subdir = ""
 
         # Call with SOURCE_GIT_REPO
-        result_git = loader._load_metadata_by_source(
-            SOURCE_GIT_REPO, file_path, repo_path, file_name, getter, subdir
-        )
+        result_git = loader._load_metadata_by_source(SOURCE_GIT_REPO, file_path, repo_path, file_name, getter, subdir)
 
         # Call with SOURCE_URL
         getter.reset_mock()
-        result_url = loader._load_metadata_by_source(
-            SOURCE_URL, file_path, repo_path, file_name, getter, subdir
-        )
+        result_url = loader._load_metadata_by_source(SOURCE_URL, file_path, repo_path, file_name, getter, subdir)
 
         # Both should call getter with the same constructed path
         assert result_git == result_url
@@ -85,18 +79,14 @@ class TestLoadMetadataBySource:
         assert result == (None, None)
         getter.assert_not_called()
 
-    def test_file_path_source_uses_file_path(
-        self, loader: ExternalMetadataLoader
-    ) -> None:
+    def test_file_path_source_uses_file_path(self, loader: ExternalMetadataLoader) -> None:
         """File path source should call getter with provided file_path."""
         getter = MagicMock(return_value=({"data": "test"}, "/file/path"))
         file_path = "/custom/file/path.json"
         repo_path = "https://github.com/example/repo.git"
         file_name = "steamDB.json"
 
-        result = loader._load_metadata_by_source(
-            SOURCE_FILE_PATH, file_path, repo_path, file_name, getter
-        )
+        result = loader._load_metadata_by_source(SOURCE_FILE_PATH, file_path, repo_path, file_name, getter)
 
         getter.assert_called_once_with(file_path)
         assert result == ({"data": "test"}, "/file/path")
@@ -115,9 +105,7 @@ class TestLoadMetadataSourceDispatch:
     def loader(self, manager: MagicMock) -> ExternalMetadataLoader:
         return ExternalMetadataLoader(manager)
 
-    def test_url_source_uses_repo_path_for_directory_derivation(
-        self, loader: ExternalMetadataLoader
-    ) -> None:
+    def test_url_source_uses_repo_path_for_directory_derivation(self, loader: ExternalMetadataLoader) -> None:
         """When source is URL, the repo URL (not archive URL) should be used for directory path derivation."""
         getter = MagicMock(return_value=({"data": True}, "/some/path"))
 

--- a/tests/utils/test_external_metadata_loaders.py
+++ b/tests/utils/test_external_metadata_loaders.py
@@ -100,3 +100,34 @@ class TestLoadMetadataBySource:
 
         getter.assert_called_once_with(file_path)
         assert result == ({"data": "test"}, "/file/path")
+
+
+class TestLoadMetadataSourceDispatch:
+    """Verify URL source uses repo path for directory derivation."""
+
+    @pytest.fixture
+    def manager(self) -> MagicMock:
+        manager = MagicMock()
+        manager.show_warning_signal = MagicMock()
+        return manager
+
+    @pytest.fixture
+    def loader(self, manager: MagicMock) -> ExternalMetadataLoader:
+        return ExternalMetadataLoader(manager)
+
+    def test_url_source_uses_repo_path_for_directory_derivation(
+        self, loader: ExternalMetadataLoader
+    ) -> None:
+        """When source is URL, the repo URL (not archive URL) should be used for directory path derivation."""
+        getter = MagicMock(return_value=({"data": True}, "/some/path"))
+
+        loader._load_metadata_by_source(
+            SOURCE_URL,
+            "",
+            "https://github.com/RimSort/Steam-Workshop-Database",
+            "steamDB.json",
+            getter,
+        )
+
+        called_path = getter.call_args[0][0]
+        assert "Steam-Workshop-Database" in called_path

--- a/tests/utils/test_external_metadata_loaders.py
+++ b/tests/utils/test_external_metadata_loaders.py
@@ -1,0 +1,102 @@
+"""Tests for ExternalMetadataLoader source constants and path resolution."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.utils.external_metadata_loaders import (
+    SOURCE_DISABLED,
+    SOURCE_FILE_PATH,
+    SOURCE_GIT_REPO,
+    SOURCE_URL,
+    ExternalMetadataLoader,
+)
+
+
+class TestSourceConstants:
+    """Test that all source constants are defined and distinct."""
+
+    def test_source_url_constant_exists(self) -> None:
+        """SOURCE_URL constant should exist with expected value."""
+        assert SOURCE_URL == "Configured URL"
+
+    def test_all_source_constants_are_distinct(self) -> None:
+        """All four source constants should be unique strings."""
+        sources = {SOURCE_FILE_PATH, SOURCE_GIT_REPO, SOURCE_URL, SOURCE_DISABLED}
+        assert len(sources) == 4, "Source constants must all be distinct"
+        assert all(isinstance(s, str) for s in sources)
+
+
+class TestLoadMetadataBySource:
+    """Test _load_metadata_by_source path resolution for different sources."""
+
+    @pytest.fixture
+    def manager(self) -> MagicMock:
+        """Create a mock manager with show_warning_signal."""
+        manager = MagicMock()
+        manager.show_warning_signal = MagicMock()
+        return manager
+
+    @pytest.fixture
+    def loader(self, manager: MagicMock) -> ExternalMetadataLoader:
+        """Create an ExternalMetadataLoader instance with mock manager."""
+        return ExternalMetadataLoader(manager)
+
+    def test_url_source_resolves_path_like_git_repo(
+        self, loader: ExternalMetadataLoader
+    ) -> None:
+        """URL source should call getter with same path as git repo source."""
+        getter = MagicMock(return_value=({"key": "value"}, "/some/path"))
+        file_path = "/custom/file/path.json"
+        repo_path = "https://github.com/example/repo.git"
+        file_name = "steamDB.json"
+        subdir = ""
+
+        # Call with SOURCE_GIT_REPO
+        result_git = loader._load_metadata_by_source(
+            SOURCE_GIT_REPO, file_path, repo_path, file_name, getter, subdir
+        )
+
+        # Call with SOURCE_URL
+        getter.reset_mock()
+        result_url = loader._load_metadata_by_source(
+            SOURCE_URL, file_path, repo_path, file_name, getter, subdir
+        )
+
+        # Both should call getter with the same constructed path
+        assert result_git == result_url
+        assert getter.call_count == 1
+        # Verify getter was called with constructed repo path, not file_path
+        called_path = getter.call_args[0][0]
+        assert called_path != file_path
+        assert file_name in called_path
+
+    def test_disabled_source_returns_none(self, loader: ExternalMetadataLoader) -> None:
+        """Disabled source should return (None, None) without calling getter."""
+        getter = MagicMock()
+        result = loader._load_metadata_by_source(
+            SOURCE_DISABLED,
+            "/some/path.json",
+            "https://example.com/repo.git",
+            "file.json",
+            getter,
+        )
+
+        assert result == (None, None)
+        getter.assert_not_called()
+
+    def test_file_path_source_uses_file_path(
+        self, loader: ExternalMetadataLoader
+    ) -> None:
+        """File path source should call getter with provided file_path."""
+        getter = MagicMock(return_value=({"data": "test"}, "/file/path"))
+        file_path = "/custom/file/path.json"
+        repo_path = "https://github.com/example/repo.git"
+        file_name = "steamDB.json"
+
+        result = loader._load_metadata_by_source(
+            SOURCE_FILE_PATH, file_path, repo_path, file_name, getter
+        )
+
+        getter.assert_called_once_with(file_path)
+        assert result == ({"data": "test"}, "/file/path")

--- a/tests/utils/test_http_download_worker.py
+++ b/tests/utils/test_http_download_worker.py
@@ -1,0 +1,106 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from app.utils.http_downloader import (
+    DatabaseDownloadTask,
+    DownloadResult,
+    HttpDownloadWorker,
+)
+
+
+class TestDatabaseDownloadTask:
+    def test_dataclass_fields(self) -> None:
+        task = DatabaseDownloadTask(
+            url="https://example.com/archive.zip",
+            target_dir=Path("/tmp/dbs"),
+            repo_name="TestRepo",
+            display_name="Test Repository",
+        )
+        assert task.url == "https://example.com/archive.zip"
+        assert task.target_dir == Path("/tmp/dbs")
+        assert task.repo_name == "TestRepo"
+        assert task.display_name == "Test Repository"
+
+
+class TestHttpDownloadWorker:
+    @patch("app.utils.http_downloader.HttpDatabaseDownloader.download")
+    def test_worker_processes_all_tasks(self, mock_download: MagicMock) -> None:
+        mock_download.return_value = (DownloadResult.UPDATED, None)
+
+        tasks = [
+            DatabaseDownloadTask(
+                url="https://example.com/a.zip",
+                target_dir=Path("/tmp"),
+                repo_name="RepoA",
+                display_name="Repo A",
+            ),
+            DatabaseDownloadTask(
+                url="https://example.com/b.zip",
+                target_dir=Path("/tmp"),
+                repo_name="RepoB",
+                display_name="Repo B",
+            ),
+        ]
+
+        worker = HttpDownloadWorker(tasks)
+        results: list[dict[str, DownloadResult]] = []
+        worker.finished.connect(lambda r: results.append(r))
+        worker.run()  # Call run() directly, not start()
+
+        assert mock_download.call_count == 2
+        assert len(results) == 1
+        assert results[0]["RepoA"] == DownloadResult.UPDATED
+        assert results[0]["RepoB"] == DownloadResult.UPDATED
+
+    @patch("app.utils.http_downloader.HttpDatabaseDownloader.download")
+    def test_single_failure_does_not_abort_batch(
+        self, mock_download: MagicMock
+    ) -> None:
+        mock_download.side_effect = [
+            (DownloadResult.FAILED, "timeout"),
+            (DownloadResult.UPDATED, None),
+        ]
+
+        tasks = [
+            DatabaseDownloadTask(
+                url="https://example.com/a.zip",
+                target_dir=Path("/tmp"),
+                repo_name="RepoA",
+                display_name="Repo A",
+            ),
+            DatabaseDownloadTask(
+                url="https://example.com/b.zip",
+                target_dir=Path("/tmp"),
+                repo_name="RepoB",
+                display_name="Repo B",
+            ),
+        ]
+
+        worker = HttpDownloadWorker(tasks)
+        results: list[dict[str, DownloadResult]] = []
+        worker.finished.connect(lambda r: results.append(r))
+        worker.run()
+
+        assert mock_download.call_count == 2
+        assert results[0]["RepoA"] == DownloadResult.FAILED
+        assert results[0]["RepoB"] == DownloadResult.UPDATED
+
+    @patch("app.utils.http_downloader.HttpDatabaseDownloader.download")
+    def test_progress_signals_emitted(self, mock_download: MagicMock) -> None:
+        mock_download.return_value = (DownloadResult.UP_TO_DATE, None)
+
+        tasks = [
+            DatabaseDownloadTask(
+                url="https://example.com/a.zip",
+                target_dir=Path("/tmp"),
+                repo_name="RepoA",
+                display_name="Repo A",
+            ),
+        ]
+
+        worker = HttpDownloadWorker(tasks)
+        progress_messages: list[str] = []
+        worker.progress.connect(lambda msg: progress_messages.append(msg))
+        worker.run()
+
+        assert len(progress_messages) >= 1

--- a/tests/utils/test_http_download_worker.py
+++ b/tests/utils/test_http_download_worker.py
@@ -44,7 +44,7 @@ class TestHttpDownloadWorker:
 
         worker = HttpDownloadWorker(tasks)
         results: list[dict[str, DownloadResult]] = []
-        worker.finished.connect(lambda r: results.append(r))
+        worker.download_finished.connect(lambda r: results.append(r))
         worker.run()  # Call run() directly, not start()
 
         assert mock_download.call_count == 2
@@ -78,7 +78,7 @@ class TestHttpDownloadWorker:
 
         worker = HttpDownloadWorker(tasks)
         results: list[dict[str, DownloadResult]] = []
-        worker.finished.connect(lambda r: results.append(r))
+        worker.download_finished.connect(lambda r: results.append(r))
         worker.run()
 
         assert mock_download.call_count == 2

--- a/tests/utils/test_http_download_worker.py
+++ b/tests/utils/test_http_download_worker.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from app.utils.http_downloader import (
     DatabaseDownloadTask,
     DownloadResult,
@@ -22,30 +24,35 @@ class TestDatabaseDownloadTask:
         assert task.display_name == "Test Repository"
 
 
+@pytest.fixture
+def two_task_batch() -> list[DatabaseDownloadTask]:
+    return [
+        DatabaseDownloadTask(
+            url="https://example.com/a.zip",
+            target_dir=Path("/tmp"),
+            repo_name="RepoA",
+            display_name="Repo A",
+        ),
+        DatabaseDownloadTask(
+            url="https://example.com/b.zip",
+            target_dir=Path("/tmp"),
+            repo_name="RepoB",
+            display_name="Repo B",
+        ),
+    ]
+
+
 class TestHttpDownloadWorker:
     @patch("app.utils.http_downloader.HttpDatabaseDownloader.download")
-    def test_worker_processes_all_tasks(self, mock_download: MagicMock) -> None:
+    def test_worker_processes_all_tasks(
+        self, mock_download: MagicMock, two_task_batch: list[DatabaseDownloadTask]
+    ) -> None:
         mock_download.return_value = (DownloadResult.UPDATED, None)
 
-        tasks = [
-            DatabaseDownloadTask(
-                url="https://example.com/a.zip",
-                target_dir=Path("/tmp"),
-                repo_name="RepoA",
-                display_name="Repo A",
-            ),
-            DatabaseDownloadTask(
-                url="https://example.com/b.zip",
-                target_dir=Path("/tmp"),
-                repo_name="RepoB",
-                display_name="Repo B",
-            ),
-        ]
-
-        worker = HttpDownloadWorker(tasks)
+        worker = HttpDownloadWorker(two_task_batch)
         results: list[dict[str, DownloadResult]] = []
         worker.download_finished.connect(lambda r: results.append(r))
-        worker.run()  # Call run() directly, not start()
+        worker.run()
 
         assert mock_download.call_count == 2
         assert len(results) == 1
@@ -54,29 +61,14 @@ class TestHttpDownloadWorker:
 
     @patch("app.utils.http_downloader.HttpDatabaseDownloader.download")
     def test_single_failure_does_not_abort_batch(
-        self, mock_download: MagicMock
+        self, mock_download: MagicMock, two_task_batch: list[DatabaseDownloadTask]
     ) -> None:
         mock_download.side_effect = [
             (DownloadResult.FAILED, "timeout"),
             (DownloadResult.UPDATED, None),
         ]
 
-        tasks = [
-            DatabaseDownloadTask(
-                url="https://example.com/a.zip",
-                target_dir=Path("/tmp"),
-                repo_name="RepoA",
-                display_name="Repo A",
-            ),
-            DatabaseDownloadTask(
-                url="https://example.com/b.zip",
-                target_dir=Path("/tmp"),
-                repo_name="RepoB",
-                display_name="Repo B",
-            ),
-        ]
-
-        worker = HttpDownloadWorker(tasks)
+        worker = HttpDownloadWorker(two_task_batch)
         results: list[dict[str, DownloadResult]] = []
         worker.download_finished.connect(lambda r: results.append(r))
         worker.run()

--- a/tests/utils/test_http_downloader.py
+++ b/tests/utils/test_http_downloader.py
@@ -1,0 +1,331 @@
+import json
+import zipfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import requests
+
+from app.utils.http_downloader import (
+    HTTP_CACHE_FILENAME,
+    DownloadResult,
+    HttpDatabaseDownloader,
+)
+
+
+def _create_fake_zip(
+    tmp_path: Path, repo_name: str, branch: str, files: dict[str, str]
+) -> bytes:
+    """Create a zip archive mimicking GitHub's format: <repo>-<branch>/<files>."""
+    zip_path = tmp_path / "test.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        for name, content in files.items():
+            zf.writestr(f"{repo_name}-{branch}/{name}", content)
+    return zip_path.read_bytes()
+
+
+def _make_200_response(
+    zip_bytes: bytes,
+    etag: str = '"new_etag"',
+    last_modified: str = "Wed, 21 May 2026 10:00:00 GMT",
+) -> MagicMock:
+    """Build a mock response for a 200 with streaming zip content."""
+    headers_dict = {
+        "ETag": etag,
+        "Last-Modified": last_modified,
+        "Content-Length": str(len(zip_bytes)),
+    }
+    response = MagicMock()
+    response.status_code = 200
+    # Use a real dict — it already has .get() and [] access
+    response.headers = headers_dict
+    response.iter_content = MagicMock(return_value=[zip_bytes])
+    response.raise_for_status = MagicMock()
+    return response
+
+
+def _make_304_response() -> MagicMock:
+    """Build a mock response for a 304 Not Modified."""
+    response = MagicMock()
+    response.status_code = 304
+    response.raise_for_status = MagicMock()
+    return response
+
+
+class TestDownloadResult:
+    def test_enum_members_exist(self) -> None:
+        assert DownloadResult.UPDATED is not None
+        assert DownloadResult.UP_TO_DATE is not None
+        assert DownloadResult.FAILED is not None
+
+    def test_enum_members_are_distinct(self) -> None:
+        assert DownloadResult.UPDATED != DownloadResult.UP_TO_DATE
+        assert DownloadResult.UPDATED != DownloadResult.FAILED
+        assert DownloadResult.UP_TO_DATE != DownloadResult.FAILED
+
+
+class TestHttpDatabaseDownloader304:
+    """304 conditional response returns UP_TO_DATE."""
+
+    @patch("app.utils.http_downloader.http.get")
+    def test_returns_up_to_date_on_304(
+        self, mock_get: MagicMock, tmp_path: Path
+    ) -> None:
+        mock_get.return_value = _make_304_response()
+
+        # Pre-populate a repo dir with cache metadata so conditional headers are sent
+        repo_dir = tmp_path / "TestRepo"
+        repo_dir.mkdir()
+        cache_file = repo_dir / HTTP_CACHE_FILENAME
+        cache_file.write_text(
+            json.dumps(
+                {"etag": '"old_etag"', "last_modified": "Mon, 19 May 2026 08:00:00 GMT"}
+            )
+        )
+
+        downloader = HttpDatabaseDownloader()
+        result, error = downloader.download(
+            "https://example.com/test.zip", tmp_path, "TestRepo"
+        )
+
+        assert result == DownloadResult.UP_TO_DATE
+        assert error is None
+
+    @patch("app.utils.http_downloader.http.get")
+    def test_sends_conditional_headers_from_cache(
+        self, mock_get: MagicMock, tmp_path: Path
+    ) -> None:
+        mock_get.return_value = _make_304_response()
+
+        repo_dir = tmp_path / "TestRepo"
+        repo_dir.mkdir()
+        cache_file = repo_dir / HTTP_CACHE_FILENAME
+        cache_file.write_text(
+            json.dumps(
+                {
+                    "etag": '"cached_etag"',
+                    "last_modified": "Mon, 19 May 2026 08:00:00 GMT",
+                }
+            )
+        )
+
+        downloader = HttpDatabaseDownloader()
+        downloader.download("https://example.com/test.zip", tmp_path, "TestRepo")
+
+        call_kwargs = mock_get.call_args
+        sent_headers = call_kwargs.kwargs.get("headers", {})
+        assert sent_headers.get("If-None-Match") == '"cached_etag"'
+        assert sent_headers.get("If-Modified-Since") == "Mon, 19 May 2026 08:00:00 GMT"
+
+
+class TestHttpDatabaseDownloader200:
+    """200 response extracts zip and returns UPDATED."""
+
+    @patch("app.utils.http_downloader.http.get")
+    def test_returns_updated_on_200(self, mock_get: MagicMock, tmp_path: Path) -> None:
+        zip_bytes = _create_fake_zip(
+            tmp_path, "TestRepo", "main", {"data.json": '{"key": "value"}'}
+        )
+        mock_get.return_value = _make_200_response(zip_bytes)
+
+        downloader = HttpDatabaseDownloader()
+        result, error = downloader.download(
+            "https://example.com/test.zip", tmp_path, "TestRepo"
+        )
+
+        assert result == DownloadResult.UPDATED
+        assert error is None
+
+    @patch("app.utils.http_downloader.http.get")
+    def test_extracts_zip_contents(self, mock_get: MagicMock, tmp_path: Path) -> None:
+        zip_bytes = _create_fake_zip(
+            tmp_path, "TestRepo", "main", {"data.json": '{"key": "value"}'}
+        )
+        mock_get.return_value = _make_200_response(zip_bytes)
+
+        downloader = HttpDatabaseDownloader()
+        downloader.download("https://example.com/test.zip", tmp_path, "TestRepo")
+
+        extracted = tmp_path / "TestRepo" / "data.json"
+        assert extracted.exists()
+        assert json.loads(extracted.read_text()) == {"key": "value"}
+
+    @patch("app.utils.http_downloader.http.get")
+    def test_writes_cache_metadata(self, mock_get: MagicMock, tmp_path: Path) -> None:
+        zip_bytes = _create_fake_zip(tmp_path, "TestRepo", "main", {"data.json": "{}"})
+        mock_get.return_value = _make_200_response(
+            zip_bytes,
+            etag='"fresh_etag"',
+            last_modified="Thu, 22 May 2026 12:00:00 GMT",
+        )
+
+        downloader = HttpDatabaseDownloader()
+        downloader.download("https://example.com/test.zip", tmp_path, "TestRepo")
+
+        cache_file = tmp_path / "TestRepo" / HTTP_CACHE_FILENAME
+        assert cache_file.exists()
+        cache = json.loads(cache_file.read_text())
+        assert cache["etag"] == '"fresh_etag"'
+        assert cache["last_modified"] == "Thu, 22 May 2026 12:00:00 GMT"
+        assert "downloaded_at" in cache
+
+    @patch("app.utils.http_downloader.http.get")
+    def test_replaces_existing_repo_dir(
+        self, mock_get: MagicMock, tmp_path: Path
+    ) -> None:
+        """Updating should replace the existing dir without leaving stale files."""
+        repo_dir = tmp_path / "TestRepo"
+        repo_dir.mkdir()
+        (repo_dir / "old_file.txt").write_text("stale")
+
+        zip_bytes = _create_fake_zip(
+            tmp_path, "TestRepo", "main", {"new_file.txt": "fresh"}
+        )
+        mock_get.return_value = _make_200_response(zip_bytes)
+
+        downloader = HttpDatabaseDownloader()
+        downloader.download("https://example.com/test.zip", tmp_path, "TestRepo")
+
+        assert (tmp_path / "TestRepo" / "new_file.txt").read_text() == "fresh"
+        assert not (tmp_path / "TestRepo" / "old_file.txt").exists()
+
+
+class TestHttpDatabaseDownloaderFailure:
+    """Network error returns FAILED and preserves existing files."""
+
+    @patch("app.utils.http_downloader.http.get")
+    def test_network_error_returns_failed(
+        self, mock_get: MagicMock, tmp_path: Path
+    ) -> None:
+        mock_get.side_effect = requests.ConnectionError("Connection refused")
+
+        downloader = HttpDatabaseDownloader()
+        result, error = downloader.download(
+            "https://example.com/test.zip", tmp_path, "TestRepo"
+        )
+
+        assert result == DownloadResult.FAILED
+        assert error is not None
+        assert "TestRepo" in error
+
+    @patch("app.utils.http_downloader.http.get")
+    def test_network_error_preserves_existing_files(
+        self, mock_get: MagicMock, tmp_path: Path
+    ) -> None:
+        repo_dir = tmp_path / "TestRepo"
+        repo_dir.mkdir()
+        existing_file = repo_dir / "data.json"
+        existing_file.write_text('{"existing": true}')
+
+        mock_get.side_effect = requests.ConnectionError("Connection refused")
+
+        downloader = HttpDatabaseDownloader()
+        downloader.download("https://example.com/test.zip", tmp_path, "TestRepo")
+
+        assert existing_file.exists()
+        assert json.loads(existing_file.read_text()) == {"existing": True}
+
+    @patch("app.utils.http_downloader.http.get")
+    def test_http_error_returns_failed(
+        self, mock_get: MagicMock, tmp_path: Path
+    ) -> None:
+        response = MagicMock()
+        response.raise_for_status.side_effect = requests.HTTPError("404 Not Found")
+        mock_get.return_value = response
+
+        downloader = HttpDatabaseDownloader()
+        result, error = downloader.download(
+            "https://example.com/test.zip", tmp_path, "TestRepo"
+        )
+
+        assert result == DownloadResult.FAILED
+        assert error is not None
+
+    @patch("app.utils.http_downloader.http.get")
+    def test_bad_zip_returns_failed_preserves_existing(
+        self, mock_get: MagicMock, tmp_path: Path
+    ) -> None:
+        repo_dir = tmp_path / "TestRepo"
+        repo_dir.mkdir()
+        existing_file = repo_dir / "data.json"
+        existing_file.write_text('{"existing": true}')
+
+        response = MagicMock()
+        response.status_code = 200
+        response.headers = {"Content-Length": "10"}
+        response.iter_content = MagicMock(return_value=[b"not a zip file"])
+        response.raise_for_status = MagicMock()
+        mock_get.return_value = response
+
+        downloader = HttpDatabaseDownloader()
+        result, error = downloader.download(
+            "https://example.com/test.zip", tmp_path, "TestRepo"
+        )
+
+        assert result == DownloadResult.FAILED
+        assert error is not None
+        # Existing files must survive
+        assert existing_file.exists()
+        assert json.loads(existing_file.read_text()) == {"existing": True}
+
+
+class TestHttpDatabaseDownloaderProgress:
+    """Progress callback is called during download."""
+
+    @patch("app.utils.http_downloader.http.get")
+    def test_progress_callback_called(
+        self, mock_get: MagicMock, tmp_path: Path
+    ) -> None:
+        zip_bytes = _create_fake_zip(tmp_path, "TestRepo", "main", {"data.json": "{}"})
+        mock_get.return_value = _make_200_response(zip_bytes)
+
+        progress_calls: list[tuple[int, int | None]] = []
+
+        def on_progress(downloaded: int, total: int | None) -> None:
+            progress_calls.append((downloaded, total))
+
+        downloader = HttpDatabaseDownloader()
+        downloader.download(
+            "https://example.com/test.zip",
+            tmp_path,
+            "TestRepo",
+            progress_callback=on_progress,
+        )
+
+        assert len(progress_calls) > 0
+        last_downloaded, last_total = progress_calls[-1]
+        assert last_downloaded == len(zip_bytes)
+        assert last_total == len(zip_bytes)
+
+    @patch("app.utils.http_downloader.http.get")
+    def test_no_callback_does_not_error(
+        self, mock_get: MagicMock, tmp_path: Path
+    ) -> None:
+        zip_bytes = _create_fake_zip(tmp_path, "TestRepo", "main", {"data.json": "{}"})
+        mock_get.return_value = _make_200_response(zip_bytes)
+
+        downloader = HttpDatabaseDownloader()
+        result, error = downloader.download(
+            "https://example.com/test.zip", tmp_path, "TestRepo"
+        )
+
+        assert result == DownloadResult.UPDATED
+        assert error is None
+
+
+class TestHttpDatabaseDownloaderNoCache:
+    """When no cache exists, no conditional headers are sent."""
+
+    @patch("app.utils.http_downloader.http.get")
+    def test_no_conditional_headers_without_cache(
+        self, mock_get: MagicMock, tmp_path: Path
+    ) -> None:
+        zip_bytes = _create_fake_zip(tmp_path, "TestRepo", "main", {"data.json": "{}"})
+        mock_get.return_value = _make_200_response(zip_bytes)
+
+        downloader = HttpDatabaseDownloader()
+        downloader.download("https://example.com/test.zip", tmp_path, "TestRepo")
+
+        call_kwargs = mock_get.call_args
+        sent_headers = call_kwargs.kwargs.get("headers", {})
+        assert "If-None-Match" not in sent_headers
+        assert "If-Modified-Since" not in sent_headers

--- a/tests/utils/test_http_downloader.py
+++ b/tests/utils/test_http_downloader.py
@@ -12,9 +12,7 @@ from app.utils.http_downloader import (
 )
 
 
-def _create_fake_zip(
-    tmp_path: Path, repo_name: str, branch: str, files: dict[str, str]
-) -> bytes:
+def _create_fake_zip(tmp_path: Path, repo_name: str, branch: str, files: dict[str, str]) -> bytes:
     """Create a zip archive mimicking GitHub's format: <repo>-<branch>/<files>."""
     zip_path = tmp_path / "test.zip"
     with zipfile.ZipFile(zip_path, "w") as zf:
@@ -67,33 +65,23 @@ class TestHttpDatabaseDownloader304:
     """304 conditional response returns UP_TO_DATE."""
 
     @patch("app.utils.http_downloader.http.get")
-    def test_returns_up_to_date_on_304(
-        self, mock_get: MagicMock, tmp_path: Path
-    ) -> None:
+    def test_returns_up_to_date_on_304(self, mock_get: MagicMock, tmp_path: Path) -> None:
         mock_get.return_value = _make_304_response()
 
         # Pre-populate a repo dir with cache metadata so conditional headers are sent
         repo_dir = tmp_path / "TestRepo"
         repo_dir.mkdir()
         cache_file = repo_dir / HTTP_CACHE_FILENAME
-        cache_file.write_text(
-            json.dumps(
-                {"etag": '"old_etag"', "last_modified": "Mon, 19 May 2026 08:00:00 GMT"}
-            )
-        )
+        cache_file.write_text(json.dumps({"etag": '"old_etag"', "last_modified": "Mon, 19 May 2026 08:00:00 GMT"}))
 
         downloader = HttpDatabaseDownloader()
-        result, error = downloader.download(
-            "https://example.com/test.zip", tmp_path, "TestRepo"
-        )
+        result, error = downloader.download("https://example.com/test.zip", tmp_path, "TestRepo")
 
         assert result == DownloadResult.UP_TO_DATE
         assert error is None
 
     @patch("app.utils.http_downloader.http.get")
-    def test_sends_conditional_headers_from_cache(
-        self, mock_get: MagicMock, tmp_path: Path
-    ) -> None:
+    def test_sends_conditional_headers_from_cache(self, mock_get: MagicMock, tmp_path: Path) -> None:
         mock_get.return_value = _make_304_response()
 
         repo_dir = tmp_path / "TestRepo"
@@ -122,24 +110,18 @@ class TestHttpDatabaseDownloader200:
 
     @patch("app.utils.http_downloader.http.get")
     def test_returns_updated_on_200(self, mock_get: MagicMock, tmp_path: Path) -> None:
-        zip_bytes = _create_fake_zip(
-            tmp_path, "TestRepo", "main", {"data.json": '{"key": "value"}'}
-        )
+        zip_bytes = _create_fake_zip(tmp_path, "TestRepo", "main", {"data.json": '{"key": "value"}'})
         mock_get.return_value = _make_200_response(zip_bytes)
 
         downloader = HttpDatabaseDownloader()
-        result, error = downloader.download(
-            "https://example.com/test.zip", tmp_path, "TestRepo"
-        )
+        result, error = downloader.download("https://example.com/test.zip", tmp_path, "TestRepo")
 
         assert result == DownloadResult.UPDATED
         assert error is None
 
     @patch("app.utils.http_downloader.http.get")
     def test_extracts_zip_contents(self, mock_get: MagicMock, tmp_path: Path) -> None:
-        zip_bytes = _create_fake_zip(
-            tmp_path, "TestRepo", "main", {"data.json": '{"key": "value"}'}
-        )
+        zip_bytes = _create_fake_zip(tmp_path, "TestRepo", "main", {"data.json": '{"key": "value"}'})
         mock_get.return_value = _make_200_response(zip_bytes)
 
         downloader = HttpDatabaseDownloader()
@@ -169,17 +151,13 @@ class TestHttpDatabaseDownloader200:
         assert "downloaded_at" in cache
 
     @patch("app.utils.http_downloader.http.get")
-    def test_replaces_existing_repo_dir(
-        self, mock_get: MagicMock, tmp_path: Path
-    ) -> None:
+    def test_replaces_existing_repo_dir(self, mock_get: MagicMock, tmp_path: Path) -> None:
         """Updating should replace the existing dir without leaving stale files."""
         repo_dir = tmp_path / "TestRepo"
         repo_dir.mkdir()
         (repo_dir / "old_file.txt").write_text("stale")
 
-        zip_bytes = _create_fake_zip(
-            tmp_path, "TestRepo", "main", {"new_file.txt": "fresh"}
-        )
+        zip_bytes = _create_fake_zip(tmp_path, "TestRepo", "main", {"new_file.txt": "fresh"})
         mock_get.return_value = _make_200_response(zip_bytes)
 
         downloader = HttpDatabaseDownloader()
@@ -193,24 +171,18 @@ class TestHttpDatabaseDownloaderFailure:
     """Network error returns FAILED and preserves existing files."""
 
     @patch("app.utils.http_downloader.http.get")
-    def test_network_error_returns_failed(
-        self, mock_get: MagicMock, tmp_path: Path
-    ) -> None:
+    def test_network_error_returns_failed(self, mock_get: MagicMock, tmp_path: Path) -> None:
         mock_get.side_effect = requests.ConnectionError("Connection refused")
 
         downloader = HttpDatabaseDownloader()
-        result, error = downloader.download(
-            "https://example.com/test.zip", tmp_path, "TestRepo"
-        )
+        result, error = downloader.download("https://example.com/test.zip", tmp_path, "TestRepo")
 
         assert result == DownloadResult.FAILED
         assert error is not None
         assert "TestRepo" in error
 
     @patch("app.utils.http_downloader.http.get")
-    def test_network_error_preserves_existing_files(
-        self, mock_get: MagicMock, tmp_path: Path
-    ) -> None:
+    def test_network_error_preserves_existing_files(self, mock_get: MagicMock, tmp_path: Path) -> None:
         repo_dir = tmp_path / "TestRepo"
         repo_dir.mkdir()
         existing_file = repo_dir / "data.json"
@@ -225,25 +197,19 @@ class TestHttpDatabaseDownloaderFailure:
         assert json.loads(existing_file.read_text()) == {"existing": True}
 
     @patch("app.utils.http_downloader.http.get")
-    def test_http_error_returns_failed(
-        self, mock_get: MagicMock, tmp_path: Path
-    ) -> None:
+    def test_http_error_returns_failed(self, mock_get: MagicMock, tmp_path: Path) -> None:
         response = MagicMock()
         response.raise_for_status.side_effect = requests.HTTPError("404 Not Found")
         mock_get.return_value = response
 
         downloader = HttpDatabaseDownloader()
-        result, error = downloader.download(
-            "https://example.com/test.zip", tmp_path, "TestRepo"
-        )
+        result, error = downloader.download("https://example.com/test.zip", tmp_path, "TestRepo")
 
         assert result == DownloadResult.FAILED
         assert error is not None
 
     @patch("app.utils.http_downloader.http.get")
-    def test_bad_zip_returns_failed_preserves_existing(
-        self, mock_get: MagicMock, tmp_path: Path
-    ) -> None:
+    def test_bad_zip_returns_failed_preserves_existing(self, mock_get: MagicMock, tmp_path: Path) -> None:
         repo_dir = tmp_path / "TestRepo"
         repo_dir.mkdir()
         existing_file = repo_dir / "data.json"
@@ -257,9 +223,7 @@ class TestHttpDatabaseDownloaderFailure:
         mock_get.return_value = response
 
         downloader = HttpDatabaseDownloader()
-        result, error = downloader.download(
-            "https://example.com/test.zip", tmp_path, "TestRepo"
-        )
+        result, error = downloader.download("https://example.com/test.zip", tmp_path, "TestRepo")
 
         assert result == DownloadResult.FAILED
         assert error is not None
@@ -272,9 +236,7 @@ class TestHttpDatabaseDownloaderProgress:
     """Progress callback is called during download."""
 
     @patch("app.utils.http_downloader.http.get")
-    def test_progress_callback_called(
-        self, mock_get: MagicMock, tmp_path: Path
-    ) -> None:
+    def test_progress_callback_called(self, mock_get: MagicMock, tmp_path: Path) -> None:
         zip_bytes = _create_fake_zip(tmp_path, "TestRepo", "main", {"data.json": "{}"})
         mock_get.return_value = _make_200_response(zip_bytes)
 
@@ -297,16 +259,12 @@ class TestHttpDatabaseDownloaderProgress:
         assert last_total == len(zip_bytes)
 
     @patch("app.utils.http_downloader.http.get")
-    def test_no_callback_does_not_error(
-        self, mock_get: MagicMock, tmp_path: Path
-    ) -> None:
+    def test_no_callback_does_not_error(self, mock_get: MagicMock, tmp_path: Path) -> None:
         zip_bytes = _create_fake_zip(tmp_path, "TestRepo", "main", {"data.json": "{}"})
         mock_get.return_value = _make_200_response(zip_bytes)
 
         downloader = HttpDatabaseDownloader()
-        result, error = downloader.download(
-            "https://example.com/test.zip", tmp_path, "TestRepo"
-        )
+        result, error = downloader.download("https://example.com/test.zip", tmp_path, "TestRepo")
 
         assert result == DownloadResult.UPDATED
         assert error is None
@@ -316,9 +274,7 @@ class TestHttpDatabaseDownloaderNoCache:
     """When no cache exists, no conditional headers are sent."""
 
     @patch("app.utils.http_downloader.http.get")
-    def test_no_conditional_headers_without_cache(
-        self, mock_get: MagicMock, tmp_path: Path
-    ) -> None:
+    def test_no_conditional_headers_without_cache(self, mock_get: MagicMock, tmp_path: Path) -> None:
         zip_bytes = _create_fake_zip(tmp_path, "TestRepo", "main", {"data.json": "{}"})
         mock_get.return_value = _make_200_response(zip_bytes)
 


### PR DESCRIPTION
## Summary

- Adds HTTP zip archive downloads as the default mechanism for syncing external databases (Steam Workshop DB, Community Rules DB, NoVersionWarning, UseThisInstead), replacing git clone/pull as the default
- Git-based syncing remains available as a power-user option via the "GitHub" radio button in settings
- New `HttpDatabaseDownloader` class downloads GitHub zip archives with ETag-based conditional caching, extracts them, and atomically replaces the target directory
- New "URL" radio button in Settings > Databases for each of the four databases, pre-filled with GitHub archive URLs
- Existing users' settings are preserved — only new installs default to "Configured URL"

## Motivation

The current git-based approach uses `pygit2` (a native C dependency) to shallow-clone entire GitHub repos just to read a single JSON/XML file from each. This brings platform-specific packaging complexity, SSL certificate workarounds, ~110 lines of corruption detection/retry logic, and no download progress feedback. HTTP downloads eliminate all of this for the common case.

## Key Changes

| Component | What Changed |
|-----------|-------------|
| `app/utils/http_downloader.py` | New module: `HttpDatabaseDownloader`, `HttpDownloadWorker` (QThread), `DatabaseDownloadTask` |
| `app/utils/external_metadata_loaders.py` | Added `SOURCE_URL` constant, URL branch in `_load_metadata_by_source` |
| `app/models/settings.py` | New `external_*_url` fields, defaults changed to `"Configured URL"` |
| `app/controllers/main_content_controller.py` | Startup + manual download dispatch routes to HTTP or git based on source type |
| `app/views/settings_dialog.py` | "URL" radio button + URL input field for all four databases |
| `app/controllers/settings_controller.py` | Load/save/radio handlers for new URL option |

## Design

- **Conditional requests**: ETag/Last-Modified cached in `.http_cache.json` sidecar files — 304 responses skip re-download
- **Atomic replacement**: Extract to temp dir → rename old to `.bak` → rename new to target → delete `.bak`
- **Fault isolation**: Individual database download failures don't abort the batch
- **Cancellation support**: `HttpDownloadWorker.cancel()` for aborting in-progress downloads
- **No changes to metadata loading**: `ExternalMetadataLoader` reads files from `dbs/<repo-name>/` regardless of how they got there

## Test plan

- [x] 28 new tests covering downloader (conditional requests, zip extraction, error handling, progress), worker (batch processing, failure isolation, cancellation), metadata loader (SOURCE_URL dispatch), and settings (defaults, backward compat)
- [x] Manual: fresh install defaults to URL, downloads databases on startup
- [x] Manual: existing install preserves git settings, can switch to URL in settings
- [x] Manual: URL download button works in settings dialog
- [x] Manual: git download still works when "GitHub" radio selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)