### PR TITLE
feat: add orphaned workshop items cleaner

### DIFF
--- a/app/controllers/troubleshooting_controller.py
+++ b/app/controllers/troubleshooting_controller.py
@@ -9,6 +9,7 @@ from loguru import logger
 from PySide6.QtCore import QCoreApplication
 
 from app.models.settings import Settings
+from app.utils.acf_utils import cleanup_orphaned_workshop_items
 from app.utils.event_bus import EventBus
 from app.utils.generic import platform_specific_open
 from app.utils.gui_info import (
@@ -27,18 +28,37 @@ class TroubleshootingController:
         self.translate = QCoreApplication.translate
 
         # Connect button signals
-        self.dialog.integrity_apply_button.clicked.connect(self._on_integrity_apply_button_clicked)
-        self.dialog.integrity_cancel_button.clicked.connect(self._on_integrity_cancel_button_clicked)
+        self.dialog.integrity_apply_button.clicked.connect(
+            self._on_integrity_apply_button_clicked
+        )
+        self.dialog.integrity_cancel_button.clicked.connect(
+            self._on_integrity_cancel_button_clicked
+        )
 
         # Connect mod configuration buttons
-        self.dialog.clear_mods_button.clicked.connect(self._on_clear_mods_button_clicked)
-        self.dialog.mod_export_list_button.clicked.connect(self._on_mod_export_list_button_clicked)
-        self.dialog.mod_import_list_button.clicked.connect(self._on_mod_import_list_button_clicked)
+        self.dialog.clear_mods_button.clicked.connect(
+            self._on_clear_mods_button_clicked
+        )
+        self.dialog.mod_export_list_button.clicked.connect(
+            self._on_mod_export_list_button_clicked
+        )
+        self.dialog.mod_import_list_button.clicked.connect(
+            self._on_mod_import_list_button_clicked
+        )
 
         # Connect Steam utility buttons
-        self.dialog.steam_clear_cache_button.clicked.connect(self._on_steam_clear_cache_clicked)
-        self.dialog.steam_verify_game_button.clicked.connect(self._on_steam_verify_game_clicked)
-        self.dialog.steam_repair_library_button.clicked.connect(self._on_steam_repair_library_clicked)
+        self.dialog.steam_clear_cache_button.clicked.connect(
+            self._on_steam_clear_cache_clicked
+        )
+        self.dialog.steam_verify_game_button.clicked.connect(
+            self._on_steam_verify_game_clicked
+        )
+        self.dialog.steam_repair_library_button.clicked.connect(
+            self._on_steam_repair_library_clicked
+        )
+        self.dialog.steam_cleanup_orphaned_workshop_button.clicked.connect(
+            self._on_steam_cleanup_orphaned_workshop_clicked
+        )
 
     @property
     def game_location(self) -> Optional[str]:
@@ -52,7 +72,9 @@ class TroubleshootingController:
     def steam_mods_location(self) -> Optional[str]:
         return self.settings.instances[self.settings.current_instance].workshop_folder
 
-    def _delete_files_in_directory(self, directory: Path, exclude: Optional[List[str]] = None) -> None:
+    def _delete_files_in_directory(
+        self, directory: Path, exclude: Optional[List[str]] = None
+    ) -> None:
         """Helper method to delete files and folders in a directory, excluding specified names."""
         if exclude is None:
             exclude = []
@@ -124,7 +146,9 @@ class TroubleshootingController:
         except Exception as e:
             logger.error(f"Failed to launch Steam installation: {e}")
             show_dialogue_conditional(
-                title=self.translate("TroubleshootingController", "Steam Launch Failed"),
+                title=self.translate(
+                    "TroubleshootingController", "Steam Launch Failed"
+                ),
                 text=self.translate(
                     "TroubleshootingController",
                     "Could not automatically start game installation through Steam.\n\nPlease manually verify/install the game through Steam.",
@@ -148,7 +172,9 @@ class TroubleshootingController:
         # get list of mod IDs before deleting
         mod_ids = []
         for item in steam_mods_dir.iterdir():
-            if item.is_dir() and item.name.isdigit():  # workshop folders are numeric IDs
+            if (
+                item.is_dir() and item.name.isdigit()
+            ):  # workshop folders are numeric IDs
                 mod_ids.append(item.name)
 
         # delete all files and folders
@@ -169,12 +195,16 @@ class TroubleshootingController:
 
             # then trigger download for each mod
             for mod_id in mod_ids:
-                platform_specific_open(f"steam://workshop_download_item/294100/{mod_id}")
+                platform_specific_open(
+                    f"steam://workshop_download_item/294100/{mod_id}"
+                )
                 logger.info(f"opening: steam://workshop_download_item/294100/{mod_id}")
         except Exception as e:
             logger.error(f"Failed to trigger Steam workshop redownload: {e}")
             show_dialogue_conditional(
-                title=self.translate("TroubleshootingController", "Steam Workshop Redownload"),
+                title=self.translate(
+                    "TroubleshootingController", "Steam Workshop Redownload"
+                ),
                 text=self.translate(
                     "TroubleshootingController",
                     "Mods have been deleted. Please restart Steam to trigger automatic redownload of subscribed mods.\n\nIf mods don't download automatically, try:\n1. Restart Steam\n2. Verify game files in Steam\n3. Visit the Workshop page of each mod",
@@ -248,10 +278,12 @@ class TroubleshootingController:
                     item.unlink()
                     logger.info(f"Deleted {item} successfully.")
                     show_information(
-                        title=self.translate("TroubleshootingController", "Process complete"),
-                        text=self.translate("TroubleshootingController", "Deleted {item} successfully.").format(
-                            item=item
+                        title=self.translate(
+                            "TroubleshootingController", "Process complete"
                         ),
+                        text=self.translate(
+                            "TroubleshootingController", "Deleted {item} successfully."
+                        ).format(item=item),
                     )
                 except Exception as e:
                     logger.error(f"Failed to delete game config file {item}: {e}")
@@ -344,9 +376,13 @@ class TroubleshootingController:
   </knownExpansions>
 </ModsConfigData>"""
                 mods_config.write_text(vanilla_content)
-                logger.info("Successfully deleted all mods and resetting ModsConfig.xml to vanilla state.")
+                logger.info(
+                    "Successfully deleted all mods and resetting ModsConfig.xml to vanilla state."
+                )
                 show_information(
-                    title=self.translate("TroubleshootingController", "Process complete"),
+                    title=self.translate(
+                        "TroubleshootingController", "Process complete"
+                    ),
                     text=self.translate(
                         "TroubleshootingController",
                         "Successfully deleted all mods and resetting ModsConfig.xml to vanilla state.",
@@ -356,7 +392,9 @@ class TroubleshootingController:
                 logger.error(f"Failed to reset ModsConfig.xml: {e}")
                 show_dialogue_conditional(
                     title=self.translate("TroubleshootingController", "Error"),
-                    text=self.translate("TroubleshootingController", "Failed to reset ModsConfig.xml."),
+                    text=self.translate(
+                        "TroubleshootingController", "Failed to reset ModsConfig.xml."
+                    ),
                     icon="warning",
                 )
                 return
@@ -403,7 +441,9 @@ class TroubleshootingController:
 
         if not show_dialogue_conditional(
             self.translate("TroubleshootingController", "Confirm Export"),
-            self.translate("TroubleshootingController", "Export current mod list to file?"),
+            self.translate(
+                "TroubleshootingController", "Export current mod list to file?"
+            ),
         ):
             return
 
@@ -412,7 +452,9 @@ class TroubleshootingController:
             content = mods_config.read_text()
             tree = ElementTree.fromstring(content)
             active_mod_list = [mod.text for mod in tree.findall(".//activeMods/li")]
-            known_expansions_list = [exp.text for exp in tree.findall(".//knownExpansions/li")]
+            known_expansions_list = [
+                exp.text for exp in tree.findall(".//knownExpansions/li")
+            ]
 
             # create new ModsConfig.xml content
             root = ElementTree.Element("ModsConfigData")
@@ -452,7 +494,9 @@ class TroubleshootingController:
             logger.error(f"Failed to export mod list: {e}")
             show_warning(
                 title=self.translate("TroubleshootingController", "Error"),
-                text=self.translate("TroubleshootingController", "Failed to export mod list."),
+                text=self.translate(
+                    "TroubleshootingController", "Failed to export mod list."
+                ),
                 information=self.translate(
                     "TroubleshootingController",
                     "Error: {e}",
@@ -532,7 +576,9 @@ class TroubleshootingController:
             logger.error(f"Failed to import mod list: {e}")
             show_dialogue_conditional(
                 self.translate("TroubleshootingController", "Error"),
-                self.translate("TroubleshootingController", "Failed to import mod list"),
+                self.translate(
+                    "TroubleshootingController", "Failed to import mod list"
+                ),
                 self.translate(
                     "TroubleshootingController",
                     "The selected file is not a valid mod list file.\nDetails: {e}",
@@ -552,7 +598,10 @@ class TroubleshootingController:
         try:
             if "steamapps" in str(workshop_path):
                 steam_root = workshop_path
-                while steam_root.name.lower() != "steam" and steam_root.parent != steam_root:
+                while (
+                    steam_root.name.lower() != "steam"
+                    and steam_root.parent != steam_root
+                ):
                     steam_root = steam_root.parent
                 if steam_root.name.lower() == "steam":
                     return steam_root
@@ -658,7 +707,9 @@ class TroubleshootingController:
 
             # ask for confirmation since this will validate all games
             if not show_dialogue_conditional(
-                title=self.translate("TroubleshootingController", "Confirm Library Repair"),
+                title=self.translate(
+                    "TroubleshootingController", "Confirm Library Repair"
+                ),
                 text=self.translate(
                     "TroubleshootingController",
                     "This will verify all {len} games in your Steam library.\nThis may take a while. Continue?",
@@ -671,7 +722,9 @@ class TroubleshootingController:
                 platform_specific_open(f"steam://validate/{app_id}")
 
             show_dialogue_conditional(
-                title=self.translate("TroubleshootingController", "Library Repair Started"),
+                title=self.translate(
+                    "TroubleshootingController", "Library Repair Started"
+                ),
                 text=self.translate(
                     "TroubleshootingController",
                     "Steam will now verify {len} games.\nYou can monitor progress in the Steam client.",
@@ -682,12 +735,84 @@ class TroubleshootingController:
         except Exception as e:
             logger.error(f"Failed to repair Steam library: {e}")
             show_dialogue_conditional(
-                title=self.translate("TroubleshootingController", "Steam Action Failed"),
+                title=self.translate(
+                    "TroubleshootingController", "Steam Action Failed"
+                ),
                 text=self.translate(
                     "TroubleshootingController",
                     "Could not repair Steam library.\nPlease verify your games manually through Steam.\nDetails: {e}",
                 ).format(e=str(e)),
                 icon="warning",
+            )
+
+    def _on_steam_cleanup_orphaned_workshop_clicked(self) -> None:
+        """Clean orphaned entries from the Steam Workshop ACF metadata file."""
+        if not self.steam_mods_location:
+            self.show_steam_user_warning()
+            return
+
+        workshop_path = Path(self.steam_mods_location)
+        acf_path = workshop_path.parent.parent / "appworkshop_294100.acf"
+
+        if not acf_path.exists():
+            show_warning(
+                title=self.translate("TroubleshootingController", "ACF File Not Found"),
+                text=self.translate(
+                    "TroubleshootingController",
+                    "Could not find the Steam Workshop ACF file at:\n{acf_path}",
+                ).format(acf_path=acf_path),
+            )
+            return
+
+        if not show_dialogue_conditional(
+            title=self.translate(
+                "TroubleshootingController", "Clean Orphaned Workshop Items"
+            ),
+            text=self.translate(
+                "TroubleshootingController",
+                "This will remove stale workshop entries from the ACF metadata file for mods that no longer exist on disk.\n\nA backup will be created before any changes are made.\n\nContinue?",
+            ),
+            icon="warning",
+        ):
+            return
+
+        try:
+            removed_pfids = cleanup_orphaned_workshop_items(acf_path, workshop_path)
+
+            if removed_pfids:
+                backup_path = str(acf_path) + ".backup"
+                details = (
+                    "\n".join(removed_pfids) + f"\n\nBackup saved to: {backup_path}"
+                )
+                show_information(
+                    title=self.translate(
+                        "TroubleshootingController", "Cleanup Complete"
+                    ),
+                    text=self.translate(
+                        "TroubleshootingController",
+                        "Removed {count} orphaned workshop entries.",
+                    ).format(count=len(removed_pfids)),
+                    details=details,
+                )
+            else:
+                show_information(
+                    title=self.translate(
+                        "TroubleshootingController", "No Orphans Found"
+                    ),
+                    text=self.translate(
+                        "TroubleshootingController",
+                        "No orphaned workshop entries were found. The ACF file is clean.",
+                    ),
+                )
+        except Exception as e:
+            logger.error(f"Failed to clean orphaned workshop items: {e}")
+            show_warning(
+                title=self.translate("TroubleshootingController", "Cleanup Failed"),
+                text=self.translate(
+                    "TroubleshootingController",
+                    "Failed to clean orphaned workshop items.",
+                ),
+                information=str(e),
             )
 
     def show_location_warning(self) -> None:
@@ -702,7 +827,9 @@ class TroubleshootingController:
     def show_failed_warning(self, item: Path | str, e: Exception) -> None:
         show_warning(
             title=self.translate("TroubleshootingController", "Process failed"),
-            text=self.translate("TroubleshootingController", "Could not process: {item}").format(item=item),
+            text=self.translate(
+                "TroubleshootingController", "Could not process: {item}"
+            ).format(item=item),
             information=self.translate(
                 "TroubleshootingController",
                 "Failed to process item: {item} due to the following error: {e}",
@@ -711,7 +838,9 @@ class TroubleshootingController:
 
     def show_steam_user_warning(self) -> None:
         show_warning(
-            title=self.translate("TroubleshootingController", "Steam user Check failed"),
+            title=self.translate(
+                "TroubleshootingController", "Steam user Check failed"
+            ),
             text=self.translate(
                 "TroubleshootingController",
                 "You are not a Steam user, or Path not set, Please check settings and try again.",

--- a/app/controllers/troubleshooting_controller.py
+++ b/app/controllers/troubleshooting_controller.py
@@ -28,34 +28,18 @@ class TroubleshootingController:
         self.translate = QCoreApplication.translate
 
         # Connect button signals
-        self.dialog.integrity_apply_button.clicked.connect(
-            self._on_integrity_apply_button_clicked
-        )
-        self.dialog.integrity_cancel_button.clicked.connect(
-            self._on_integrity_cancel_button_clicked
-        )
+        self.dialog.integrity_apply_button.clicked.connect(self._on_integrity_apply_button_clicked)
+        self.dialog.integrity_cancel_button.clicked.connect(self._on_integrity_cancel_button_clicked)
 
         # Connect mod configuration buttons
-        self.dialog.clear_mods_button.clicked.connect(
-            self._on_clear_mods_button_clicked
-        )
-        self.dialog.mod_export_list_button.clicked.connect(
-            self._on_mod_export_list_button_clicked
-        )
-        self.dialog.mod_import_list_button.clicked.connect(
-            self._on_mod_import_list_button_clicked
-        )
+        self.dialog.clear_mods_button.clicked.connect(self._on_clear_mods_button_clicked)
+        self.dialog.mod_export_list_button.clicked.connect(self._on_mod_export_list_button_clicked)
+        self.dialog.mod_import_list_button.clicked.connect(self._on_mod_import_list_button_clicked)
 
         # Connect Steam utility buttons
-        self.dialog.steam_clear_cache_button.clicked.connect(
-            self._on_steam_clear_cache_clicked
-        )
-        self.dialog.steam_verify_game_button.clicked.connect(
-            self._on_steam_verify_game_clicked
-        )
-        self.dialog.steam_repair_library_button.clicked.connect(
-            self._on_steam_repair_library_clicked
-        )
+        self.dialog.steam_clear_cache_button.clicked.connect(self._on_steam_clear_cache_clicked)
+        self.dialog.steam_verify_game_button.clicked.connect(self._on_steam_verify_game_clicked)
+        self.dialog.steam_repair_library_button.clicked.connect(self._on_steam_repair_library_clicked)
         self.dialog.steam_cleanup_orphaned_workshop_button.clicked.connect(
             self._on_steam_cleanup_orphaned_workshop_clicked
         )
@@ -72,9 +56,7 @@ class TroubleshootingController:
     def steam_mods_location(self) -> Optional[str]:
         return self.settings.instances[self.settings.current_instance].workshop_folder
 
-    def _delete_files_in_directory(
-        self, directory: Path, exclude: Optional[List[str]] = None
-    ) -> None:
+    def _delete_files_in_directory(self, directory: Path, exclude: Optional[List[str]] = None) -> None:
         """Helper method to delete files and folders in a directory, excluding specified names."""
         if exclude is None:
             exclude = []
@@ -146,9 +128,7 @@ class TroubleshootingController:
         except Exception as e:
             logger.error(f"Failed to launch Steam installation: {e}")
             show_dialogue_conditional(
-                title=self.translate(
-                    "TroubleshootingController", "Steam Launch Failed"
-                ),
+                title=self.translate("TroubleshootingController", "Steam Launch Failed"),
                 text=self.translate(
                     "TroubleshootingController",
                     "Could not automatically start game installation through Steam.\n\nPlease manually verify/install the game through Steam.",
@@ -172,9 +152,7 @@ class TroubleshootingController:
         # get list of mod IDs before deleting
         mod_ids = []
         for item in steam_mods_dir.iterdir():
-            if (
-                item.is_dir() and item.name.isdigit()
-            ):  # workshop folders are numeric IDs
+            if item.is_dir() and item.name.isdigit():  # workshop folders are numeric IDs
                 mod_ids.append(item.name)
 
         # delete all files and folders
@@ -195,16 +173,12 @@ class TroubleshootingController:
 
             # then trigger download for each mod
             for mod_id in mod_ids:
-                platform_specific_open(
-                    f"steam://workshop_download_item/294100/{mod_id}"
-                )
+                platform_specific_open(f"steam://workshop_download_item/294100/{mod_id}")
                 logger.info(f"opening: steam://workshop_download_item/294100/{mod_id}")
         except Exception as e:
             logger.error(f"Failed to trigger Steam workshop redownload: {e}")
             show_dialogue_conditional(
-                title=self.translate(
-                    "TroubleshootingController", "Steam Workshop Redownload"
-                ),
+                title=self.translate("TroubleshootingController", "Steam Workshop Redownload"),
                 text=self.translate(
                     "TroubleshootingController",
                     "Mods have been deleted. Please restart Steam to trigger automatic redownload of subscribed mods.\n\nIf mods don't download automatically, try:\n1. Restart Steam\n2. Verify game files in Steam\n3. Visit the Workshop page of each mod",
@@ -278,12 +252,10 @@ class TroubleshootingController:
                     item.unlink()
                     logger.info(f"Deleted {item} successfully.")
                     show_information(
-                        title=self.translate(
-                            "TroubleshootingController", "Process complete"
+                        title=self.translate("TroubleshootingController", "Process complete"),
+                        text=self.translate("TroubleshootingController", "Deleted {item} successfully.").format(
+                            item=item
                         ),
-                        text=self.translate(
-                            "TroubleshootingController", "Deleted {item} successfully."
-                        ).format(item=item),
                     )
                 except Exception as e:
                     logger.error(f"Failed to delete game config file {item}: {e}")
@@ -376,13 +348,9 @@ class TroubleshootingController:
   </knownExpansions>
 </ModsConfigData>"""
                 mods_config.write_text(vanilla_content)
-                logger.info(
-                    "Successfully deleted all mods and resetting ModsConfig.xml to vanilla state."
-                )
+                logger.info("Successfully deleted all mods and resetting ModsConfig.xml to vanilla state.")
                 show_information(
-                    title=self.translate(
-                        "TroubleshootingController", "Process complete"
-                    ),
+                    title=self.translate("TroubleshootingController", "Process complete"),
                     text=self.translate(
                         "TroubleshootingController",
                         "Successfully deleted all mods and resetting ModsConfig.xml to vanilla state.",
@@ -392,9 +360,7 @@ class TroubleshootingController:
                 logger.error(f"Failed to reset ModsConfig.xml: {e}")
                 show_dialogue_conditional(
                     title=self.translate("TroubleshootingController", "Error"),
-                    text=self.translate(
-                        "TroubleshootingController", "Failed to reset ModsConfig.xml."
-                    ),
+                    text=self.translate("TroubleshootingController", "Failed to reset ModsConfig.xml."),
                     icon="warning",
                 )
                 return
@@ -441,9 +407,7 @@ class TroubleshootingController:
 
         if not show_dialogue_conditional(
             self.translate("TroubleshootingController", "Confirm Export"),
-            self.translate(
-                "TroubleshootingController", "Export current mod list to file?"
-            ),
+            self.translate("TroubleshootingController", "Export current mod list to file?"),
         ):
             return
 
@@ -452,9 +416,7 @@ class TroubleshootingController:
             content = mods_config.read_text()
             tree = ElementTree.fromstring(content)
             active_mod_list = [mod.text for mod in tree.findall(".//activeMods/li")]
-            known_expansions_list = [
-                exp.text for exp in tree.findall(".//knownExpansions/li")
-            ]
+            known_expansions_list = [exp.text for exp in tree.findall(".//knownExpansions/li")]
 
             # create new ModsConfig.xml content
             root = ElementTree.Element("ModsConfigData")
@@ -494,9 +456,7 @@ class TroubleshootingController:
             logger.error(f"Failed to export mod list: {e}")
             show_warning(
                 title=self.translate("TroubleshootingController", "Error"),
-                text=self.translate(
-                    "TroubleshootingController", "Failed to export mod list."
-                ),
+                text=self.translate("TroubleshootingController", "Failed to export mod list."),
                 information=self.translate(
                     "TroubleshootingController",
                     "Error: {e}",
@@ -576,9 +536,7 @@ class TroubleshootingController:
             logger.error(f"Failed to import mod list: {e}")
             show_dialogue_conditional(
                 self.translate("TroubleshootingController", "Error"),
-                self.translate(
-                    "TroubleshootingController", "Failed to import mod list"
-                ),
+                self.translate("TroubleshootingController", "Failed to import mod list"),
                 self.translate(
                     "TroubleshootingController",
                     "The selected file is not a valid mod list file.\nDetails: {e}",
@@ -598,10 +556,7 @@ class TroubleshootingController:
         try:
             if "steamapps" in str(workshop_path):
                 steam_root = workshop_path
-                while (
-                    steam_root.name.lower() != "steam"
-                    and steam_root.parent != steam_root
-                ):
+                while steam_root.name.lower() != "steam" and steam_root.parent != steam_root:
                     steam_root = steam_root.parent
                 if steam_root.name.lower() == "steam":
                     return steam_root
@@ -707,9 +662,7 @@ class TroubleshootingController:
 
             # ask for confirmation since this will validate all games
             if not show_dialogue_conditional(
-                title=self.translate(
-                    "TroubleshootingController", "Confirm Library Repair"
-                ),
+                title=self.translate("TroubleshootingController", "Confirm Library Repair"),
                 text=self.translate(
                     "TroubleshootingController",
                     "This will verify all {len} games in your Steam library.\nThis may take a while. Continue?",
@@ -722,9 +675,7 @@ class TroubleshootingController:
                 platform_specific_open(f"steam://validate/{app_id}")
 
             show_dialogue_conditional(
-                title=self.translate(
-                    "TroubleshootingController", "Library Repair Started"
-                ),
+                title=self.translate("TroubleshootingController", "Library Repair Started"),
                 text=self.translate(
                     "TroubleshootingController",
                     "Steam will now verify {len} games.\nYou can monitor progress in the Steam client.",
@@ -735,9 +686,7 @@ class TroubleshootingController:
         except Exception as e:
             logger.error(f"Failed to repair Steam library: {e}")
             show_dialogue_conditional(
-                title=self.translate(
-                    "TroubleshootingController", "Steam Action Failed"
-                ),
+                title=self.translate("TroubleshootingController", "Steam Action Failed"),
                 text=self.translate(
                     "TroubleshootingController",
                     "Could not repair Steam library.\nPlease verify your games manually through Steam.\nDetails: {e}",
@@ -765,9 +714,7 @@ class TroubleshootingController:
             return
 
         if not show_dialogue_conditional(
-            title=self.translate(
-                "TroubleshootingController", "Clean Orphaned Workshop Items"
-            ),
+            title=self.translate("TroubleshootingController", "Clean Orphaned Workshop Items"),
             text=self.translate(
                 "TroubleshootingController",
                 "This will remove stale workshop entries from the ACF metadata file for mods that no longer exist on disk.\n\nA backup will be created before any changes are made.\n\nContinue?",
@@ -781,13 +728,9 @@ class TroubleshootingController:
 
             if removed_pfids:
                 backup_path = str(acf_path) + ".backup"
-                details = (
-                    "\n".join(removed_pfids) + f"\n\nBackup saved to: {backup_path}"
-                )
+                details = "\n".join(removed_pfids) + f"\n\nBackup saved to: {backup_path}"
                 show_information(
-                    title=self.translate(
-                        "TroubleshootingController", "Cleanup Complete"
-                    ),
+                    title=self.translate("TroubleshootingController", "Cleanup Complete"),
                     text=self.translate(
                         "TroubleshootingController",
                         "Removed {count} orphaned workshop entries.",
@@ -796,9 +739,7 @@ class TroubleshootingController:
                 )
             else:
                 show_information(
-                    title=self.translate(
-                        "TroubleshootingController", "No Orphans Found"
-                    ),
+                    title=self.translate("TroubleshootingController", "No Orphans Found"),
                     text=self.translate(
                         "TroubleshootingController",
                         "No orphaned workshop entries were found. The ACF file is clean.",
@@ -827,9 +768,7 @@ class TroubleshootingController:
     def show_failed_warning(self, item: Path | str, e: Exception) -> None:
         show_warning(
             title=self.translate("TroubleshootingController", "Process failed"),
-            text=self.translate(
-                "TroubleshootingController", "Could not process: {item}"
-            ).format(item=item),
+            text=self.translate("TroubleshootingController", "Could not process: {item}").format(item=item),
             information=self.translate(
                 "TroubleshootingController",
                 "Failed to process item: {item} due to the following error: {e}",
@@ -838,9 +777,7 @@ class TroubleshootingController:
 
     def show_steam_user_warning(self) -> None:
         show_warning(
-            title=self.translate(
-                "TroubleshootingController", "Steam user Check failed"
-            ),
+            title=self.translate("TroubleshootingController", "Steam user Check failed"),
             text=self.translate(
                 "TroubleshootingController",
                 "You are not a Steam user, or Path not set, Please check settings and try again.",

--- a/app/utils/acf_utils.py
+++ b/app/utils/acf_utils.py
@@ -67,9 +67,7 @@ def load_acf_from_path(acf_path: str | Path) -> dict[str, Any]:
         return {}
 
 
-def refresh_acf_metadata(
-    metadata_manager: "MetadataManager", steamclient: bool = True, steamcmd: bool = True
-) -> None:
+def refresh_acf_metadata(metadata_manager: "MetadataManager", steamclient: bool = True, steamcmd: bool = True) -> None:
     """
     Load and cache ACF metadata from Steam and SteamCMD sources.
 
@@ -103,9 +101,7 @@ def refresh_acf_metadata(
 
     # Load SteamCMD appworkshop_294100.acf if enabled
     if steamcmd:
-        steamcmd_data = load_acf_from_path(
-            metadata_manager.steamcmd_wrapper.steamcmd_appworkshop_acf_path
-        )
+        steamcmd_data = load_acf_from_path(metadata_manager.steamcmd_wrapper.steamcmd_appworkshop_acf_path)
         if steamcmd_data:
             metadata_manager.steamcmd_acf_data = steamcmd_data
             logger.info(
@@ -222,9 +218,7 @@ def _merge_workshop_items_from_sources(
             # Parse timestamp with validation
             timeupdated_int = parse_timeupdated(item.get("timeupdated"))
             if timeupdated_int is None and item.get("timeupdated") is not None:
-                logger.warning(
-                    f"Invalid timeupdated for PFID {pfid_str}: {item.get('timeupdated')}"
-                )
+                logger.warning(f"Invalid timeupdated for PFID {pfid_str}: {item.get('timeupdated')}")
             entries.append((pfid_str, steamcmd_source, timeupdated_int))
             seen_pfids.add(pfid_str)
 
@@ -237,9 +231,7 @@ def _merge_workshop_items_from_sources(
             # Parse timestamp with validation
             timeupdated_int = parse_timeupdated(item.get("timeupdated"))
             if timeupdated_int is None and item.get("timeupdated") is not None:
-                logger.warning(
-                    f"Invalid timeupdated for PFID {pfid_str}: {item.get('timeupdated')}"
-                )
+                logger.warning(f"Invalid timeupdated for PFID {pfid_str}: {item.get('timeupdated')}")
             entries.append((pfid_str, steam_source, timeupdated_int))
             seen_pfids.add(pfid_str)
 
@@ -276,21 +268,15 @@ def get_acf_workshop_items(
     """
     # Extract workshop items from cached SteamCMD ACF data
     steamcmd_items = (
-        get_workshop_items_from_acf(metadata_manager.steamcmd_acf_data)
-        if metadata_manager.steamcmd_acf_data
-        else {}
+        get_workshop_items_from_acf(metadata_manager.steamcmd_acf_data) if metadata_manager.steamcmd_acf_data else {}
     )
     # Extract workshop items from cached Steam ACF data
     workshop_items = (
-        get_workshop_items_from_acf(metadata_manager.workshop_acf_data)
-        if metadata_manager.workshop_acf_data
-        else {}
+        get_workshop_items_from_acf(metadata_manager.workshop_acf_data) if metadata_manager.workshop_acf_data else {}
     )
 
     # Merge items with source attribution and deduplication
-    entries = _merge_workshop_items_from_sources(
-        steamcmd_items, workshop_items, "SteamCMD", "Steam"
-    )
+    entries = _merge_workshop_items_from_sources(steamcmd_items, workshop_items, "SteamCMD", "Steam")
 
     return (
         entries,
@@ -325,9 +311,7 @@ def load_and_merge_acf_data(
         ValueError: If no ACF data could be loaded from either source.
     """
     # Load ACF files from both sources
-    steamcmd_acf_data = (
-        load_acf_from_path(steamcmd_acf_path) if steamcmd_acf_path else {}
-    )
+    steamcmd_acf_data = load_acf_from_path(steamcmd_acf_path) if steamcmd_acf_path else {}
     steam_acf_data = load_acf_from_path(steam_acf_path) if steam_acf_path else {}
 
     if not steamcmd_acf_data and not steam_acf_data:
@@ -341,16 +325,12 @@ def load_and_merge_acf_data(
         raise ValueError("Invalid workshop items data format")
 
     # Merge items with source attribution using shared helper
-    entries = _merge_workshop_items_from_sources(
-        steamcmd_items, steam_items, "SteamCMD", "Steam"
-    )
+    entries = _merge_workshop_items_from_sources(steamcmd_items, steam_items, "SteamCMD", "Steam")
 
     return entries, steamcmd_acf_data, steam_acf_data
 
 
-def _extract_manifest_ids_and_remove_pfid(
-    workshop_section: dict[str, Any] | None, delete_pfid: str
-) -> set[str]:
+def _extract_manifest_ids_and_remove_pfid(workshop_section: dict[str, Any] | None, delete_pfid: str) -> set[str]:
     """
     Extract manifest IDs from a workshop section and remove a PFID entry.
 
@@ -421,21 +401,15 @@ def steamcmd_purge_mods(
     acf_path = metadata_manager.steamcmd_wrapper.steamcmd_appworkshop_acf_path
     acf_metadata = load_acf_from_path(acf_path)
     if not acf_metadata:
-        logger.warning(
-            f"SteamCMD ACF file not found or failed to parse at: {acf_path}. Skipping mod removal."
-        )
+        logger.warning(f"SteamCMD ACF file not found or failed to parse at: {acf_path}. Skipping mod removal.")
         return
 
     # Get depotcache directory path for manifest file cleanup
     depotcache_path = metadata_manager.steamcmd_wrapper.steamcmd_depotcache_path
 
     # Extract workshop sections from ACF metadata
-    workshop_items_installed = acf_metadata.get("AppWorkshop", {}).get(
-        "WorkshopItemsInstalled"
-    )
-    workshop_item_details = acf_metadata.get("AppWorkshop", {}).get(
-        "WorkshopItemDetails"
-    )
+    workshop_items_installed = acf_metadata.get("AppWorkshop", {}).get("WorkshopItemsInstalled")
+    workshop_item_details = acf_metadata.get("AppWorkshop", {}).get("WorkshopItemDetails")
 
     # Collect manifest IDs associated with mods being removed
     mod_manifest_ids = set()
@@ -443,12 +417,8 @@ def steamcmd_purge_mods(
     # Process each PFID to be removed
     for delete_pfid in publishedfileids:
         # Extract manifest IDs from both sections and remove entries
-        manifest_ids_installed = _extract_manifest_ids_and_remove_pfid(
-            workshop_items_installed, delete_pfid
-        )
-        manifest_ids_details = _extract_manifest_ids_and_remove_pfid(
-            workshop_item_details, delete_pfid
-        )
+        manifest_ids_installed = _extract_manifest_ids_and_remove_pfid(workshop_items_installed, delete_pfid)
+        manifest_ids_details = _extract_manifest_ids_and_remove_pfid(workshop_item_details, delete_pfid)
         # Accumulate all manifest IDs found
         mod_manifest_ids.update(manifest_ids_installed)
         mod_manifest_ids.update(manifest_ids_details)
@@ -493,9 +463,7 @@ def validate_acf_file_exists(steam_mods_location: str) -> bool:
         return False
 
     try:
-        acf_file_path = (
-            Path(steam_mods_location).parent.parent / "appworkshop_294100.acf"
-        )
+        acf_file_path = Path(steam_mods_location).parent.parent / "appworkshop_294100.acf"
         exists = acf_file_path.exists() and acf_file_path.is_file()
 
         if exists:
@@ -531,9 +499,7 @@ def cleanup_orphaned_workshop_items(
     """
     acf_path = Path(acf_path) if isinstance(acf_path, str) else acf_path
     workshop_content_path = (
-        Path(workshop_content_path)
-        if isinstance(workshop_content_path, str)
-        else workshop_content_path
+        Path(workshop_content_path) if isinstance(workshop_content_path, str) else workshop_content_path
     )
 
     if not acf_path.exists():
@@ -550,17 +516,11 @@ def cleanup_orphaned_workshop_items(
         return []
 
     installed_dirs: set[str] = {
-        entry.name
-        for entry in workshop_content_path.iterdir()
-        if entry.is_dir() and entry.name.isdigit()
+        entry.name for entry in workshop_content_path.iterdir() if entry.is_dir() and entry.name.isdigit()
     }
 
-    workshop_installed: dict[str, Any] = acf_data.get("AppWorkshop", {}).get(
-        "WorkshopItemsInstalled", {}
-    )
-    workshop_details: dict[str, Any] = acf_data.get("AppWorkshop", {}).get(
-        "WorkshopItemDetails", {}
-    )
+    workshop_installed: dict[str, Any] = acf_data.get("AppWorkshop", {}).get("WorkshopItemsInstalled", {})
+    workshop_details: dict[str, Any] = acf_data.get("AppWorkshop", {}).get("WorkshopItemDetails", {})
 
     acf_pfids = set(workshop_installed.keys()) | set(workshop_details.keys())
     orphaned_pfids = acf_pfids - installed_dirs
@@ -580,14 +540,10 @@ def cleanup_orphaned_workshop_items(
     try:
         dict_to_acf(data=acf_data, path=str(acf_path))
     except Exception:
-        logger.error(
-            f"Failed to write updated ACF file, restoring backup from {backup_path}"
-        )
+        logger.error(f"Failed to write updated ACF file, restoring backup from {backup_path}")
         shutil.copy2(backup_path, acf_path)
         raise
 
     sorted_orphans = sorted(orphaned_pfids)
-    logger.info(
-        f"Removed {len(sorted_orphans)} orphaned workshop entries: {sorted_orphans}"
-    )
+    logger.info(f"Removed {len(sorted_orphans)} orphaned workshop entries: {sorted_orphans}")
     return sorted_orphans

--- a/app/utils/acf_utils.py
+++ b/app/utils/acf_utils.py
@@ -17,6 +17,7 @@ Key functions:
 - validate_acf_file_exists: Validate that appworkshop_294100.acf exists
 """
 
+import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -66,7 +67,9 @@ def load_acf_from_path(acf_path: str | Path) -> dict[str, Any]:
         return {}
 
 
-def refresh_acf_metadata(metadata_manager: "MetadataManager", steamclient: bool = True, steamcmd: bool = True) -> None:
+def refresh_acf_metadata(
+    metadata_manager: "MetadataManager", steamclient: bool = True, steamcmd: bool = True
+) -> None:
     """
     Load and cache ACF metadata from Steam and SteamCMD sources.
 
@@ -100,7 +103,9 @@ def refresh_acf_metadata(metadata_manager: "MetadataManager", steamclient: bool 
 
     # Load SteamCMD appworkshop_294100.acf if enabled
     if steamcmd:
-        steamcmd_data = load_acf_from_path(metadata_manager.steamcmd_wrapper.steamcmd_appworkshop_acf_path)
+        steamcmd_data = load_acf_from_path(
+            metadata_manager.steamcmd_wrapper.steamcmd_appworkshop_acf_path
+        )
         if steamcmd_data:
             metadata_manager.steamcmd_acf_data = steamcmd_data
             logger.info(
@@ -217,7 +222,9 @@ def _merge_workshop_items_from_sources(
             # Parse timestamp with validation
             timeupdated_int = parse_timeupdated(item.get("timeupdated"))
             if timeupdated_int is None and item.get("timeupdated") is not None:
-                logger.warning(f"Invalid timeupdated for PFID {pfid_str}: {item.get('timeupdated')}")
+                logger.warning(
+                    f"Invalid timeupdated for PFID {pfid_str}: {item.get('timeupdated')}"
+                )
             entries.append((pfid_str, steamcmd_source, timeupdated_int))
             seen_pfids.add(pfid_str)
 
@@ -230,7 +237,9 @@ def _merge_workshop_items_from_sources(
             # Parse timestamp with validation
             timeupdated_int = parse_timeupdated(item.get("timeupdated"))
             if timeupdated_int is None and item.get("timeupdated") is not None:
-                logger.warning(f"Invalid timeupdated for PFID {pfid_str}: {item.get('timeupdated')}")
+                logger.warning(
+                    f"Invalid timeupdated for PFID {pfid_str}: {item.get('timeupdated')}"
+                )
             entries.append((pfid_str, steam_source, timeupdated_int))
             seen_pfids.add(pfid_str)
 
@@ -267,15 +276,21 @@ def get_acf_workshop_items(
     """
     # Extract workshop items from cached SteamCMD ACF data
     steamcmd_items = (
-        get_workshop_items_from_acf(metadata_manager.steamcmd_acf_data) if metadata_manager.steamcmd_acf_data else {}
+        get_workshop_items_from_acf(metadata_manager.steamcmd_acf_data)
+        if metadata_manager.steamcmd_acf_data
+        else {}
     )
     # Extract workshop items from cached Steam ACF data
     workshop_items = (
-        get_workshop_items_from_acf(metadata_manager.workshop_acf_data) if metadata_manager.workshop_acf_data else {}
+        get_workshop_items_from_acf(metadata_manager.workshop_acf_data)
+        if metadata_manager.workshop_acf_data
+        else {}
     )
 
     # Merge items with source attribution and deduplication
-    entries = _merge_workshop_items_from_sources(steamcmd_items, workshop_items, "SteamCMD", "Steam")
+    entries = _merge_workshop_items_from_sources(
+        steamcmd_items, workshop_items, "SteamCMD", "Steam"
+    )
 
     return (
         entries,
@@ -310,7 +325,9 @@ def load_and_merge_acf_data(
         ValueError: If no ACF data could be loaded from either source.
     """
     # Load ACF files from both sources
-    steamcmd_acf_data = load_acf_from_path(steamcmd_acf_path) if steamcmd_acf_path else {}
+    steamcmd_acf_data = (
+        load_acf_from_path(steamcmd_acf_path) if steamcmd_acf_path else {}
+    )
     steam_acf_data = load_acf_from_path(steam_acf_path) if steam_acf_path else {}
 
     if not steamcmd_acf_data and not steam_acf_data:
@@ -324,12 +341,16 @@ def load_and_merge_acf_data(
         raise ValueError("Invalid workshop items data format")
 
     # Merge items with source attribution using shared helper
-    entries = _merge_workshop_items_from_sources(steamcmd_items, steam_items, "SteamCMD", "Steam")
+    entries = _merge_workshop_items_from_sources(
+        steamcmd_items, steam_items, "SteamCMD", "Steam"
+    )
 
     return entries, steamcmd_acf_data, steam_acf_data
 
 
-def _extract_manifest_ids_and_remove_pfid(workshop_section: dict[str, Any] | None, delete_pfid: str) -> set[str]:
+def _extract_manifest_ids_and_remove_pfid(
+    workshop_section: dict[str, Any] | None, delete_pfid: str
+) -> set[str]:
     """
     Extract manifest IDs from a workshop section and remove a PFID entry.
 
@@ -400,15 +421,21 @@ def steamcmd_purge_mods(
     acf_path = metadata_manager.steamcmd_wrapper.steamcmd_appworkshop_acf_path
     acf_metadata = load_acf_from_path(acf_path)
     if not acf_metadata:
-        logger.warning(f"SteamCMD ACF file not found or failed to parse at: {acf_path}. Skipping mod removal.")
+        logger.warning(
+            f"SteamCMD ACF file not found or failed to parse at: {acf_path}. Skipping mod removal."
+        )
         return
 
     # Get depotcache directory path for manifest file cleanup
     depotcache_path = metadata_manager.steamcmd_wrapper.steamcmd_depotcache_path
 
     # Extract workshop sections from ACF metadata
-    workshop_items_installed = acf_metadata.get("AppWorkshop", {}).get("WorkshopItemsInstalled")
-    workshop_item_details = acf_metadata.get("AppWorkshop", {}).get("WorkshopItemDetails")
+    workshop_items_installed = acf_metadata.get("AppWorkshop", {}).get(
+        "WorkshopItemsInstalled"
+    )
+    workshop_item_details = acf_metadata.get("AppWorkshop", {}).get(
+        "WorkshopItemDetails"
+    )
 
     # Collect manifest IDs associated with mods being removed
     mod_manifest_ids = set()
@@ -416,8 +443,12 @@ def steamcmd_purge_mods(
     # Process each PFID to be removed
     for delete_pfid in publishedfileids:
         # Extract manifest IDs from both sections and remove entries
-        manifest_ids_installed = _extract_manifest_ids_and_remove_pfid(workshop_items_installed, delete_pfid)
-        manifest_ids_details = _extract_manifest_ids_and_remove_pfid(workshop_item_details, delete_pfid)
+        manifest_ids_installed = _extract_manifest_ids_and_remove_pfid(
+            workshop_items_installed, delete_pfid
+        )
+        manifest_ids_details = _extract_manifest_ids_and_remove_pfid(
+            workshop_item_details, delete_pfid
+        )
         # Accumulate all manifest IDs found
         mod_manifest_ids.update(manifest_ids_installed)
         mod_manifest_ids.update(manifest_ids_details)
@@ -462,7 +493,9 @@ def validate_acf_file_exists(steam_mods_location: str) -> bool:
         return False
 
     try:
-        acf_file_path = Path(steam_mods_location).parent.parent / "appworkshop_294100.acf"
+        acf_file_path = (
+            Path(steam_mods_location).parent.parent / "appworkshop_294100.acf"
+        )
         exists = acf_file_path.exists() and acf_file_path.is_file()
 
         if exists:
@@ -474,3 +507,87 @@ def validate_acf_file_exists(steam_mods_location: str) -> bool:
     except Exception as e:
         logger.warning(f"Error validating ACF file path for {steam_mods_location}: {e}")
         return False
+
+
+def cleanup_orphaned_workshop_items(
+    acf_path: str | Path,
+    workshop_content_path: str | Path,
+) -> list[str]:
+    """
+    Remove orphaned entries from a Steam Workshop ACF metadata file.
+
+    Orphaned entries are workshop items that have metadata records in the ACF
+    file but no corresponding mod folder on disk. This can happen when users
+    manually delete mod folders or when Steam fails to fully unsubscribe.
+
+    Creates a backup of the ACF file before modification. If the write fails,
+    the backup is automatically restored.
+
+    :param acf_path: Path to the appworkshop_294100.acf file.
+    :param workshop_content_path: Path to the workshop content directory
+        (typically steamapps/workshop/content/294100/).
+    :return: Sorted list of removed PFID strings. Empty list if no orphans
+        found or if input validation fails.
+    """
+    acf_path = Path(acf_path) if isinstance(acf_path, str) else acf_path
+    workshop_content_path = (
+        Path(workshop_content_path)
+        if isinstance(workshop_content_path, str)
+        else workshop_content_path
+    )
+
+    if not acf_path.exists():
+        logger.warning(f"ACF file not found: {acf_path}")
+        return []
+
+    if not workshop_content_path.exists() or not workshop_content_path.is_dir():
+        logger.warning(f"Workshop content directory not found: {workshop_content_path}")
+        return []
+
+    acf_data = load_acf_from_path(acf_path)
+    if not acf_data:
+        logger.warning(f"Failed to parse ACF file: {acf_path}")
+        return []
+
+    installed_dirs: set[str] = {
+        entry.name
+        for entry in workshop_content_path.iterdir()
+        if entry.is_dir() and entry.name.isdigit()
+    }
+
+    workshop_installed: dict[str, Any] = acf_data.get("AppWorkshop", {}).get(
+        "WorkshopItemsInstalled", {}
+    )
+    workshop_details: dict[str, Any] = acf_data.get("AppWorkshop", {}).get(
+        "WorkshopItemDetails", {}
+    )
+
+    acf_pfids = set(workshop_installed.keys()) | set(workshop_details.keys())
+    orphaned_pfids = acf_pfids - installed_dirs
+
+    if not orphaned_pfids:
+        logger.info("No orphaned workshop entries found in ACF file")
+        return []
+
+    backup_path = str(acf_path) + ".backup"
+    shutil.copy2(acf_path, backup_path)
+    logger.info(f"Created ACF backup at: {backup_path}")
+
+    for pfid in orphaned_pfids:
+        workshop_installed.pop(pfid, None)
+        workshop_details.pop(pfid, None)
+
+    try:
+        dict_to_acf(data=acf_data, path=str(acf_path))
+    except Exception:
+        logger.error(
+            f"Failed to write updated ACF file, restoring backup from {backup_path}"
+        )
+        shutil.copy2(backup_path, acf_path)
+        raise
+
+    sorted_orphans = sorted(orphaned_pfids)
+    logger.info(
+        f"Removed {len(sorted_orphans)} orphaned workshop entries: {sorted_orphans}"
+    )
+    return sorted_orphans

--- a/app/views/troubleshooting_dialog.py
+++ b/app/views/troubleshooting_dialog.py
@@ -126,8 +126,8 @@ class TroubleshootingDialog(QDialog):
 
     def _create_game_recovery_section(self, parent_layout: QVBoxLayout) -> None:
         """Create the game files recovery section"""
-        section_frame, section_layout, content_widget, content_layout = (
-            self._setup_section_base(parent_layout, self.tr("Game Files Recovery"))
+        section_frame, section_layout, content_widget, content_layout = self._setup_section_base(
+            parent_layout, self.tr("Game Files Recovery")
         )
 
         # Description
@@ -140,9 +140,7 @@ class TroubleshootingDialog(QDialog):
         description.setAlignment(Qt.AlignmentFlag.AlignCenter)
         content_layout.addWidget(description)
 
-        warning_label = QLabel(
-            self.tr("Warning: These operations will delete selected files permanently!")
-        )
+        warning_label = QLabel(self.tr("Warning: These operations will delete selected files permanently!"))
         warning_label.setObjectName("warningLabel")
         warning_label.setWordWrap(True)
         warning_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
@@ -171,27 +169,19 @@ class TroubleshootingDialog(QDialog):
         checkboxes_layout.addLayout(center_layout)
 
         self.integrity_delete_game_files = QCheckBox(
-            self.tr(
-                "Reset game files (Preserves local mods, deletes and redownloads game files)"
-            )
+            self.tr("Reset game files (Preserves local mods, deletes and redownloads game files)")
         )
         self.integrity_delete_game_files.setObjectName("styledCheckbox")
         self.integrity_delete_game_files.setToolTip(
-            self.tr(
-                "Deletes and redownloads game files but keeps your local mods intact."
-            )
+            self.tr("Deletes and redownloads game files but keeps your local mods intact.")
         )
         checkbox_items_layout.addWidget(self.integrity_delete_game_files)
 
         self.integrity_delete_steam_mods = QCheckBox(
-            self.tr(
-                "Reset Steam Workshop mods (Deletes and redownloads all Steam mods)"
-            )
+            self.tr("Reset Steam Workshop mods (Deletes and redownloads all Steam mods)")
         )
         self.integrity_delete_steam_mods.setObjectName("styledCheckbox")
-        self.integrity_delete_steam_mods.setToolTip(
-            self.tr("Deletes all Steam Workshop mods and triggers redownload.")
-        )
+        self.integrity_delete_steam_mods.setToolTip(self.tr("Deletes all Steam Workshop mods and triggers redownload."))
         checkbox_items_layout.addWidget(self.integrity_delete_steam_mods)
 
         self.integrity_delete_mod_configs = QCheckBox(
@@ -199,22 +189,16 @@ class TroubleshootingDialog(QDialog):
         )
         self.integrity_delete_mod_configs.setObjectName("styledCheckbox")
         self.integrity_delete_mod_configs.setToolTip(
-            self.tr(
-                "Deletes mod configuration files except ModsConfig.xml and Prefs.xml."
-            )
+            self.tr("Deletes mod configuration files except ModsConfig.xml and Prefs.xml.")
         )
         checkbox_items_layout.addWidget(self.integrity_delete_mod_configs)
 
         self.integrity_delete_game_configs = QCheckBox(
-            self.tr(
-                "Reset game configurations (ModsConfig.xml, Prefs.xml, KeyPrefs.xml)*"
-            )
+            self.tr("Reset game configurations (ModsConfig.xml, Prefs.xml, KeyPrefs.xml)*")
         )
         self.integrity_delete_game_configs.setObjectName("styledCheckbox")
         self.integrity_delete_game_configs.setToolTip(
-            self.tr(
-                "Deletes game configuration files including ModsConfig.xml, Prefs.xml, and KeyPrefs.xml."
-            )
+            self.tr("Deletes game configuration files including ModsConfig.xml, Prefs.xml, and KeyPrefs.xml.")
         )
         checkbox_items_layout.addWidget(self.integrity_delete_game_configs)
 
@@ -252,10 +236,8 @@ class TroubleshootingDialog(QDialog):
 
     def _create_mod_configuration_section(self, parent_layout: QVBoxLayout) -> None:
         """Create the mod configuration section"""
-        section_frame, section_layout, content_widget, content_layout = (
-            self._setup_section_base(
-                parent_layout, self.tr("Mod Configuration Options")
-            )
+        section_frame, section_layout, content_widget, content_layout = self._setup_section_base(
+            parent_layout, self.tr("Mod Configuration Options")
         )
 
         # Set specific spacing for this section
@@ -286,9 +268,7 @@ class TroubleshootingDialog(QDialog):
         export_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         export_layout.addWidget(export_label)
 
-        export_desc = QLabel(
-            self.tr("Save your current mod list to a .xml file to share with others.")
-        )
+        export_desc = QLabel(self.tr("Save your current mod list to a .xml file to share with others."))
         export_desc.setObjectName("sectionDescription")
         export_desc.setWordWrap(True)
         export_desc.setAlignment(Qt.AlignmentFlag.AlignCenter)
@@ -296,9 +276,7 @@ class TroubleshootingDialog(QDialog):
 
         self.mod_export_list_button = QPushButton(self.tr("Export List"))
         self.mod_export_list_button.setObjectName("actionButton")
-        self.mod_export_list_button.setToolTip(
-            self.tr("Export your current mod list to a file")
-        )
+        self.mod_export_list_button.setToolTip(self.tr("Export your current mod list to a file"))
         export_layout.addWidget(self.mod_export_list_button)
 
         # Import section
@@ -311,9 +289,7 @@ class TroubleshootingDialog(QDialog):
         import_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         import_layout.addWidget(import_label)
 
-        import_desc = QLabel(
-            self.tr("Import a mod list in .xml format from another player")
-        )
+        import_desc = QLabel(self.tr("Import a mod list in .xml format from another player"))
         import_desc.setObjectName("sectionDescription")
         import_desc.setWordWrap(True)
         import_desc.setAlignment(Qt.AlignmentFlag.AlignCenter)
@@ -341,11 +317,7 @@ class TroubleshootingDialog(QDialog):
         clear_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         clear_layout.addWidget(clear_label)
 
-        clear_warning = QLabel(
-            self.tr(
-                "This will delete all mods in your Mods folder and reset to vanilla state"
-            )
-        )
+        clear_warning = QLabel(self.tr("This will delete all mods in your Mods folder and reset to vanilla state"))
         clear_warning.setObjectName("warningLabel")
         clear_warning.setWordWrap(True)
         clear_warning.setAlignment(Qt.AlignmentFlag.AlignCenter)
@@ -357,9 +329,7 @@ class TroubleshootingDialog(QDialog):
 
         self.clear_mods_button = QPushButton(self.tr("Clear All Mods"))
         self.clear_mods_button.setObjectName("dangerButton")
-        self.clear_mods_button.setToolTip(
-            self.tr("Delete all mods and reset to vanilla state")
-        )
+        self.clear_mods_button.setToolTip(self.tr("Delete all mods and reset to vanilla state"))
         clear_button_layout.addStretch()
         clear_button_layout.addWidget(self.clear_mods_button)
         clear_button_layout.addStretch()
@@ -368,15 +338,13 @@ class TroubleshootingDialog(QDialog):
 
     def _create_steam_utilities_section(self, parent_layout: QVBoxLayout) -> None:
         """Create the Steam utilities section"""
-        section_frame, section_layout, content_widget, content_layout = (
-            self._setup_section_base(parent_layout, self.tr("Steam Utilities"))
+        section_frame, section_layout, content_widget, content_layout = self._setup_section_base(
+            parent_layout, self.tr("Steam Utilities")
         )
 
         # Description
         content_description = self._create_description_label(
-            self.tr(
-                "Steam-specific utilities to help resolve download and game file issues."
-            )
+            self.tr("Steam-specific utilities to help resolve download and game file issues.")
         )
         content_description.setAlignment(Qt.AlignmentFlag.AlignCenter)
         content_layout.addWidget(content_description)
@@ -405,22 +373,18 @@ class TroubleshootingDialog(QDialog):
         utilities_layout.addLayout(verify_layout)
         utilities_layout.addStretch()
 
-        self.steam_repair_library_button, repair_layout = (
-            self._create_button_with_layout(
-                self.tr("Repair Steam Library"),
-                self.tr("Verify integrity of all installed Steam games"),
-                "primaryButton",
-            )
+        self.steam_repair_library_button, repair_layout = self._create_button_with_layout(
+            self.tr("Repair Steam Library"),
+            self.tr("Verify integrity of all installed Steam games"),
+            "primaryButton",
         )
         utilities_layout.addLayout(repair_layout)
         utilities_layout.addStretch()
 
-        self.steam_cleanup_orphaned_workshop_button, cleanup_layout = (
-            self._create_button_with_layout(
-                self.tr("Clean Orphaned Mods"),
-                self.tr("Remove stale workshop entries for mods no longer on disk"),
-                "primaryButton",
-            )
+        self.steam_cleanup_orphaned_workshop_button, cleanup_layout = self._create_button_with_layout(
+            self.tr("Clean Orphaned Mods"),
+            self.tr("Remove stale workshop entries for mods no longer on disk"),
+            "primaryButton",
         )
         utilities_layout.addLayout(cleanup_layout)
         utilities_layout.addStretch()

--- a/app/views/troubleshooting_dialog.py
+++ b/app/views/troubleshooting_dialog.py
@@ -126,8 +126,8 @@ class TroubleshootingDialog(QDialog):
 
     def _create_game_recovery_section(self, parent_layout: QVBoxLayout) -> None:
         """Create the game files recovery section"""
-        section_frame, section_layout, content_widget, content_layout = self._setup_section_base(
-            parent_layout, self.tr("Game Files Recovery")
+        section_frame, section_layout, content_widget, content_layout = (
+            self._setup_section_base(parent_layout, self.tr("Game Files Recovery"))
         )
 
         # Description
@@ -140,7 +140,9 @@ class TroubleshootingDialog(QDialog):
         description.setAlignment(Qt.AlignmentFlag.AlignCenter)
         content_layout.addWidget(description)
 
-        warning_label = QLabel(self.tr("Warning: These operations will delete selected files permanently!"))
+        warning_label = QLabel(
+            self.tr("Warning: These operations will delete selected files permanently!")
+        )
         warning_label.setObjectName("warningLabel")
         warning_label.setWordWrap(True)
         warning_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
@@ -169,19 +171,27 @@ class TroubleshootingDialog(QDialog):
         checkboxes_layout.addLayout(center_layout)
 
         self.integrity_delete_game_files = QCheckBox(
-            self.tr("Reset game files (Preserves local mods, deletes and redownloads game files)")
+            self.tr(
+                "Reset game files (Preserves local mods, deletes and redownloads game files)"
+            )
         )
         self.integrity_delete_game_files.setObjectName("styledCheckbox")
         self.integrity_delete_game_files.setToolTip(
-            self.tr("Deletes and redownloads game files but keeps your local mods intact.")
+            self.tr(
+                "Deletes and redownloads game files but keeps your local mods intact."
+            )
         )
         checkbox_items_layout.addWidget(self.integrity_delete_game_files)
 
         self.integrity_delete_steam_mods = QCheckBox(
-            self.tr("Reset Steam Workshop mods (Deletes and redownloads all Steam mods)")
+            self.tr(
+                "Reset Steam Workshop mods (Deletes and redownloads all Steam mods)"
+            )
         )
         self.integrity_delete_steam_mods.setObjectName("styledCheckbox")
-        self.integrity_delete_steam_mods.setToolTip(self.tr("Deletes all Steam Workshop mods and triggers redownload."))
+        self.integrity_delete_steam_mods.setToolTip(
+            self.tr("Deletes all Steam Workshop mods and triggers redownload.")
+        )
         checkbox_items_layout.addWidget(self.integrity_delete_steam_mods)
 
         self.integrity_delete_mod_configs = QCheckBox(
@@ -189,16 +199,22 @@ class TroubleshootingDialog(QDialog):
         )
         self.integrity_delete_mod_configs.setObjectName("styledCheckbox")
         self.integrity_delete_mod_configs.setToolTip(
-            self.tr("Deletes mod configuration files except ModsConfig.xml and Prefs.xml.")
+            self.tr(
+                "Deletes mod configuration files except ModsConfig.xml and Prefs.xml."
+            )
         )
         checkbox_items_layout.addWidget(self.integrity_delete_mod_configs)
 
         self.integrity_delete_game_configs = QCheckBox(
-            self.tr("Reset game configurations (ModsConfig.xml, Prefs.xml, KeyPrefs.xml)*")
+            self.tr(
+                "Reset game configurations (ModsConfig.xml, Prefs.xml, KeyPrefs.xml)*"
+            )
         )
         self.integrity_delete_game_configs.setObjectName("styledCheckbox")
         self.integrity_delete_game_configs.setToolTip(
-            self.tr("Deletes game configuration files including ModsConfig.xml, Prefs.xml, and KeyPrefs.xml.")
+            self.tr(
+                "Deletes game configuration files including ModsConfig.xml, Prefs.xml, and KeyPrefs.xml."
+            )
         )
         checkbox_items_layout.addWidget(self.integrity_delete_game_configs)
 
@@ -236,8 +252,10 @@ class TroubleshootingDialog(QDialog):
 
     def _create_mod_configuration_section(self, parent_layout: QVBoxLayout) -> None:
         """Create the mod configuration section"""
-        section_frame, section_layout, content_widget, content_layout = self._setup_section_base(
-            parent_layout, self.tr("Mod Configuration Options")
+        section_frame, section_layout, content_widget, content_layout = (
+            self._setup_section_base(
+                parent_layout, self.tr("Mod Configuration Options")
+            )
         )
 
         # Set specific spacing for this section
@@ -268,7 +286,9 @@ class TroubleshootingDialog(QDialog):
         export_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         export_layout.addWidget(export_label)
 
-        export_desc = QLabel(self.tr("Save your current mod list to a .xml file to share with others."))
+        export_desc = QLabel(
+            self.tr("Save your current mod list to a .xml file to share with others.")
+        )
         export_desc.setObjectName("sectionDescription")
         export_desc.setWordWrap(True)
         export_desc.setAlignment(Qt.AlignmentFlag.AlignCenter)
@@ -276,7 +296,9 @@ class TroubleshootingDialog(QDialog):
 
         self.mod_export_list_button = QPushButton(self.tr("Export List"))
         self.mod_export_list_button.setObjectName("actionButton")
-        self.mod_export_list_button.setToolTip(self.tr("Export your current mod list to a file"))
+        self.mod_export_list_button.setToolTip(
+            self.tr("Export your current mod list to a file")
+        )
         export_layout.addWidget(self.mod_export_list_button)
 
         # Import section
@@ -289,7 +311,9 @@ class TroubleshootingDialog(QDialog):
         import_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         import_layout.addWidget(import_label)
 
-        import_desc = QLabel(self.tr("Import a mod list in .xml format from another player"))
+        import_desc = QLabel(
+            self.tr("Import a mod list in .xml format from another player")
+        )
         import_desc.setObjectName("sectionDescription")
         import_desc.setWordWrap(True)
         import_desc.setAlignment(Qt.AlignmentFlag.AlignCenter)
@@ -317,7 +341,11 @@ class TroubleshootingDialog(QDialog):
         clear_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         clear_layout.addWidget(clear_label)
 
-        clear_warning = QLabel(self.tr("This will delete all mods in your Mods folder and reset to vanilla state"))
+        clear_warning = QLabel(
+            self.tr(
+                "This will delete all mods in your Mods folder and reset to vanilla state"
+            )
+        )
         clear_warning.setObjectName("warningLabel")
         clear_warning.setWordWrap(True)
         clear_warning.setAlignment(Qt.AlignmentFlag.AlignCenter)
@@ -329,7 +357,9 @@ class TroubleshootingDialog(QDialog):
 
         self.clear_mods_button = QPushButton(self.tr("Clear All Mods"))
         self.clear_mods_button.setObjectName("dangerButton")
-        self.clear_mods_button.setToolTip(self.tr("Delete all mods and reset to vanilla state"))
+        self.clear_mods_button.setToolTip(
+            self.tr("Delete all mods and reset to vanilla state")
+        )
         clear_button_layout.addStretch()
         clear_button_layout.addWidget(self.clear_mods_button)
         clear_button_layout.addStretch()
@@ -338,13 +368,15 @@ class TroubleshootingDialog(QDialog):
 
     def _create_steam_utilities_section(self, parent_layout: QVBoxLayout) -> None:
         """Create the Steam utilities section"""
-        section_frame, section_layout, content_widget, content_layout = self._setup_section_base(
-            parent_layout, self.tr("Steam Utilities")
+        section_frame, section_layout, content_widget, content_layout = (
+            self._setup_section_base(parent_layout, self.tr("Steam Utilities"))
         )
 
         # Description
         content_description = self._create_description_label(
-            self.tr("Steam-specific utilities to help resolve download and game file issues.")
+            self.tr(
+                "Steam-specific utilities to help resolve download and game file issues."
+            )
         )
         content_description.setAlignment(Qt.AlignmentFlag.AlignCenter)
         content_layout.addWidget(content_description)
@@ -373,12 +405,24 @@ class TroubleshootingDialog(QDialog):
         utilities_layout.addLayout(verify_layout)
         utilities_layout.addStretch()
 
-        self.steam_repair_library_button, repair_layout = self._create_button_with_layout(
-            self.tr("Repair Steam Library"),
-            self.tr("Verify integrity of all installed Steam games"),
-            "primaryButton",
+        self.steam_repair_library_button, repair_layout = (
+            self._create_button_with_layout(
+                self.tr("Repair Steam Library"),
+                self.tr("Verify integrity of all installed Steam games"),
+                "primaryButton",
+            )
         )
         utilities_layout.addLayout(repair_layout)
+        utilities_layout.addStretch()
+
+        self.steam_cleanup_orphaned_workshop_button, cleanup_layout = (
+            self._create_button_with_layout(
+                self.tr("Clean Orphaned Mods"),
+                self.tr("Remove stale workshop entries for mods no longer on disk"),
+                "primaryButton",
+            )
+        )
+        utilities_layout.addLayout(cleanup_layout)
         utilities_layout.addStretch()
 
         content_layout.addStretch(1)

--- a/tests/controllers/test_troubleshooting.py
+++ b/tests/controllers/test_troubleshooting.py
@@ -164,18 +164,14 @@ class TestUIInteractions:
         (test_mod / "About.xml").write_text("<ModMetaData></ModMetaData>")
 
         mods_config = config_dir / "ModsConfig.xml"
-        mods_config.write_text(
-            "<ModsConfigData><activeMods><li>test.mod</li></activeMods></ModsConfigData>"
-        )
+        mods_config.write_text("<ModsConfigData><activeMods><li>test.mod</li></activeMods></ModsConfigData>")
 
         with (
             patch(
                 "app.controllers.troubleshooting_controller.show_dialogue_conditional",
                 return_value=True,
             ),
-            patch(
-                "app.controllers.troubleshooting_controller.EventBus"
-            ) as mock_event_bus,
+            patch("app.controllers.troubleshooting_controller.EventBus") as mock_event_bus,
         ):
             mock_event_bus_instance = mock_event_bus.return_value
             mock_event_bus_instance.do_refresh_mods_lists = mock_event_bus_instance
@@ -256,9 +252,7 @@ class TestSteamUtilities:
 
         steam_path = Path("C:/Program Files (x86)/Steam")
         with (
-            patch(
-                "app.controllers.troubleshooting_controller.platform_specific_open"
-            ) as mock_open,
+            patch("app.controllers.troubleshooting_controller.platform_specific_open") as mock_open,
             patch(
                 "app.controllers.troubleshooting_controller.show_dialogue_conditional",
                 return_value=True,
@@ -273,9 +267,7 @@ class TestSteamUtilities:
             controller._on_steam_clear_cache_clicked()
 
         mock_open.reset_mock()
-        with patch(
-            "app.controllers.troubleshooting_controller.EventBus"
-        ) as mock_eventbus:
+        with patch("app.controllers.troubleshooting_controller.EventBus") as mock_eventbus:
             controller._on_steam_verify_game_clicked()
             mock_eventbus.return_value.do_steam_verify_game_files.emit.assert_called_once()
 
@@ -284,9 +276,7 @@ class TestSteamUtilities:
                 "pathlib.Path.exists",
                 side_effect=lambda p: False if str(p).endswith("downloading") else True,
             ),
-            patch(
-                "app.controllers.troubleshooting_controller.show_dialogue_conditional"
-            ) as mock_dialog,
+            patch("app.controllers.troubleshooting_controller.show_dialogue_conditional") as mock_dialog,
         ):
             controller._on_steam_clear_cache_clicked()
             assert mock_dialog.call_args.kwargs["title"] in [
@@ -316,9 +306,7 @@ class TestSteamUtilities:
                 "app.controllers.troubleshooting_controller.show_dialogue_conditional",
                 return_value=True,
             ),
-            patch(
-                "app.controllers.troubleshooting_controller.platform_specific_open"
-            ) as mock_open,
+            patch("app.controllers.troubleshooting_controller.platform_specific_open") as mock_open,
         ):
             controller._on_steam_repair_library_clicked()
             assert mock_open.call_count == 2
@@ -333,9 +321,7 @@ class TestSteamUtilities:
         controller, _, _, _ = troubleshooting_controller
         controller.settings.instances["default"].workshop_folder = ""
 
-        with patch(
-            "app.controllers.troubleshooting_controller.show_warning"
-        ) as mock_warning:
+        with patch("app.controllers.troubleshooting_controller.show_warning") as mock_warning:
             controller._on_steam_cleanup_orphaned_workshop_clicked()
             mock_warning.assert_called_once()
 
@@ -413,9 +399,7 @@ class TestSteamUtilities:
                 "app.controllers.troubleshooting_controller.show_dialogue_conditional",
                 return_value=True,
             ),
-            patch(
-                "app.controllers.troubleshooting_controller.show_information"
-            ) as mock_info,
+            patch("app.controllers.troubleshooting_controller.show_information") as mock_info,
         ):
             controller._on_steam_cleanup_orphaned_workshop_clicked()
             mock_info.assert_called_once()
@@ -466,9 +450,7 @@ class TestSteamUtilities:
                 "app.controllers.troubleshooting_controller.show_dialogue_conditional",
                 return_value=False,
             ),
-            patch(
-                "app.controllers.troubleshooting_controller.cleanup_orphaned_workshop_items"
-            ) as mock_cleanup,
+            patch("app.controllers.troubleshooting_controller.cleanup_orphaned_workshop_items") as mock_cleanup,
         ):
             controller._on_steam_cleanup_orphaned_workshop_clicked()
             mock_cleanup.assert_not_called()
@@ -565,9 +547,7 @@ class TestModListImportExport:
             ),
             patch("builtins.open", create=True) as mock_open,
             patch("json.load", return_value=import_data),
-            patch(
-                "app.controllers.troubleshooting_controller.EventBus"
-            ) as mock_event_bus,
+            patch("app.controllers.troubleshooting_controller.EventBus") as mock_event_bus,
         ):
             controller._on_mod_import_list_button_clicked()
             mock_open.assert_called()

--- a/tests/controllers/test_troubleshooting.py
+++ b/tests/controllers/test_troubleshooting.py
@@ -9,6 +9,7 @@ from PySide6.QtWidgets import QApplication
 from app.controllers.troubleshooting_controller import TroubleshootingController
 from app.models.instance import Instance
 from app.models.settings import Settings
+from app.utils.steam.steamfiles.wrapper import dict_to_acf
 from app.views.troubleshooting_dialog import TroubleshootingDialog
 
 
@@ -163,14 +164,18 @@ class TestUIInteractions:
         (test_mod / "About.xml").write_text("<ModMetaData></ModMetaData>")
 
         mods_config = config_dir / "ModsConfig.xml"
-        mods_config.write_text("<ModsConfigData><activeMods><li>test.mod</li></activeMods></ModsConfigData>")
+        mods_config.write_text(
+            "<ModsConfigData><activeMods><li>test.mod</li></activeMods></ModsConfigData>"
+        )
 
         with (
             patch(
                 "app.controllers.troubleshooting_controller.show_dialogue_conditional",
                 return_value=True,
             ),
-            patch("app.controllers.troubleshooting_controller.EventBus") as mock_event_bus,
+            patch(
+                "app.controllers.troubleshooting_controller.EventBus"
+            ) as mock_event_bus,
         ):
             mock_event_bus_instance = mock_event_bus.return_value
             mock_event_bus_instance.do_refresh_mods_lists = mock_event_bus_instance
@@ -251,7 +256,9 @@ class TestSteamUtilities:
 
         steam_path = Path("C:/Program Files (x86)/Steam")
         with (
-            patch("app.controllers.troubleshooting_controller.platform_specific_open") as mock_open,
+            patch(
+                "app.controllers.troubleshooting_controller.platform_specific_open"
+            ) as mock_open,
             patch(
                 "app.controllers.troubleshooting_controller.show_dialogue_conditional",
                 return_value=True,
@@ -266,7 +273,9 @@ class TestSteamUtilities:
             controller._on_steam_clear_cache_clicked()
 
         mock_open.reset_mock()
-        with patch("app.controllers.troubleshooting_controller.EventBus") as mock_eventbus:
+        with patch(
+            "app.controllers.troubleshooting_controller.EventBus"
+        ) as mock_eventbus:
             controller._on_steam_verify_game_clicked()
             mock_eventbus.return_value.do_steam_verify_game_files.emit.assert_called_once()
 
@@ -275,7 +284,9 @@ class TestSteamUtilities:
                 "pathlib.Path.exists",
                 side_effect=lambda p: False if str(p).endswith("downloading") else True,
             ),
-            patch("app.controllers.troubleshooting_controller.show_dialogue_conditional") as mock_dialog,
+            patch(
+                "app.controllers.troubleshooting_controller.show_dialogue_conditional"
+            ) as mock_dialog,
         ):
             controller._on_steam_clear_cache_clicked()
             assert mock_dialog.call_args.kwargs["title"] in [
@@ -305,12 +316,162 @@ class TestSteamUtilities:
                 "app.controllers.troubleshooting_controller.show_dialogue_conditional",
                 return_value=True,
             ),
-            patch("app.controllers.troubleshooting_controller.platform_specific_open") as mock_open,
+            patch(
+                "app.controllers.troubleshooting_controller.platform_specific_open"
+            ) as mock_open,
         ):
             controller._on_steam_repair_library_clicked()
             assert mock_open.call_count == 2
             mock_open.assert_any_call("steam://validate/294100")
             mock_open.assert_any_call("steam://validate/123456")
+
+    def test_steam_cleanup_orphaned_workshop_no_steam_location(
+        self,
+        troubleshooting_controller: tuple[TroubleshootingController, Path, Path, Path],
+    ) -> None:
+        """Test that cleanup shows warning when steam location is not set."""
+        controller, _, _, _ = troubleshooting_controller
+        controller.settings.instances["default"].workshop_folder = ""
+
+        with patch(
+            "app.controllers.troubleshooting_controller.show_warning"
+        ) as mock_warning:
+            controller._on_steam_cleanup_orphaned_workshop_clicked()
+            mock_warning.assert_called_once()
+
+    def test_steam_cleanup_orphaned_workshop_with_orphans(
+        self,
+        troubleshooting_controller: tuple[TroubleshootingController, Path, Path, Path],
+        tmp_path: Path,
+    ) -> None:
+        """Test successful cleanup of orphaned workshop entries."""
+        controller, _, _, _ = troubleshooting_controller
+
+        # Build proper directory structure for ACF path computation
+        workshop_base = tmp_path / "steamapps" / "workshop"
+        content_dir = workshop_base / "content" / "294100"
+        content_dir.mkdir(parents=True)
+
+        # Create some mod directories
+        (content_dir / "111").mkdir()
+        (content_dir / "222").mkdir()
+
+        # Write ACF file at the expected location
+        acf_path = workshop_base / "appworkshop_294100.acf"
+        acf_data = {
+            "AppWorkshop": {
+                "appid": "294100",
+                "SizeOnDisk": "0",
+                "NeedsUpdate": "0",
+                "NeedsDownload": "0",
+                "TimeLastUpdated": "0",
+                "TimeLastAppRan": "0",
+                "LastBuildID": "0",
+                "WorkshopItemsInstalled": {
+                    "111": {
+                        "size": "100",
+                        "timeupdated": "1700000000",
+                        "manifest": "123",
+                    },
+                    "222": {
+                        "size": "100",
+                        "timeupdated": "1700000000",
+                        "manifest": "123",
+                    },
+                    "333": {
+                        "size": "100",
+                        "timeupdated": "1700000000",
+                        "manifest": "123",
+                    },
+                },
+                "WorkshopItemDetails": {
+                    "111": {
+                        "manifest": "123",
+                        "timeupdated": "1700000000",
+                        "timetouched": "1700000000",
+                    },
+                    "222": {
+                        "manifest": "123",
+                        "timeupdated": "1700000000",
+                        "timetouched": "1700000000",
+                    },
+                    "333": {
+                        "manifest": "123",
+                        "timeupdated": "1700000000",
+                        "timetouched": "1700000000",
+                    },
+                },
+            }
+        }
+        dict_to_acf(data=acf_data, path=str(acf_path))
+
+        # Point the controller at our directory structure
+        controller.settings.instances["default"].workshop_folder = str(content_dir)
+
+        with (
+            patch(
+                "app.controllers.troubleshooting_controller.show_dialogue_conditional",
+                return_value=True,
+            ),
+            patch(
+                "app.controllers.troubleshooting_controller.show_information"
+            ) as mock_info,
+        ):
+            controller._on_steam_cleanup_orphaned_workshop_clicked()
+            mock_info.assert_called_once()
+            assert "Cleanup Complete" in str(mock_info.call_args)
+
+        # Verify the ACF file no longer contains "333"
+        from app.utils.acf_utils import load_acf_from_path
+
+        updated = load_acf_from_path(acf_path)
+        assert "333" not in updated["AppWorkshop"]["WorkshopItemsInstalled"]
+        assert "333" not in updated["AppWorkshop"]["WorkshopItemDetails"]
+        assert "111" in updated["AppWorkshop"]["WorkshopItemsInstalled"]
+        assert "222" in updated["AppWorkshop"]["WorkshopItemsInstalled"]
+
+    def test_steam_cleanup_orphaned_workshop_user_cancels(
+        self,
+        troubleshooting_controller: tuple[TroubleshootingController, Path, Path, Path],
+        tmp_path: Path,
+    ) -> None:
+        """Test that cancelling the confirmation dialog prevents cleanup."""
+        controller, _, _, _ = troubleshooting_controller
+
+        # Build proper directory structure so we reach the confirmation dialog
+        workshop_base = tmp_path / "steamapps" / "workshop"
+        content_dir = workshop_base / "content" / "294100"
+        content_dir.mkdir(parents=True)
+
+        acf_path = workshop_base / "appworkshop_294100.acf"
+        acf_data = {
+            "AppWorkshop": {
+                "appid": "294100",
+                "SizeOnDisk": "0",
+                "NeedsUpdate": "0",
+                "NeedsDownload": "0",
+                "TimeLastUpdated": "0",
+                "TimeLastAppRan": "0",
+                "LastBuildID": "0",
+                "WorkshopItemsInstalled": {},
+                "WorkshopItemDetails": {},
+            }
+        }
+        dict_to_acf(data=acf_data, path=str(acf_path))
+
+        controller.settings.instances["default"].workshop_folder = str(content_dir)
+
+        with (
+            patch(
+                "app.controllers.troubleshooting_controller.show_dialogue_conditional",
+                return_value=False,
+            ),
+            patch(
+                "app.controllers.troubleshooting_controller.cleanup_orphaned_workshop_items"
+            ) as mock_cleanup,
+        ):
+            controller._on_steam_cleanup_orphaned_workshop_clicked()
+            mock_cleanup.assert_not_called()
 
 
 class TestEdgeCases:
@@ -404,7 +565,9 @@ class TestModListImportExport:
             ),
             patch("builtins.open", create=True) as mock_open,
             patch("json.load", return_value=import_data),
-            patch("app.controllers.troubleshooting_controller.EventBus") as mock_event_bus,
+            patch(
+                "app.controllers.troubleshooting_controller.EventBus"
+            ) as mock_event_bus,
         ):
             controller._on_mod_import_list_button_clicked()
             mock_open.assert_called()

--- a/tests/utils/test_acf_utils.py
+++ b/tests/utils/test_acf_utils.py
@@ -1,0 +1,219 @@
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from app.utils.acf_utils import cleanup_orphaned_workshop_items
+from app.utils.steam.steamfiles.wrapper import dict_to_acf
+
+
+def _create_acf_file(
+    path: Path,
+    installed_pfids: list[str],
+    details_pfids: list[str],
+) -> None:
+    """Write a valid ACF file with the given PFIDs in both sections."""
+    acf_data: dict[str, Any] = {
+        "AppWorkshop": {
+            "appid": "294100",
+            "SizeOnDisk": "0",
+            "NeedsUpdate": "0",
+            "NeedsDownload": "0",
+            "TimeLastUpdated": "0",
+            "TimeLastAppRan": "0",
+            "LastBuildID": "0",
+            "WorkshopItemsInstalled": {
+                pfid: {"size": "100", "timeupdated": "1700000000", "manifest": "123"}
+                for pfid in installed_pfids
+            },
+            "WorkshopItemDetails": {
+                pfid: {
+                    "manifest": "123",
+                    "timeupdated": "1700000000",
+                    "timetouched": "1700000000",
+                }
+                for pfid in details_pfids
+            },
+        }
+    }
+    dict_to_acf(data=acf_data, path=str(path))
+
+
+@pytest.fixture
+def acf_workshop_setup(tmp_path: Path) -> tuple[Path, Path, list[str], list[str]]:
+    """Create a workshop directory structure with some installed mods and an ACF file with orphans."""
+    workshop_dir = tmp_path / "workshop" / "content" / "294100"
+    workshop_dir.mkdir(parents=True)
+
+    existing_pfids = ["111111111", "222222222", "333333333"]
+    for pfid in existing_pfids:
+        (workshop_dir / pfid).mkdir()
+
+    all_pfids = existing_pfids + ["444444444", "555555555"]
+    orphaned_pfids = ["444444444", "555555555"]
+
+    acf_path = tmp_path / "workshop" / "appworkshop_294100.acf"
+    _create_acf_file(acf_path, all_pfids, all_pfids)
+
+    return acf_path, workshop_dir, existing_pfids, orphaned_pfids
+
+
+class TestCleanupOrphanedWorkshopItems:
+    def test_removes_orphaned_entries(
+        self, acf_workshop_setup: tuple[Path, Path, list[str], list[str]]
+    ) -> None:
+        """Orphaned PFIDs should be removed from both ACF sections."""
+        acf_path, workshop_dir, existing_pfids, orphaned_pfids = acf_workshop_setup
+
+        result = cleanup_orphaned_workshop_items(acf_path, workshop_dir)
+
+        assert result == sorted(orphaned_pfids)
+
+        from app.utils.acf_utils import load_acf_from_path
+
+        updated = load_acf_from_path(acf_path)
+        installed = updated["AppWorkshop"]["WorkshopItemsInstalled"]
+        details = updated["AppWorkshop"]["WorkshopItemDetails"]
+
+        for pfid in orphaned_pfids:
+            assert pfid not in installed
+            assert pfid not in details
+
+        for pfid in existing_pfids:
+            assert pfid in installed
+            assert pfid in details
+
+    def test_no_orphans_returns_empty(self, tmp_path: Path) -> None:
+        """When all ACF entries have matching directories, return empty list and create no backup."""
+        workshop_dir = tmp_path / "content"
+        workshop_dir.mkdir()
+
+        pfids = ["111", "222"]
+        for pfid in pfids:
+            (workshop_dir / pfid).mkdir()
+
+        acf_path = tmp_path / "appworkshop_294100.acf"
+        _create_acf_file(acf_path, pfids, pfids)
+
+        result = cleanup_orphaned_workshop_items(acf_path, workshop_dir)
+
+        assert result == []
+        assert not Path(str(acf_path) + ".backup").exists()
+
+    def test_creates_backup_file(self, tmp_path: Path) -> None:
+        """A backup should be created before modifying the ACF file."""
+        workshop_dir = tmp_path / "content"
+        workshop_dir.mkdir()
+        (workshop_dir / "111").mkdir()
+
+        acf_path = tmp_path / "appworkshop_294100.acf"
+        _create_acf_file(acf_path, ["111", "222"], ["111", "222"])
+
+        original_content = acf_path.read_bytes()
+
+        cleanup_orphaned_workshop_items(acf_path, workshop_dir)
+
+        backup_path = Path(str(acf_path) + ".backup")
+        assert backup_path.exists()
+        assert backup_path.read_bytes() == original_content
+
+    def test_write_failure_restores_backup(self, tmp_path: Path) -> None:
+        """If dict_to_acf fails, the original ACF should be restored from backup."""
+        workshop_dir = tmp_path / "content"
+        workshop_dir.mkdir()
+        (workshop_dir / "111").mkdir()
+
+        acf_path = tmp_path / "appworkshop_294100.acf"
+        _create_acf_file(acf_path, ["111", "222"], ["111", "222"])
+
+        original_content = acf_path.read_bytes()
+
+        with (
+            patch("app.utils.acf_utils.dict_to_acf", side_effect=OSError("disk full")),
+            pytest.raises(OSError, match="disk full"),
+        ):
+            cleanup_orphaned_workshop_items(acf_path, workshop_dir)
+
+        assert acf_path.read_bytes() == original_content
+
+    def test_missing_acf_file_returns_empty(self, tmp_path: Path) -> None:
+        """A non-existent ACF path should return empty list without crashing."""
+        workshop_dir = tmp_path / "content"
+        workshop_dir.mkdir()
+
+        result = cleanup_orphaned_workshop_items(
+            tmp_path / "nonexistent.acf", workshop_dir
+        )
+
+        assert result == []
+
+    def test_missing_workshop_directory_returns_empty(self, tmp_path: Path) -> None:
+        """A non-existent workshop content path should return empty list."""
+        acf_path = tmp_path / "appworkshop_294100.acf"
+        _create_acf_file(acf_path, ["111"], ["111"])
+
+        result = cleanup_orphaned_workshop_items(acf_path, tmp_path / "nonexistent")
+
+        assert result == []
+
+    def test_mixed_sections(self, tmp_path: Path) -> None:
+        """Orphans should be removed from whichever section contains them."""
+        workshop_dir = tmp_path / "content"
+        workshop_dir.mkdir()
+        (workshop_dir / "111").mkdir()
+
+        acf_path = tmp_path / "appworkshop_294100.acf"
+        # 222 only in WorkshopItemsInstalled, 333 only in WorkshopItemDetails
+        _create_acf_file(acf_path, ["111", "222"], ["111", "333"])
+
+        result = cleanup_orphaned_workshop_items(acf_path, workshop_dir)
+
+        assert result == ["222", "333"]
+
+        from app.utils.acf_utils import load_acf_from_path
+
+        updated = load_acf_from_path(acf_path)
+        installed = updated["AppWorkshop"]["WorkshopItemsInstalled"]
+        details = updated["AppWorkshop"]["WorkshopItemDetails"]
+
+        assert "222" not in installed
+        assert "333" not in details
+        assert "111" in installed
+        assert "111" in details
+
+    def test_all_entries_orphaned(self, tmp_path: Path) -> None:
+        """When no directories exist, all entries should be removed."""
+        workshop_dir = tmp_path / "content"
+        workshop_dir.mkdir()
+
+        acf_path = tmp_path / "appworkshop_294100.acf"
+        _create_acf_file(acf_path, ["111", "222"], ["111", "222"])
+
+        result = cleanup_orphaned_workshop_items(acf_path, workshop_dir)
+
+        assert result == ["111", "222"]
+
+        from app.utils.acf_utils import load_acf_from_path
+
+        updated = load_acf_from_path(acf_path)
+        installed = updated["AppWorkshop"]["WorkshopItemsInstalled"]
+        details = updated["AppWorkshop"]["WorkshopItemDetails"]
+
+        assert installed == {}
+        assert details == {}
+
+    def test_ignores_non_numeric_directories(self, tmp_path: Path) -> None:
+        """Non-numeric directory names should not count as installed mods."""
+        workshop_dir = tmp_path / "content"
+        workshop_dir.mkdir()
+        (workshop_dir / "111").mkdir()
+        (workshop_dir / "not_a_mod").mkdir()
+        (workshop_dir / ".tmp").mkdir()
+
+        acf_path = tmp_path / "appworkshop_294100.acf"
+        _create_acf_file(acf_path, ["111", "222"], ["111", "222"])
+
+        result = cleanup_orphaned_workshop_items(acf_path, workshop_dir)
+
+        assert result == ["222"]

--- a/tests/utils/test_acf_utils.py
+++ b/tests/utils/test_acf_utils.py
@@ -24,8 +24,7 @@ def _create_acf_file(
             "TimeLastAppRan": "0",
             "LastBuildID": "0",
             "WorkshopItemsInstalled": {
-                pfid: {"size": "100", "timeupdated": "1700000000", "manifest": "123"}
-                for pfid in installed_pfids
+                pfid: {"size": "100", "timeupdated": "1700000000", "manifest": "123"} for pfid in installed_pfids
             },
             "WorkshopItemDetails": {
                 pfid: {
@@ -60,9 +59,7 @@ def acf_workshop_setup(tmp_path: Path) -> tuple[Path, Path, list[str], list[str]
 
 
 class TestCleanupOrphanedWorkshopItems:
-    def test_removes_orphaned_entries(
-        self, acf_workshop_setup: tuple[Path, Path, list[str], list[str]]
-    ) -> None:
+    def test_removes_orphaned_entries(self, acf_workshop_setup: tuple[Path, Path, list[str], list[str]]) -> None:
         """Orphaned PFIDs should be removed from both ACF sections."""
         acf_path, workshop_dir, existing_pfids, orphaned_pfids = acf_workshop_setup
 
@@ -142,9 +139,7 @@ class TestCleanupOrphanedWorkshopItems:
         workshop_dir = tmp_path / "content"
         workshop_dir.mkdir()
 
-        result = cleanup_orphaned_workshop_items(
-            tmp_path / "nonexistent.acf", workshop_dir
-        )
+        result = cleanup_orphaned_workshop_items(tmp_path / "nonexistent.acf", workshop_dir)
 
         assert result == []
 


### PR DESCRIPTION
## Summary

- Add a "Clean Orphaned Workshop Items" troubleshooting utility that removes stale entries from Steam Workshop ACF metadata files
- Orphaned entries (workshop items with metadata records but no corresponding mod folders on disk) can cause RimWorld errors about missing mods
- Creates backup before modifying ACF, auto-restores on write failure

Part of the Steam integration refactor (decomposition of #1623).

## Changes

- `app/utils/acf_utils.py` — new `cleanup_orphaned_workshop_items()` function
- `app/controllers/troubleshooting_controller.py` — button handler with confirmation dialog
- `app/views/troubleshooting_dialog.py` — new button in Steam utilities section
- `tests/utils/test_acf_utils.py` — 9 unit tests
- `tests/controllers/test_troubleshooting.py` — 3 controller tests

## Test plan

- [x] Orphaned entries correctly identified and removed
- [x] No-op when no orphans found
- [x] Backup created before modification
- [x] Write failure triggers backup restoration
- [x] Missing ACF/workshop paths handled gracefully
- [x] Non-numeric directories filtered out
- [x] Controller guard, confirmation, and error flows tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)