### PR TITLE
[TO BE REIMPLEMENTED] feat: add Steam auto-launch and status handler

### DIFF
--- a/app/controllers/app_controller.py
+++ b/app/controllers/app_controller.py
@@ -76,9 +76,7 @@ class AppController(QObject):
         self.settings.load()
         self.initialize_translator(self.settings.language)
         self.settings_dialog = SettingsDialog()
-        self.settings_controller = SettingsController(
-            model=self.settings, view=self.settings_dialog
-        )
+        self.settings_controller = SettingsController(model=self.settings, view=self.settings_dialog)
 
     def initialize_theme_controller(self) -> None:
         """Initializes the ThemeController."""
@@ -92,9 +90,7 @@ class AppController(QObject):
         else:
             print(f"Translation file {path} not found.")
 
-        qt_translations_path = QLibraryInfo.path(
-            QLibraryInfo.LibraryPath.TranslationsPath
-        )
+        qt_translations_path = QLibraryInfo.path(QLibraryInfo.LibraryPath.TranslationsPath)
 
         qt_file_path = os.path.join(qt_translations_path, f"qtbase_{language}.qm")
         if qt_translator.load(qt_file_path):
@@ -123,9 +119,7 @@ class AppController(QObject):
 
     def initialize_metadata_manager(self) -> None:
         """Initializes the MetadataManager."""
-        self.metadata_manager = MetadataManager.instance(
-            settings_controller=self.settings_controller
-        )
+        self.metadata_manager = MetadataManager.instance(settings_controller=self.settings_controller)
 
     def initialize_main_window(self) -> None:
         """Initializes the main window and its controller."""

--- a/app/controllers/app_controller.py
+++ b/app/controllers/app_controller.py
@@ -76,7 +76,9 @@ class AppController(QObject):
         self.settings.load()
         self.initialize_translator(self.settings.language)
         self.settings_dialog = SettingsDialog()
-        self.settings_controller = SettingsController(model=self.settings, view=self.settings_dialog)
+        self.settings_controller = SettingsController(
+            model=self.settings, view=self.settings_dialog
+        )
 
     def initialize_theme_controller(self) -> None:
         """Initializes the ThemeController."""
@@ -90,7 +92,9 @@ class AppController(QObject):
         else:
             print(f"Translation file {path} not found.")
 
-        qt_translations_path = QLibraryInfo.path(QLibraryInfo.LibraryPath.TranslationsPath)
+        qt_translations_path = QLibraryInfo.path(
+            QLibraryInfo.LibraryPath.TranslationsPath
+        )
 
         qt_file_path = os.path.join(qt_translations_path, f"qtbase_{language}.qm")
         if qt_translator.load(qt_file_path):
@@ -119,7 +123,9 @@ class AppController(QObject):
 
     def initialize_metadata_manager(self) -> None:
         """Initializes the MetadataManager."""
-        self.metadata_manager = MetadataManager.instance(settings_controller=self.settings_controller)
+        self.metadata_manager = MetadataManager.instance(
+            settings_controller=self.settings_controller
+        )
 
     def initialize_main_window(self) -> None:
         """Initializes the main window and its controller."""

--- a/app/controllers/app_controller.py
+++ b/app/controllers/app_controller.py
@@ -13,6 +13,7 @@ from app.utils.dds_utility import DDSUtility
 from app.utils.gui_info import GUIInfo
 from app.utils.metadata import MetadataManager
 from app.utils.steam.steamcmd.wrapper import SteamcmdInterface
+from app.utils.steam_status_handler import SteamStatusHandler
 from app.views.main_window import MainWindow
 from app.views.settings_dialog import SettingsDialog
 
@@ -36,6 +37,8 @@ class AppController(QObject):
         self.initialize_theme_controller()
         # Set the theme of the application.
         self.set_theme()
+        # Initialize the Steam status handler
+        self.initialize_steam_status_handler()
         # Initialize the Steamcmd interface
         self.initialize_steamcmd_interface()
         # Perform cleanup of orphaned DDS files if the setting is enabled
@@ -98,6 +101,10 @@ class AppController(QObject):
             QCoreApplication.installTranslator(qt_translator)
         else:
             print(f"Qt translation file {qt_file_path} not found.")
+
+    def initialize_steam_status_handler(self) -> None:
+        """Initializes the SteamStatusHandler for Steam detection and auto-launch."""
+        self.steam_status_handler = SteamStatusHandler(settings=self.settings)
 
     def initialize_steamcmd_interface(self) -> None:
         """Initializes the SteamcmdInterface."""

--- a/app/controllers/menu_bar_controller.py
+++ b/app/controllers/menu_bar_controller.py
@@ -29,9 +29,7 @@ class MenuBarController(QObject):
 
         # Update menu (only if updater is not disabled)
         if self.menu_bar.check_for_updates_action is not None:
-            self.menu_bar.check_for_updates_action.triggered.connect(
-                EventBus().do_check_for_application_update.emit
-            )
+            self.menu_bar.check_for_updates_action.triggered.connect(EventBus().do_check_for_application_update.emit)
         if self.menu_bar.check_for_updates_on_startup_action is not None:
             self.menu_bar.check_for_updates_on_startup_action.toggled.connect(
                 self._on_menu_bar_check_for_updates_on_startup_triggered
@@ -41,32 +39,18 @@ class MenuBarController(QObject):
             )
 
         # Settings menu
-        self.menu_bar.settings_action.triggered.connect(
-            self.settings_controller.show_settings_dialog
-        )
+        self.menu_bar.settings_action.triggered.connect(self.settings_controller.show_settings_dialog)
 
         # File menu
-        self.menu_bar.open_mod_list_action.triggered.connect(
-            EventBus().do_open_mod_list.emit
-        )
-        self.menu_bar.save_mod_list_action.triggered.connect(
-            EventBus().do_save_mod_list_as.emit
-        )
-        self.menu_bar.import_from_rentry_action.triggered.connect(
-            EventBus().do_import_mod_list_from_rentry
-        )
+        self.menu_bar.open_mod_list_action.triggered.connect(EventBus().do_open_mod_list.emit)
+        self.menu_bar.save_mod_list_action.triggered.connect(EventBus().do_save_mod_list_as.emit)
+        self.menu_bar.import_from_rentry_action.triggered.connect(EventBus().do_import_mod_list_from_rentry)
         self.menu_bar.import_from_workshop_collection_action.triggered.connect(
             EventBus().do_import_mod_list_from_workshop_collection
         )
-        self.menu_bar.import_from_save_file_action.triggered.connect(
-            EventBus().do_import_mod_list_from_save_file
-        )
-        self.menu_bar.export_to_clipboard_action.triggered.connect(
-            EventBus().do_export_mod_list_to_clipboard
-        )
-        self.menu_bar.export_to_rentry_action.triggered.connect(
-            EventBus().do_export_mod_list_to_rentry
-        )
+        self.menu_bar.import_from_save_file_action.triggered.connect(EventBus().do_import_mod_list_from_save_file)
+        self.menu_bar.export_to_clipboard_action.triggered.connect(EventBus().do_export_mod_list_to_clipboard)
+        self.menu_bar.export_to_rentry_action.triggered.connect(EventBus().do_export_mod_list_to_rentry)
 
         for action in self.menu_bar.upload_log_actions:
             action.triggered.connect(
@@ -85,120 +69,62 @@ class MenuBarController(QObject):
             )
 
         # Shortcuts SubMenu
-        self.menu_bar.open_app_directory_action.triggered.connect(
-            EventBus().do_open_app_directory
-        )
-        self.menu_bar.open_settings_directory_action.triggered.connect(
-            EventBus().do_open_settings_directory
-        )
-        self.menu_bar.open_rimsort_logs_directory_action.triggered.connect(
-            EventBus().do_open_rimsort_logs_directory
-        )
-        self.menu_bar.open_rimworld_directory_action.triggered.connect(
-            EventBus().do_open_rimworld_directory
-        )
+        self.menu_bar.open_app_directory_action.triggered.connect(EventBus().do_open_app_directory)
+        self.menu_bar.open_settings_directory_action.triggered.connect(EventBus().do_open_settings_directory)
+        self.menu_bar.open_rimsort_logs_directory_action.triggered.connect(EventBus().do_open_rimsort_logs_directory)
+        self.menu_bar.open_rimworld_directory_action.triggered.connect(EventBus().do_open_rimworld_directory)
         self.menu_bar.open_rimworld_config_directory_action.triggered.connect(
             EventBus().do_open_rimworld_config_directory
         )
-        self.menu_bar.open_rimworld_logs_directory_action.triggered.connect(
-            EventBus().do_open_rimworld_logs_directory
-        )
-        self.menu_bar.open_local_mods_directory_action.triggered.connect(
-            EventBus().do_open_local_mods_directory
-        )
-        self.menu_bar.open_steam_mods_directory_action.triggered.connect(
-            EventBus().do_open_steam_mods_directory
-        )
+        self.menu_bar.open_rimworld_logs_directory_action.triggered.connect(EventBus().do_open_rimworld_logs_directory)
+        self.menu_bar.open_local_mods_directory_action.triggered.connect(EventBus().do_open_local_mods_directory)
+        self.menu_bar.open_steam_mods_directory_action.triggered.connect(EventBus().do_open_steam_mods_directory)
 
         # Edit menu
         self.menu_bar.cut_action.triggered.connect(self._on_menu_bar_cut_triggered)
         self.menu_bar.copy_action.triggered.connect(self._on_menu_bar_copy_triggered)
         self.menu_bar.paste_action.triggered.connect(self._on_menu_bar_paste_triggered)
         self.menu_bar.rule_editor_action.triggered.connect(EventBus().do_rule_editor)
-        self.menu_bar.ignore_json_editor_action.triggered.connect(
-            EventBus().do_ignore_json_editor
-        )
-        self.menu_bar.reset_all_warnings_action.triggered.connect(
-            self._on_menu_bar_reset_warnings_triggered
-        )
-        self.menu_bar.reset_all_mod_colors_action.triggered.connect(
-            self._on_menu_bar_reset_all_mod_colors_triggered
-        )
+        self.menu_bar.ignore_json_editor_action.triggered.connect(EventBus().do_ignore_json_editor)
+        self.menu_bar.reset_all_warnings_action.triggered.connect(self._on_menu_bar_reset_warnings_triggered)
+        self.menu_bar.reset_all_mod_colors_action.triggered.connect(self._on_menu_bar_reset_all_mod_colors_triggered)
 
         # Download menu
-        self.menu_bar.add_git_mod_action.triggered.connect(
-            EventBus().do_add_git_mod.emit
-        )
-        self.menu_bar.add_zip_mod_action.triggered.connect(
-            EventBus().do_add_zip_mod.emit
-        )
-        self.menu_bar.browse_workshop_action.triggered.connect(
-            EventBus().do_browse_workshop
-        )
-        self.menu_bar.update_workshop_mods_action.triggered.connect(
-            EventBus().do_check_for_workshop_updates
-        )
-        self.menu_bar.steam_verify_game_files_action.triggered.connect(
-            EventBus().do_steam_verify_game_files
-        )
+        self.menu_bar.add_git_mod_action.triggered.connect(EventBus().do_add_git_mod.emit)
+        self.menu_bar.add_zip_mod_action.triggered.connect(EventBus().do_add_zip_mod.emit)
+        self.menu_bar.browse_workshop_action.triggered.connect(EventBus().do_browse_workshop)
+        self.menu_bar.update_workshop_mods_action.triggered.connect(EventBus().do_check_for_workshop_updates)
+        self.menu_bar.steam_verify_game_files_action.triggered.connect(EventBus().do_steam_verify_game_files)
 
         # View menu
-        self.menu_bar.show_translation_status_action.toggled.connect(
-            EventBus().do_toggle_translation_status.emit
-        )
-        self.menu_bar.auto_add_translations_action.triggered.connect(
-            EventBus().do_auto_add_translations.emit
-        )
+        self.menu_bar.show_translation_status_action.toggled.connect(EventBus().do_toggle_translation_status.emit)
+        self.menu_bar.auto_add_translations_action.triggered.connect(EventBus().do_auto_add_translations.emit)
 
         # Instances menu
-        self.menu_bar.backup_instance_action.triggered.connect(
-            self._on_do_backup_current_instance
-        )
-        self.menu_bar.restore_instance_action.triggered.connect(
-            EventBus().do_restore_instance_from_archive.emit
-        )
-        self.menu_bar.clone_instance_action.triggered.connect(
-            self._on_do_clone_current_instance
-        )
-        self.menu_bar.create_instance_action.triggered.connect(
-            EventBus().do_create_new_instance.emit
-        )
-        self.menu_bar.delete_instance_action.triggered.connect(
-            EventBus().do_delete_current_instance.emit
-        )
+        self.menu_bar.backup_instance_action.triggered.connect(self._on_do_backup_current_instance)
+        self.menu_bar.restore_instance_action.triggered.connect(EventBus().do_restore_instance_from_archive.emit)
+        self.menu_bar.clone_instance_action.triggered.connect(self._on_do_clone_current_instance)
+        self.menu_bar.create_instance_action.triggered.connect(EventBus().do_create_new_instance.emit)
+        self.menu_bar.delete_instance_action.triggered.connect(EventBus().do_delete_current_instance.emit)
 
         # Textures menu
-        self.menu_bar.optimize_textures_action.triggered.connect(
-            EventBus().do_optimize_textures
-        )
-        self.menu_bar.delete_dds_textures_action.triggered.connect(
-            EventBus().do_delete_dds_textures
-        )
+        self.menu_bar.optimize_textures_action.triggered.connect(EventBus().do_optimize_textures)
+        self.menu_bar.delete_dds_textures_action.triggered.connect(EventBus().do_delete_dds_textures)
         # Help menu
         self.menu_bar.wiki_action.triggered.connect(self._on_menu_bar_wiki_triggered)
-        self.menu_bar.github_action.triggered.connect(
-            self._on_menu_bar_github_triggered
-        )
-        self.menu_bar.check_steam_connection_action.triggered.connect(
-            EventBus().do_check_steam_connection.emit
-        )
-        self.menu_bar.launch_steam_action.triggered.connect(
-            EventBus().do_launch_steam.emit
-        )
+        self.menu_bar.github_action.triggered.connect(self._on_menu_bar_github_triggered)
+        self.menu_bar.check_steam_connection_action.triggered.connect(EventBus().do_check_steam_connection.emit)
+        self.menu_bar.launch_steam_action.triggered.connect(EventBus().do_launch_steam.emit)
 
         # External signals
         EventBus().refresh_started.connect(self._on_refresh_started)
         EventBus().refresh_finished.connect(self._on_refresh_finished)
 
     def _on_do_backup_current_instance(self) -> None:
-        EventBus().do_backup_existing_instance.emit(
-            self.settings_controller.settings.current_instance
-        )
+        EventBus().do_backup_existing_instance.emit(self.settings_controller.settings.current_instance)
 
     def _on_do_clone_current_instance(self) -> None:
-        EventBus().do_clone_existing_instance.emit(
-            self.settings_controller.settings.current_instance
-        )
+        EventBus().do_clone_existing_instance.emit(self.settings_controller.settings.current_instance)
 
     def _on_instances_submenu_population(self, instance_names: list[str]) -> None:
         self.menu_bar.instances_submenu.clear()
@@ -213,22 +139,12 @@ class MenuBarController(QObject):
             )
         self.menu_bar.instances_submenu.addActions(actions)
 
-    def _on_set_current_instance(
-        self, current_instance: str, initialize: bool = False
-    ) -> None:
+    def _on_set_current_instance(self, current_instance: str, initialize: bool = False) -> None:
         self.menu_bar.instances_submenu.setTitle(
-            self.tr("Current: {current_instance}").format(
-                current_instance=current_instance
-            )
+            self.tr("Current: {current_instance}").format(current_instance=current_instance)
         )
         self.menu_bar.instances_submenu.setActiveAction(
-            next(
-                (
-                    action
-                    for action in self.menu_bar.instances_submenu.actions()
-                    if action.text() == current_instance
-                )
-            )
+            next((action for action in self.menu_bar.instances_submenu.actions() if action.text() == current_instance))
         )
         if initialize:
             EventBus().do_activate_current_instance.emit(current_instance)

--- a/app/controllers/menu_bar_controller.py
+++ b/app/controllers/menu_bar_controller.py
@@ -29,7 +29,9 @@ class MenuBarController(QObject):
 
         # Update menu (only if updater is not disabled)
         if self.menu_bar.check_for_updates_action is not None:
-            self.menu_bar.check_for_updates_action.triggered.connect(EventBus().do_check_for_application_update.emit)
+            self.menu_bar.check_for_updates_action.triggered.connect(
+                EventBus().do_check_for_application_update.emit
+            )
         if self.menu_bar.check_for_updates_on_startup_action is not None:
             self.menu_bar.check_for_updates_on_startup_action.toggled.connect(
                 self._on_menu_bar_check_for_updates_on_startup_triggered
@@ -39,18 +41,32 @@ class MenuBarController(QObject):
             )
 
         # Settings menu
-        self.menu_bar.settings_action.triggered.connect(self.settings_controller.show_settings_dialog)
+        self.menu_bar.settings_action.triggered.connect(
+            self.settings_controller.show_settings_dialog
+        )
 
         # File menu
-        self.menu_bar.open_mod_list_action.triggered.connect(EventBus().do_open_mod_list.emit)
-        self.menu_bar.save_mod_list_action.triggered.connect(EventBus().do_save_mod_list_as.emit)
-        self.menu_bar.import_from_rentry_action.triggered.connect(EventBus().do_import_mod_list_from_rentry)
+        self.menu_bar.open_mod_list_action.triggered.connect(
+            EventBus().do_open_mod_list.emit
+        )
+        self.menu_bar.save_mod_list_action.triggered.connect(
+            EventBus().do_save_mod_list_as.emit
+        )
+        self.menu_bar.import_from_rentry_action.triggered.connect(
+            EventBus().do_import_mod_list_from_rentry
+        )
         self.menu_bar.import_from_workshop_collection_action.triggered.connect(
             EventBus().do_import_mod_list_from_workshop_collection
         )
-        self.menu_bar.import_from_save_file_action.triggered.connect(EventBus().do_import_mod_list_from_save_file)
-        self.menu_bar.export_to_clipboard_action.triggered.connect(EventBus().do_export_mod_list_to_clipboard)
-        self.menu_bar.export_to_rentry_action.triggered.connect(EventBus().do_export_mod_list_to_rentry)
+        self.menu_bar.import_from_save_file_action.triggered.connect(
+            EventBus().do_import_mod_list_from_save_file
+        )
+        self.menu_bar.export_to_clipboard_action.triggered.connect(
+            EventBus().do_export_mod_list_to_clipboard
+        )
+        self.menu_bar.export_to_rentry_action.triggered.connect(
+            EventBus().do_export_mod_list_to_rentry
+        )
 
         for action in self.menu_bar.upload_log_actions:
             action.triggered.connect(
@@ -69,62 +85,120 @@ class MenuBarController(QObject):
             )
 
         # Shortcuts SubMenu
-        self.menu_bar.open_app_directory_action.triggered.connect(EventBus().do_open_app_directory)
-        self.menu_bar.open_settings_directory_action.triggered.connect(EventBus().do_open_settings_directory)
-        self.menu_bar.open_rimsort_logs_directory_action.triggered.connect(EventBus().do_open_rimsort_logs_directory)
-        self.menu_bar.open_rimworld_directory_action.triggered.connect(EventBus().do_open_rimworld_directory)
+        self.menu_bar.open_app_directory_action.triggered.connect(
+            EventBus().do_open_app_directory
+        )
+        self.menu_bar.open_settings_directory_action.triggered.connect(
+            EventBus().do_open_settings_directory
+        )
+        self.menu_bar.open_rimsort_logs_directory_action.triggered.connect(
+            EventBus().do_open_rimsort_logs_directory
+        )
+        self.menu_bar.open_rimworld_directory_action.triggered.connect(
+            EventBus().do_open_rimworld_directory
+        )
         self.menu_bar.open_rimworld_config_directory_action.triggered.connect(
             EventBus().do_open_rimworld_config_directory
         )
-        self.menu_bar.open_rimworld_logs_directory_action.triggered.connect(EventBus().do_open_rimworld_logs_directory)
-        self.menu_bar.open_local_mods_directory_action.triggered.connect(EventBus().do_open_local_mods_directory)
-        self.menu_bar.open_steam_mods_directory_action.triggered.connect(EventBus().do_open_steam_mods_directory)
+        self.menu_bar.open_rimworld_logs_directory_action.triggered.connect(
+            EventBus().do_open_rimworld_logs_directory
+        )
+        self.menu_bar.open_local_mods_directory_action.triggered.connect(
+            EventBus().do_open_local_mods_directory
+        )
+        self.menu_bar.open_steam_mods_directory_action.triggered.connect(
+            EventBus().do_open_steam_mods_directory
+        )
 
         # Edit menu
         self.menu_bar.cut_action.triggered.connect(self._on_menu_bar_cut_triggered)
         self.menu_bar.copy_action.triggered.connect(self._on_menu_bar_copy_triggered)
         self.menu_bar.paste_action.triggered.connect(self._on_menu_bar_paste_triggered)
         self.menu_bar.rule_editor_action.triggered.connect(EventBus().do_rule_editor)
-        self.menu_bar.ignore_json_editor_action.triggered.connect(EventBus().do_ignore_json_editor)
-        self.menu_bar.reset_all_warnings_action.triggered.connect(self._on_menu_bar_reset_warnings_triggered)
-        self.menu_bar.reset_all_mod_colors_action.triggered.connect(self._on_menu_bar_reset_all_mod_colors_triggered)
+        self.menu_bar.ignore_json_editor_action.triggered.connect(
+            EventBus().do_ignore_json_editor
+        )
+        self.menu_bar.reset_all_warnings_action.triggered.connect(
+            self._on_menu_bar_reset_warnings_triggered
+        )
+        self.menu_bar.reset_all_mod_colors_action.triggered.connect(
+            self._on_menu_bar_reset_all_mod_colors_triggered
+        )
 
         # Download menu
-        self.menu_bar.add_git_mod_action.triggered.connect(EventBus().do_add_git_mod.emit)
-        self.menu_bar.add_zip_mod_action.triggered.connect(EventBus().do_add_zip_mod.emit)
-        self.menu_bar.browse_workshop_action.triggered.connect(EventBus().do_browse_workshop)
-        self.menu_bar.update_workshop_mods_action.triggered.connect(EventBus().do_check_for_workshop_updates)
-        self.menu_bar.steam_verify_game_files_action.triggered.connect(EventBus().do_steam_verify_game_files)
+        self.menu_bar.add_git_mod_action.triggered.connect(
+            EventBus().do_add_git_mod.emit
+        )
+        self.menu_bar.add_zip_mod_action.triggered.connect(
+            EventBus().do_add_zip_mod.emit
+        )
+        self.menu_bar.browse_workshop_action.triggered.connect(
+            EventBus().do_browse_workshop
+        )
+        self.menu_bar.update_workshop_mods_action.triggered.connect(
+            EventBus().do_check_for_workshop_updates
+        )
+        self.menu_bar.steam_verify_game_files_action.triggered.connect(
+            EventBus().do_steam_verify_game_files
+        )
 
         # View menu
-        self.menu_bar.show_translation_status_action.toggled.connect(EventBus().do_toggle_translation_status.emit)
-        self.menu_bar.auto_add_translations_action.triggered.connect(EventBus().do_auto_add_translations.emit)
+        self.menu_bar.show_translation_status_action.toggled.connect(
+            EventBus().do_toggle_translation_status.emit
+        )
+        self.menu_bar.auto_add_translations_action.triggered.connect(
+            EventBus().do_auto_add_translations.emit
+        )
 
         # Instances menu
-        self.menu_bar.backup_instance_action.triggered.connect(self._on_do_backup_current_instance)
-        self.menu_bar.restore_instance_action.triggered.connect(EventBus().do_restore_instance_from_archive.emit)
-        self.menu_bar.clone_instance_action.triggered.connect(self._on_do_clone_current_instance)
-        self.menu_bar.create_instance_action.triggered.connect(EventBus().do_create_new_instance.emit)
-        self.menu_bar.delete_instance_action.triggered.connect(EventBus().do_delete_current_instance.emit)
+        self.menu_bar.backup_instance_action.triggered.connect(
+            self._on_do_backup_current_instance
+        )
+        self.menu_bar.restore_instance_action.triggered.connect(
+            EventBus().do_restore_instance_from_archive.emit
+        )
+        self.menu_bar.clone_instance_action.triggered.connect(
+            self._on_do_clone_current_instance
+        )
+        self.menu_bar.create_instance_action.triggered.connect(
+            EventBus().do_create_new_instance.emit
+        )
+        self.menu_bar.delete_instance_action.triggered.connect(
+            EventBus().do_delete_current_instance.emit
+        )
 
         # Textures menu
-        self.menu_bar.optimize_textures_action.triggered.connect(EventBus().do_optimize_textures)
-        self.menu_bar.delete_dds_textures_action.triggered.connect(EventBus().do_delete_dds_textures)
+        self.menu_bar.optimize_textures_action.triggered.connect(
+            EventBus().do_optimize_textures
+        )
+        self.menu_bar.delete_dds_textures_action.triggered.connect(
+            EventBus().do_delete_dds_textures
+        )
         # Help menu
         self.menu_bar.wiki_action.triggered.connect(self._on_menu_bar_wiki_triggered)
-        self.menu_bar.github_action.triggered.connect(self._on_menu_bar_github_triggered)
-        self.menu_bar.check_steam_connection_action.triggered.connect(EventBus().do_check_steam_connection.emit)
-        self.menu_bar.launch_steam_action.triggered.connect(EventBus().do_launch_steam.emit)
+        self.menu_bar.github_action.triggered.connect(
+            self._on_menu_bar_github_triggered
+        )
+        self.menu_bar.check_steam_connection_action.triggered.connect(
+            EventBus().do_check_steam_connection.emit
+        )
+        self.menu_bar.launch_steam_action.triggered.connect(
+            EventBus().do_launch_steam.emit
+        )
 
         # External signals
         EventBus().refresh_started.connect(self._on_refresh_started)
         EventBus().refresh_finished.connect(self._on_refresh_finished)
 
     def _on_do_backup_current_instance(self) -> None:
-        EventBus().do_backup_existing_instance.emit(self.settings_controller.settings.current_instance)
+        EventBus().do_backup_existing_instance.emit(
+            self.settings_controller.settings.current_instance
+        )
 
     def _on_do_clone_current_instance(self) -> None:
-        EventBus().do_clone_existing_instance.emit(self.settings_controller.settings.current_instance)
+        EventBus().do_clone_existing_instance.emit(
+            self.settings_controller.settings.current_instance
+        )
 
     def _on_instances_submenu_population(self, instance_names: list[str]) -> None:
         self.menu_bar.instances_submenu.clear()
@@ -139,12 +213,22 @@ class MenuBarController(QObject):
             )
         self.menu_bar.instances_submenu.addActions(actions)
 
-    def _on_set_current_instance(self, current_instance: str, initialize: bool = False) -> None:
+    def _on_set_current_instance(
+        self, current_instance: str, initialize: bool = False
+    ) -> None:
         self.menu_bar.instances_submenu.setTitle(
-            self.tr("Current: {current_instance}").format(current_instance=current_instance)
+            self.tr("Current: {current_instance}").format(
+                current_instance=current_instance
+            )
         )
         self.menu_bar.instances_submenu.setActiveAction(
-            next((action for action in self.menu_bar.instances_submenu.actions() if action.text() == current_instance))
+            next(
+                (
+                    action
+                    for action in self.menu_bar.instances_submenu.actions()
+                    if action.text() == current_instance
+                )
+            )
         )
         if initialize:
             EventBus().do_activate_current_instance.emit(current_instance)

--- a/app/controllers/menu_bar_controller.py
+++ b/app/controllers/menu_bar_controller.py
@@ -179,6 +179,12 @@ class MenuBarController(QObject):
         self.menu_bar.github_action.triggered.connect(
             self._on_menu_bar_github_triggered
         )
+        self.menu_bar.check_steam_connection_action.triggered.connect(
+            EventBus().do_check_steam_connection.emit
+        )
+        self.menu_bar.launch_steam_action.triggered.connect(
+            EventBus().do_launch_steam.emit
+        )
 
         # External signals
         EventBus().refresh_started.connect(self._on_refresh_started)

--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -93,13 +93,9 @@ class SettingsController(QObject):
             self._on_global_reset_to_defaults_button_clicked
         )
 
-        self.settings_dialog.global_cancel_button.clicked.connect(
-            self._on_global_cancel_button_clicked
-        )
+        self.settings_dialog.global_cancel_button.clicked.connect(self._on_global_cancel_button_clicked)
 
-        self.settings_dialog.global_ok_button.clicked.connect(
-            self._on_global_ok_button_clicked
-        )
+        self.settings_dialog.global_ok_button.clicked.connect(self._on_global_ok_button_clicked)
 
         # Connect launch state radio buttons to update spinbox enabled/disabled state
         # Main Window
@@ -141,22 +137,12 @@ class SettingsController(QObject):
         )
 
         # Locations tab
-        self.settings_dialog.game_location.textChanged.connect(
-            self._on_game_location_text_changed
-        )
-        self.settings_dialog.game_location_open_button.clicked.connect(
-            self._on_game_location_open_button_clicked
-        )
-        self.settings_dialog.game_location_choose_button.clicked.connect(
-            self._on_game_location_choose_button_clicked
-        )
-        self.settings_dialog.game_location_clear_button.clicked.connect(
-            self._on_game_location_clear_button_clicked
-        )
+        self.settings_dialog.game_location.textChanged.connect(self._on_game_location_text_changed)
+        self.settings_dialog.game_location_open_button.clicked.connect(self._on_game_location_open_button_clicked)
+        self.settings_dialog.game_location_choose_button.clicked.connect(self._on_game_location_choose_button_clicked)
+        self.settings_dialog.game_location_clear_button.clicked.connect(self._on_game_location_clear_button_clicked)
 
-        self.settings_dialog.config_folder_location.textChanged.connect(
-            self._on_config_folder_location_text_changed
-        )
+        self.settings_dialog.config_folder_location.textChanged.connect(self._on_config_folder_location_text_changed)
         self.settings_dialog.config_folder_location_open_button.clicked.connect(
             self._on_config_folder_location_open_button_clicked
         )
@@ -205,30 +191,18 @@ class SettingsController(QObject):
             # Buttons may not exist if UI hasn't been updated yet
             pass
 
-        self.settings_dialog.locations_clear_button.clicked.connect(
-            self._on_locations_clear_button_clicked
-        )
+        self.settings_dialog.locations_clear_button.clicked.connect(self._on_locations_clear_button_clicked)
 
-        self.settings_dialog.locations_autodetect_button.clicked.connect(
-            self._on_locations_autodetect_button_clicked
-        )
+        self.settings_dialog.locations_autodetect_button.clicked.connect(self._on_locations_autodetect_button_clicked)
 
         # Game Launch tab
-        self.settings_dialog.run_args.textChanged.connect(
-            self._on_run_args_text_changed
-        )
+        self.settings_dialog.run_args.textChanged.connect(self._on_run_args_text_changed)
 
         # Wire up the Databases tab buttons
 
-        self.settings_dialog.community_rules_db_none_radio.clicked.connect(
-            self._on_community_rules_db_radio_clicked
-        )
-        self.settings_dialog.community_rules_db_github_radio.clicked.connect(
-            self._on_community_rules_db_radio_clicked
-        )
-        self.settings_dialog.community_rules_db_url_radio.clicked.connect(
-            self._on_community_rules_db_radio_clicked
-        )
+        self.settings_dialog.community_rules_db_none_radio.clicked.connect(self._on_community_rules_db_radio_clicked)
+        self.settings_dialog.community_rules_db_github_radio.clicked.connect(self._on_community_rules_db_radio_clicked)
+        self.settings_dialog.community_rules_db_url_radio.clicked.connect(self._on_community_rules_db_radio_clicked)
         self.settings_dialog.community_rules_db_local_file_radio.clicked.connect(
             self._on_community_rules_db_radio_clicked
         )
@@ -250,15 +224,9 @@ class SettingsController(QObject):
             )
         )
 
-        self.settings_dialog.steam_workshop_db_none_radio.clicked.connect(
-            self._on_steam_workshop_db_radio_clicked
-        )
-        self.settings_dialog.steam_workshop_db_github_radio.clicked.connect(
-            self._on_steam_workshop_db_radio_clicked
-        )
-        self.settings_dialog.steam_workshop_db_url_radio.clicked.connect(
-            self._on_steam_workshop_db_radio_clicked
-        )
+        self.settings_dialog.steam_workshop_db_none_radio.clicked.connect(self._on_steam_workshop_db_radio_clicked)
+        self.settings_dialog.steam_workshop_db_github_radio.clicked.connect(self._on_steam_workshop_db_radio_clicked)
+        self.settings_dialog.steam_workshop_db_url_radio.clicked.connect(self._on_steam_workshop_db_radio_clicked)
         self.settings_dialog.steam_workshop_db_local_file_radio.clicked.connect(
             self._on_steam_workshop_db_radio_clicked
         )
@@ -311,15 +279,11 @@ class SettingsController(QObject):
             )
         )
 
-        self.settings_dialog.use_this_instead_db_none_radio.clicked.connect(
-            self._on_use_this_instead_db_radio_clicked
-        )
+        self.settings_dialog.use_this_instead_db_none_radio.clicked.connect(self._on_use_this_instead_db_radio_clicked)
         self.settings_dialog.use_this_instead_db_github_radio.clicked.connect(
             self._on_use_this_instead_db_radio_clicked
         )
-        self.settings_dialog.use_this_instead_db_url_radio.clicked.connect(
-            self._on_use_this_instead_db_radio_clicked
-        )
+        self.settings_dialog.use_this_instead_db_url_radio.clicked.connect(self._on_use_this_instead_db_radio_clicked)
         self.settings_dialog.use_this_instead_db_local_file_radio.clicked.connect(
             self._on_use_this_instead_db_radio_clicked
         )
@@ -365,15 +329,9 @@ class SettingsController(QObject):
         self.settings_dialog.steamcmd_clear_depot_cache_button.clicked.connect(
             self._on_steamcmd_clear_depot_cache_button_clicked
         )
-        self.settings_dialog.steamcmd_import_acf_button.clicked.connect(
-            self._on_steamcmd_import_acf_button_clicked
-        )
-        self.settings_dialog.steamcmd_delete_acf_button.clicked.connect(
-            self._on_steamcmd_delete_acf_button_clicked
-        )
-        self.settings_dialog.steamcmd_install_button.clicked.connect(
-            self._on_steamcmd_install_button_clicked
-        )
+        self.settings_dialog.steamcmd_import_acf_button.clicked.connect(self._on_steamcmd_import_acf_button_clicked)
+        self.settings_dialog.steamcmd_delete_acf_button.clicked.connect(self._on_steamcmd_delete_acf_button_clicked)
+        self.settings_dialog.steamcmd_install_button.clicked.connect(self._on_steamcmd_install_button_clicked)
 
         # Other External Tools Tab
         self.settings_dialog.text_editor_location_choose_button.clicked.connect(
@@ -381,9 +339,7 @@ class SettingsController(QObject):
         )
 
         # Theme tab
-        self.settings_dialog.theme_location_open_button.clicked.connect(
-            self._on_theme_location_open_button_clicked
-        )
+        self.settings_dialog.theme_location_open_button.clicked.connect(self._on_theme_location_open_button_clicked)
 
         # Advanced tab
         self.settings_dialog.color_background_instead_of_text_checkbox.stateChanged.connect(
@@ -417,24 +373,9 @@ class SettingsController(QObject):
         Get the mod paths for the current instance. Return the Default instance if the current instance is not found.
         """
         return [
-            str(
-                Path(
-                    self.settings.instances[self.settings.current_instance].game_folder
-                )
-                / "Data"
-            ),
-            str(
-                Path(
-                    self.settings.instances[self.settings.current_instance].local_folder
-                )
-            ),
-            str(
-                Path(
-                    self.settings.instances[
-                        self.settings.current_instance
-                    ].workshop_folder
-                )
-            ),
+            str(Path(self.settings.instances[self.settings.current_instance].game_folder) / "Data"),
+            str(Path(self.settings.instances[self.settings.current_instance].local_folder)),
+            str(Path(self.settings.instances[self.settings.current_instance].workshop_folder)),
         ]
 
     def resolve_data_source(self, path: str) -> str | None:
@@ -444,16 +385,9 @@ class SettingsController(QObject):
         # Pathlib the provided path string
         sanitized_path = Path(path)
         # Grab paths from Settings
-        expansions_path = (
-            Path(self.settings.instances[self.settings.current_instance].game_folder)
-            / "Data"
-        )
-        local_path = Path(
-            self.settings.instances[self.settings.current_instance].local_folder
-        )
-        workshop_path = Path(
-            self.settings.instances[self.settings.current_instance].workshop_folder
-        )
+        expansions_path = Path(self.settings.instances[self.settings.current_instance].game_folder) / "Data"
+        local_path = Path(self.settings.instances[self.settings.current_instance].local_folder)
+        workshop_path = Path(self.settings.instances[self.settings.current_instance].workshop_folder)
         # Validate data source, then emit if path is valid and not mapped
         if sanitized_path.parent == expansions_path:
             return "expansion"
@@ -542,9 +476,7 @@ class SettingsController(QObject):
             str(self.settings.instances[self.settings.current_instance].game_folder)
         )
         self.settings_dialog.game_location.setCursorPosition(0)
-        self.settings_dialog.game_location_open_button.setEnabled(
-            self.settings_dialog.game_location.text() != ""
-        )
+        self.settings_dialog.game_location_open_button.setEnabled(self.settings_dialog.game_location.text() != "")
         self.settings_dialog.config_folder_location.setText(
             str(self.settings.instances[self.settings.current_instance].config_folder)
         )
@@ -567,255 +499,146 @@ class SettingsController(QObject):
             self.settings_dialog.local_mods_folder_location.text() != ""
         )
         self.settings_dialog.steam_client_integration_checkbox.setChecked(
-            self.settings.instances[
-                self.settings.current_instance
-            ].steam_client_integration
+            self.settings.instances[self.settings.current_instance].steam_client_integration
         )
         # Enable/disable Steam mods location fields based on checkbox state
         checked = self.settings_dialog.steam_client_integration_checkbox.isChecked()
         self.settings_dialog.steam_mods_folder_location.setEnabled(checked)
         self.settings_dialog.steam_mods_folder_location_open_button.setEnabled(checked)
-        self.settings_dialog.steam_mods_folder_location_choose_button.setEnabled(
-            checked
-        )
+        self.settings_dialog.steam_mods_folder_location_choose_button.setEnabled(checked)
         self.settings_dialog.steam_mods_folder_location_clear_button.setEnabled(checked)
 
         # Load Steam protocol launch option
         self.settings_dialog.launch_via_steam_protocol_checkbox.setChecked(
-            self.settings.instances[
-                self.settings.current_instance
-            ].launch_via_steam_protocol
+            self.settings.instances[self.settings.current_instance].launch_via_steam_protocol
         )
         # Update run_args group enabled state based on Steam protocol setting
-        launch_via_steam_protocol = self.settings.instances[
-            self.settings.current_instance
-        ].launch_via_steam_protocol
+        launch_via_steam_protocol = self.settings.instances[self.settings.current_instance].launch_via_steam_protocol
         self.settings_dialog.run_args_group.setEnabled(not launch_via_steam_protocol)
 
         # Instance folder location (custom override)
         # Only enable for Default instance
         is_default_instance = self.settings.current_instance == DEFAULT_INSTANCE_NAME
         self.settings_dialog.instance_folder_location.setText(
-            self.settings.instances[
-                self.settings.current_instance
-            ].instance_folder_override
+            self.settings.instances[self.settings.current_instance].instance_folder_override
         )
         self.settings_dialog.instance_folder_location.setCursorPosition(0)
         self.settings_dialog.instance_folder_location.setEnabled(is_default_instance)
-        self.settings_dialog.instance_folder_location_choose_button.setEnabled(
-            is_default_instance
-        )
-        self.settings_dialog.instance_folder_location_clear_button.setEnabled(
-            is_default_instance
-        )
+        self.settings_dialog.instance_folder_location_choose_button.setEnabled(is_default_instance)
+        self.settings_dialog.instance_folder_location_clear_button.setEnabled(is_default_instance)
 
         # Databases tab
         if self.settings.external_community_rules_metadata_source == "None":
             self.settings_dialog.community_rules_db_none_radio.setChecked(True)
             self.settings_dialog.community_rules_db_github_url.setEnabled(False)
-            self.settings_dialog.community_rules_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.community_rules_db_github_download_button.setEnabled(False)
             self.settings_dialog.community_rules_db_url_input.setEnabled(False)
-            self.settings_dialog.community_rules_db_url_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.community_rules_db_url_download_button.setEnabled(False)
             self.settings_dialog.community_rules_db_local_file.setEnabled(False)
-            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(
-                False
-            )
-        elif (
-            self.settings.external_community_rules_metadata_source
-            == "Configured git repository"
-        ):
+            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(False)
+        elif self.settings.external_community_rules_metadata_source == "Configured git repository":
             self.settings_dialog.community_rules_db_github_radio.setChecked(True)
             self.settings_dialog.community_rules_db_github_url.setEnabled(True)
-            self.settings_dialog.community_rules_db_github_download_button.setEnabled(
-                True
-            )
+            self.settings_dialog.community_rules_db_github_download_button.setEnabled(True)
             self.settings_dialog.community_rules_db_url_input.setEnabled(False)
-            self.settings_dialog.community_rules_db_url_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.community_rules_db_url_download_button.setEnabled(False)
             self.settings_dialog.community_rules_db_local_file.setEnabled(False)
-            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(
-                False
-            )
+            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(False)
         elif self.settings.external_community_rules_metadata_source == "Configured URL":
             self.settings_dialog.community_rules_db_url_radio.setChecked(True)
             self.settings_dialog.community_rules_db_url_input.setEnabled(True)
             self.settings_dialog.community_rules_db_url_download_button.setEnabled(True)
             self.settings_dialog.community_rules_db_github_url.setEnabled(False)
-            self.settings_dialog.community_rules_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.community_rules_db_github_download_button.setEnabled(False)
             self.settings_dialog.community_rules_db_local_file.setEnabled(False)
-            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(
-                False
-            )
-        elif (
-            self.settings.external_community_rules_metadata_source
-            == "Configured file path"
-        ):
+            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(False)
+        elif self.settings.external_community_rules_metadata_source == "Configured file path":
             self.settings_dialog.community_rules_db_local_file_radio.setChecked(True)
             self.settings_dialog.community_rules_db_github_url.setEnabled(False)
-            self.settings_dialog.community_rules_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.community_rules_db_github_download_button.setEnabled(False)
             self.settings_dialog.community_rules_db_url_input.setEnabled(False)
-            self.settings_dialog.community_rules_db_url_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.community_rules_db_url_download_button.setEnabled(False)
             self.settings_dialog.community_rules_db_local_file.setEnabled(True)
-            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(
-                True
-            )
-        self.settings_dialog.community_rules_db_local_file.setText(
-            self.settings.external_community_rules_file_path
-        )
+            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(True)
+        self.settings_dialog.community_rules_db_local_file.setText(self.settings.external_community_rules_file_path)
         self.settings_dialog.community_rules_db_local_file.setCursorPosition(0)
-        self.settings_dialog.community_rules_db_github_url.setText(
-            self.settings.external_community_rules_repo
-        )
-        self.settings_dialog.community_rules_db_url_input.setText(
-            self.settings.external_community_rules_url
-        )
+        self.settings_dialog.community_rules_db_github_url.setText(self.settings.external_community_rules_repo)
+        self.settings_dialog.community_rules_db_url_input.setText(self.settings.external_community_rules_url)
 
         if self.settings.external_steam_metadata_source == "None":
             self.settings_dialog.steam_workshop_db_none_radio.setChecked(True)
             self.settings_dialog.steam_workshop_db_github_url.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(False)
             self.settings_dialog.steam_workshop_db_url_input.setEnabled(False)
             self.settings_dialog.steam_workshop_db_url_download_button.setEnabled(False)
             self.settings_dialog.steam_workshop_db_local_file.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(
-                False
-            )
-        elif (
-            self.settings.external_steam_metadata_source == "Configured git repository"
-        ):
+            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(False)
+        elif self.settings.external_steam_metadata_source == "Configured git repository":
             self.settings_dialog.steam_workshop_db_github_radio.setChecked(True)
             self.settings_dialog.steam_workshop_db_github_url.setEnabled(True)
-            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(
-                True
-            )
+            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(True)
             self.settings_dialog.steam_workshop_db_url_input.setEnabled(False)
             self.settings_dialog.steam_workshop_db_url_download_button.setEnabled(False)
             self.settings_dialog.steam_workshop_db_local_file.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(
-                False
-            )
+            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(False)
         elif self.settings.external_steam_metadata_source == "Configured URL":
             self.settings_dialog.steam_workshop_db_url_radio.setChecked(True)
             self.settings_dialog.steam_workshop_db_url_input.setEnabled(True)
             self.settings_dialog.steam_workshop_db_url_download_button.setEnabled(True)
             self.settings_dialog.steam_workshop_db_github_url.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(False)
             self.settings_dialog.steam_workshop_db_local_file.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(
-                False
-            )
+            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(False)
         elif self.settings.external_steam_metadata_source == "Configured file path":
             self.settings_dialog.steam_workshop_db_local_file_radio.setChecked(True)
             self.settings_dialog.steam_workshop_db_github_url.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(False)
             self.settings_dialog.steam_workshop_db_url_input.setEnabled(False)
             self.settings_dialog.steam_workshop_db_url_download_button.setEnabled(False)
             self.settings_dialog.steam_workshop_db_local_file.setEnabled(True)
-            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(
-                True
-            )
-        self.settings_dialog.steam_workshop_db_local_file.setText(
-            self.settings.external_steam_metadata_file_path
-        )
+            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(True)
+        self.settings_dialog.steam_workshop_db_local_file.setText(self.settings.external_steam_metadata_file_path)
         self.settings_dialog.steam_workshop_db_local_file.setCursorPosition(0)
-        self.settings_dialog.steam_workshop_db_github_url.setText(
-            self.settings.external_steam_metadata_repo
-        )
+        self.settings_dialog.steam_workshop_db_github_url.setText(self.settings.external_steam_metadata_repo)
         self.settings_dialog.steam_workshop_db_github_url.setCursorPosition(0)
-        self.settings_dialog.steam_workshop_db_url_input.setText(
-            self.settings.external_steam_metadata_url
-        )
+        self.settings_dialog.steam_workshop_db_url_input.setText(self.settings.external_steam_metadata_url)
         self.settings_dialog.database_expiry.setText(str(self.settings.database_expiry))
-        self.settings_dialog.aux_db_time_limit.setText(
-            str(self.settings.aux_db_time_limit)
-        )
-        self.settings_dialog.aux_db_time_limit.setEnabled(
-            self.settings.enable_aux_db_behavior_editing
-        )
+        self.settings_dialog.aux_db_time_limit.setText(str(self.settings.aux_db_time_limit))
+        self.settings_dialog.aux_db_time_limit.setEnabled(self.settings.enable_aux_db_behavior_editing)
 
         # Cross Version DB Tab
         if self.settings.external_no_version_warning_metadata_source == "None":
             self.settings_dialog.no_version_warning_db_none_radio.setChecked(True)
             self.settings_dialog.no_version_warning_db_github_url.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(False)
             self.settings_dialog.no_version_warning_db_url_input.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(False)
             self.settings_dialog.no_version_warning_db_local_file.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(
-                False
-            )
-        elif (
-            self.settings.external_no_version_warning_metadata_source
-            == "Configured git repository"
-        ):
+            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(False)
+        elif self.settings.external_no_version_warning_metadata_source == "Configured git repository":
             self.settings_dialog.no_version_warning_db_github_radio.setChecked(True)
             self.settings_dialog.no_version_warning_db_github_url.setEnabled(True)
-            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(
-                True
-            )
+            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(True)
             self.settings_dialog.no_version_warning_db_url_input.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(False)
             self.settings_dialog.no_version_warning_db_local_file.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(
-                False
-            )
-        elif (
-            self.settings.external_no_version_warning_metadata_source
-            == "Configured URL"
-        ):
+            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(False)
+        elif self.settings.external_no_version_warning_metadata_source == "Configured URL":
             self.settings_dialog.no_version_warning_db_url_radio.setChecked(True)
             self.settings_dialog.no_version_warning_db_url_input.setEnabled(True)
-            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(
-                True
-            )
+            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(True)
             self.settings_dialog.no_version_warning_db_github_url.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(False)
             self.settings_dialog.no_version_warning_db_local_file.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(
-                False
-            )
-        elif (
-            self.settings.external_no_version_warning_metadata_source
-            == "Configured file path"
-        ):
+            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(False)
+        elif self.settings.external_no_version_warning_metadata_source == "Configured file path":
             self.settings_dialog.no_version_warning_db_local_file_radio.setChecked(True)
             self.settings_dialog.no_version_warning_db_github_url.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(False)
             self.settings_dialog.no_version_warning_db_url_input.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(False)
             self.settings_dialog.no_version_warning_db_local_file.setEnabled(True)
-            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(
-                True
-            )
+            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(True)
         self.settings_dialog.no_version_warning_db_local_file.setText(
             self.settings.external_no_version_warning_file_path
         )
@@ -824,85 +647,45 @@ class SettingsController(QObject):
             self.settings.external_no_version_warning_repo_path
         )
         self.settings_dialog.no_version_warning_db_github_url.setCursorPosition(0)
-        self.settings_dialog.no_version_warning_db_url_input.setText(
-            self.settings.external_no_version_warning_url
-        )
+        self.settings_dialog.no_version_warning_db_url_input.setText(self.settings.external_no_version_warning_url)
 
         if self.settings.external_use_this_instead_metadata_source == "None":
             self.settings_dialog.use_this_instead_db_none_radio.setChecked(True)
             self.settings_dialog.use_this_instead_db_github_url.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(False)
             self.settings_dialog.use_this_instead_db_url_input.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(False)
             self.settings_dialog.use_this_instead_db_local_file.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(
-                False
-            )
-        elif (
-            self.settings.external_use_this_instead_metadata_source
-            == "Configured git repository"
-        ):
+            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(False)
+        elif self.settings.external_use_this_instead_metadata_source == "Configured git repository":
             self.settings_dialog.use_this_instead_db_github_radio.setChecked(True)
             self.settings_dialog.use_this_instead_db_github_url.setEnabled(True)
-            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(
-                True
-            )
+            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(True)
             self.settings_dialog.use_this_instead_db_url_input.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(False)
             self.settings_dialog.use_this_instead_db_local_file.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(
-                False
-            )
-        elif (
-            self.settings.external_use_this_instead_metadata_source == "Configured URL"
-        ):
+            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(False)
+        elif self.settings.external_use_this_instead_metadata_source == "Configured URL":
             self.settings_dialog.use_this_instead_db_url_radio.setChecked(True)
             self.settings_dialog.use_this_instead_db_url_input.setEnabled(True)
-            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(
-                True
-            )
+            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(True)
             self.settings_dialog.use_this_instead_db_github_url.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(False)
             self.settings_dialog.use_this_instead_db_local_file.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(
-                False
-            )
-        elif (
-            self.settings.external_use_this_instead_metadata_source
-            == "Configured file path"
-        ):
+            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(False)
+        elif self.settings.external_use_this_instead_metadata_source == "Configured file path":
             self.settings_dialog.use_this_instead_db_local_file_radio.setChecked(True)
             self.settings_dialog.use_this_instead_db_github_url.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(False)
             self.settings_dialog.use_this_instead_db_url_input.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(False)
             self.settings_dialog.use_this_instead_db_local_file.setEnabled(True)
-            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(
-                True
-            )
-        self.settings_dialog.use_this_instead_db_local_file.setText(
-            self.settings.external_use_this_instead_file_path
-        )
+            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(True)
+        self.settings_dialog.use_this_instead_db_local_file.setText(self.settings.external_use_this_instead_file_path)
         self.settings_dialog.use_this_instead_db_local_file.setCursorPosition(0)
-        self.settings_dialog.use_this_instead_db_github_url.setText(
-            self.settings.external_use_this_instead_repo_path
-        )
+        self.settings_dialog.use_this_instead_db_github_url.setText(self.settings.external_use_this_instead_repo_path)
         self.settings_dialog.use_this_instead_db_github_url.setCursorPosition(0)
-        self.settings_dialog.use_this_instead_db_url_input.setText(
-            self.settings.external_use_this_instead_url
-        )
+        self.settings_dialog.use_this_instead_db_url_input.setText(self.settings.external_use_this_instead_url)
 
         # Sorting tab
         if self.settings.sorting_algorithm == SortMethod.ALPHABETICAL:
@@ -911,47 +694,29 @@ class SettingsController(QObject):
             self.settings_dialog.sorting_topological_radio.setChecked(True)
         # Use dependencies for sorting checkbox
         if self.settings.use_moddependencies_as_loadTheseBefore:
-            (
-                self.settings_dialog.use_moddependencies_as_loadTheseBefore.setChecked(
-                    True
-                )
-            )
+            (self.settings_dialog.use_moddependencies_as_loadTheseBefore.setChecked(True))
         # Use alternativePackageIds as satisfying dependencies
         if self.settings.use_alternative_package_ids_as_satisfying_dependencies:
-            self.settings_dialog.use_alternative_package_ids_as_satisfying_dependencies_checkbox.setChecked(
-                True
-            )
+            self.settings_dialog.use_alternative_package_ids_as_satisfying_dependencies_checkbox.setChecked(True)
         # Set dependencies checkbox
-        self.settings_dialog.check_deps_checkbox.setChecked(
-            self.settings.check_dependencies_on_sort
-        )
+        self.settings_dialog.check_deps_checkbox.setChecked(self.settings.check_dependencies_on_sort)
         # Prefer versioned About.xml tags over base tags
         if self.settings.prefer_versioned_about_tags:
             self.settings_dialog.prefer_versioned_about_tags_checkbox.setChecked(True)
         # Download missing mods checkbox
-        self.settings_dialog.download_missing_mods_checkbox.setChecked(
-            self.settings.try_download_missing_mods
-        )
+        self.settings_dialog.download_missing_mods_checkbox.setChecked(self.settings.try_download_missing_mods)
         # Duplicate mod notification checkbox
-        self.settings_dialog.show_duplicate_mods_warning_checkbox.setChecked(
-            self.settings.duplicate_mods_warning
-        )
+        self.settings_dialog.show_duplicate_mods_warning_checkbox.setChecked(self.settings.duplicate_mods_warning)
         # Mod type filter checkbox
-        self.settings_dialog.mod_type_filter_checkbox.setChecked(
-            self.settings.mod_type_filter
-        )
+        self.settings_dialog.mod_type_filter_checkbox.setChecked(self.settings.mod_type_filter)
         # Hide invalid mod filtering checkbox
         self.settings_dialog.hide_invalid_mods_when_filtering_checkbox.setChecked(
             self.settings.hide_invalid_mods_when_filtering
         )
         # Inactive mods sorting options checkbox
-        self.settings_dialog.enable_inactive_mods_sorting_checkbox.setChecked(
-            self.settings.inactive_mods_sorting
-        )
+        self.settings_dialog.enable_inactive_mods_sorting_checkbox.setChecked(self.settings.inactive_mods_sorting)
         # Enable/disable the inactive mods sorting group box based on the checkbox state
-        self.settings_dialog.inactive_mods_sorting_group_box.setEnabled(
-            self.settings.inactive_mods_sorting
-        )
+        self.settings_dialog.inactive_mods_sorting_group_box.setEnabled(self.settings.inactive_mods_sorting)
         # Save inactive mods sort state
         self.settings_dialog.save_inactive_mods_sort_state_checkbox.setChecked(
             self.settings.save_inactive_mods_sort_state
@@ -962,34 +727,22 @@ class SettingsController(QObject):
             self.settings_dialog.db_builder_include_all_radio.setChecked(True)
         elif self.settings.db_builder_include == "no_local":
             self.settings_dialog.db_builder_include_no_local_radio.setChecked(True)
-        self.settings_dialog.db_builder_query_dlc_checkbox.setChecked(
-            self.settings.build_steam_database_dlc_data
-        )
+        self.settings_dialog.db_builder_query_dlc_checkbox.setChecked(self.settings.build_steam_database_dlc_data)
         self.settings_dialog.db_builder_update_instead_of_overwriting_checkbox.setChecked(
             self.settings.build_steam_database_update_toggle
         )
-        self.settings_dialog.db_builder_steam_api_key.setText(
-            self.settings.steam_apikey
-        )
+        self.settings_dialog.db_builder_steam_api_key.setText(self.settings.steam_apikey)
 
         # SteamCMD tab
-        self.settings_dialog.steamcmd_validate_downloads_checkbox.setChecked(
-            self.settings.steamcmd_validate_downloads
-        )
+        self.settings_dialog.steamcmd_validate_downloads_checkbox.setChecked(self.settings.steamcmd_validate_downloads)
         self.settings_dialog.steamcmd_auto_clear_depot_cache_checkbox.setChecked(
-            self.settings.instances[
-                self.settings.current_instance
-            ].steamcmd_auto_clear_depot_cache
+            self.settings.instances[self.settings.current_instance].steamcmd_auto_clear_depot_cache
         )
         self.settings_dialog.steamcmd_delete_before_update_checkbox.setChecked(
             self.settings.steamcmd_delete_before_update
         )
         self.settings_dialog.steamcmd_install_location.setText(
-            str(
-                self.settings.instances[
-                    self.settings.current_instance
-                ].steamcmd_install_path
-            )
+            str(self.settings.instances[self.settings.current_instance].steamcmd_install_path)
         )
 
         # todds tab
@@ -1006,48 +759,26 @@ class SettingsController(QObject):
             self.settings_dialog.todds_active_mods_only_radio.setChecked(True)
         else:
             self.settings_dialog.todds_all_mods_radio.setChecked(True)
-        self.settings_dialog.todds_dry_run_checkbox.setChecked(
-            self.settings.todds_dry_run
-        )
-        self.settings_dialog.todds_overwrite_checkbox.setChecked(
-            self.settings.todds_overwrite
-        )
-        self.settings_dialog.todds_custom_command_lineedit.setText(
-            self.settings.todds_custom_command
-        )
-        self.settings_dialog.auto_delete_orphaned_dds_checkbox.setChecked(
-            self.settings.auto_delete_orphaned_dds
-        )
+        self.settings_dialog.todds_dry_run_checkbox.setChecked(self.settings.todds_dry_run)
+        self.settings_dialog.todds_overwrite_checkbox.setChecked(self.settings.todds_overwrite)
+        self.settings_dialog.todds_custom_command_lineedit.setText(self.settings.todds_custom_command)
+        self.settings_dialog.auto_delete_orphaned_dds_checkbox.setChecked(self.settings.auto_delete_orphaned_dds)
         self.settings_dialog.auto_run_todds_before_launch_checkbox.setChecked(
             self.settings.auto_run_todds_before_launch
         )
 
         # External Tools Tab
-        self.settings_dialog.text_editor_location.setText(
-            self.settings.text_editor_location
-        )
-        self.settings_dialog.text_editor_folder_arg.setText(
-            self.settings.text_editor_folder_arg
-        )
-        self.settings_dialog.text_editor_file_arg.setText(
-            self.settings.text_editor_file_arg
-        )
+        self.settings_dialog.text_editor_location.setText(self.settings.text_editor_location)
+        self.settings_dialog.text_editor_folder_arg.setText(self.settings.text_editor_folder_arg)
+        self.settings_dialog.text_editor_file_arg.setText(self.settings.text_editor_file_arg)
 
         # Themes tab
-        self.settings_dialog.enable_themes_checkbox.setChecked(
-            self.settings.enable_themes
-        )
-        self.theme_controller.populate_themes_combobox(
-            self.settings_dialog.themes_combobox
-        )
+        self.settings_dialog.enable_themes_checkbox.setChecked(self.settings.enable_themes)
+        self.theme_controller.populate_themes_combobox(self.settings_dialog.themes_combobox)
         self.theme_controller.setup_theme_dialog(self.settings_dialog, self.settings)
 
-        self.language_controller.populate_languages_combobox(
-            self.settings_dialog.language_combobox
-        )
-        self.language_controller.setup_language_dialog(
-            self.settings_dialog, self.settings
-        )
+        self.language_controller.populate_languages_combobox(self.settings_dialog.language_combobox)
+        self.language_controller.setup_language_dialog(self.settings_dialog, self.settings)
 
         # Advanced tab values
         try:
@@ -1112,57 +843,31 @@ class SettingsController(QObject):
             self.settings_dialog.browser_launch_maximized_radio.setChecked(True)
 
         # Settings Window (only custom option)
-        self.settings_dialog.settings_custom_width_spinbox.setValue(
-            self.settings.settings_window_custom_width
-        )
-        self.settings_dialog.settings_custom_height_spinbox.setValue(
-            self.settings.settings_window_custom_height
-        )
+        self.settings_dialog.settings_custom_width_spinbox.setValue(self.settings.settings_window_custom_width)
+        self.settings_dialog.settings_custom_height_spinbox.setValue(self.settings.settings_window_custom_height)
 
         # Advanced tab
-        self.settings_dialog.debug_logging_checkbox.setChecked(
-            self.settings.debug_logging_enabled
-        )
+        self.settings_dialog.debug_logging_checkbox.setChecked(self.settings.debug_logging_enabled)
         self.settings_dialog.watchdog_checkbox.setChecked(self.settings.watchdog_toggle)
-        self.settings_dialog.backup_saves_on_launch_checkbox.setChecked(
-            self.settings.backup_saves_on_launch
-        )
-        self.settings_dialog.auto_backup_retention_count_spinbox.setValue(
-            self.settings.auto_backup_retention_count
-        )
-        self.settings_dialog.auto_backup_compression_count_spinbox.setValue(
-            self.settings.auto_backup_compression_count
-        )
+        self.settings_dialog.backup_saves_on_launch_checkbox.setChecked(self.settings.backup_saves_on_launch)
+        self.settings_dialog.auto_backup_retention_count_spinbox.setValue(self.settings.auto_backup_retention_count)
+        self.settings_dialog.auto_backup_compression_count_spinbox.setValue(self.settings.auto_backup_compression_count)
         self.settings_dialog.color_background_instead_of_text_checkbox.setChecked(
             self.settings.color_background_instead_of_text_toggle
         )
         # Clear button behavior
-        self.settings_dialog.clear_moves_dlc_checkbox.setChecked(
-            self.settings.clear_moves_dlc
-        )
-        self.settings_dialog.auto_launch_steam_checkbox.setChecked(
-            self.settings.auto_launch_steam
-        )
-        self.settings_dialog.show_mod_updates_checkbox.setChecked(
-            self.settings.steam_mods_update_check
-        )
-        self.settings_dialog.render_unity_rich_text_checkbox.setChecked(
-            self.settings.render_unity_rich_text
-        )
-        self.settings_dialog.update_databases_on_startup_checkbox.setChecked(
-            self.settings.update_databases_on_startup
-        )
+        self.settings_dialog.clear_moves_dlc_checkbox.setChecked(self.settings.clear_moves_dlc)
+        self.settings_dialog.auto_launch_steam_checkbox.setChecked(self.settings.auto_launch_steam)
+        self.settings_dialog.show_mod_updates_checkbox.setChecked(self.settings.steam_mods_update_check)
+        self.settings_dialog.render_unity_rich_text_checkbox.setChecked(self.settings.render_unity_rich_text)
+        self.settings_dialog.update_databases_on_startup_checkbox.setChecked(self.settings.update_databases_on_startup)
         self.settings_dialog.include_mod_notes_in_mod_name_filter_checkbox.setChecked(
             self.settings.include_mod_notes_in_mod_name_filter
         )
 
-        self.settings_dialog.enable_backup_before_update_checkbox.setChecked(
-            self.settings.enable_backup_before_update
-        )
+        self.settings_dialog.enable_backup_before_update_checkbox.setChecked(self.settings.enable_backup_before_update)
         self.settings_dialog.max_backups_spinbox.setValue(self.settings.max_backups)
-        self.settings_dialog.enable_aux_db_behavior_editing.setChecked(
-            self.settings.enable_aux_db_behavior_editing
-        )
+        self.settings_dialog.enable_aux_db_behavior_editing.setChecked(self.settings.enable_aux_db_behavior_editing)
         self.settings_dialog.rentry_auth_code.setText(self.settings.rentry_auth_code)
         self.settings_dialog.rentry_auth_code.setCursorPosition(0)
         self.settings_dialog.github_username.setText(self.settings.github_username)
@@ -1171,17 +876,10 @@ class SettingsController(QObject):
         self.settings_dialog.github_token.setCursorPosition(0)
 
         # Migrate old comma-separated format to new space-separated format if needed
-        run_args_list = self._migrate_run_args(
-            self.settings.instances[self.settings.current_instance].run_args
-        )
+        run_args_list = self._migrate_run_args(self.settings.instances[self.settings.current_instance].run_args)
         # Save migrated format back to settings
-        if (
-            run_args_list
-            != self.settings.instances[self.settings.current_instance].run_args
-        ):
-            self.settings.instances[
-                self.settings.current_instance
-            ].run_args = run_args_list
+        if run_args_list != self.settings.instances[self.settings.current_instance].run_args:
+            self.settings.instances[self.settings.current_instance].run_args = run_args_list
             self.settings.save()
             logger.info(f"Saved migrated run_args: {run_args_list}")
 
@@ -1196,9 +894,7 @@ class SettingsController(QObject):
         """
 
         # Locations tab
-        self.settings.instances[
-            self.settings.current_instance
-        ].game_folder = self.settings_dialog.game_location.text()
+        self.settings.instances[self.settings.current_instance].game_folder = self.settings_dialog.game_location.text()
         self.settings.instances[
             self.settings.current_instance
         ].config_folder = self.settings_dialog.config_folder_location.text()
@@ -1210,39 +906,25 @@ class SettingsController(QObject):
         ].local_folder = self.settings_dialog.local_mods_folder_location.text()
         self.settings.instances[
             self.settings.current_instance
-        ].steam_client_integration = (
-            self.settings_dialog.steam_client_integration_checkbox.isChecked()
-        )
+        ].steam_client_integration = self.settings_dialog.steam_client_integration_checkbox.isChecked()
 
         # Save Steam protocol launch option
         self.settings.instances[
             self.settings.current_instance
-        ].launch_via_steam_protocol = (
-            self.settings_dialog.launch_via_steam_protocol_checkbox.isChecked()
-        )
+        ].launch_via_steam_protocol = self.settings_dialog.launch_via_steam_protocol_checkbox.isChecked()
 
         # Databases tab
         if self.settings_dialog.community_rules_db_none_radio.isChecked():
             self.settings.external_community_rules_metadata_source = "None"
         elif self.settings_dialog.community_rules_db_local_file_radio.isChecked():
-            self.settings.external_community_rules_metadata_source = (
-                "Configured file path"
-            )
+            self.settings.external_community_rules_metadata_source = "Configured file path"
         elif self.settings_dialog.community_rules_db_github_radio.isChecked():
-            self.settings.external_community_rules_metadata_source = (
-                "Configured git repository"
-            )
+            self.settings.external_community_rules_metadata_source = "Configured git repository"
         elif self.settings_dialog.community_rules_db_url_radio.isChecked():
             self.settings.external_community_rules_metadata_source = "Configured URL"
-        self.settings.external_community_rules_file_path = (
-            self.settings_dialog.community_rules_db_local_file.text()
-        )
-        self.settings.external_community_rules_repo = (
-            self.settings_dialog.community_rules_db_github_url.text()
-        )
-        self.settings.external_community_rules_url = (
-            self.settings_dialog.community_rules_db_url_input.text()
-        )
+        self.settings.external_community_rules_file_path = self.settings_dialog.community_rules_db_local_file.text()
+        self.settings.external_community_rules_repo = self.settings_dialog.community_rules_db_github_url.text()
+        self.settings.external_community_rules_url = self.settings_dialog.community_rules_db_url_input.text()
         if self.settings_dialog.steam_workshop_db_none_radio.isChecked():
             self.settings.external_steam_metadata_source = "None"
         elif self.settings_dialog.steam_workshop_db_local_file_radio.isChecked():
@@ -1251,28 +933,18 @@ class SettingsController(QObject):
             self.settings.external_steam_metadata_source = "Configured git repository"
         elif self.settings_dialog.steam_workshop_db_url_radio.isChecked():
             self.settings.external_steam_metadata_source = "Configured URL"
-        self.settings.external_steam_metadata_repo = (
-            self.settings_dialog.steam_workshop_db_github_url.text()
-        )
-        self.settings.external_steam_metadata_file_path = (
-            self.settings_dialog.steam_workshop_db_local_file.text()
-        )
-        self.settings.external_steam_metadata_url = (
-            self.settings_dialog.steam_workshop_db_url_input.text()
-        )
+        self.settings.external_steam_metadata_repo = self.settings_dialog.steam_workshop_db_github_url.text()
+        self.settings.external_steam_metadata_file_path = self.settings_dialog.steam_workshop_db_local_file.text()
+        self.settings.external_steam_metadata_url = self.settings_dialog.steam_workshop_db_url_input.text()
         self.settings.database_expiry = int(self.settings_dialog.database_expiry.text())
 
         # Cross Version Databases Tab
         if self.settings_dialog.no_version_warning_db_none_radio.isChecked():
             self.settings.external_no_version_warning_metadata_source = "None"
         elif self.settings_dialog.no_version_warning_db_local_file_radio.isChecked():
-            self.settings.external_no_version_warning_metadata_source = (
-                "Configured file path"
-            )
+            self.settings.external_no_version_warning_metadata_source = "Configured file path"
         elif self.settings_dialog.no_version_warning_db_github_radio.isChecked():
-            self.settings.external_no_version_warning_metadata_source = (
-                "Configured git repository"
-            )
+            self.settings.external_no_version_warning_metadata_source = "Configured git repository"
         elif self.settings_dialog.no_version_warning_db_url_radio.isChecked():
             self.settings.external_no_version_warning_metadata_source = "Configured URL"
         self.settings.external_no_version_warning_file_path = (
@@ -1281,35 +953,21 @@ class SettingsController(QObject):
         self.settings.external_no_version_warning_repo_path = (
             self.settings_dialog.no_version_warning_db_github_url.text()
         )
-        self.settings.external_no_version_warning_url = (
-            self.settings_dialog.no_version_warning_db_url_input.text()
-        )
+        self.settings.external_no_version_warning_url = self.settings_dialog.no_version_warning_db_url_input.text()
 
         if self.settings_dialog.use_this_instead_db_none_radio.isChecked():
             self.settings.external_use_this_instead_metadata_source = "None"
         elif self.settings_dialog.use_this_instead_db_local_file_radio.isChecked():
-            self.settings.external_use_this_instead_metadata_source = (
-                "Configured file path"
-            )
+            self.settings.external_use_this_instead_metadata_source = "Configured file path"
         elif self.settings_dialog.use_this_instead_db_github_radio.isChecked():
-            self.settings.external_use_this_instead_metadata_source = (
-                "Configured git repository"
-            )
+            self.settings.external_use_this_instead_metadata_source = "Configured git repository"
         elif self.settings_dialog.use_this_instead_db_url_radio.isChecked():
             self.settings.external_use_this_instead_metadata_source = "Configured URL"
-        self.settings.external_use_this_instead_file_path = (
-            self.settings_dialog.use_this_instead_db_local_file.text()
-        )
-        self.settings.external_use_this_instead_repo_path = (
-            self.settings_dialog.use_this_instead_db_github_url.text()
-        )
-        self.settings.external_use_this_instead_url = (
-            self.settings_dialog.use_this_instead_db_url_input.text()
-        )
+        self.settings.external_use_this_instead_file_path = self.settings_dialog.use_this_instead_db_local_file.text()
+        self.settings.external_use_this_instead_repo_path = self.settings_dialog.use_this_instead_db_github_url.text()
+        self.settings.external_use_this_instead_url = self.settings_dialog.use_this_instead_db_url_input.text()
         try:
-            self.settings.aux_db_time_limit = int(
-                self.settings_dialog.aux_db_time_limit.text()
-            )
+            self.settings.aux_db_time_limit = int(self.settings_dialog.aux_db_time_limit.text())
         except Exception:
             logger.warning("Failed setting Aux DB time limit, falling back to -1")
             self.settings.aux_db_time_limit = -1
@@ -1325,35 +983,27 @@ class SettingsController(QObject):
             self.settings_dialog.use_moddependencies_as_loadTheseBefore.isChecked()
         )
         # Use alternativePackageIds as satisfying dependencies
-        self.settings.use_alternative_package_ids_as_satisfying_dependencies = self.settings_dialog.use_alternative_package_ids_as_satisfying_dependencies_checkbox.isChecked()
-        # Set dependencies checkbox
-        self.settings.check_dependencies_on_sort = (
-            self.settings_dialog.check_deps_checkbox.isChecked()
+        self.settings.use_alternative_package_ids_as_satisfying_dependencies = (
+            self.settings_dialog.use_alternative_package_ids_as_satisfying_dependencies_checkbox.isChecked()
         )
+        # Set dependencies checkbox
+        self.settings.check_dependencies_on_sort = self.settings_dialog.check_deps_checkbox.isChecked()
         # Prefer versioned About.xml tags over base tags
         self.settings.prefer_versioned_about_tags = (
             self.settings_dialog.prefer_versioned_about_tags_checkbox.isChecked()
         )
         # Download missing mods checkbox
-        self.settings.try_download_missing_mods = (
-            self.settings_dialog.download_missing_mods_checkbox.isChecked()
-        )
+        self.settings.try_download_missing_mods = self.settings_dialog.download_missing_mods_checkbox.isChecked()
         # Duplicate mod notification checkbox
-        self.settings.duplicate_mods_warning = (
-            self.settings_dialog.show_duplicate_mods_warning_checkbox.isChecked()
-        )
+        self.settings.duplicate_mods_warning = self.settings_dialog.show_duplicate_mods_warning_checkbox.isChecked()
         # Mod type filter checkbox
-        self.settings.mod_type_filter = (
-            self.settings_dialog.mod_type_filter_checkbox.isChecked()
-        )
+        self.settings.mod_type_filter = self.settings_dialog.mod_type_filter_checkbox.isChecked()
         # Hide invalid mod filtering checkbox
         self.settings.hide_invalid_mods_when_filtering = (
             self.settings_dialog.hide_invalid_mods_when_filtering_checkbox.isChecked()
         )
         # Inactive mods sorting options checkbox
-        self.settings.inactive_mods_sorting = (
-            self.settings_dialog.enable_inactive_mods_sorting_checkbox.isChecked()
-        )
+        self.settings.inactive_mods_sorting = self.settings_dialog.enable_inactive_mods_sorting_checkbox.isChecked()
         # Save inactive mods sort state
         self.settings.save_inactive_mods_sort_state = (
             self.settings_dialog.save_inactive_mods_sort_state_checkbox.isChecked()
@@ -1364,13 +1014,11 @@ class SettingsController(QObject):
             self.settings.db_builder_include = "all_mods"
         elif self.settings_dialog.db_builder_include_no_local_radio.isChecked():
             self.settings.db_builder_include = "no_local"
-        self.settings.build_steam_database_dlc_data = (
-            self.settings_dialog.db_builder_query_dlc_checkbox.isChecked()
+        self.settings.build_steam_database_dlc_data = self.settings_dialog.db_builder_query_dlc_checkbox.isChecked()
+        self.settings.build_steam_database_update_toggle = (
+            self.settings_dialog.db_builder_update_instead_of_overwriting_checkbox.isChecked()
         )
-        self.settings.build_steam_database_update_toggle = self.settings_dialog.db_builder_update_instead_of_overwriting_checkbox.isChecked()
-        self.settings.steam_apikey = (
-            self.settings_dialog.db_builder_steam_api_key.text()
-        )
+        self.settings.steam_apikey = self.settings_dialog.db_builder_steam_api_key.text()
 
         # SteamCMD tab
         self.settings.steamcmd_validate_downloads = (
@@ -1381,9 +1029,7 @@ class SettingsController(QObject):
         )
         self.settings.instances[
             self.settings.current_instance
-        ].steamcmd_auto_clear_depot_cache = (
-            self.settings_dialog.steamcmd_auto_clear_depot_cache_checkbox.isChecked()
-        )
+        ].steamcmd_auto_clear_depot_cache = self.settings_dialog.steamcmd_auto_clear_depot_cache_checkbox.isChecked()
         self.settings.instances[
             self.settings.current_instance
         ].steamcmd_install_path = self.settings_dialog.steamcmd_install_location.text()
@@ -1393,54 +1039,38 @@ class SettingsController(QObject):
             self.settings.todds_preset = "optimized"
         if self.settings_dialog.todds_preset_custom_radio.isChecked():
             self.settings.todds_preset = "custom"
-            self.settings.todds_custom_command = (
-                self.settings_dialog.todds_custom_command_lineedit.text()
-            )
+            self.settings.todds_custom_command = self.settings_dialog.todds_custom_command_lineedit.text()
         else:
             self.settings.todds_preset = "optimized"
         if self.settings_dialog.todds_active_mods_only_radio.isChecked():
             self.settings.todds_active_mods_target = True
         elif self.settings_dialog.todds_all_mods_radio.isChecked():
             self.settings.todds_active_mods_target = False
-        self.settings.todds_dry_run = (
-            self.settings_dialog.todds_dry_run_checkbox.isChecked()
-        )
-        self.settings.todds_overwrite = (
-            self.settings_dialog.todds_overwrite_checkbox.isChecked()
-        )
-        self.settings.auto_delete_orphaned_dds = (
-            self.settings_dialog.auto_delete_orphaned_dds_checkbox.isChecked()
-        )
+        self.settings.todds_dry_run = self.settings_dialog.todds_dry_run_checkbox.isChecked()
+        self.settings.todds_overwrite = self.settings_dialog.todds_overwrite_checkbox.isChecked()
+        self.settings.auto_delete_orphaned_dds = self.settings_dialog.auto_delete_orphaned_dds_checkbox.isChecked()
         self.settings.auto_run_todds_before_launch = (
             self.settings_dialog.auto_run_todds_before_launch_checkbox.isChecked()
         )
 
         # Other External Tools Tab
-        self.settings.text_editor_location = (
-            self.settings_dialog.text_editor_location.text()
-        )
-        self.settings.text_editor_folder_arg = (
-            self.settings_dialog.text_editor_folder_arg.text()
-        )
-        self.settings.text_editor_file_arg = (
-            self.settings_dialog.text_editor_file_arg.text()
-        )
+        self.settings.text_editor_location = self.settings_dialog.text_editor_location.text()
+        self.settings.text_editor_folder_arg = self.settings_dialog.text_editor_folder_arg.text()
+        self.settings.text_editor_file_arg = self.settings_dialog.text_editor_file_arg.text()
 
         # Themes tab
-        self.settings.enable_themes = (
-            self.settings_dialog.enable_themes_checkbox.isChecked()
-        )
+        self.settings.enable_themes = self.settings_dialog.enable_themes_checkbox.isChecked()
         self.settings.theme_name = self.settings_dialog.themes_combobox.currentText()
 
-        self.settings.font_family = (
-            self.settings_dialog.font_family_combobox.currentText()
-        )
+        self.settings.font_family = self.settings_dialog.font_family_combobox.currentText()
         self.settings.font_size = self.settings_dialog.font_size_spinbox.value()
         self.settings.language = self.settings_dialog.language_combobox.currentData()
 
         # Launch State tab
         # Dialogue positioning
-        self.settings.constrain_dialogues_to_main_window_monitor = self.settings_dialog.constrain_dialogues_to_main_window_monitor_checkbox.isChecked()
+        self.settings.constrain_dialogues_to_main_window_monitor = (
+            self.settings_dialog.constrain_dialogues_to_main_window_monitor_checkbox.isChecked()
+        )
 
         # Windows launch state
         # Main Window
@@ -1450,12 +1080,8 @@ class SettingsController(QObject):
             self.settings.main_window_launch_state = "normal"
         elif self.settings_dialog.main_launch_custom_radio.isChecked():
             self.settings.main_window_launch_state = "custom"
-            self.settings.main_window_custom_width = (
-                self.settings_dialog.main_custom_width_spinbox.value()
-            )
-            self.settings.main_window_custom_height = (
-                self.settings_dialog.main_custom_height_spinbox.value()
-            )
+            self.settings.main_window_custom_width = self.settings_dialog.main_custom_width_spinbox.value()
+            self.settings.main_window_custom_height = self.settings_dialog.main_custom_height_spinbox.value()
         else:
             self.settings.main_window_launch_state = "maximized"
         # Browser Window
@@ -1465,74 +1091,46 @@ class SettingsController(QObject):
             self.settings.browser_window_launch_state = "normal"
         elif self.settings_dialog.browser_launch_custom_radio.isChecked():
             self.settings.browser_window_launch_state = "custom"
-            self.settings.browser_window_custom_width = (
-                self.settings_dialog.browser_custom_width_spinbox.value()
-            )
-            self.settings.browser_window_custom_height = (
-                self.settings_dialog.browser_custom_height_spinbox.value()
-            )
+            self.settings.browser_window_custom_width = self.settings_dialog.browser_custom_width_spinbox.value()
+            self.settings.browser_window_custom_height = self.settings_dialog.browser_custom_height_spinbox.value()
         else:
             self.settings.browser_window_launch_state = "maximized"
 
         # Settings Window (only custom option)
-        self.settings.settings_window_custom_width = (
-            self.settings_dialog.settings_custom_width_spinbox.value()
-        )
-        self.settings.settings_window_custom_height = (
-            self.settings_dialog.settings_custom_height_spinbox.value()
-        )
+        self.settings.settings_window_custom_width = self.settings_dialog.settings_custom_width_spinbox.value()
+        self.settings.settings_window_custom_height = self.settings_dialog.settings_custom_height_spinbox.value()
 
         # Advanced tab
-        self.settings.debug_logging_enabled = (
-            self.settings_dialog.debug_logging_checkbox.isChecked()
-        )
-        self.settings.watchdog_toggle = (
-            self.settings_dialog.watchdog_checkbox.isChecked()
-        )
-        self.settings.backup_saves_on_launch = (
-            self.settings_dialog.backup_saves_on_launch_checkbox.isChecked()
-        )
-        self.settings.auto_backup_retention_count = (
-            self.settings_dialog.auto_backup_retention_count_spinbox.value()
-        )
-        self.settings.auto_backup_compression_count = (
-            self.settings_dialog.auto_backup_compression_count_spinbox.value()
-        )
+        self.settings.debug_logging_enabled = self.settings_dialog.debug_logging_checkbox.isChecked()
+        self.settings.watchdog_toggle = self.settings_dialog.watchdog_checkbox.isChecked()
+        self.settings.backup_saves_on_launch = self.settings_dialog.backup_saves_on_launch_checkbox.isChecked()
+        self.settings.auto_backup_retention_count = self.settings_dialog.auto_backup_retention_count_spinbox.value()
+        self.settings.auto_backup_compression_count = self.settings_dialog.auto_backup_compression_count_spinbox.value()
         self.settings.color_background_instead_of_text_toggle = (
             self.settings_dialog.color_background_instead_of_text_checkbox.isChecked()
         )
         # Clear button behavior
-        self.settings.clear_moves_dlc = (
-            self.settings_dialog.clear_moves_dlc_checkbox.isChecked()
-        )
-        self.settings.auto_launch_steam = (
-            self.settings_dialog.auto_launch_steam_checkbox.isChecked()
-        )
-        self.settings.steam_mods_update_check = (
-            self.settings_dialog.show_mod_updates_checkbox.isChecked()
-        )
-        self.settings.render_unity_rich_text = (
-            self.settings_dialog.render_unity_rich_text_checkbox.isChecked()
-        )
+        self.settings.clear_moves_dlc = self.settings_dialog.clear_moves_dlc_checkbox.isChecked()
+        self.settings.auto_launch_steam = self.settings_dialog.auto_launch_steam_checkbox.isChecked()
+        self.settings.steam_mods_update_check = self.settings_dialog.show_mod_updates_checkbox.isChecked()
+        self.settings.render_unity_rich_text = self.settings_dialog.render_unity_rich_text_checkbox.isChecked()
         self.settings.update_databases_on_startup = (
             self.settings_dialog.update_databases_on_startup_checkbox.isChecked()
         )
-        self.settings.include_mod_notes_in_mod_name_filter = self.settings_dialog.include_mod_notes_in_mod_name_filter_checkbox.isChecked()
+        self.settings.include_mod_notes_in_mod_name_filter = (
+            self.settings_dialog.include_mod_notes_in_mod_name_filter_checkbox.isChecked()
+        )
 
         self.settings.enable_backup_before_update = (
             self.settings_dialog.enable_backup_before_update_checkbox.isChecked()
         )
         self.settings.max_backups = self.settings_dialog.max_backups_spinbox.value()
-        self.settings.enable_aux_db_behavior_editing = (
-            self.settings_dialog.enable_aux_db_behavior_editing.isChecked()
-        )
+        self.settings.enable_aux_db_behavior_editing = self.settings_dialog.enable_aux_db_behavior_editing.isChecked()
         self.settings.rentry_auth_code = self.settings_dialog.rentry_auth_code.text()
         self.settings.github_username = self.settings_dialog.github_username.text()
         self.settings.github_token = self.settings_dialog.github_token.text()
         # Migrate and extract command string from single-element list
-        run_args_list = self._migrate_run_args(
-            self.settings.instances[self.settings.current_instance].run_args
-        )
+        run_args_list = self._migrate_run_args(self.settings.instances[self.settings.current_instance].run_args)
         run_args_str = run_args_list[0] if run_args_list else ""
         self.settings_dialog.run_args.setText(run_args_str)
 
@@ -1543,9 +1141,7 @@ class SettingsController(QObject):
         """
         answer = BinaryChoiceDialog(
             title=self.tr("Reset to defaults"),
-            text=self.tr(
-                "Are you sure you want to reset all settings to their default values?"
-            ),
+            text=self.tr("Are you sure you want to reset all settings to their default values?"),
         )
         if not answer.exec_is_positive():
             return
@@ -1597,9 +1193,7 @@ class SettingsController(QObject):
             return False
         return True
 
-    def _check_steam_integration_validity(
-        self, steam_client_integration: bool, steam_mods_location: str
-    ) -> bool:
+    def _check_steam_integration_validity(self, steam_client_integration: bool, steam_mods_location: str) -> bool:
         """
         Check if Steam client integration and Steam mods location are valid.
 
@@ -1645,12 +1239,8 @@ class SettingsController(QObject):
 
         :return: True if valid configuration, False if invalid.
         """
-        steam_client_integration = (
-            self.settings_dialog.steam_client_integration_checkbox.isChecked()
-        )
-        steam_mods_location = (
-            self.settings_dialog.steam_mods_folder_location.text().strip()
-        )
+        steam_client_integration = self.settings_dialog.steam_client_integration_checkbox.isChecked()
+        steam_mods_location = self.settings_dialog.steam_mods_folder_location.text().strip()
 
         # Handle user explicitly disabling Steam integration
         if not steam_client_integration:
@@ -1666,9 +1256,7 @@ class SettingsController(QObject):
             self.settings_dialog.launch_via_steam_protocol_checkbox.setChecked(False)
 
         # Validate Steam integration configuration
-        is_valid = self._check_steam_integration_validity(
-            steam_client_integration, steam_mods_location
-        )
+        is_valid = self._check_steam_integration_validity(steam_client_integration, steam_mods_location)
 
         if not is_valid:
             # Disable all Steam integration settings if validation fails
@@ -1684,9 +1272,7 @@ class SettingsController(QObject):
                         "Steam client integration, Steam mods location, and Steam protocol launch have been disabled."
                     ),
                 )
-            elif steam_mods_location and not validate_acf_file_exists(
-                steam_mods_location
-            ):
+            elif steam_mods_location and not validate_acf_file_exists(steam_mods_location):
                 QMessageBox.warning(
                     self.settings_dialog,
                     self.tr("Steam Workshop File Not Found"),
@@ -1711,9 +1297,7 @@ class SettingsController(QObject):
 
         # Validate config folder if set
         config_folder_text = self.settings_dialog.config_folder_location.text().strip()
-        if config_folder_text and not self._validate_config_folder_location(
-            config_folder_text
-        ):
+        if config_folder_text and not self._validate_config_folder_location(config_folder_text):
             return
 
         # Validate Steam integration if enabled
@@ -1737,9 +1321,7 @@ class SettingsController(QObject):
 
     @Slot()
     def _on_game_location_text_changed(self) -> None:
-        self.settings_dialog.game_location_open_button.setEnabled(
-            self.settings_dialog.game_location.text() != ""
-        )
+        self.settings_dialog.game_location_open_button.setEnabled(self.settings_dialog.game_location.text() != "")
 
     @Slot()
     def _on_game_location_open_button_clicked(self) -> None:
@@ -1760,9 +1342,7 @@ class SettingsController(QObject):
         if not self._validate_game_location(str(game_location)):
             return
         self.settings_dialog.game_location.setText(str(game_location))
-        self.settings_dialog.local_mods_folder_location.setText(
-            str(game_location / "Mods")
-        )
+        self.settings_dialog.local_mods_folder_location.setText(str(game_location / "Mods"))
         self._last_file_dialog_path = str(game_location)
 
     def _on_game_location_choose_button_clicked_macos(self) -> Path | None:
@@ -1854,9 +1434,7 @@ class SettingsController(QObject):
         if not steam_mods_folder_location:
             return
 
-        self.settings_dialog.steam_mods_folder_location.setText(
-            steam_mods_folder_location
-        )
+        self.settings_dialog.steam_mods_folder_location.setText(steam_mods_folder_location)
         self._last_file_dialog_path = str(Path(steam_mods_folder_location).parent)
 
     @Slot()
@@ -1876,9 +1454,7 @@ class SettingsController(QObject):
         if not local_mods_folder_location:
             return
 
-        self.settings_dialog.local_mods_folder_location.setText(
-            local_mods_folder_location
-        )
+        self.settings_dialog.local_mods_folder_location.setText(local_mods_folder_location)
         self._last_file_dialog_path = str(Path(local_mods_folder_location).parent)
 
     @Slot()
@@ -1896,9 +1472,7 @@ class SettingsController(QObject):
         self.settings_dialog.local_mods_folder_location.setText("")
 
     @Slot()
-    def _on_locations_clear_button_clicked(
-        self, skip_confirmation: bool = False
-    ) -> None:
+    def _on_locations_clear_button_clicked(self, skip_confirmation: bool = False) -> None:
         """
         Clear the settings dialog's location fields.
         """
@@ -1945,9 +1519,7 @@ class SettingsController(QObject):
 
         path_groups = [
             _PathGroup(os_paths[0], self.settings_dialog.game_location, "game"),
-            _PathGroup(
-                os_paths[1], self.settings_dialog.config_folder_location, "config"
-            ),
+            _PathGroup(os_paths[1], self.settings_dialog.config_folder_location, "config"),
             _PathGroup(
                 os_paths[2],
                 self.settings_dialog.steam_mods_folder_location,
@@ -1962,20 +1534,14 @@ class SettingsController(QObject):
 
         for group in path_groups:
             if group.folder.exists():
-                logger.info(
-                    f"Auto-detected {group.name} folder path exists: {group.folder}"
-                )
+                logger.info(f"Auto-detected {group.name} folder path exists: {group.folder}")
                 if not group.settings_line.text():
-                    logger.info(
-                        f"No value set currently for {group.name} folder. Overwriting with auto-detected path"
-                    )
+                    logger.info(f"No value set currently for {group.name} folder. Overwriting with auto-detected path")
                     group.settings_line.setText(str(group.folder))
                 else:
                     logger.info(f"Value already set for {group.name} folder. Passing")
             else:
-                logger.warning(
-                    f"Auto-detected {group.name} folder path does not exist: {group.folder}"
-                )
+                logger.warning(f"Auto-detected {group.name} folder path does not exist: {group.folder}")
 
     def __get_darwin_paths(self) -> tuple[Path, Path, Path]:
         """
@@ -1985,15 +1551,9 @@ class SettingsController(QObject):
             tuple[Path, Path, Path]: game_folder, config_folder, steam_mods_folder
         """
         user_home = Path.home()
-        game_folder = Path(
-            f"/{user_home}/Library/Application Support/Steam/steamapps/common/Rimworld/RimworldMac.app"
-        )
-        config_folder = Path(
-            f"/{user_home}/Library/Application Support/Rimworld/Config"
-        )
-        steam_mods_folder = Path(
-            f"/{user_home}/Library/Application Support/Steam/steamapps/workshop/content/294100"
-        )
+        game_folder = Path(f"/{user_home}/Library/Application Support/Steam/steamapps/common/Rimworld/RimworldMac.app")
+        config_folder = Path(f"/{user_home}/Library/Application Support/Rimworld/Config")
+        steam_mods_folder = Path(f"/{user_home}/Library/Application Support/Steam/steamapps/workshop/content/294100")
 
         return game_folder, config_folder, steam_mods_folder
 
@@ -2010,10 +1570,7 @@ class SettingsController(QObject):
             steam_path = user_home / ".steam/steam"
             debian_path = steam_path / "steamapps/common/RimWorld"
         game_folder = debian_path / "steamapps/common/RimWorld"
-        config_folder = (
-            user_home
-            / ".config/unity3d/Ludeon Studios/RimWorld by Ludeon Studios/Config"
-        )
+        config_folder = user_home / ".config/unity3d/Ludeon Studios/RimWorld by Ludeon Studios/Config"
         steam_mods_folder = debian_path / "steamapps/workshop/content/294100"
 
         return game_folder, config_folder, steam_mods_folder
@@ -2032,9 +1589,7 @@ class SettingsController(QObject):
             steam_folder, found = find_steam_folder()
 
             if not found:
-                logger.error(
-                    "[win32] Could not find Steam folder. Using fallback assumptions"
-                )
+                logger.error("[win32] Could not find Steam folder. Using fallback assumptions")
                 steam_folder = "C:/Program Files (x86)/Steam"
 
             game_folder: str | Path = find_steam_rimworld(steam_folder)
@@ -2044,18 +1599,12 @@ class SettingsController(QObject):
                 game_folder = f"{steam_folder}/steamapps/common/RimWorld"
             game_folder = Path(game_folder)
 
-            config_folder = Path(
-                f"{user_home}/AppData/LocalLow/Ludeon Studios/RimWorld by Ludeon Studios/Config"
-            )
+            config_folder = Path(f"{user_home}/AppData/LocalLow/Ludeon Studios/RimWorld by Ludeon Studios/Config")
 
-            steam_mods_folder = get_path_up_to_string(
-                game_folder, "common", exclude=True
-            )
+            steam_mods_folder = get_path_up_to_string(game_folder, "common", exclude=True)
             if steam_mods_folder == "":
                 # Fallback steam mods path
-                steam_mods_folder = Path(
-                    f"{steam_folder}/steamapps/workshop/content/294100"
-                )
+                steam_mods_folder = Path(f"{steam_folder}/steamapps/workshop/content/294100")
             else:
                 steam_mods_folder = Path(steam_mods_folder) / "workshop/content/294100"
 
@@ -2064,9 +1613,7 @@ class SettingsController(QObject):
             raise ValueError("This function should only be called on Windows")
 
     @Slot(bool)
-    def _do_http_download_from_dialog(
-        self, url: str, repo_url: str, display_name: str
-    ) -> None:
+    def _do_http_download_from_dialog(self, url: str, repo_url: str, display_name: str) -> None:
         """Download a database via HTTP using the URL currently in the settings dialog."""
         if not url:
             show_warning(
@@ -2076,11 +1623,7 @@ class SettingsController(QObject):
             )
             return
 
-        repo_name = (
-            extract_git_dir_name(repo_url)
-            if repo_url
-            else display_name.replace(" ", "-")
-        )
+        repo_name = extract_git_dir_name(repo_url) if repo_url else display_name.replace(" ", "-")
         task = DatabaseDownloadTask(
             url=url,
             target_dir=AppInfo().databases_folder,
@@ -2098,19 +1641,13 @@ class SettingsController(QObject):
             self._http_download_worker = None
 
         self._http_download_worker = HttpDownloadWorker([task])
-        self._http_download_worker.download_finished.connect(
-            self._on_http_download_from_dialog_finished
-        )
+        self._http_download_worker.download_finished.connect(self._on_http_download_from_dialog_finished)
         self._http_download_worker.start()
 
     @Slot(dict)
-    def _on_http_download_from_dialog_finished(
-        self, results: dict[str, DownloadResult]
-    ) -> None:
+    def _on_http_download_from_dialog_finished(self, results: dict[str, DownloadResult]) -> None:
         updated = [name for name, r in results.items() if r == DownloadResult.UPDATED]
-        up_to_date = [
-            name for name, r in results.items() if r == DownloadResult.UP_TO_DATE
-        ]
+        up_to_date = [name for name, r in results.items() if r == DownloadResult.UP_TO_DATE]
         failed = [name for name, r in results.items() if r == DownloadResult.FAILED]
 
         if failed:
@@ -2142,80 +1679,46 @@ class SettingsController(QObject):
         This function handles the community rules db radio buttons. Clicking one button
         enables the associated widgets and disables the other widgets.
         """
-        if (
-            self.sender() == self.settings_dialog.community_rules_db_none_radio
-            and checked
-        ):
+        if self.sender() == self.settings_dialog.community_rules_db_none_radio and checked:
             self.settings_dialog.community_rules_db_github_url.setEnabled(False)
-            self.settings_dialog.community_rules_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.community_rules_db_github_download_button.setEnabled(False)
             self.settings_dialog.community_rules_db_url_input.setEnabled(False)
-            self.settings_dialog.community_rules_db_url_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.community_rules_db_url_download_button.setEnabled(False)
             self.settings_dialog.community_rules_db_local_file.setEnabled(False)
-            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(
-                False
-            )
+            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(False)
             if isinstance(self.app_instance, QApplication):
                 focused_widget = self.app_instance.focusWidget()
                 if focused_widget is not None:
                     focused_widget.clearFocus()
             return
 
-        if (
-            self.sender() == self.settings_dialog.community_rules_db_github_radio
-            and checked
-        ):
+        if self.sender() == self.settings_dialog.community_rules_db_github_radio and checked:
             self.settings_dialog.community_rules_db_github_url.setEnabled(True)
-            self.settings_dialog.community_rules_db_github_download_button.setEnabled(
-                True
-            )
+            self.settings_dialog.community_rules_db_github_download_button.setEnabled(True)
             self.settings_dialog.community_rules_db_url_input.setEnabled(False)
-            self.settings_dialog.community_rules_db_url_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.community_rules_db_url_download_button.setEnabled(False)
             self.settings_dialog.community_rules_db_local_file.setEnabled(False)
-            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(
-                False
-            )
+            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(False)
             self.settings_dialog.community_rules_db_github_url.setFocus()
             return
 
-        if (
-            self.sender() == self.settings_dialog.community_rules_db_url_radio
-            and checked
-        ):
+        if self.sender() == self.settings_dialog.community_rules_db_url_radio and checked:
             self.settings_dialog.community_rules_db_url_input.setEnabled(True)
             self.settings_dialog.community_rules_db_url_download_button.setEnabled(True)
             self.settings_dialog.community_rules_db_github_url.setEnabled(False)
-            self.settings_dialog.community_rules_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.community_rules_db_github_download_button.setEnabled(False)
             self.settings_dialog.community_rules_db_local_file.setEnabled(False)
-            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(
-                False
-            )
+            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(False)
             self.settings_dialog.community_rules_db_url_input.setFocus()
             return
 
-        if (
-            self.sender() == self.settings_dialog.community_rules_db_local_file_radio
-            and checked
-        ):
+        if self.sender() == self.settings_dialog.community_rules_db_local_file_radio and checked:
             self.settings_dialog.community_rules_db_github_url.setEnabled(False)
-            self.settings_dialog.community_rules_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.community_rules_db_github_download_button.setEnabled(False)
             self.settings_dialog.community_rules_db_url_input.setEnabled(False)
-            self.settings_dialog.community_rules_db_url_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.community_rules_db_url_download_button.setEnabled(False)
             self.settings_dialog.community_rules_db_local_file.setEnabled(True)
-            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(
-                True
-            )
+            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(True)
             self.settings_dialog.community_rules_db_local_file.setFocus()
             return
 
@@ -2232,9 +1735,7 @@ class SettingsController(QObject):
         if not community_rules_db_location:
             return
 
-        self.settings_dialog.community_rules_db_local_file.setText(
-            community_rules_db_location
-        )
+        self.settings_dialog.community_rules_db_local_file.setText(community_rules_db_location)
         self._last_file_dialog_path = str(Path(community_rules_db_location).parent)
 
     @Slot(bool)
@@ -2243,74 +1744,46 @@ class SettingsController(QObject):
         This function handles the Steam workshop db radio buttons. Clicking one button
         enables the associated widgets and disables the other widgets.
         """
-        if (
-            self.sender() == self.settings_dialog.steam_workshop_db_none_radio
-            and checked
-        ):
+        if self.sender() == self.settings_dialog.steam_workshop_db_none_radio and checked:
             self.settings_dialog.steam_workshop_db_github_url.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(False)
             self.settings_dialog.steam_workshop_db_url_input.setEnabled(False)
             self.settings_dialog.steam_workshop_db_url_download_button.setEnabled(False)
             self.settings_dialog.steam_workshop_db_local_file.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(
-                False
-            )
+            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(False)
             if isinstance(self.app_instance, QApplication):
                 focused_widget = self.app_instance.focusWidget()
                 if focused_widget is not None:
                     focused_widget.clearFocus()
             return
 
-        if (
-            self.sender() == self.settings_dialog.steam_workshop_db_github_radio
-            and checked
-        ):
+        if self.sender() == self.settings_dialog.steam_workshop_db_github_radio and checked:
             self.settings_dialog.steam_workshop_db_github_url.setEnabled(True)
-            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(
-                True
-            )
+            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(True)
             self.settings_dialog.steam_workshop_db_url_input.setEnabled(False)
             self.settings_dialog.steam_workshop_db_url_download_button.setEnabled(False)
             self.settings_dialog.steam_workshop_db_local_file.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(
-                False
-            )
+            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(False)
             self.settings_dialog.steam_workshop_db_github_url.setFocus()
             return
 
-        if (
-            self.sender() == self.settings_dialog.steam_workshop_db_url_radio
-            and checked
-        ):
+        if self.sender() == self.settings_dialog.steam_workshop_db_url_radio and checked:
             self.settings_dialog.steam_workshop_db_url_input.setEnabled(True)
             self.settings_dialog.steam_workshop_db_url_download_button.setEnabled(True)
             self.settings_dialog.steam_workshop_db_github_url.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(False)
             self.settings_dialog.steam_workshop_db_local_file.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(
-                False
-            )
+            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(False)
             self.settings_dialog.steam_workshop_db_url_input.setFocus()
             return
 
-        if (
-            self.sender() == self.settings_dialog.steam_workshop_db_local_file_radio
-            and checked
-        ):
+        if self.sender() == self.settings_dialog.steam_workshop_db_local_file_radio and checked:
             self.settings_dialog.steam_workshop_db_github_url.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(False)
             self.settings_dialog.steam_workshop_db_url_input.setEnabled(False)
             self.settings_dialog.steam_workshop_db_url_download_button.setEnabled(False)
             self.settings_dialog.steam_workshop_db_local_file.setEnabled(True)
-            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(
-                True
-            )
+            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(True)
             self.settings_dialog.steam_workshop_db_local_file.setFocus()
             return
 
@@ -2327,9 +1800,7 @@ class SettingsController(QObject):
         if not steam_workshop_db_location:
             return
 
-        self.settings_dialog.steam_workshop_db_local_file.setText(
-            steam_workshop_db_location
-        )
+        self.settings_dialog.steam_workshop_db_local_file.setText(steam_workshop_db_location)
         self._last_file_dialog_path = str(Path(steam_workshop_db_location).parent)
 
     @Slot(bool)
@@ -2338,22 +1809,13 @@ class SettingsController(QObject):
         This function handles the "No Version Warning" db radio buttons. Clicking one button
         enables the associated widgets and disables the other widgets.
         """
-        if (
-            self.sender() == self.settings_dialog.no_version_warning_db_none_radio
-            and checked
-        ):
+        if self.sender() == self.settings_dialog.no_version_warning_db_none_radio and checked:
             self.settings_dialog.no_version_warning_db_github_url.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(False)
             self.settings_dialog.no_version_warning_db_url_input.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(False)
             self.settings_dialog.no_version_warning_db_local_file.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(
-                False
-            )
+            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(False)
             app_instance = QApplication.instance()
             if isinstance(app_instance, QApplication):
                 focused_widget = app_instance.focusWidget()
@@ -2361,60 +1823,33 @@ class SettingsController(QObject):
                     focused_widget.clearFocus()
             return
 
-        if (
-            self.sender() == self.settings_dialog.no_version_warning_db_github_radio
-            and checked
-        ):
+        if self.sender() == self.settings_dialog.no_version_warning_db_github_radio and checked:
             self.settings_dialog.no_version_warning_db_github_url.setEnabled(True)
-            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(
-                True
-            )
+            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(True)
             self.settings_dialog.no_version_warning_db_url_input.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(False)
             self.settings_dialog.no_version_warning_db_local_file.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(
-                False
-            )
+            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(False)
             self.settings_dialog.no_version_warning_db_github_url.setFocus()
             return
 
-        if (
-            self.sender() == self.settings_dialog.no_version_warning_db_url_radio
-            and checked
-        ):
+        if self.sender() == self.settings_dialog.no_version_warning_db_url_radio and checked:
             self.settings_dialog.no_version_warning_db_url_input.setEnabled(True)
-            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(
-                True
-            )
+            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(True)
             self.settings_dialog.no_version_warning_db_github_url.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(False)
             self.settings_dialog.no_version_warning_db_local_file.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(
-                False
-            )
+            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(False)
             self.settings_dialog.no_version_warning_db_url_input.setFocus()
             return
 
-        if (
-            self.sender() == self.settings_dialog.no_version_warning_db_local_file_radio
-            and checked
-        ):
+        if self.sender() == self.settings_dialog.no_version_warning_db_local_file_radio and checked:
             self.settings_dialog.no_version_warning_db_github_url.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(False)
             self.settings_dialog.no_version_warning_db_url_input.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(False)
             self.settings_dialog.no_version_warning_db_local_file.setEnabled(True)
-            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(
-                True
-            )
+            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(True)
             self.settings_dialog.no_version_warning_db_local_file.setFocus()
             return
 
@@ -2431,9 +1866,7 @@ class SettingsController(QObject):
         if not no_version_warning_db_location:
             return
 
-        self.settings_dialog.no_version_warning_db_local_file.setText(
-            no_version_warning_db_location
-        )
+        self.settings_dialog.no_version_warning_db_local_file.setText(no_version_warning_db_location)
         self._last_file_dialog_path = str(Path(no_version_warning_db_location).parent)
 
     @Slot(bool)
@@ -2442,22 +1875,13 @@ class SettingsController(QObject):
         This function handles the "Use This Instead" db radio buttons. Clicking one button
         enables the associated widgets and disables the other widgets.
         """
-        if (
-            self.sender() == self.settings_dialog.use_this_instead_db_none_radio
-            and checked
-        ):
+        if self.sender() == self.settings_dialog.use_this_instead_db_none_radio and checked:
             self.settings_dialog.use_this_instead_db_github_url.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(False)
             self.settings_dialog.use_this_instead_db_url_input.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(False)
             self.settings_dialog.use_this_instead_db_local_file.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(
-                False
-            )
+            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(False)
             app_instance = QApplication.instance()
             if isinstance(app_instance, QApplication):
                 focused_widget = app_instance.focusWidget()
@@ -2465,60 +1889,33 @@ class SettingsController(QObject):
                     focused_widget.clearFocus()
             return
 
-        if (
-            self.sender() == self.settings_dialog.use_this_instead_db_github_radio
-            and checked
-        ):
+        if self.sender() == self.settings_dialog.use_this_instead_db_github_radio and checked:
             self.settings_dialog.use_this_instead_db_github_url.setEnabled(True)
-            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(
-                True
-            )
+            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(True)
             self.settings_dialog.use_this_instead_db_url_input.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(False)
             self.settings_dialog.use_this_instead_db_local_file.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(
-                False
-            )
+            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(False)
             self.settings_dialog.use_this_instead_db_github_url.setFocus()
             return
 
-        if (
-            self.sender() == self.settings_dialog.use_this_instead_db_url_radio
-            and checked
-        ):
+        if self.sender() == self.settings_dialog.use_this_instead_db_url_radio and checked:
             self.settings_dialog.use_this_instead_db_url_input.setEnabled(True)
-            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(
-                True
-            )
+            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(True)
             self.settings_dialog.use_this_instead_db_github_url.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(False)
             self.settings_dialog.use_this_instead_db_local_file.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(
-                False
-            )
+            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(False)
             self.settings_dialog.use_this_instead_db_url_input.setFocus()
             return
 
-        if (
-            self.sender() == self.settings_dialog.use_this_instead_db_local_file_radio
-            and checked
-        ):
+        if self.sender() == self.settings_dialog.use_this_instead_db_local_file_radio and checked:
             self.settings_dialog.use_this_instead_db_github_url.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(False)
             self.settings_dialog.use_this_instead_db_url_input.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(
-                False
-            )
+            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(False)
             self.settings_dialog.use_this_instead_db_local_file.setEnabled(True)
-            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(
-                True
-            )
+            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(True)
             self.settings_dialog.use_this_instead_db_local_file.setFocus()
             return
 
@@ -2536,9 +1933,7 @@ class SettingsController(QObject):
         if not use_this_instead_db_location:
             return
 
-        self.settings_dialog.use_this_instead_db_local_file.setText(
-            use_this_instead_db_location
-        )
+        self.settings_dialog.use_this_instead_db_local_file.setText(use_this_instead_db_location)
         self._last_file_dialog_path = str(Path(use_this_instead_db_location).parent)
 
     @Slot()
@@ -2554,9 +1949,7 @@ class SettingsController(QObject):
         if not steamcmd_install_location:
             return
 
-        self.settings_dialog.steamcmd_install_location.setText(
-            steamcmd_install_location
-        )
+        self.settings_dialog.steamcmd_install_location.setText(steamcmd_install_location)
         self._last_file_dialog_path = str(Path(steamcmd_install_location).parent)
 
     @Slot()
@@ -2754,9 +2147,7 @@ class SettingsController(QObject):
 
         # Validate the path before setting it
 
-        test_controller = InstanceController(
-            self.settings.instances[self.settings.current_instance]
-        )
+        test_controller = InstanceController(self.settings.instances[self.settings.current_instance])
         test_controller.instance.instance_folder_override = instance_folder_location
         is_valid, error_msg = test_controller.validate_instance_folder_override()
 
@@ -2769,9 +2160,7 @@ class SettingsController(QObject):
             return
 
         # Update the instance and UI
-        self.settings.instances[
-            self.settings.current_instance
-        ].instance_folder_override = instance_folder_location
+        self.settings.instances[self.settings.current_instance].instance_folder_override = instance_folder_location
         self.settings_dialog.instance_folder_location.setText(instance_folder_location)
         self._last_file_dialog_path = str(Path(instance_folder_location).parent)
         self.settings.save()
@@ -2788,9 +2177,7 @@ class SettingsController(QObject):
             )
             return
 
-        self.settings.instances[
-            self.settings.current_instance
-        ].instance_folder_override = ""
+        self.settings.instances[self.settings.current_instance].instance_folder_override = ""
         self.settings_dialog.instance_folder_location.setText("")
         self.settings.save()
 
@@ -2807,16 +2194,12 @@ class SettingsController(QObject):
         """
         selected_theme_name = self.settings_dialog.themes_combobox.currentText()
         logger.info(f"Opening theme location: {selected_theme_name}")
-        stylesheet_path = self.theme_controller.get_theme_stylesheet_path(
-            selected_theme_name
-        )
+        stylesheet_path = self.theme_controller.get_theme_stylesheet_path(selected_theme_name)
 
         if stylesheet_path and stylesheet_path.exists():
             platform_specific_open(stylesheet_path.parent)
         else:
-            logger.warning(
-                f"Failed to open theme location: {stylesheet_path} not found or does not exist"
-            )
+            logger.warning(f"Failed to open theme location: {stylesheet_path} not found or does not exist")
 
     @Slot()
     def _on_use_background_coloring_checkbox_changed(self) -> None:
@@ -2824,7 +2207,9 @@ class SettingsController(QObject):
 
     @Slot()
     def _on_include_mod_notes_in_mod_name_filter_changed(self) -> None:
-        self.settings.include_mod_notes_in_mod_name_filter = self.settings_dialog.include_mod_notes_in_mod_name_filter_checkbox.isChecked()
+        self.settings.include_mod_notes_in_mod_name_filter = (
+            self.settings_dialog.include_mod_notes_in_mod_name_filter_checkbox.isChecked()
+        )
 
     @Slot()
     def _handle_mod_coloring_mode_changed(self) -> None:

--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -1140,6 +1140,9 @@ class SettingsController(QObject):
         self.settings_dialog.clear_moves_dlc_checkbox.setChecked(
             self.settings.clear_moves_dlc
         )
+        self.settings_dialog.auto_launch_steam_checkbox.setChecked(
+            self.settings.auto_launch_steam
+        )
         self.settings_dialog.show_mod_updates_checkbox.setChecked(
             self.settings.steam_mods_update_check
         )
@@ -1501,6 +1504,9 @@ class SettingsController(QObject):
         # Clear button behavior
         self.settings.clear_moves_dlc = (
             self.settings_dialog.clear_moves_dlc_checkbox.isChecked()
+        )
+        self.settings.auto_launch_steam = (
+            self.settings_dialog.auto_launch_steam_checkbox.isChecked()
         )
         self.settings.steam_mods_update_check = (
             self.settings_dialog.show_mod_updates_checkbox.isChecked()

--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -93,9 +93,13 @@ class SettingsController(QObject):
             self._on_global_reset_to_defaults_button_clicked
         )
 
-        self.settings_dialog.global_cancel_button.clicked.connect(self._on_global_cancel_button_clicked)
+        self.settings_dialog.global_cancel_button.clicked.connect(
+            self._on_global_cancel_button_clicked
+        )
 
-        self.settings_dialog.global_ok_button.clicked.connect(self._on_global_ok_button_clicked)
+        self.settings_dialog.global_ok_button.clicked.connect(
+            self._on_global_ok_button_clicked
+        )
 
         # Connect launch state radio buttons to update spinbox enabled/disabled state
         # Main Window
@@ -137,12 +141,22 @@ class SettingsController(QObject):
         )
 
         # Locations tab
-        self.settings_dialog.game_location.textChanged.connect(self._on_game_location_text_changed)
-        self.settings_dialog.game_location_open_button.clicked.connect(self._on_game_location_open_button_clicked)
-        self.settings_dialog.game_location_choose_button.clicked.connect(self._on_game_location_choose_button_clicked)
-        self.settings_dialog.game_location_clear_button.clicked.connect(self._on_game_location_clear_button_clicked)
+        self.settings_dialog.game_location.textChanged.connect(
+            self._on_game_location_text_changed
+        )
+        self.settings_dialog.game_location_open_button.clicked.connect(
+            self._on_game_location_open_button_clicked
+        )
+        self.settings_dialog.game_location_choose_button.clicked.connect(
+            self._on_game_location_choose_button_clicked
+        )
+        self.settings_dialog.game_location_clear_button.clicked.connect(
+            self._on_game_location_clear_button_clicked
+        )
 
-        self.settings_dialog.config_folder_location.textChanged.connect(self._on_config_folder_location_text_changed)
+        self.settings_dialog.config_folder_location.textChanged.connect(
+            self._on_config_folder_location_text_changed
+        )
         self.settings_dialog.config_folder_location_open_button.clicked.connect(
             self._on_config_folder_location_open_button_clicked
         )
@@ -191,18 +205,30 @@ class SettingsController(QObject):
             # Buttons may not exist if UI hasn't been updated yet
             pass
 
-        self.settings_dialog.locations_clear_button.clicked.connect(self._on_locations_clear_button_clicked)
+        self.settings_dialog.locations_clear_button.clicked.connect(
+            self._on_locations_clear_button_clicked
+        )
 
-        self.settings_dialog.locations_autodetect_button.clicked.connect(self._on_locations_autodetect_button_clicked)
+        self.settings_dialog.locations_autodetect_button.clicked.connect(
+            self._on_locations_autodetect_button_clicked
+        )
 
         # Game Launch tab
-        self.settings_dialog.run_args.textChanged.connect(self._on_run_args_text_changed)
+        self.settings_dialog.run_args.textChanged.connect(
+            self._on_run_args_text_changed
+        )
 
         # Wire up the Databases tab buttons
 
-        self.settings_dialog.community_rules_db_none_radio.clicked.connect(self._on_community_rules_db_radio_clicked)
-        self.settings_dialog.community_rules_db_github_radio.clicked.connect(self._on_community_rules_db_radio_clicked)
-        self.settings_dialog.community_rules_db_url_radio.clicked.connect(self._on_community_rules_db_radio_clicked)
+        self.settings_dialog.community_rules_db_none_radio.clicked.connect(
+            self._on_community_rules_db_radio_clicked
+        )
+        self.settings_dialog.community_rules_db_github_radio.clicked.connect(
+            self._on_community_rules_db_radio_clicked
+        )
+        self.settings_dialog.community_rules_db_url_radio.clicked.connect(
+            self._on_community_rules_db_radio_clicked
+        )
         self.settings_dialog.community_rules_db_local_file_radio.clicked.connect(
             self._on_community_rules_db_radio_clicked
         )
@@ -224,9 +250,15 @@ class SettingsController(QObject):
             )
         )
 
-        self.settings_dialog.steam_workshop_db_none_radio.clicked.connect(self._on_steam_workshop_db_radio_clicked)
-        self.settings_dialog.steam_workshop_db_github_radio.clicked.connect(self._on_steam_workshop_db_radio_clicked)
-        self.settings_dialog.steam_workshop_db_url_radio.clicked.connect(self._on_steam_workshop_db_radio_clicked)
+        self.settings_dialog.steam_workshop_db_none_radio.clicked.connect(
+            self._on_steam_workshop_db_radio_clicked
+        )
+        self.settings_dialog.steam_workshop_db_github_radio.clicked.connect(
+            self._on_steam_workshop_db_radio_clicked
+        )
+        self.settings_dialog.steam_workshop_db_url_radio.clicked.connect(
+            self._on_steam_workshop_db_radio_clicked
+        )
         self.settings_dialog.steam_workshop_db_local_file_radio.clicked.connect(
             self._on_steam_workshop_db_radio_clicked
         )
@@ -279,11 +311,15 @@ class SettingsController(QObject):
             )
         )
 
-        self.settings_dialog.use_this_instead_db_none_radio.clicked.connect(self._on_use_this_instead_db_radio_clicked)
+        self.settings_dialog.use_this_instead_db_none_radio.clicked.connect(
+            self._on_use_this_instead_db_radio_clicked
+        )
         self.settings_dialog.use_this_instead_db_github_radio.clicked.connect(
             self._on_use_this_instead_db_radio_clicked
         )
-        self.settings_dialog.use_this_instead_db_url_radio.clicked.connect(self._on_use_this_instead_db_radio_clicked)
+        self.settings_dialog.use_this_instead_db_url_radio.clicked.connect(
+            self._on_use_this_instead_db_radio_clicked
+        )
         self.settings_dialog.use_this_instead_db_local_file_radio.clicked.connect(
             self._on_use_this_instead_db_radio_clicked
         )
@@ -329,9 +365,15 @@ class SettingsController(QObject):
         self.settings_dialog.steamcmd_clear_depot_cache_button.clicked.connect(
             self._on_steamcmd_clear_depot_cache_button_clicked
         )
-        self.settings_dialog.steamcmd_import_acf_button.clicked.connect(self._on_steamcmd_import_acf_button_clicked)
-        self.settings_dialog.steamcmd_delete_acf_button.clicked.connect(self._on_steamcmd_delete_acf_button_clicked)
-        self.settings_dialog.steamcmd_install_button.clicked.connect(self._on_steamcmd_install_button_clicked)
+        self.settings_dialog.steamcmd_import_acf_button.clicked.connect(
+            self._on_steamcmd_import_acf_button_clicked
+        )
+        self.settings_dialog.steamcmd_delete_acf_button.clicked.connect(
+            self._on_steamcmd_delete_acf_button_clicked
+        )
+        self.settings_dialog.steamcmd_install_button.clicked.connect(
+            self._on_steamcmd_install_button_clicked
+        )
 
         # Other External Tools Tab
         self.settings_dialog.text_editor_location_choose_button.clicked.connect(
@@ -339,7 +381,9 @@ class SettingsController(QObject):
         )
 
         # Theme tab
-        self.settings_dialog.theme_location_open_button.clicked.connect(self._on_theme_location_open_button_clicked)
+        self.settings_dialog.theme_location_open_button.clicked.connect(
+            self._on_theme_location_open_button_clicked
+        )
 
         # Advanced tab
         self.settings_dialog.color_background_instead_of_text_checkbox.stateChanged.connect(
@@ -373,9 +417,24 @@ class SettingsController(QObject):
         Get the mod paths for the current instance. Return the Default instance if the current instance is not found.
         """
         return [
-            str(Path(self.settings.instances[self.settings.current_instance].game_folder) / "Data"),
-            str(Path(self.settings.instances[self.settings.current_instance].local_folder)),
-            str(Path(self.settings.instances[self.settings.current_instance].workshop_folder)),
+            str(
+                Path(
+                    self.settings.instances[self.settings.current_instance].game_folder
+                )
+                / "Data"
+            ),
+            str(
+                Path(
+                    self.settings.instances[self.settings.current_instance].local_folder
+                )
+            ),
+            str(
+                Path(
+                    self.settings.instances[
+                        self.settings.current_instance
+                    ].workshop_folder
+                )
+            ),
         ]
 
     def resolve_data_source(self, path: str) -> str | None:
@@ -385,9 +444,16 @@ class SettingsController(QObject):
         # Pathlib the provided path string
         sanitized_path = Path(path)
         # Grab paths from Settings
-        expansions_path = Path(self.settings.instances[self.settings.current_instance].game_folder) / "Data"
-        local_path = Path(self.settings.instances[self.settings.current_instance].local_folder)
-        workshop_path = Path(self.settings.instances[self.settings.current_instance].workshop_folder)
+        expansions_path = (
+            Path(self.settings.instances[self.settings.current_instance].game_folder)
+            / "Data"
+        )
+        local_path = Path(
+            self.settings.instances[self.settings.current_instance].local_folder
+        )
+        workshop_path = Path(
+            self.settings.instances[self.settings.current_instance].workshop_folder
+        )
         # Validate data source, then emit if path is valid and not mapped
         if sanitized_path.parent == expansions_path:
             return "expansion"
@@ -476,7 +542,9 @@ class SettingsController(QObject):
             str(self.settings.instances[self.settings.current_instance].game_folder)
         )
         self.settings_dialog.game_location.setCursorPosition(0)
-        self.settings_dialog.game_location_open_button.setEnabled(self.settings_dialog.game_location.text() != "")
+        self.settings_dialog.game_location_open_button.setEnabled(
+            self.settings_dialog.game_location.text() != ""
+        )
         self.settings_dialog.config_folder_location.setText(
             str(self.settings.instances[self.settings.current_instance].config_folder)
         )
@@ -499,146 +567,255 @@ class SettingsController(QObject):
             self.settings_dialog.local_mods_folder_location.text() != ""
         )
         self.settings_dialog.steam_client_integration_checkbox.setChecked(
-            self.settings.instances[self.settings.current_instance].steam_client_integration
+            self.settings.instances[
+                self.settings.current_instance
+            ].steam_client_integration
         )
         # Enable/disable Steam mods location fields based on checkbox state
         checked = self.settings_dialog.steam_client_integration_checkbox.isChecked()
         self.settings_dialog.steam_mods_folder_location.setEnabled(checked)
         self.settings_dialog.steam_mods_folder_location_open_button.setEnabled(checked)
-        self.settings_dialog.steam_mods_folder_location_choose_button.setEnabled(checked)
+        self.settings_dialog.steam_mods_folder_location_choose_button.setEnabled(
+            checked
+        )
         self.settings_dialog.steam_mods_folder_location_clear_button.setEnabled(checked)
 
         # Load Steam protocol launch option
         self.settings_dialog.launch_via_steam_protocol_checkbox.setChecked(
-            self.settings.instances[self.settings.current_instance].launch_via_steam_protocol
+            self.settings.instances[
+                self.settings.current_instance
+            ].launch_via_steam_protocol
         )
         # Update run_args group enabled state based on Steam protocol setting
-        launch_via_steam_protocol = self.settings.instances[self.settings.current_instance].launch_via_steam_protocol
+        launch_via_steam_protocol = self.settings.instances[
+            self.settings.current_instance
+        ].launch_via_steam_protocol
         self.settings_dialog.run_args_group.setEnabled(not launch_via_steam_protocol)
 
         # Instance folder location (custom override)
         # Only enable for Default instance
         is_default_instance = self.settings.current_instance == DEFAULT_INSTANCE_NAME
         self.settings_dialog.instance_folder_location.setText(
-            self.settings.instances[self.settings.current_instance].instance_folder_override
+            self.settings.instances[
+                self.settings.current_instance
+            ].instance_folder_override
         )
         self.settings_dialog.instance_folder_location.setCursorPosition(0)
         self.settings_dialog.instance_folder_location.setEnabled(is_default_instance)
-        self.settings_dialog.instance_folder_location_choose_button.setEnabled(is_default_instance)
-        self.settings_dialog.instance_folder_location_clear_button.setEnabled(is_default_instance)
+        self.settings_dialog.instance_folder_location_choose_button.setEnabled(
+            is_default_instance
+        )
+        self.settings_dialog.instance_folder_location_clear_button.setEnabled(
+            is_default_instance
+        )
 
         # Databases tab
         if self.settings.external_community_rules_metadata_source == "None":
             self.settings_dialog.community_rules_db_none_radio.setChecked(True)
             self.settings_dialog.community_rules_db_github_url.setEnabled(False)
-            self.settings_dialog.community_rules_db_github_download_button.setEnabled(False)
+            self.settings_dialog.community_rules_db_github_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.community_rules_db_url_input.setEnabled(False)
-            self.settings_dialog.community_rules_db_url_download_button.setEnabled(False)
+            self.settings_dialog.community_rules_db_url_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.community_rules_db_local_file.setEnabled(False)
-            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(False)
-        elif self.settings.external_community_rules_metadata_source == "Configured git repository":
+            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(
+                False
+            )
+        elif (
+            self.settings.external_community_rules_metadata_source
+            == "Configured git repository"
+        ):
             self.settings_dialog.community_rules_db_github_radio.setChecked(True)
             self.settings_dialog.community_rules_db_github_url.setEnabled(True)
-            self.settings_dialog.community_rules_db_github_download_button.setEnabled(True)
+            self.settings_dialog.community_rules_db_github_download_button.setEnabled(
+                True
+            )
             self.settings_dialog.community_rules_db_url_input.setEnabled(False)
-            self.settings_dialog.community_rules_db_url_download_button.setEnabled(False)
+            self.settings_dialog.community_rules_db_url_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.community_rules_db_local_file.setEnabled(False)
-            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(False)
+            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(
+                False
+            )
         elif self.settings.external_community_rules_metadata_source == "Configured URL":
             self.settings_dialog.community_rules_db_url_radio.setChecked(True)
             self.settings_dialog.community_rules_db_url_input.setEnabled(True)
             self.settings_dialog.community_rules_db_url_download_button.setEnabled(True)
             self.settings_dialog.community_rules_db_github_url.setEnabled(False)
-            self.settings_dialog.community_rules_db_github_download_button.setEnabled(False)
+            self.settings_dialog.community_rules_db_github_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.community_rules_db_local_file.setEnabled(False)
-            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(False)
-        elif self.settings.external_community_rules_metadata_source == "Configured file path":
+            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(
+                False
+            )
+        elif (
+            self.settings.external_community_rules_metadata_source
+            == "Configured file path"
+        ):
             self.settings_dialog.community_rules_db_local_file_radio.setChecked(True)
             self.settings_dialog.community_rules_db_github_url.setEnabled(False)
-            self.settings_dialog.community_rules_db_github_download_button.setEnabled(False)
+            self.settings_dialog.community_rules_db_github_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.community_rules_db_url_input.setEnabled(False)
-            self.settings_dialog.community_rules_db_url_download_button.setEnabled(False)
+            self.settings_dialog.community_rules_db_url_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.community_rules_db_local_file.setEnabled(True)
-            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(True)
-        self.settings_dialog.community_rules_db_local_file.setText(self.settings.external_community_rules_file_path)
+            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(
+                True
+            )
+        self.settings_dialog.community_rules_db_local_file.setText(
+            self.settings.external_community_rules_file_path
+        )
         self.settings_dialog.community_rules_db_local_file.setCursorPosition(0)
-        self.settings_dialog.community_rules_db_github_url.setText(self.settings.external_community_rules_repo)
-        self.settings_dialog.community_rules_db_url_input.setText(self.settings.external_community_rules_url)
+        self.settings_dialog.community_rules_db_github_url.setText(
+            self.settings.external_community_rules_repo
+        )
+        self.settings_dialog.community_rules_db_url_input.setText(
+            self.settings.external_community_rules_url
+        )
 
         if self.settings.external_steam_metadata_source == "None":
             self.settings_dialog.steam_workshop_db_none_radio.setChecked(True)
             self.settings_dialog.steam_workshop_db_github_url.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(False)
+            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.steam_workshop_db_url_input.setEnabled(False)
             self.settings_dialog.steam_workshop_db_url_download_button.setEnabled(False)
             self.settings_dialog.steam_workshop_db_local_file.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(False)
-        elif self.settings.external_steam_metadata_source == "Configured git repository":
+            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(
+                False
+            )
+        elif (
+            self.settings.external_steam_metadata_source == "Configured git repository"
+        ):
             self.settings_dialog.steam_workshop_db_github_radio.setChecked(True)
             self.settings_dialog.steam_workshop_db_github_url.setEnabled(True)
-            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(True)
+            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(
+                True
+            )
             self.settings_dialog.steam_workshop_db_url_input.setEnabled(False)
             self.settings_dialog.steam_workshop_db_url_download_button.setEnabled(False)
             self.settings_dialog.steam_workshop_db_local_file.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(False)
+            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(
+                False
+            )
         elif self.settings.external_steam_metadata_source == "Configured URL":
             self.settings_dialog.steam_workshop_db_url_radio.setChecked(True)
             self.settings_dialog.steam_workshop_db_url_input.setEnabled(True)
             self.settings_dialog.steam_workshop_db_url_download_button.setEnabled(True)
             self.settings_dialog.steam_workshop_db_github_url.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(False)
+            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.steam_workshop_db_local_file.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(False)
+            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(
+                False
+            )
         elif self.settings.external_steam_metadata_source == "Configured file path":
             self.settings_dialog.steam_workshop_db_local_file_radio.setChecked(True)
             self.settings_dialog.steam_workshop_db_github_url.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(False)
+            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.steam_workshop_db_url_input.setEnabled(False)
             self.settings_dialog.steam_workshop_db_url_download_button.setEnabled(False)
             self.settings_dialog.steam_workshop_db_local_file.setEnabled(True)
-            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(True)
-        self.settings_dialog.steam_workshop_db_local_file.setText(self.settings.external_steam_metadata_file_path)
+            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(
+                True
+            )
+        self.settings_dialog.steam_workshop_db_local_file.setText(
+            self.settings.external_steam_metadata_file_path
+        )
         self.settings_dialog.steam_workshop_db_local_file.setCursorPosition(0)
-        self.settings_dialog.steam_workshop_db_github_url.setText(self.settings.external_steam_metadata_repo)
+        self.settings_dialog.steam_workshop_db_github_url.setText(
+            self.settings.external_steam_metadata_repo
+        )
         self.settings_dialog.steam_workshop_db_github_url.setCursorPosition(0)
-        self.settings_dialog.steam_workshop_db_url_input.setText(self.settings.external_steam_metadata_url)
+        self.settings_dialog.steam_workshop_db_url_input.setText(
+            self.settings.external_steam_metadata_url
+        )
         self.settings_dialog.database_expiry.setText(str(self.settings.database_expiry))
-        self.settings_dialog.aux_db_time_limit.setText(str(self.settings.aux_db_time_limit))
-        self.settings_dialog.aux_db_time_limit.setEnabled(self.settings.enable_aux_db_behavior_editing)
+        self.settings_dialog.aux_db_time_limit.setText(
+            str(self.settings.aux_db_time_limit)
+        )
+        self.settings_dialog.aux_db_time_limit.setEnabled(
+            self.settings.enable_aux_db_behavior_editing
+        )
 
         # Cross Version DB Tab
         if self.settings.external_no_version_warning_metadata_source == "None":
             self.settings_dialog.no_version_warning_db_none_radio.setChecked(True)
             self.settings_dialog.no_version_warning_db_github_url.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(False)
+            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.no_version_warning_db_url_input.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(False)
+            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.no_version_warning_db_local_file.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(False)
-        elif self.settings.external_no_version_warning_metadata_source == "Configured git repository":
+            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(
+                False
+            )
+        elif (
+            self.settings.external_no_version_warning_metadata_source
+            == "Configured git repository"
+        ):
             self.settings_dialog.no_version_warning_db_github_radio.setChecked(True)
             self.settings_dialog.no_version_warning_db_github_url.setEnabled(True)
-            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(True)
+            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(
+                True
+            )
             self.settings_dialog.no_version_warning_db_url_input.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(False)
+            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.no_version_warning_db_local_file.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(False)
-        elif self.settings.external_no_version_warning_metadata_source == "Configured URL":
+            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(
+                False
+            )
+        elif (
+            self.settings.external_no_version_warning_metadata_source
+            == "Configured URL"
+        ):
             self.settings_dialog.no_version_warning_db_url_radio.setChecked(True)
             self.settings_dialog.no_version_warning_db_url_input.setEnabled(True)
-            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(True)
+            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(
+                True
+            )
             self.settings_dialog.no_version_warning_db_github_url.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(False)
+            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.no_version_warning_db_local_file.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(False)
-        elif self.settings.external_no_version_warning_metadata_source == "Configured file path":
+            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(
+                False
+            )
+        elif (
+            self.settings.external_no_version_warning_metadata_source
+            == "Configured file path"
+        ):
             self.settings_dialog.no_version_warning_db_local_file_radio.setChecked(True)
             self.settings_dialog.no_version_warning_db_github_url.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(False)
+            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.no_version_warning_db_url_input.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(False)
+            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.no_version_warning_db_local_file.setEnabled(True)
-            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(True)
+            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(
+                True
+            )
         self.settings_dialog.no_version_warning_db_local_file.setText(
             self.settings.external_no_version_warning_file_path
         )
@@ -647,45 +824,85 @@ class SettingsController(QObject):
             self.settings.external_no_version_warning_repo_path
         )
         self.settings_dialog.no_version_warning_db_github_url.setCursorPosition(0)
-        self.settings_dialog.no_version_warning_db_url_input.setText(self.settings.external_no_version_warning_url)
+        self.settings_dialog.no_version_warning_db_url_input.setText(
+            self.settings.external_no_version_warning_url
+        )
 
         if self.settings.external_use_this_instead_metadata_source == "None":
             self.settings_dialog.use_this_instead_db_none_radio.setChecked(True)
             self.settings_dialog.use_this_instead_db_github_url.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(False)
+            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.use_this_instead_db_url_input.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(False)
+            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.use_this_instead_db_local_file.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(False)
-        elif self.settings.external_use_this_instead_metadata_source == "Configured git repository":
+            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(
+                False
+            )
+        elif (
+            self.settings.external_use_this_instead_metadata_source
+            == "Configured git repository"
+        ):
             self.settings_dialog.use_this_instead_db_github_radio.setChecked(True)
             self.settings_dialog.use_this_instead_db_github_url.setEnabled(True)
-            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(True)
+            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(
+                True
+            )
             self.settings_dialog.use_this_instead_db_url_input.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(False)
+            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.use_this_instead_db_local_file.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(False)
-        elif self.settings.external_use_this_instead_metadata_source == "Configured URL":
+            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(
+                False
+            )
+        elif (
+            self.settings.external_use_this_instead_metadata_source == "Configured URL"
+        ):
             self.settings_dialog.use_this_instead_db_url_radio.setChecked(True)
             self.settings_dialog.use_this_instead_db_url_input.setEnabled(True)
-            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(True)
+            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(
+                True
+            )
             self.settings_dialog.use_this_instead_db_github_url.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(False)
+            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.use_this_instead_db_local_file.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(False)
-        elif self.settings.external_use_this_instead_metadata_source == "Configured file path":
+            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(
+                False
+            )
+        elif (
+            self.settings.external_use_this_instead_metadata_source
+            == "Configured file path"
+        ):
             self.settings_dialog.use_this_instead_db_local_file_radio.setChecked(True)
             self.settings_dialog.use_this_instead_db_github_url.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(False)
+            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.use_this_instead_db_url_input.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(False)
+            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.use_this_instead_db_local_file.setEnabled(True)
-            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(True)
-        self.settings_dialog.use_this_instead_db_local_file.setText(self.settings.external_use_this_instead_file_path)
+            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(
+                True
+            )
+        self.settings_dialog.use_this_instead_db_local_file.setText(
+            self.settings.external_use_this_instead_file_path
+        )
         self.settings_dialog.use_this_instead_db_local_file.setCursorPosition(0)
-        self.settings_dialog.use_this_instead_db_github_url.setText(self.settings.external_use_this_instead_repo_path)
+        self.settings_dialog.use_this_instead_db_github_url.setText(
+            self.settings.external_use_this_instead_repo_path
+        )
         self.settings_dialog.use_this_instead_db_github_url.setCursorPosition(0)
-        self.settings_dialog.use_this_instead_db_url_input.setText(self.settings.external_use_this_instead_url)
+        self.settings_dialog.use_this_instead_db_url_input.setText(
+            self.settings.external_use_this_instead_url
+        )
 
         # Sorting tab
         if self.settings.sorting_algorithm == SortMethod.ALPHABETICAL:
@@ -694,29 +911,47 @@ class SettingsController(QObject):
             self.settings_dialog.sorting_topological_radio.setChecked(True)
         # Use dependencies for sorting checkbox
         if self.settings.use_moddependencies_as_loadTheseBefore:
-            (self.settings_dialog.use_moddependencies_as_loadTheseBefore.setChecked(True))
+            (
+                self.settings_dialog.use_moddependencies_as_loadTheseBefore.setChecked(
+                    True
+                )
+            )
         # Use alternativePackageIds as satisfying dependencies
         if self.settings.use_alternative_package_ids_as_satisfying_dependencies:
-            self.settings_dialog.use_alternative_package_ids_as_satisfying_dependencies_checkbox.setChecked(True)
+            self.settings_dialog.use_alternative_package_ids_as_satisfying_dependencies_checkbox.setChecked(
+                True
+            )
         # Set dependencies checkbox
-        self.settings_dialog.check_deps_checkbox.setChecked(self.settings.check_dependencies_on_sort)
+        self.settings_dialog.check_deps_checkbox.setChecked(
+            self.settings.check_dependencies_on_sort
+        )
         # Prefer versioned About.xml tags over base tags
         if self.settings.prefer_versioned_about_tags:
             self.settings_dialog.prefer_versioned_about_tags_checkbox.setChecked(True)
         # Download missing mods checkbox
-        self.settings_dialog.download_missing_mods_checkbox.setChecked(self.settings.try_download_missing_mods)
+        self.settings_dialog.download_missing_mods_checkbox.setChecked(
+            self.settings.try_download_missing_mods
+        )
         # Duplicate mod notification checkbox
-        self.settings_dialog.show_duplicate_mods_warning_checkbox.setChecked(self.settings.duplicate_mods_warning)
+        self.settings_dialog.show_duplicate_mods_warning_checkbox.setChecked(
+            self.settings.duplicate_mods_warning
+        )
         # Mod type filter checkbox
-        self.settings_dialog.mod_type_filter_checkbox.setChecked(self.settings.mod_type_filter)
+        self.settings_dialog.mod_type_filter_checkbox.setChecked(
+            self.settings.mod_type_filter
+        )
         # Hide invalid mod filtering checkbox
         self.settings_dialog.hide_invalid_mods_when_filtering_checkbox.setChecked(
             self.settings.hide_invalid_mods_when_filtering
         )
         # Inactive mods sorting options checkbox
-        self.settings_dialog.enable_inactive_mods_sorting_checkbox.setChecked(self.settings.inactive_mods_sorting)
+        self.settings_dialog.enable_inactive_mods_sorting_checkbox.setChecked(
+            self.settings.inactive_mods_sorting
+        )
         # Enable/disable the inactive mods sorting group box based on the checkbox state
-        self.settings_dialog.inactive_mods_sorting_group_box.setEnabled(self.settings.inactive_mods_sorting)
+        self.settings_dialog.inactive_mods_sorting_group_box.setEnabled(
+            self.settings.inactive_mods_sorting
+        )
         # Save inactive mods sort state
         self.settings_dialog.save_inactive_mods_sort_state_checkbox.setChecked(
             self.settings.save_inactive_mods_sort_state
@@ -727,22 +962,34 @@ class SettingsController(QObject):
             self.settings_dialog.db_builder_include_all_radio.setChecked(True)
         elif self.settings.db_builder_include == "no_local":
             self.settings_dialog.db_builder_include_no_local_radio.setChecked(True)
-        self.settings_dialog.db_builder_query_dlc_checkbox.setChecked(self.settings.build_steam_database_dlc_data)
+        self.settings_dialog.db_builder_query_dlc_checkbox.setChecked(
+            self.settings.build_steam_database_dlc_data
+        )
         self.settings_dialog.db_builder_update_instead_of_overwriting_checkbox.setChecked(
             self.settings.build_steam_database_update_toggle
         )
-        self.settings_dialog.db_builder_steam_api_key.setText(self.settings.steam_apikey)
+        self.settings_dialog.db_builder_steam_api_key.setText(
+            self.settings.steam_apikey
+        )
 
         # SteamCMD tab
-        self.settings_dialog.steamcmd_validate_downloads_checkbox.setChecked(self.settings.steamcmd_validate_downloads)
+        self.settings_dialog.steamcmd_validate_downloads_checkbox.setChecked(
+            self.settings.steamcmd_validate_downloads
+        )
         self.settings_dialog.steamcmd_auto_clear_depot_cache_checkbox.setChecked(
-            self.settings.instances[self.settings.current_instance].steamcmd_auto_clear_depot_cache
+            self.settings.instances[
+                self.settings.current_instance
+            ].steamcmd_auto_clear_depot_cache
         )
         self.settings_dialog.steamcmd_delete_before_update_checkbox.setChecked(
             self.settings.steamcmd_delete_before_update
         )
         self.settings_dialog.steamcmd_install_location.setText(
-            str(self.settings.instances[self.settings.current_instance].steamcmd_install_path)
+            str(
+                self.settings.instances[
+                    self.settings.current_instance
+                ].steamcmd_install_path
+            )
         )
 
         # todds tab
@@ -759,26 +1006,48 @@ class SettingsController(QObject):
             self.settings_dialog.todds_active_mods_only_radio.setChecked(True)
         else:
             self.settings_dialog.todds_all_mods_radio.setChecked(True)
-        self.settings_dialog.todds_dry_run_checkbox.setChecked(self.settings.todds_dry_run)
-        self.settings_dialog.todds_overwrite_checkbox.setChecked(self.settings.todds_overwrite)
-        self.settings_dialog.todds_custom_command_lineedit.setText(self.settings.todds_custom_command)
-        self.settings_dialog.auto_delete_orphaned_dds_checkbox.setChecked(self.settings.auto_delete_orphaned_dds)
+        self.settings_dialog.todds_dry_run_checkbox.setChecked(
+            self.settings.todds_dry_run
+        )
+        self.settings_dialog.todds_overwrite_checkbox.setChecked(
+            self.settings.todds_overwrite
+        )
+        self.settings_dialog.todds_custom_command_lineedit.setText(
+            self.settings.todds_custom_command
+        )
+        self.settings_dialog.auto_delete_orphaned_dds_checkbox.setChecked(
+            self.settings.auto_delete_orphaned_dds
+        )
         self.settings_dialog.auto_run_todds_before_launch_checkbox.setChecked(
             self.settings.auto_run_todds_before_launch
         )
 
         # External Tools Tab
-        self.settings_dialog.text_editor_location.setText(self.settings.text_editor_location)
-        self.settings_dialog.text_editor_folder_arg.setText(self.settings.text_editor_folder_arg)
-        self.settings_dialog.text_editor_file_arg.setText(self.settings.text_editor_file_arg)
+        self.settings_dialog.text_editor_location.setText(
+            self.settings.text_editor_location
+        )
+        self.settings_dialog.text_editor_folder_arg.setText(
+            self.settings.text_editor_folder_arg
+        )
+        self.settings_dialog.text_editor_file_arg.setText(
+            self.settings.text_editor_file_arg
+        )
 
         # Themes tab
-        self.settings_dialog.enable_themes_checkbox.setChecked(self.settings.enable_themes)
-        self.theme_controller.populate_themes_combobox(self.settings_dialog.themes_combobox)
+        self.settings_dialog.enable_themes_checkbox.setChecked(
+            self.settings.enable_themes
+        )
+        self.theme_controller.populate_themes_combobox(
+            self.settings_dialog.themes_combobox
+        )
         self.theme_controller.setup_theme_dialog(self.settings_dialog, self.settings)
 
-        self.language_controller.populate_languages_combobox(self.settings_dialog.language_combobox)
-        self.language_controller.setup_language_dialog(self.settings_dialog, self.settings)
+        self.language_controller.populate_languages_combobox(
+            self.settings_dialog.language_combobox
+        )
+        self.language_controller.setup_language_dialog(
+            self.settings_dialog, self.settings
+        )
 
         # Advanced tab values
         try:
@@ -843,31 +1112,57 @@ class SettingsController(QObject):
             self.settings_dialog.browser_launch_maximized_radio.setChecked(True)
 
         # Settings Window (only custom option)
-        self.settings_dialog.settings_custom_width_spinbox.setValue(self.settings.settings_window_custom_width)
-        self.settings_dialog.settings_custom_height_spinbox.setValue(self.settings.settings_window_custom_height)
+        self.settings_dialog.settings_custom_width_spinbox.setValue(
+            self.settings.settings_window_custom_width
+        )
+        self.settings_dialog.settings_custom_height_spinbox.setValue(
+            self.settings.settings_window_custom_height
+        )
 
         # Advanced tab
-        self.settings_dialog.debug_logging_checkbox.setChecked(self.settings.debug_logging_enabled)
+        self.settings_dialog.debug_logging_checkbox.setChecked(
+            self.settings.debug_logging_enabled
+        )
         self.settings_dialog.watchdog_checkbox.setChecked(self.settings.watchdog_toggle)
-        self.settings_dialog.backup_saves_on_launch_checkbox.setChecked(self.settings.backup_saves_on_launch)
-        self.settings_dialog.auto_backup_retention_count_spinbox.setValue(self.settings.auto_backup_retention_count)
-        self.settings_dialog.auto_backup_compression_count_spinbox.setValue(self.settings.auto_backup_compression_count)
+        self.settings_dialog.backup_saves_on_launch_checkbox.setChecked(
+            self.settings.backup_saves_on_launch
+        )
+        self.settings_dialog.auto_backup_retention_count_spinbox.setValue(
+            self.settings.auto_backup_retention_count
+        )
+        self.settings_dialog.auto_backup_compression_count_spinbox.setValue(
+            self.settings.auto_backup_compression_count
+        )
         self.settings_dialog.color_background_instead_of_text_checkbox.setChecked(
             self.settings.color_background_instead_of_text_toggle
         )
         # Clear button behavior
-        self.settings_dialog.clear_moves_dlc_checkbox.setChecked(self.settings.clear_moves_dlc)
-        self.settings_dialog.auto_launch_steam_checkbox.setChecked(self.settings.auto_launch_steam)
-        self.settings_dialog.show_mod_updates_checkbox.setChecked(self.settings.steam_mods_update_check)
-        self.settings_dialog.render_unity_rich_text_checkbox.setChecked(self.settings.render_unity_rich_text)
-        self.settings_dialog.update_databases_on_startup_checkbox.setChecked(self.settings.update_databases_on_startup)
+        self.settings_dialog.clear_moves_dlc_checkbox.setChecked(
+            self.settings.clear_moves_dlc
+        )
+        self.settings_dialog.auto_launch_steam_checkbox.setChecked(
+            self.settings.auto_launch_steam
+        )
+        self.settings_dialog.show_mod_updates_checkbox.setChecked(
+            self.settings.steam_mods_update_check
+        )
+        self.settings_dialog.render_unity_rich_text_checkbox.setChecked(
+            self.settings.render_unity_rich_text
+        )
+        self.settings_dialog.update_databases_on_startup_checkbox.setChecked(
+            self.settings.update_databases_on_startup
+        )
         self.settings_dialog.include_mod_notes_in_mod_name_filter_checkbox.setChecked(
             self.settings.include_mod_notes_in_mod_name_filter
         )
 
-        self.settings_dialog.enable_backup_before_update_checkbox.setChecked(self.settings.enable_backup_before_update)
+        self.settings_dialog.enable_backup_before_update_checkbox.setChecked(
+            self.settings.enable_backup_before_update
+        )
         self.settings_dialog.max_backups_spinbox.setValue(self.settings.max_backups)
-        self.settings_dialog.enable_aux_db_behavior_editing.setChecked(self.settings.enable_aux_db_behavior_editing)
+        self.settings_dialog.enable_aux_db_behavior_editing.setChecked(
+            self.settings.enable_aux_db_behavior_editing
+        )
         self.settings_dialog.rentry_auth_code.setText(self.settings.rentry_auth_code)
         self.settings_dialog.rentry_auth_code.setCursorPosition(0)
         self.settings_dialog.github_username.setText(self.settings.github_username)
@@ -876,10 +1171,17 @@ class SettingsController(QObject):
         self.settings_dialog.github_token.setCursorPosition(0)
 
         # Migrate old comma-separated format to new space-separated format if needed
-        run_args_list = self._migrate_run_args(self.settings.instances[self.settings.current_instance].run_args)
+        run_args_list = self._migrate_run_args(
+            self.settings.instances[self.settings.current_instance].run_args
+        )
         # Save migrated format back to settings
-        if run_args_list != self.settings.instances[self.settings.current_instance].run_args:
-            self.settings.instances[self.settings.current_instance].run_args = run_args_list
+        if (
+            run_args_list
+            != self.settings.instances[self.settings.current_instance].run_args
+        ):
+            self.settings.instances[
+                self.settings.current_instance
+            ].run_args = run_args_list
             self.settings.save()
             logger.info(f"Saved migrated run_args: {run_args_list}")
 
@@ -894,7 +1196,9 @@ class SettingsController(QObject):
         """
 
         # Locations tab
-        self.settings.instances[self.settings.current_instance].game_folder = self.settings_dialog.game_location.text()
+        self.settings.instances[
+            self.settings.current_instance
+        ].game_folder = self.settings_dialog.game_location.text()
         self.settings.instances[
             self.settings.current_instance
         ].config_folder = self.settings_dialog.config_folder_location.text()
@@ -906,25 +1210,39 @@ class SettingsController(QObject):
         ].local_folder = self.settings_dialog.local_mods_folder_location.text()
         self.settings.instances[
             self.settings.current_instance
-        ].steam_client_integration = self.settings_dialog.steam_client_integration_checkbox.isChecked()
+        ].steam_client_integration = (
+            self.settings_dialog.steam_client_integration_checkbox.isChecked()
+        )
 
         # Save Steam protocol launch option
         self.settings.instances[
             self.settings.current_instance
-        ].launch_via_steam_protocol = self.settings_dialog.launch_via_steam_protocol_checkbox.isChecked()
+        ].launch_via_steam_protocol = (
+            self.settings_dialog.launch_via_steam_protocol_checkbox.isChecked()
+        )
 
         # Databases tab
         if self.settings_dialog.community_rules_db_none_radio.isChecked():
             self.settings.external_community_rules_metadata_source = "None"
         elif self.settings_dialog.community_rules_db_local_file_radio.isChecked():
-            self.settings.external_community_rules_metadata_source = "Configured file path"
+            self.settings.external_community_rules_metadata_source = (
+                "Configured file path"
+            )
         elif self.settings_dialog.community_rules_db_github_radio.isChecked():
-            self.settings.external_community_rules_metadata_source = "Configured git repository"
+            self.settings.external_community_rules_metadata_source = (
+                "Configured git repository"
+            )
         elif self.settings_dialog.community_rules_db_url_radio.isChecked():
             self.settings.external_community_rules_metadata_source = "Configured URL"
-        self.settings.external_community_rules_file_path = self.settings_dialog.community_rules_db_local_file.text()
-        self.settings.external_community_rules_repo = self.settings_dialog.community_rules_db_github_url.text()
-        self.settings.external_community_rules_url = self.settings_dialog.community_rules_db_url_input.text()
+        self.settings.external_community_rules_file_path = (
+            self.settings_dialog.community_rules_db_local_file.text()
+        )
+        self.settings.external_community_rules_repo = (
+            self.settings_dialog.community_rules_db_github_url.text()
+        )
+        self.settings.external_community_rules_url = (
+            self.settings_dialog.community_rules_db_url_input.text()
+        )
         if self.settings_dialog.steam_workshop_db_none_radio.isChecked():
             self.settings.external_steam_metadata_source = "None"
         elif self.settings_dialog.steam_workshop_db_local_file_radio.isChecked():
@@ -933,18 +1251,28 @@ class SettingsController(QObject):
             self.settings.external_steam_metadata_source = "Configured git repository"
         elif self.settings_dialog.steam_workshop_db_url_radio.isChecked():
             self.settings.external_steam_metadata_source = "Configured URL"
-        self.settings.external_steam_metadata_repo = self.settings_dialog.steam_workshop_db_github_url.text()
-        self.settings.external_steam_metadata_file_path = self.settings_dialog.steam_workshop_db_local_file.text()
-        self.settings.external_steam_metadata_url = self.settings_dialog.steam_workshop_db_url_input.text()
+        self.settings.external_steam_metadata_repo = (
+            self.settings_dialog.steam_workshop_db_github_url.text()
+        )
+        self.settings.external_steam_metadata_file_path = (
+            self.settings_dialog.steam_workshop_db_local_file.text()
+        )
+        self.settings.external_steam_metadata_url = (
+            self.settings_dialog.steam_workshop_db_url_input.text()
+        )
         self.settings.database_expiry = int(self.settings_dialog.database_expiry.text())
 
         # Cross Version Databases Tab
         if self.settings_dialog.no_version_warning_db_none_radio.isChecked():
             self.settings.external_no_version_warning_metadata_source = "None"
         elif self.settings_dialog.no_version_warning_db_local_file_radio.isChecked():
-            self.settings.external_no_version_warning_metadata_source = "Configured file path"
+            self.settings.external_no_version_warning_metadata_source = (
+                "Configured file path"
+            )
         elif self.settings_dialog.no_version_warning_db_github_radio.isChecked():
-            self.settings.external_no_version_warning_metadata_source = "Configured git repository"
+            self.settings.external_no_version_warning_metadata_source = (
+                "Configured git repository"
+            )
         elif self.settings_dialog.no_version_warning_db_url_radio.isChecked():
             self.settings.external_no_version_warning_metadata_source = "Configured URL"
         self.settings.external_no_version_warning_file_path = (
@@ -953,21 +1281,35 @@ class SettingsController(QObject):
         self.settings.external_no_version_warning_repo_path = (
             self.settings_dialog.no_version_warning_db_github_url.text()
         )
-        self.settings.external_no_version_warning_url = self.settings_dialog.no_version_warning_db_url_input.text()
+        self.settings.external_no_version_warning_url = (
+            self.settings_dialog.no_version_warning_db_url_input.text()
+        )
 
         if self.settings_dialog.use_this_instead_db_none_radio.isChecked():
             self.settings.external_use_this_instead_metadata_source = "None"
         elif self.settings_dialog.use_this_instead_db_local_file_radio.isChecked():
-            self.settings.external_use_this_instead_metadata_source = "Configured file path"
+            self.settings.external_use_this_instead_metadata_source = (
+                "Configured file path"
+            )
         elif self.settings_dialog.use_this_instead_db_github_radio.isChecked():
-            self.settings.external_use_this_instead_metadata_source = "Configured git repository"
+            self.settings.external_use_this_instead_metadata_source = (
+                "Configured git repository"
+            )
         elif self.settings_dialog.use_this_instead_db_url_radio.isChecked():
             self.settings.external_use_this_instead_metadata_source = "Configured URL"
-        self.settings.external_use_this_instead_file_path = self.settings_dialog.use_this_instead_db_local_file.text()
-        self.settings.external_use_this_instead_repo_path = self.settings_dialog.use_this_instead_db_github_url.text()
-        self.settings.external_use_this_instead_url = self.settings_dialog.use_this_instead_db_url_input.text()
+        self.settings.external_use_this_instead_file_path = (
+            self.settings_dialog.use_this_instead_db_local_file.text()
+        )
+        self.settings.external_use_this_instead_repo_path = (
+            self.settings_dialog.use_this_instead_db_github_url.text()
+        )
+        self.settings.external_use_this_instead_url = (
+            self.settings_dialog.use_this_instead_db_url_input.text()
+        )
         try:
-            self.settings.aux_db_time_limit = int(self.settings_dialog.aux_db_time_limit.text())
+            self.settings.aux_db_time_limit = int(
+                self.settings_dialog.aux_db_time_limit.text()
+            )
         except Exception:
             logger.warning("Failed setting Aux DB time limit, falling back to -1")
             self.settings.aux_db_time_limit = -1
@@ -983,27 +1325,35 @@ class SettingsController(QObject):
             self.settings_dialog.use_moddependencies_as_loadTheseBefore.isChecked()
         )
         # Use alternativePackageIds as satisfying dependencies
-        self.settings.use_alternative_package_ids_as_satisfying_dependencies = (
-            self.settings_dialog.use_alternative_package_ids_as_satisfying_dependencies_checkbox.isChecked()
-        )
+        self.settings.use_alternative_package_ids_as_satisfying_dependencies = self.settings_dialog.use_alternative_package_ids_as_satisfying_dependencies_checkbox.isChecked()
         # Set dependencies checkbox
-        self.settings.check_dependencies_on_sort = self.settings_dialog.check_deps_checkbox.isChecked()
+        self.settings.check_dependencies_on_sort = (
+            self.settings_dialog.check_deps_checkbox.isChecked()
+        )
         # Prefer versioned About.xml tags over base tags
         self.settings.prefer_versioned_about_tags = (
             self.settings_dialog.prefer_versioned_about_tags_checkbox.isChecked()
         )
         # Download missing mods checkbox
-        self.settings.try_download_missing_mods = self.settings_dialog.download_missing_mods_checkbox.isChecked()
+        self.settings.try_download_missing_mods = (
+            self.settings_dialog.download_missing_mods_checkbox.isChecked()
+        )
         # Duplicate mod notification checkbox
-        self.settings.duplicate_mods_warning = self.settings_dialog.show_duplicate_mods_warning_checkbox.isChecked()
+        self.settings.duplicate_mods_warning = (
+            self.settings_dialog.show_duplicate_mods_warning_checkbox.isChecked()
+        )
         # Mod type filter checkbox
-        self.settings.mod_type_filter = self.settings_dialog.mod_type_filter_checkbox.isChecked()
+        self.settings.mod_type_filter = (
+            self.settings_dialog.mod_type_filter_checkbox.isChecked()
+        )
         # Hide invalid mod filtering checkbox
         self.settings.hide_invalid_mods_when_filtering = (
             self.settings_dialog.hide_invalid_mods_when_filtering_checkbox.isChecked()
         )
         # Inactive mods sorting options checkbox
-        self.settings.inactive_mods_sorting = self.settings_dialog.enable_inactive_mods_sorting_checkbox.isChecked()
+        self.settings.inactive_mods_sorting = (
+            self.settings_dialog.enable_inactive_mods_sorting_checkbox.isChecked()
+        )
         # Save inactive mods sort state
         self.settings.save_inactive_mods_sort_state = (
             self.settings_dialog.save_inactive_mods_sort_state_checkbox.isChecked()
@@ -1014,11 +1364,13 @@ class SettingsController(QObject):
             self.settings.db_builder_include = "all_mods"
         elif self.settings_dialog.db_builder_include_no_local_radio.isChecked():
             self.settings.db_builder_include = "no_local"
-        self.settings.build_steam_database_dlc_data = self.settings_dialog.db_builder_query_dlc_checkbox.isChecked()
-        self.settings.build_steam_database_update_toggle = (
-            self.settings_dialog.db_builder_update_instead_of_overwriting_checkbox.isChecked()
+        self.settings.build_steam_database_dlc_data = (
+            self.settings_dialog.db_builder_query_dlc_checkbox.isChecked()
         )
-        self.settings.steam_apikey = self.settings_dialog.db_builder_steam_api_key.text()
+        self.settings.build_steam_database_update_toggle = self.settings_dialog.db_builder_update_instead_of_overwriting_checkbox.isChecked()
+        self.settings.steam_apikey = (
+            self.settings_dialog.db_builder_steam_api_key.text()
+        )
 
         # SteamCMD tab
         self.settings.steamcmd_validate_downloads = (
@@ -1029,7 +1381,9 @@ class SettingsController(QObject):
         )
         self.settings.instances[
             self.settings.current_instance
-        ].steamcmd_auto_clear_depot_cache = self.settings_dialog.steamcmd_auto_clear_depot_cache_checkbox.isChecked()
+        ].steamcmd_auto_clear_depot_cache = (
+            self.settings_dialog.steamcmd_auto_clear_depot_cache_checkbox.isChecked()
+        )
         self.settings.instances[
             self.settings.current_instance
         ].steamcmd_install_path = self.settings_dialog.steamcmd_install_location.text()
@@ -1039,38 +1393,54 @@ class SettingsController(QObject):
             self.settings.todds_preset = "optimized"
         if self.settings_dialog.todds_preset_custom_radio.isChecked():
             self.settings.todds_preset = "custom"
-            self.settings.todds_custom_command = self.settings_dialog.todds_custom_command_lineedit.text()
+            self.settings.todds_custom_command = (
+                self.settings_dialog.todds_custom_command_lineedit.text()
+            )
         else:
             self.settings.todds_preset = "optimized"
         if self.settings_dialog.todds_active_mods_only_radio.isChecked():
             self.settings.todds_active_mods_target = True
         elif self.settings_dialog.todds_all_mods_radio.isChecked():
             self.settings.todds_active_mods_target = False
-        self.settings.todds_dry_run = self.settings_dialog.todds_dry_run_checkbox.isChecked()
-        self.settings.todds_overwrite = self.settings_dialog.todds_overwrite_checkbox.isChecked()
-        self.settings.auto_delete_orphaned_dds = self.settings_dialog.auto_delete_orphaned_dds_checkbox.isChecked()
+        self.settings.todds_dry_run = (
+            self.settings_dialog.todds_dry_run_checkbox.isChecked()
+        )
+        self.settings.todds_overwrite = (
+            self.settings_dialog.todds_overwrite_checkbox.isChecked()
+        )
+        self.settings.auto_delete_orphaned_dds = (
+            self.settings_dialog.auto_delete_orphaned_dds_checkbox.isChecked()
+        )
         self.settings.auto_run_todds_before_launch = (
             self.settings_dialog.auto_run_todds_before_launch_checkbox.isChecked()
         )
 
         # Other External Tools Tab
-        self.settings.text_editor_location = self.settings_dialog.text_editor_location.text()
-        self.settings.text_editor_folder_arg = self.settings_dialog.text_editor_folder_arg.text()
-        self.settings.text_editor_file_arg = self.settings_dialog.text_editor_file_arg.text()
+        self.settings.text_editor_location = (
+            self.settings_dialog.text_editor_location.text()
+        )
+        self.settings.text_editor_folder_arg = (
+            self.settings_dialog.text_editor_folder_arg.text()
+        )
+        self.settings.text_editor_file_arg = (
+            self.settings_dialog.text_editor_file_arg.text()
+        )
 
         # Themes tab
-        self.settings.enable_themes = self.settings_dialog.enable_themes_checkbox.isChecked()
+        self.settings.enable_themes = (
+            self.settings_dialog.enable_themes_checkbox.isChecked()
+        )
         self.settings.theme_name = self.settings_dialog.themes_combobox.currentText()
 
-        self.settings.font_family = self.settings_dialog.font_family_combobox.currentText()
+        self.settings.font_family = (
+            self.settings_dialog.font_family_combobox.currentText()
+        )
         self.settings.font_size = self.settings_dialog.font_size_spinbox.value()
         self.settings.language = self.settings_dialog.language_combobox.currentData()
 
         # Launch State tab
         # Dialogue positioning
-        self.settings.constrain_dialogues_to_main_window_monitor = (
-            self.settings_dialog.constrain_dialogues_to_main_window_monitor_checkbox.isChecked()
-        )
+        self.settings.constrain_dialogues_to_main_window_monitor = self.settings_dialog.constrain_dialogues_to_main_window_monitor_checkbox.isChecked()
 
         # Windows launch state
         # Main Window
@@ -1080,8 +1450,12 @@ class SettingsController(QObject):
             self.settings.main_window_launch_state = "normal"
         elif self.settings_dialog.main_launch_custom_radio.isChecked():
             self.settings.main_window_launch_state = "custom"
-            self.settings.main_window_custom_width = self.settings_dialog.main_custom_width_spinbox.value()
-            self.settings.main_window_custom_height = self.settings_dialog.main_custom_height_spinbox.value()
+            self.settings.main_window_custom_width = (
+                self.settings_dialog.main_custom_width_spinbox.value()
+            )
+            self.settings.main_window_custom_height = (
+                self.settings_dialog.main_custom_height_spinbox.value()
+            )
         else:
             self.settings.main_window_launch_state = "maximized"
         # Browser Window
@@ -1091,46 +1465,74 @@ class SettingsController(QObject):
             self.settings.browser_window_launch_state = "normal"
         elif self.settings_dialog.browser_launch_custom_radio.isChecked():
             self.settings.browser_window_launch_state = "custom"
-            self.settings.browser_window_custom_width = self.settings_dialog.browser_custom_width_spinbox.value()
-            self.settings.browser_window_custom_height = self.settings_dialog.browser_custom_height_spinbox.value()
+            self.settings.browser_window_custom_width = (
+                self.settings_dialog.browser_custom_width_spinbox.value()
+            )
+            self.settings.browser_window_custom_height = (
+                self.settings_dialog.browser_custom_height_spinbox.value()
+            )
         else:
             self.settings.browser_window_launch_state = "maximized"
 
         # Settings Window (only custom option)
-        self.settings.settings_window_custom_width = self.settings_dialog.settings_custom_width_spinbox.value()
-        self.settings.settings_window_custom_height = self.settings_dialog.settings_custom_height_spinbox.value()
+        self.settings.settings_window_custom_width = (
+            self.settings_dialog.settings_custom_width_spinbox.value()
+        )
+        self.settings.settings_window_custom_height = (
+            self.settings_dialog.settings_custom_height_spinbox.value()
+        )
 
         # Advanced tab
-        self.settings.debug_logging_enabled = self.settings_dialog.debug_logging_checkbox.isChecked()
-        self.settings.watchdog_toggle = self.settings_dialog.watchdog_checkbox.isChecked()
-        self.settings.backup_saves_on_launch = self.settings_dialog.backup_saves_on_launch_checkbox.isChecked()
-        self.settings.auto_backup_retention_count = self.settings_dialog.auto_backup_retention_count_spinbox.value()
-        self.settings.auto_backup_compression_count = self.settings_dialog.auto_backup_compression_count_spinbox.value()
+        self.settings.debug_logging_enabled = (
+            self.settings_dialog.debug_logging_checkbox.isChecked()
+        )
+        self.settings.watchdog_toggle = (
+            self.settings_dialog.watchdog_checkbox.isChecked()
+        )
+        self.settings.backup_saves_on_launch = (
+            self.settings_dialog.backup_saves_on_launch_checkbox.isChecked()
+        )
+        self.settings.auto_backup_retention_count = (
+            self.settings_dialog.auto_backup_retention_count_spinbox.value()
+        )
+        self.settings.auto_backup_compression_count = (
+            self.settings_dialog.auto_backup_compression_count_spinbox.value()
+        )
         self.settings.color_background_instead_of_text_toggle = (
             self.settings_dialog.color_background_instead_of_text_checkbox.isChecked()
         )
         # Clear button behavior
-        self.settings.clear_moves_dlc = self.settings_dialog.clear_moves_dlc_checkbox.isChecked()
-        self.settings.auto_launch_steam = self.settings_dialog.auto_launch_steam_checkbox.isChecked()
-        self.settings.steam_mods_update_check = self.settings_dialog.show_mod_updates_checkbox.isChecked()
-        self.settings.render_unity_rich_text = self.settings_dialog.render_unity_rich_text_checkbox.isChecked()
+        self.settings.clear_moves_dlc = (
+            self.settings_dialog.clear_moves_dlc_checkbox.isChecked()
+        )
+        self.settings.auto_launch_steam = (
+            self.settings_dialog.auto_launch_steam_checkbox.isChecked()
+        )
+        self.settings.steam_mods_update_check = (
+            self.settings_dialog.show_mod_updates_checkbox.isChecked()
+        )
+        self.settings.render_unity_rich_text = (
+            self.settings_dialog.render_unity_rich_text_checkbox.isChecked()
+        )
         self.settings.update_databases_on_startup = (
             self.settings_dialog.update_databases_on_startup_checkbox.isChecked()
         )
-        self.settings.include_mod_notes_in_mod_name_filter = (
-            self.settings_dialog.include_mod_notes_in_mod_name_filter_checkbox.isChecked()
-        )
+        self.settings.include_mod_notes_in_mod_name_filter = self.settings_dialog.include_mod_notes_in_mod_name_filter_checkbox.isChecked()
 
         self.settings.enable_backup_before_update = (
             self.settings_dialog.enable_backup_before_update_checkbox.isChecked()
         )
         self.settings.max_backups = self.settings_dialog.max_backups_spinbox.value()
-        self.settings.enable_aux_db_behavior_editing = self.settings_dialog.enable_aux_db_behavior_editing.isChecked()
+        self.settings.enable_aux_db_behavior_editing = (
+            self.settings_dialog.enable_aux_db_behavior_editing.isChecked()
+        )
         self.settings.rentry_auth_code = self.settings_dialog.rentry_auth_code.text()
         self.settings.github_username = self.settings_dialog.github_username.text()
         self.settings.github_token = self.settings_dialog.github_token.text()
         # Migrate and extract command string from single-element list
-        run_args_list = self._migrate_run_args(self.settings.instances[self.settings.current_instance].run_args)
+        run_args_list = self._migrate_run_args(
+            self.settings.instances[self.settings.current_instance].run_args
+        )
         run_args_str = run_args_list[0] if run_args_list else ""
         self.settings_dialog.run_args.setText(run_args_str)
 
@@ -1141,7 +1543,9 @@ class SettingsController(QObject):
         """
         answer = BinaryChoiceDialog(
             title=self.tr("Reset to defaults"),
-            text=self.tr("Are you sure you want to reset all settings to their default values?"),
+            text=self.tr(
+                "Are you sure you want to reset all settings to their default values?"
+            ),
         )
         if not answer.exec_is_positive():
             return
@@ -1193,7 +1597,9 @@ class SettingsController(QObject):
             return False
         return True
 
-    def _check_steam_integration_validity(self, steam_client_integration: bool, steam_mods_location: str) -> bool:
+    def _check_steam_integration_validity(
+        self, steam_client_integration: bool, steam_mods_location: str
+    ) -> bool:
         """
         Check if Steam client integration and Steam mods location are valid.
 
@@ -1239,8 +1645,12 @@ class SettingsController(QObject):
 
         :return: True if valid configuration, False if invalid.
         """
-        steam_client_integration = self.settings_dialog.steam_client_integration_checkbox.isChecked()
-        steam_mods_location = self.settings_dialog.steam_mods_folder_location.text().strip()
+        steam_client_integration = (
+            self.settings_dialog.steam_client_integration_checkbox.isChecked()
+        )
+        steam_mods_location = (
+            self.settings_dialog.steam_mods_folder_location.text().strip()
+        )
 
         # Handle user explicitly disabling Steam integration
         if not steam_client_integration:
@@ -1256,7 +1666,9 @@ class SettingsController(QObject):
             self.settings_dialog.launch_via_steam_protocol_checkbox.setChecked(False)
 
         # Validate Steam integration configuration
-        is_valid = self._check_steam_integration_validity(steam_client_integration, steam_mods_location)
+        is_valid = self._check_steam_integration_validity(
+            steam_client_integration, steam_mods_location
+        )
 
         if not is_valid:
             # Disable all Steam integration settings if validation fails
@@ -1272,7 +1684,9 @@ class SettingsController(QObject):
                         "Steam client integration, Steam mods location, and Steam protocol launch have been disabled."
                     ),
                 )
-            elif steam_mods_location and not validate_acf_file_exists(steam_mods_location):
+            elif steam_mods_location and not validate_acf_file_exists(
+                steam_mods_location
+            ):
                 QMessageBox.warning(
                     self.settings_dialog,
                     self.tr("Steam Workshop File Not Found"),
@@ -1297,7 +1711,9 @@ class SettingsController(QObject):
 
         # Validate config folder if set
         config_folder_text = self.settings_dialog.config_folder_location.text().strip()
-        if config_folder_text and not self._validate_config_folder_location(config_folder_text):
+        if config_folder_text and not self._validate_config_folder_location(
+            config_folder_text
+        ):
             return
 
         # Validate Steam integration if enabled
@@ -1321,7 +1737,9 @@ class SettingsController(QObject):
 
     @Slot()
     def _on_game_location_text_changed(self) -> None:
-        self.settings_dialog.game_location_open_button.setEnabled(self.settings_dialog.game_location.text() != "")
+        self.settings_dialog.game_location_open_button.setEnabled(
+            self.settings_dialog.game_location.text() != ""
+        )
 
     @Slot()
     def _on_game_location_open_button_clicked(self) -> None:
@@ -1342,7 +1760,9 @@ class SettingsController(QObject):
         if not self._validate_game_location(str(game_location)):
             return
         self.settings_dialog.game_location.setText(str(game_location))
-        self.settings_dialog.local_mods_folder_location.setText(str(game_location / "Mods"))
+        self.settings_dialog.local_mods_folder_location.setText(
+            str(game_location / "Mods")
+        )
         self._last_file_dialog_path = str(game_location)
 
     def _on_game_location_choose_button_clicked_macos(self) -> Path | None:
@@ -1434,7 +1854,9 @@ class SettingsController(QObject):
         if not steam_mods_folder_location:
             return
 
-        self.settings_dialog.steam_mods_folder_location.setText(steam_mods_folder_location)
+        self.settings_dialog.steam_mods_folder_location.setText(
+            steam_mods_folder_location
+        )
         self._last_file_dialog_path = str(Path(steam_mods_folder_location).parent)
 
     @Slot()
@@ -1454,7 +1876,9 @@ class SettingsController(QObject):
         if not local_mods_folder_location:
             return
 
-        self.settings_dialog.local_mods_folder_location.setText(local_mods_folder_location)
+        self.settings_dialog.local_mods_folder_location.setText(
+            local_mods_folder_location
+        )
         self._last_file_dialog_path = str(Path(local_mods_folder_location).parent)
 
     @Slot()
@@ -1472,7 +1896,9 @@ class SettingsController(QObject):
         self.settings_dialog.local_mods_folder_location.setText("")
 
     @Slot()
-    def _on_locations_clear_button_clicked(self, skip_confirmation: bool = False) -> None:
+    def _on_locations_clear_button_clicked(
+        self, skip_confirmation: bool = False
+    ) -> None:
         """
         Clear the settings dialog's location fields.
         """
@@ -1519,7 +1945,9 @@ class SettingsController(QObject):
 
         path_groups = [
             _PathGroup(os_paths[0], self.settings_dialog.game_location, "game"),
-            _PathGroup(os_paths[1], self.settings_dialog.config_folder_location, "config"),
+            _PathGroup(
+                os_paths[1], self.settings_dialog.config_folder_location, "config"
+            ),
             _PathGroup(
                 os_paths[2],
                 self.settings_dialog.steam_mods_folder_location,
@@ -1534,14 +1962,20 @@ class SettingsController(QObject):
 
         for group in path_groups:
             if group.folder.exists():
-                logger.info(f"Auto-detected {group.name} folder path exists: {group.folder}")
+                logger.info(
+                    f"Auto-detected {group.name} folder path exists: {group.folder}"
+                )
                 if not group.settings_line.text():
-                    logger.info(f"No value set currently for {group.name} folder. Overwriting with auto-detected path")
+                    logger.info(
+                        f"No value set currently for {group.name} folder. Overwriting with auto-detected path"
+                    )
                     group.settings_line.setText(str(group.folder))
                 else:
                     logger.info(f"Value already set for {group.name} folder. Passing")
             else:
-                logger.warning(f"Auto-detected {group.name} folder path does not exist: {group.folder}")
+                logger.warning(
+                    f"Auto-detected {group.name} folder path does not exist: {group.folder}"
+                )
 
     def __get_darwin_paths(self) -> tuple[Path, Path, Path]:
         """
@@ -1551,9 +1985,15 @@ class SettingsController(QObject):
             tuple[Path, Path, Path]: game_folder, config_folder, steam_mods_folder
         """
         user_home = Path.home()
-        game_folder = Path(f"/{user_home}/Library/Application Support/Steam/steamapps/common/Rimworld/RimworldMac.app")
-        config_folder = Path(f"/{user_home}/Library/Application Support/Rimworld/Config")
-        steam_mods_folder = Path(f"/{user_home}/Library/Application Support/Steam/steamapps/workshop/content/294100")
+        game_folder = Path(
+            f"/{user_home}/Library/Application Support/Steam/steamapps/common/Rimworld/RimworldMac.app"
+        )
+        config_folder = Path(
+            f"/{user_home}/Library/Application Support/Rimworld/Config"
+        )
+        steam_mods_folder = Path(
+            f"/{user_home}/Library/Application Support/Steam/steamapps/workshop/content/294100"
+        )
 
         return game_folder, config_folder, steam_mods_folder
 
@@ -1570,7 +2010,10 @@ class SettingsController(QObject):
             steam_path = user_home / ".steam/steam"
             debian_path = steam_path / "steamapps/common/RimWorld"
         game_folder = debian_path / "steamapps/common/RimWorld"
-        config_folder = user_home / ".config/unity3d/Ludeon Studios/RimWorld by Ludeon Studios/Config"
+        config_folder = (
+            user_home
+            / ".config/unity3d/Ludeon Studios/RimWorld by Ludeon Studios/Config"
+        )
         steam_mods_folder = debian_path / "steamapps/workshop/content/294100"
 
         return game_folder, config_folder, steam_mods_folder
@@ -1589,7 +2032,9 @@ class SettingsController(QObject):
             steam_folder, found = find_steam_folder()
 
             if not found:
-                logger.error("[win32] Could not find Steam folder. Using fallback assumptions")
+                logger.error(
+                    "[win32] Could not find Steam folder. Using fallback assumptions"
+                )
                 steam_folder = "C:/Program Files (x86)/Steam"
 
             game_folder: str | Path = find_steam_rimworld(steam_folder)
@@ -1599,12 +2044,18 @@ class SettingsController(QObject):
                 game_folder = f"{steam_folder}/steamapps/common/RimWorld"
             game_folder = Path(game_folder)
 
-            config_folder = Path(f"{user_home}/AppData/LocalLow/Ludeon Studios/RimWorld by Ludeon Studios/Config")
+            config_folder = Path(
+                f"{user_home}/AppData/LocalLow/Ludeon Studios/RimWorld by Ludeon Studios/Config"
+            )
 
-            steam_mods_folder = get_path_up_to_string(game_folder, "common", exclude=True)
+            steam_mods_folder = get_path_up_to_string(
+                game_folder, "common", exclude=True
+            )
             if steam_mods_folder == "":
                 # Fallback steam mods path
-                steam_mods_folder = Path(f"{steam_folder}/steamapps/workshop/content/294100")
+                steam_mods_folder = Path(
+                    f"{steam_folder}/steamapps/workshop/content/294100"
+                )
             else:
                 steam_mods_folder = Path(steam_mods_folder) / "workshop/content/294100"
 
@@ -1613,7 +2064,9 @@ class SettingsController(QObject):
             raise ValueError("This function should only be called on Windows")
 
     @Slot(bool)
-    def _do_http_download_from_dialog(self, url: str, repo_url: str, display_name: str) -> None:
+    def _do_http_download_from_dialog(
+        self, url: str, repo_url: str, display_name: str
+    ) -> None:
         """Download a database via HTTP using the URL currently in the settings dialog."""
         if not url:
             show_warning(
@@ -1623,7 +2076,11 @@ class SettingsController(QObject):
             )
             return
 
-        repo_name = extract_git_dir_name(repo_url) if repo_url else display_name.replace(" ", "-")
+        repo_name = (
+            extract_git_dir_name(repo_url)
+            if repo_url
+            else display_name.replace(" ", "-")
+        )
         task = DatabaseDownloadTask(
             url=url,
             target_dir=AppInfo().databases_folder,
@@ -1641,13 +2098,19 @@ class SettingsController(QObject):
             self._http_download_worker = None
 
         self._http_download_worker = HttpDownloadWorker([task])
-        self._http_download_worker.download_finished.connect(self._on_http_download_from_dialog_finished)
+        self._http_download_worker.download_finished.connect(
+            self._on_http_download_from_dialog_finished
+        )
         self._http_download_worker.start()
 
     @Slot(dict)
-    def _on_http_download_from_dialog_finished(self, results: dict[str, DownloadResult]) -> None:
+    def _on_http_download_from_dialog_finished(
+        self, results: dict[str, DownloadResult]
+    ) -> None:
         updated = [name for name, r in results.items() if r == DownloadResult.UPDATED]
-        up_to_date = [name for name, r in results.items() if r == DownloadResult.UP_TO_DATE]
+        up_to_date = [
+            name for name, r in results.items() if r == DownloadResult.UP_TO_DATE
+        ]
         failed = [name for name, r in results.items() if r == DownloadResult.FAILED]
 
         if failed:
@@ -1679,46 +2142,80 @@ class SettingsController(QObject):
         This function handles the community rules db radio buttons. Clicking one button
         enables the associated widgets and disables the other widgets.
         """
-        if self.sender() == self.settings_dialog.community_rules_db_none_radio and checked:
+        if (
+            self.sender() == self.settings_dialog.community_rules_db_none_radio
+            and checked
+        ):
             self.settings_dialog.community_rules_db_github_url.setEnabled(False)
-            self.settings_dialog.community_rules_db_github_download_button.setEnabled(False)
+            self.settings_dialog.community_rules_db_github_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.community_rules_db_url_input.setEnabled(False)
-            self.settings_dialog.community_rules_db_url_download_button.setEnabled(False)
+            self.settings_dialog.community_rules_db_url_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.community_rules_db_local_file.setEnabled(False)
-            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(False)
+            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(
+                False
+            )
             if isinstance(self.app_instance, QApplication):
                 focused_widget = self.app_instance.focusWidget()
                 if focused_widget is not None:
                     focused_widget.clearFocus()
             return
 
-        if self.sender() == self.settings_dialog.community_rules_db_github_radio and checked:
+        if (
+            self.sender() == self.settings_dialog.community_rules_db_github_radio
+            and checked
+        ):
             self.settings_dialog.community_rules_db_github_url.setEnabled(True)
-            self.settings_dialog.community_rules_db_github_download_button.setEnabled(True)
+            self.settings_dialog.community_rules_db_github_download_button.setEnabled(
+                True
+            )
             self.settings_dialog.community_rules_db_url_input.setEnabled(False)
-            self.settings_dialog.community_rules_db_url_download_button.setEnabled(False)
+            self.settings_dialog.community_rules_db_url_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.community_rules_db_local_file.setEnabled(False)
-            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(False)
+            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(
+                False
+            )
             self.settings_dialog.community_rules_db_github_url.setFocus()
             return
 
-        if self.sender() == self.settings_dialog.community_rules_db_url_radio and checked:
+        if (
+            self.sender() == self.settings_dialog.community_rules_db_url_radio
+            and checked
+        ):
             self.settings_dialog.community_rules_db_url_input.setEnabled(True)
             self.settings_dialog.community_rules_db_url_download_button.setEnabled(True)
             self.settings_dialog.community_rules_db_github_url.setEnabled(False)
-            self.settings_dialog.community_rules_db_github_download_button.setEnabled(False)
+            self.settings_dialog.community_rules_db_github_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.community_rules_db_local_file.setEnabled(False)
-            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(False)
+            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(
+                False
+            )
             self.settings_dialog.community_rules_db_url_input.setFocus()
             return
 
-        if self.sender() == self.settings_dialog.community_rules_db_local_file_radio and checked:
+        if (
+            self.sender() == self.settings_dialog.community_rules_db_local_file_radio
+            and checked
+        ):
             self.settings_dialog.community_rules_db_github_url.setEnabled(False)
-            self.settings_dialog.community_rules_db_github_download_button.setEnabled(False)
+            self.settings_dialog.community_rules_db_github_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.community_rules_db_url_input.setEnabled(False)
-            self.settings_dialog.community_rules_db_url_download_button.setEnabled(False)
+            self.settings_dialog.community_rules_db_url_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.community_rules_db_local_file.setEnabled(True)
-            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(True)
+            self.settings_dialog.community_rules_db_local_file_choose_button.setEnabled(
+                True
+            )
             self.settings_dialog.community_rules_db_local_file.setFocus()
             return
 
@@ -1735,7 +2232,9 @@ class SettingsController(QObject):
         if not community_rules_db_location:
             return
 
-        self.settings_dialog.community_rules_db_local_file.setText(community_rules_db_location)
+        self.settings_dialog.community_rules_db_local_file.setText(
+            community_rules_db_location
+        )
         self._last_file_dialog_path = str(Path(community_rules_db_location).parent)
 
     @Slot(bool)
@@ -1744,46 +2243,74 @@ class SettingsController(QObject):
         This function handles the Steam workshop db radio buttons. Clicking one button
         enables the associated widgets and disables the other widgets.
         """
-        if self.sender() == self.settings_dialog.steam_workshop_db_none_radio and checked:
+        if (
+            self.sender() == self.settings_dialog.steam_workshop_db_none_radio
+            and checked
+        ):
             self.settings_dialog.steam_workshop_db_github_url.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(False)
+            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.steam_workshop_db_url_input.setEnabled(False)
             self.settings_dialog.steam_workshop_db_url_download_button.setEnabled(False)
             self.settings_dialog.steam_workshop_db_local_file.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(False)
+            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(
+                False
+            )
             if isinstance(self.app_instance, QApplication):
                 focused_widget = self.app_instance.focusWidget()
                 if focused_widget is not None:
                     focused_widget.clearFocus()
             return
 
-        if self.sender() == self.settings_dialog.steam_workshop_db_github_radio and checked:
+        if (
+            self.sender() == self.settings_dialog.steam_workshop_db_github_radio
+            and checked
+        ):
             self.settings_dialog.steam_workshop_db_github_url.setEnabled(True)
-            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(True)
+            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(
+                True
+            )
             self.settings_dialog.steam_workshop_db_url_input.setEnabled(False)
             self.settings_dialog.steam_workshop_db_url_download_button.setEnabled(False)
             self.settings_dialog.steam_workshop_db_local_file.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(False)
+            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(
+                False
+            )
             self.settings_dialog.steam_workshop_db_github_url.setFocus()
             return
 
-        if self.sender() == self.settings_dialog.steam_workshop_db_url_radio and checked:
+        if (
+            self.sender() == self.settings_dialog.steam_workshop_db_url_radio
+            and checked
+        ):
             self.settings_dialog.steam_workshop_db_url_input.setEnabled(True)
             self.settings_dialog.steam_workshop_db_url_download_button.setEnabled(True)
             self.settings_dialog.steam_workshop_db_github_url.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(False)
+            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.steam_workshop_db_local_file.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(False)
+            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(
+                False
+            )
             self.settings_dialog.steam_workshop_db_url_input.setFocus()
             return
 
-        if self.sender() == self.settings_dialog.steam_workshop_db_local_file_radio and checked:
+        if (
+            self.sender() == self.settings_dialog.steam_workshop_db_local_file_radio
+            and checked
+        ):
             self.settings_dialog.steam_workshop_db_github_url.setEnabled(False)
-            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(False)
+            self.settings_dialog.steam_workshop_db_github_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.steam_workshop_db_url_input.setEnabled(False)
             self.settings_dialog.steam_workshop_db_url_download_button.setEnabled(False)
             self.settings_dialog.steam_workshop_db_local_file.setEnabled(True)
-            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(True)
+            self.settings_dialog.steam_workshop_db_local_file_choose_button.setEnabled(
+                True
+            )
             self.settings_dialog.steam_workshop_db_local_file.setFocus()
             return
 
@@ -1800,7 +2327,9 @@ class SettingsController(QObject):
         if not steam_workshop_db_location:
             return
 
-        self.settings_dialog.steam_workshop_db_local_file.setText(steam_workshop_db_location)
+        self.settings_dialog.steam_workshop_db_local_file.setText(
+            steam_workshop_db_location
+        )
         self._last_file_dialog_path = str(Path(steam_workshop_db_location).parent)
 
     @Slot(bool)
@@ -1809,13 +2338,22 @@ class SettingsController(QObject):
         This function handles the "No Version Warning" db radio buttons. Clicking one button
         enables the associated widgets and disables the other widgets.
         """
-        if self.sender() == self.settings_dialog.no_version_warning_db_none_radio and checked:
+        if (
+            self.sender() == self.settings_dialog.no_version_warning_db_none_radio
+            and checked
+        ):
             self.settings_dialog.no_version_warning_db_github_url.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(False)
+            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.no_version_warning_db_url_input.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(False)
+            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.no_version_warning_db_local_file.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(False)
+            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(
+                False
+            )
             app_instance = QApplication.instance()
             if isinstance(app_instance, QApplication):
                 focused_widget = app_instance.focusWidget()
@@ -1823,33 +2361,60 @@ class SettingsController(QObject):
                     focused_widget.clearFocus()
             return
 
-        if self.sender() == self.settings_dialog.no_version_warning_db_github_radio and checked:
+        if (
+            self.sender() == self.settings_dialog.no_version_warning_db_github_radio
+            and checked
+        ):
             self.settings_dialog.no_version_warning_db_github_url.setEnabled(True)
-            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(True)
+            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(
+                True
+            )
             self.settings_dialog.no_version_warning_db_url_input.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(False)
+            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.no_version_warning_db_local_file.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(False)
+            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(
+                False
+            )
             self.settings_dialog.no_version_warning_db_github_url.setFocus()
             return
 
-        if self.sender() == self.settings_dialog.no_version_warning_db_url_radio and checked:
+        if (
+            self.sender() == self.settings_dialog.no_version_warning_db_url_radio
+            and checked
+        ):
             self.settings_dialog.no_version_warning_db_url_input.setEnabled(True)
-            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(True)
+            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(
+                True
+            )
             self.settings_dialog.no_version_warning_db_github_url.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(False)
+            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.no_version_warning_db_local_file.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(False)
+            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(
+                False
+            )
             self.settings_dialog.no_version_warning_db_url_input.setFocus()
             return
 
-        if self.sender() == self.settings_dialog.no_version_warning_db_local_file_radio and checked:
+        if (
+            self.sender() == self.settings_dialog.no_version_warning_db_local_file_radio
+            and checked
+        ):
             self.settings_dialog.no_version_warning_db_github_url.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(False)
+            self.settings_dialog.no_version_warning_db_github_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.no_version_warning_db_url_input.setEnabled(False)
-            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(False)
+            self.settings_dialog.no_version_warning_db_url_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.no_version_warning_db_local_file.setEnabled(True)
-            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(True)
+            self.settings_dialog.no_version_warning_db_local_file_choose_button.setEnabled(
+                True
+            )
             self.settings_dialog.no_version_warning_db_local_file.setFocus()
             return
 
@@ -1866,7 +2431,9 @@ class SettingsController(QObject):
         if not no_version_warning_db_location:
             return
 
-        self.settings_dialog.no_version_warning_db_local_file.setText(no_version_warning_db_location)
+        self.settings_dialog.no_version_warning_db_local_file.setText(
+            no_version_warning_db_location
+        )
         self._last_file_dialog_path = str(Path(no_version_warning_db_location).parent)
 
     @Slot(bool)
@@ -1875,13 +2442,22 @@ class SettingsController(QObject):
         This function handles the "Use This Instead" db radio buttons. Clicking one button
         enables the associated widgets and disables the other widgets.
         """
-        if self.sender() == self.settings_dialog.use_this_instead_db_none_radio and checked:
+        if (
+            self.sender() == self.settings_dialog.use_this_instead_db_none_radio
+            and checked
+        ):
             self.settings_dialog.use_this_instead_db_github_url.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(False)
+            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.use_this_instead_db_url_input.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(False)
+            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.use_this_instead_db_local_file.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(False)
+            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(
+                False
+            )
             app_instance = QApplication.instance()
             if isinstance(app_instance, QApplication):
                 focused_widget = app_instance.focusWidget()
@@ -1889,33 +2465,60 @@ class SettingsController(QObject):
                     focused_widget.clearFocus()
             return
 
-        if self.sender() == self.settings_dialog.use_this_instead_db_github_radio and checked:
+        if (
+            self.sender() == self.settings_dialog.use_this_instead_db_github_radio
+            and checked
+        ):
             self.settings_dialog.use_this_instead_db_github_url.setEnabled(True)
-            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(True)
+            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(
+                True
+            )
             self.settings_dialog.use_this_instead_db_url_input.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(False)
+            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.use_this_instead_db_local_file.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(False)
+            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(
+                False
+            )
             self.settings_dialog.use_this_instead_db_github_url.setFocus()
             return
 
-        if self.sender() == self.settings_dialog.use_this_instead_db_url_radio and checked:
+        if (
+            self.sender() == self.settings_dialog.use_this_instead_db_url_radio
+            and checked
+        ):
             self.settings_dialog.use_this_instead_db_url_input.setEnabled(True)
-            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(True)
+            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(
+                True
+            )
             self.settings_dialog.use_this_instead_db_github_url.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(False)
+            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.use_this_instead_db_local_file.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(False)
+            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(
+                False
+            )
             self.settings_dialog.use_this_instead_db_url_input.setFocus()
             return
 
-        if self.sender() == self.settings_dialog.use_this_instead_db_local_file_radio and checked:
+        if (
+            self.sender() == self.settings_dialog.use_this_instead_db_local_file_radio
+            and checked
+        ):
             self.settings_dialog.use_this_instead_db_github_url.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(False)
+            self.settings_dialog.use_this_instead_db_github_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.use_this_instead_db_url_input.setEnabled(False)
-            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(False)
+            self.settings_dialog.use_this_instead_db_url_download_button.setEnabled(
+                False
+            )
             self.settings_dialog.use_this_instead_db_local_file.setEnabled(True)
-            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(True)
+            self.settings_dialog.use_this_instead_db_local_file_choose_button.setEnabled(
+                True
+            )
             self.settings_dialog.use_this_instead_db_local_file.setFocus()
             return
 
@@ -1933,7 +2536,9 @@ class SettingsController(QObject):
         if not use_this_instead_db_location:
             return
 
-        self.settings_dialog.use_this_instead_db_local_file.setText(use_this_instead_db_location)
+        self.settings_dialog.use_this_instead_db_local_file.setText(
+            use_this_instead_db_location
+        )
         self._last_file_dialog_path = str(Path(use_this_instead_db_location).parent)
 
     @Slot()
@@ -1949,7 +2554,9 @@ class SettingsController(QObject):
         if not steamcmd_install_location:
             return
 
-        self.settings_dialog.steamcmd_install_location.setText(steamcmd_install_location)
+        self.settings_dialog.steamcmd_install_location.setText(
+            steamcmd_install_location
+        )
         self._last_file_dialog_path = str(Path(steamcmd_install_location).parent)
 
     @Slot()
@@ -2147,7 +2754,9 @@ class SettingsController(QObject):
 
         # Validate the path before setting it
 
-        test_controller = InstanceController(self.settings.instances[self.settings.current_instance])
+        test_controller = InstanceController(
+            self.settings.instances[self.settings.current_instance]
+        )
         test_controller.instance.instance_folder_override = instance_folder_location
         is_valid, error_msg = test_controller.validate_instance_folder_override()
 
@@ -2160,7 +2769,9 @@ class SettingsController(QObject):
             return
 
         # Update the instance and UI
-        self.settings.instances[self.settings.current_instance].instance_folder_override = instance_folder_location
+        self.settings.instances[
+            self.settings.current_instance
+        ].instance_folder_override = instance_folder_location
         self.settings_dialog.instance_folder_location.setText(instance_folder_location)
         self._last_file_dialog_path = str(Path(instance_folder_location).parent)
         self.settings.save()
@@ -2177,7 +2788,9 @@ class SettingsController(QObject):
             )
             return
 
-        self.settings.instances[self.settings.current_instance].instance_folder_override = ""
+        self.settings.instances[
+            self.settings.current_instance
+        ].instance_folder_override = ""
         self.settings_dialog.instance_folder_location.setText("")
         self.settings.save()
 
@@ -2194,12 +2807,16 @@ class SettingsController(QObject):
         """
         selected_theme_name = self.settings_dialog.themes_combobox.currentText()
         logger.info(f"Opening theme location: {selected_theme_name}")
-        stylesheet_path = self.theme_controller.get_theme_stylesheet_path(selected_theme_name)
+        stylesheet_path = self.theme_controller.get_theme_stylesheet_path(
+            selected_theme_name
+        )
 
         if stylesheet_path and stylesheet_path.exists():
             platform_specific_open(stylesheet_path.parent)
         else:
-            logger.warning(f"Failed to open theme location: {stylesheet_path} not found or does not exist")
+            logger.warning(
+                f"Failed to open theme location: {stylesheet_path} not found or does not exist"
+            )
 
     @Slot()
     def _on_use_background_coloring_checkbox_changed(self) -> None:
@@ -2207,9 +2824,7 @@ class SettingsController(QObject):
 
     @Slot()
     def _on_include_mod_notes_in_mod_name_filter_changed(self) -> None:
-        self.settings.include_mod_notes_in_mod_name_filter = (
-            self.settings_dialog.include_mod_notes_in_mod_name_filter_checkbox.isChecked()
-        )
+        self.settings.include_mod_notes_in_mod_name_filter = self.settings_dialog.include_mod_notes_in_mod_name_filter_checkbox.isChecked()
 
     @Slot()
     def _handle_mod_coloring_mode_changed(self) -> None:

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -54,22 +54,18 @@ class Settings(QObject):
 
         # Databases
         self.external_steam_metadata_source: str = "Configured URL"
-        self.external_steam_metadata_file_path: str = str(
-            AppInfo().app_storage_folder / "steamDB.json"
+        self.external_steam_metadata_file_path: str = str(AppInfo().app_storage_folder / "steamDB.json")
+        self.external_steam_metadata_repo: str = "https://github.com/RimSort/Steam-Workshop-Database"
+        self.external_steam_metadata_url: str = (
+            "https://github.com/RimSort/Steam-Workshop-Database/archive/refs/heads/main.zip"
         )
-        self.external_steam_metadata_repo: str = (
-            "https://github.com/RimSort/Steam-Workshop-Database"
-        )
-        self.external_steam_metadata_url: str = "https://github.com/RimSort/Steam-Workshop-Database/archive/refs/heads/main.zip"
 
         self.external_community_rules_metadata_source: str = "Configured URL"
-        self.external_community_rules_file_path: str = str(
-            AppInfo().app_storage_folder / "communityRules.json"
+        self.external_community_rules_file_path: str = str(AppInfo().app_storage_folder / "communityRules.json")
+        self.external_community_rules_repo: str = "https://github.com/RimSort/Community-Rules-Database"
+        self.external_community_rules_url: str = (
+            "https://github.com/RimSort/Community-Rules-Database/archive/refs/heads/main.zip"
         )
-        self.external_community_rules_repo: str = (
-            "https://github.com/RimSort/Community-Rules-Database"
-        )
-        self.external_community_rules_url: str = "https://github.com/RimSort/Community-Rules-Database/archive/refs/heads/main.zip"
 
         # Disable by default previously this was 7 days "604800"
         self.database_expiry: int = 0
@@ -77,12 +73,8 @@ class Settings(QObject):
         self.aux_db_time_limit: int = -1
 
         self.external_no_version_warning_metadata_source: str = "Configured URL"
-        self.external_no_version_warning_file_path: str = str(
-            AppInfo().app_storage_folder / "ModIdsToFix.xml"
-        )
-        self.external_no_version_warning_repo_path: str = (
-            "https://github.com/emipa606/NoVersionWarning"
-        )
+        self.external_no_version_warning_file_path: str = str(AppInfo().app_storage_folder / "ModIdsToFix.xml")
+        self.external_no_version_warning_repo_path: str = "https://github.com/emipa606/NoVersionWarning"
         self.external_no_version_warning_url: str = (
             "https://github.com/emipa606/NoVersionWarning/archive/refs/heads/master.zip"
         )
@@ -91,9 +83,7 @@ class Settings(QObject):
         self.external_use_this_instead_file_path: str = str(
             AppInfo().app_storage_folder / "UseThisInstead" / "replacements.json.gz"
         )
-        self.external_use_this_instead_repo_path: str = (
-            "https://github.com/emipa606/UseThisInstead"
-        )
+        self.external_use_this_instead_repo_path: str = "https://github.com/emipa606/UseThisInstead"
         self.external_use_this_instead_url: str = (
             "https://github.com/emipa606/UseThisInstead/archive/refs/heads/master.zip"
         )
@@ -221,9 +211,7 @@ class Settings(QObject):
         # Instances
         self.current_instance: str = DEFAULT_INSTANCE_NAME
         self.current_instance_path: str = str(
-            Path(AppInfo().app_storage_folder)
-            / INSTANCE_FOLDER_NAME
-            / self.current_instance
+            Path(AppInfo().app_storage_folder) / INSTANCE_FOLDER_NAME / self.current_instance
         )
         self.instances: dict[str, Instance] = {DEFAULT_INSTANCE_NAME: Instance()}
 
@@ -238,14 +226,8 @@ class Settings(QObject):
 
         instance = self.instances[self.current_instance]
         # Default instance never uses override
-        override = (
-            ""
-            if self.current_instance == DEFAULT_INSTANCE_NAME
-            else instance.instance_folder_override
-        )
-        instance_path = InstanceController.get_instance_folder_path(
-            self.current_instance, override
-        )
+        override = "" if self.current_instance == DEFAULT_INSTANCE_NAME else instance.instance_folder_override
+        instance_path = InstanceController.get_instance_folder_path(self.current_instance, override)
         return instance_path / "aux_metadata.db"
 
     def __setattr__(self, key: str, value: Any) -> None:
@@ -272,15 +254,9 @@ class Settings(QObject):
                 mitigations = True
                 # Mitigate issues when "instances" key is not parsed, but the old path attributes are present
                 if not data.get("instances"):
-                    logger.debug(
-                        "Instances key not found in settings.json. Performing mitigation."
-                    )
+                    logger.debug("Instances key not found in settings.json. Performing mitigation.")
                     steamcmd_prefix_default_instance_path = str(
-                        Path(
-                            AppInfo().app_storage_folder
-                            / INSTANCE_FOLDER_NAME
-                            / DEFAULT_INSTANCE_NAME
-                        )
+                        Path(AppInfo().app_storage_folder / INSTANCE_FOLDER_NAME / DEFAULT_INSTANCE_NAME)
                     )
                     # Create Default instance
                     data["instances"] = {
@@ -296,25 +272,17 @@ class Settings(QObject):
                         )
                     }
                     steamcmd_prefix_to_mitigate = data.get("steamcmd_install_path", "")
-                    steamcmd_path_to_mitigate = str(
-                        Path(steamcmd_prefix_to_mitigate) / STEAMCMD_FOLDER_NAME
-                    )
-                    steam_path_to_mitigate = str(
-                        Path(steamcmd_prefix_to_mitigate) / STEAM_FOLDER_NAME
-                    )
-                    if steamcmd_prefix_to_mitigate and path.exists(
-                        steamcmd_prefix_to_mitigate
-                    ):
+                    steamcmd_path_to_mitigate = str(Path(steamcmd_prefix_to_mitigate) / STEAMCMD_FOLDER_NAME)
+                    steam_path_to_mitigate = str(Path(steamcmd_prefix_to_mitigate) / STEAM_FOLDER_NAME)
+                    if steamcmd_prefix_to_mitigate and path.exists(steamcmd_prefix_to_mitigate):
                         logger.debug(
                             "Configured SteamCMD install path found. Attempting to migrate it to the Default instance path..."
                         )
                         steamcmd_prefix_steamcmd_path = str(
-                            Path(steamcmd_prefix_default_instance_path)
-                            / STEAMCMD_FOLDER_NAME
+                            Path(steamcmd_prefix_default_instance_path) / STEAMCMD_FOLDER_NAME
                         )
                         steamcmd_prefix_steam_path = str(
-                            Path(steamcmd_prefix_default_instance_path)
-                            / STEAM_FOLDER_NAME
+                            Path(steamcmd_prefix_default_instance_path) / STEAM_FOLDER_NAME
                         )
                         try:
                             if path.exists(steamcmd_prefix_steamcmd_path):
@@ -337,9 +305,7 @@ class Settings(QObject):
                                 steamcmd_prefix_steamcmd_path,
                                 symlinks=True,
                             )
-                            logger.info(
-                                f"Deleting old SteamCMD install path at {steamcmd_path_to_mitigate}..."
-                            )
+                            logger.info(f"Deleting old SteamCMD install path at {steamcmd_path_to_mitigate}...")
                             rmtree(
                                 steamcmd_path_to_mitigate,
                                 ignore_errors=False,
@@ -353,39 +319,22 @@ class Settings(QObject):
                                 steamcmd_prefix_steam_path,
                                 symlinks=True,
                             )
-                            logger.info(
-                                f"Deleting old SteamCMD data path at {steam_path_to_mitigate}..."
-                            )
+                            logger.info(f"Deleting old SteamCMD data path at {steam_path_to_mitigate}...")
                             rmtree(
                                 steam_path_to_mitigate,
                                 ignore_errors=False,
                                 onerror=handle_remove_read_only,
                             )
                         except Exception as e:
-                            logger.error(
-                                f"Failed to migrate SteamCMD install path. Error: {e}"
-                            )
-                elif (
-                    not data.get("current_instance")
-                    or data["current_instance"] not in data["instances"]
-                ):
-                    logger.debug(
-                        "Current instance not found in settings.json. Performing mitigation."
-                    )
+                            logger.error(f"Failed to migrate SteamCMD install path. Error: {e}")
+                elif not data.get("current_instance") or data["current_instance"] not in data["instances"]:
+                    logger.debug("Current instance not found in settings.json. Performing mitigation.")
                     data["current_instance"] = DEFAULT_INSTANCE_NAME
 
-                    new_path = str(
-                        Path(AppInfo().app_storage_folder)
-                        / "instances"
-                        / data.get("current_instance")
-                    )
+                    new_path = str(Path(AppInfo().app_storage_folder) / "instances" / data.get("current_instance"))
                     data["current_instance_path"] = new_path
                 elif not data.get("current_instance_path"):
-                    new_path = str(
-                        Path(AppInfo().app_storage_folder)
-                        / "instances"
-                        / data.get("current_instance")
-                    )
+                    new_path = str(Path(AppInfo().app_storage_folder) / "instances" / data.get("current_instance"))
                     data["current_instance_path"] = new_path
                 else:
                     # There was nothing to mitigate, so don't save the model to the file
@@ -519,9 +468,7 @@ class Settings(QObject):
                 elif isinstance(instance_data, dict):
                     instances[instance_name] = msgspec.convert(instance_data, Instance)
                 else:
-                    logger.warning(
-                        f"Instance data for {instance_name} is not a valid type: {type(instance_data)}"
-                    )
+                    logger.warning(f"Instance data for {instance_name} is not a valid type: {type(instance_data)}")
             self.instances = instances
 
     def _to_dict(self, skip_private: bool = True) -> Dict[str, Any]:
@@ -542,9 +489,7 @@ class Settings(QObject):
         # Serialize instances using msgspec
         instances_dict = {}
         for name, instance in self.instances.items():
-            instances_dict[name] = msgspec.json.decode(
-                msgspec.json.encode(instance), type=dict
-            )
+            instances_dict[name] = msgspec.json.decode(msgspec.json.encode(instance), type=dict)
         data["instances"] = instances_dict
         return data
 
@@ -568,26 +513,18 @@ class Settings(QObject):
         launch_via_steam_protocol = active_instance.launch_via_steam_protocol
 
         # If neither is enabled, no validation needed
-        if (
-            not steam_client_integration
-            and not workshop_folder
-            and not launch_via_steam_protocol
-        ):
+        if not steam_client_integration and not workshop_folder and not launch_via_steam_protocol:
             return False
 
         # If launch_via_steam_protocol is enabled but steam_client_integration is not, disable it
         if launch_via_steam_protocol and not steam_client_integration:
-            logger.warning(
-                "Steam protocol launch is enabled but Steam client integration is disabled. Disabling..."
-            )
+            logger.warning("Steam protocol launch is enabled but Steam client integration is disabled. Disabling...")
             active_instance.launch_via_steam_protocol = False
             return True
 
         # If steam_client_integration is enabled but workshop_folder is not set, disable it
         if steam_client_integration and not workshop_folder:
-            logger.warning(
-                "Steam client integration is enabled but workshop folder is not configured. Disabling..."
-            )
+            logger.warning("Steam client integration is enabled but workshop folder is not configured. Disabling...")
             active_instance.steam_client_integration = False
             return True
 

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -54,18 +54,22 @@ class Settings(QObject):
 
         # Databases
         self.external_steam_metadata_source: str = "Configured URL"
-        self.external_steam_metadata_file_path: str = str(AppInfo().app_storage_folder / "steamDB.json")
-        self.external_steam_metadata_repo: str = "https://github.com/RimSort/Steam-Workshop-Database"
-        self.external_steam_metadata_url: str = (
-            "https://github.com/RimSort/Steam-Workshop-Database/archive/refs/heads/main.zip"
+        self.external_steam_metadata_file_path: str = str(
+            AppInfo().app_storage_folder / "steamDB.json"
         )
+        self.external_steam_metadata_repo: str = (
+            "https://github.com/RimSort/Steam-Workshop-Database"
+        )
+        self.external_steam_metadata_url: str = "https://github.com/RimSort/Steam-Workshop-Database/archive/refs/heads/main.zip"
 
         self.external_community_rules_metadata_source: str = "Configured URL"
-        self.external_community_rules_file_path: str = str(AppInfo().app_storage_folder / "communityRules.json")
-        self.external_community_rules_repo: str = "https://github.com/RimSort/Community-Rules-Database"
-        self.external_community_rules_url: str = (
-            "https://github.com/RimSort/Community-Rules-Database/archive/refs/heads/main.zip"
+        self.external_community_rules_file_path: str = str(
+            AppInfo().app_storage_folder / "communityRules.json"
         )
+        self.external_community_rules_repo: str = (
+            "https://github.com/RimSort/Community-Rules-Database"
+        )
+        self.external_community_rules_url: str = "https://github.com/RimSort/Community-Rules-Database/archive/refs/heads/main.zip"
 
         # Disable by default previously this was 7 days "604800"
         self.database_expiry: int = 0
@@ -73,8 +77,12 @@ class Settings(QObject):
         self.aux_db_time_limit: int = -1
 
         self.external_no_version_warning_metadata_source: str = "Configured URL"
-        self.external_no_version_warning_file_path: str = str(AppInfo().app_storage_folder / "ModIdsToFix.xml")
-        self.external_no_version_warning_repo_path: str = "https://github.com/emipa606/NoVersionWarning"
+        self.external_no_version_warning_file_path: str = str(
+            AppInfo().app_storage_folder / "ModIdsToFix.xml"
+        )
+        self.external_no_version_warning_repo_path: str = (
+            "https://github.com/emipa606/NoVersionWarning"
+        )
         self.external_no_version_warning_url: str = (
             "https://github.com/emipa606/NoVersionWarning/archive/refs/heads/master.zip"
         )
@@ -83,7 +91,9 @@ class Settings(QObject):
         self.external_use_this_instead_file_path: str = str(
             AppInfo().app_storage_folder / "UseThisInstead" / "replacements.json.gz"
         )
-        self.external_use_this_instead_repo_path: str = "https://github.com/emipa606/UseThisInstead"
+        self.external_use_this_instead_repo_path: str = (
+            "https://github.com/emipa606/UseThisInstead"
+        )
         self.external_use_this_instead_url: str = (
             "https://github.com/emipa606/UseThisInstead/archive/refs/heads/master.zip"
         )
@@ -211,7 +221,9 @@ class Settings(QObject):
         # Instances
         self.current_instance: str = DEFAULT_INSTANCE_NAME
         self.current_instance_path: str = str(
-            Path(AppInfo().app_storage_folder) / INSTANCE_FOLDER_NAME / self.current_instance
+            Path(AppInfo().app_storage_folder)
+            / INSTANCE_FOLDER_NAME
+            / self.current_instance
         )
         self.instances: dict[str, Instance] = {DEFAULT_INSTANCE_NAME: Instance()}
 
@@ -226,8 +238,14 @@ class Settings(QObject):
 
         instance = self.instances[self.current_instance]
         # Default instance never uses override
-        override = "" if self.current_instance == DEFAULT_INSTANCE_NAME else instance.instance_folder_override
-        instance_path = InstanceController.get_instance_folder_path(self.current_instance, override)
+        override = (
+            ""
+            if self.current_instance == DEFAULT_INSTANCE_NAME
+            else instance.instance_folder_override
+        )
+        instance_path = InstanceController.get_instance_folder_path(
+            self.current_instance, override
+        )
         return instance_path / "aux_metadata.db"
 
     def __setattr__(self, key: str, value: Any) -> None:
@@ -254,9 +272,15 @@ class Settings(QObject):
                 mitigations = True
                 # Mitigate issues when "instances" key is not parsed, but the old path attributes are present
                 if not data.get("instances"):
-                    logger.debug("Instances key not found in settings.json. Performing mitigation.")
+                    logger.debug(
+                        "Instances key not found in settings.json. Performing mitigation."
+                    )
                     steamcmd_prefix_default_instance_path = str(
-                        Path(AppInfo().app_storage_folder / INSTANCE_FOLDER_NAME / DEFAULT_INSTANCE_NAME)
+                        Path(
+                            AppInfo().app_storage_folder
+                            / INSTANCE_FOLDER_NAME
+                            / DEFAULT_INSTANCE_NAME
+                        )
                     )
                     # Create Default instance
                     data["instances"] = {
@@ -272,17 +296,25 @@ class Settings(QObject):
                         )
                     }
                     steamcmd_prefix_to_mitigate = data.get("steamcmd_install_path", "")
-                    steamcmd_path_to_mitigate = str(Path(steamcmd_prefix_to_mitigate) / STEAMCMD_FOLDER_NAME)
-                    steam_path_to_mitigate = str(Path(steamcmd_prefix_to_mitigate) / STEAM_FOLDER_NAME)
-                    if steamcmd_prefix_to_mitigate and path.exists(steamcmd_prefix_to_mitigate):
+                    steamcmd_path_to_mitigate = str(
+                        Path(steamcmd_prefix_to_mitigate) / STEAMCMD_FOLDER_NAME
+                    )
+                    steam_path_to_mitigate = str(
+                        Path(steamcmd_prefix_to_mitigate) / STEAM_FOLDER_NAME
+                    )
+                    if steamcmd_prefix_to_mitigate and path.exists(
+                        steamcmd_prefix_to_mitigate
+                    ):
                         logger.debug(
                             "Configured SteamCMD install path found. Attempting to migrate it to the Default instance path..."
                         )
                         steamcmd_prefix_steamcmd_path = str(
-                            Path(steamcmd_prefix_default_instance_path) / STEAMCMD_FOLDER_NAME
+                            Path(steamcmd_prefix_default_instance_path)
+                            / STEAMCMD_FOLDER_NAME
                         )
                         steamcmd_prefix_steam_path = str(
-                            Path(steamcmd_prefix_default_instance_path) / STEAM_FOLDER_NAME
+                            Path(steamcmd_prefix_default_instance_path)
+                            / STEAM_FOLDER_NAME
                         )
                         try:
                             if path.exists(steamcmd_prefix_steamcmd_path):
@@ -305,7 +337,9 @@ class Settings(QObject):
                                 steamcmd_prefix_steamcmd_path,
                                 symlinks=True,
                             )
-                            logger.info(f"Deleting old SteamCMD install path at {steamcmd_path_to_mitigate}...")
+                            logger.info(
+                                f"Deleting old SteamCMD install path at {steamcmd_path_to_mitigate}..."
+                            )
                             rmtree(
                                 steamcmd_path_to_mitigate,
                                 ignore_errors=False,
@@ -319,22 +353,39 @@ class Settings(QObject):
                                 steamcmd_prefix_steam_path,
                                 symlinks=True,
                             )
-                            logger.info(f"Deleting old SteamCMD data path at {steam_path_to_mitigate}...")
+                            logger.info(
+                                f"Deleting old SteamCMD data path at {steam_path_to_mitigate}..."
+                            )
                             rmtree(
                                 steam_path_to_mitigate,
                                 ignore_errors=False,
                                 onerror=handle_remove_read_only,
                             )
                         except Exception as e:
-                            logger.error(f"Failed to migrate SteamCMD install path. Error: {e}")
-                elif not data.get("current_instance") or data["current_instance"] not in data["instances"]:
-                    logger.debug("Current instance not found in settings.json. Performing mitigation.")
+                            logger.error(
+                                f"Failed to migrate SteamCMD install path. Error: {e}"
+                            )
+                elif (
+                    not data.get("current_instance")
+                    or data["current_instance"] not in data["instances"]
+                ):
+                    logger.debug(
+                        "Current instance not found in settings.json. Performing mitigation."
+                    )
                     data["current_instance"] = DEFAULT_INSTANCE_NAME
 
-                    new_path = str(Path(AppInfo().app_storage_folder) / "instances" / data.get("current_instance"))
+                    new_path = str(
+                        Path(AppInfo().app_storage_folder)
+                        / "instances"
+                        / data.get("current_instance")
+                    )
                     data["current_instance_path"] = new_path
                 elif not data.get("current_instance_path"):
-                    new_path = str(Path(AppInfo().app_storage_folder) / "instances" / data.get("current_instance"))
+                    new_path = str(
+                        Path(AppInfo().app_storage_folder)
+                        / "instances"
+                        / data.get("current_instance")
+                    )
                     data["current_instance_path"] = new_path
                 else:
                     # There was nothing to mitigate, so don't save the model to the file
@@ -468,7 +519,9 @@ class Settings(QObject):
                 elif isinstance(instance_data, dict):
                     instances[instance_name] = msgspec.convert(instance_data, Instance)
                 else:
-                    logger.warning(f"Instance data for {instance_name} is not a valid type: {type(instance_data)}")
+                    logger.warning(
+                        f"Instance data for {instance_name} is not a valid type: {type(instance_data)}"
+                    )
             self.instances = instances
 
     def _to_dict(self, skip_private: bool = True) -> Dict[str, Any]:
@@ -489,7 +542,9 @@ class Settings(QObject):
         # Serialize instances using msgspec
         instances_dict = {}
         for name, instance in self.instances.items():
-            instances_dict[name] = msgspec.json.decode(msgspec.json.encode(instance), type=dict)
+            instances_dict[name] = msgspec.json.decode(
+                msgspec.json.encode(instance), type=dict
+            )
         data["instances"] = instances_dict
         return data
 
@@ -513,18 +568,26 @@ class Settings(QObject):
         launch_via_steam_protocol = active_instance.launch_via_steam_protocol
 
         # If neither is enabled, no validation needed
-        if not steam_client_integration and not workshop_folder and not launch_via_steam_protocol:
+        if (
+            not steam_client_integration
+            and not workshop_folder
+            and not launch_via_steam_protocol
+        ):
             return False
 
         # If launch_via_steam_protocol is enabled but steam_client_integration is not, disable it
         if launch_via_steam_protocol and not steam_client_integration:
-            logger.warning("Steam protocol launch is enabled but Steam client integration is disabled. Disabling...")
+            logger.warning(
+                "Steam protocol launch is enabled but Steam client integration is disabled. Disabling..."
+            )
             active_instance.launch_via_steam_protocol = False
             return True
 
         # If steam_client_integration is enabled but workshop_folder is not set, disable it
         if steam_client_integration and not workshop_folder:
-            logger.warning("Steam client integration is enabled but workshop folder is not configured. Disabling...")
+            logger.warning(
+                "Steam client integration is enabled but workshop folder is not configured. Disabling..."
+            )
             active_instance.steam_client_integration = False
             return True
 

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -133,6 +133,9 @@ class Settings(QObject):
         self.build_steam_database_update_toggle: bool = False
         self.steam_apikey: str = ""
 
+        # Steam
+        self.auto_launch_steam: bool = False
+
         # SteamCMD
         self.steamcmd_validate_downloads: bool = True
         self.steamcmd_delete_before_update: bool = False

--- a/app/utils/event_bus.py
+++ b/app/utils/event_bus.py
@@ -125,6 +125,12 @@ class EventBus(QObject):
 
     # Help Menu bar signals
     do_check_for_application_update = Signal()
+    do_check_steam_connection = Signal()
+    do_launch_steam = Signal()
+
+    # Steam status signals
+    steam_not_running = Signal()
+    steam_operation_failed = Signal(str, str)  # (pfid, reason)
 
     # Loading animation signals
     do_threaded_loading_animation = Signal(str, object, str)

--- a/app/utils/steam_status_handler.py
+++ b/app/utils/steam_status_handler.py
@@ -54,9 +54,7 @@ def _find_steam_executable() -> Path | None:
     elif sys.platform == "win32":
         import os
 
-        program_files_x86 = os.environ.get(
-            "ProgramFiles(x86)", r"C:\Program Files (x86)"
-        )
+        program_files_x86 = os.environ.get("ProgramFiles(x86)", r"C:\Program Files (x86)")
         program_files = os.environ.get("ProgramFiles", r"C:\Program Files")
         candidates = [
             Path(program_files_x86) / "Steam" / "steam.exe",
@@ -188,9 +186,7 @@ class SteamStatusHandler(QObject):
         """
         logger.warning(f"Steam operation failed for pfid={pfid}: {reason}")
         show_warning(
-            title=QCoreApplication.translate(
-                "SteamStatusHandler", "Steam Operation Failed"
-            ),
+            title=QCoreApplication.translate("SteamStatusHandler", "Steam Operation Failed"),
             text=QCoreApplication.translate(
                 "SteamStatusHandler",
                 "A Steam operation has failed.",
@@ -219,8 +215,7 @@ class SteamStatusHandler(QObject):
                 ),
                 information=QCoreApplication.translate(
                     "SteamStatusHandler",
-                    "Some features require Steam to be running. "
-                    "You can launch Steam from Help > Launch Steam.",
+                    "Some features require Steam to be running. You can launch Steam from Help > Launch Steam.",
                 ),
             )
 
@@ -268,12 +263,9 @@ class SteamStatusHandler(QObject):
             ),
             information=QCoreApplication.translate(
                 "SteamStatusHandler",
-                "Steam is required for this operation. "
-                "You can enable automatic launching in Settings > Advanced.",
+                "Steam is required for this operation. You can enable automatic launching in Settings > Advanced.",
             ),
-            positive_text=QCoreApplication.translate(
-                "SteamStatusHandler", "Launch Steam"
-            ),
+            positive_text=QCoreApplication.translate("SteamStatusHandler", "Launch Steam"),
             negative_text=QCoreApplication.translate("SteamStatusHandler", "Cancel"),
         )
         if dialog.exec_is_positive():
@@ -290,17 +282,14 @@ class SteamStatusHandler(QObject):
         steam_path = _find_steam_executable()
         if steam_path is None:
             show_warning(
-                title=QCoreApplication.translate(
-                    "SteamStatusHandler", "Steam Not Found"
-                ),
+                title=QCoreApplication.translate("SteamStatusHandler", "Steam Not Found"),
                 text=QCoreApplication.translate(
                     "SteamStatusHandler",
                     "Could not find the Steam executable.",
                 ),
                 information=QCoreApplication.translate(
                     "SteamStatusHandler",
-                    "Please ensure Steam is installed in a standard location, "
-                    "or launch it manually.",
+                    "Please ensure Steam is installed in a standard location, or launch it manually.",
                 ),
             )
             return
@@ -319,8 +308,7 @@ class SteamStatusHandler(QObject):
             title=QCoreApplication.translate("SteamStatusHandler", "Steam Launched"),
             text=QCoreApplication.translate(
                 "SteamStatusHandler",
-                "Steam has been launched successfully. "
-                "You may now retry the operation.",
+                "Steam has been launched successfully. You may now retry the operation.",
             ),
         )
 
@@ -332,9 +320,7 @@ class SteamStatusHandler(QObject):
         """
         logger.warning(f"Steam launch failed: {reason}")
         show_warning(
-            title=QCoreApplication.translate(
-                "SteamStatusHandler", "Steam Launch Failed"
-            ),
+            title=QCoreApplication.translate("SteamStatusHandler", "Steam Launch Failed"),
             text=QCoreApplication.translate(
                 "SteamStatusHandler",
                 "Failed to launch Steam.",

--- a/app/utils/steam_status_handler.py
+++ b/app/utils/steam_status_handler.py
@@ -54,7 +54,9 @@ def _find_steam_executable() -> Path | None:
     elif sys.platform == "win32":
         import os
 
-        program_files_x86 = os.environ.get("ProgramFiles(x86)", r"C:\Program Files (x86)")
+        program_files_x86 = os.environ.get(
+            "ProgramFiles(x86)", r"C:\Program Files (x86)"
+        )
         program_files = os.environ.get("ProgramFiles", r"C:\Program Files")
         candidates = [
             Path(program_files_x86) / "Steam" / "steam.exe",
@@ -186,7 +188,9 @@ class SteamStatusHandler(QObject):
         """
         logger.warning(f"Steam operation failed for pfid={pfid}: {reason}")
         show_warning(
-            title=QCoreApplication.translate("SteamStatusHandler", "Steam Operation Failed"),
+            title=QCoreApplication.translate(
+                "SteamStatusHandler", "Steam Operation Failed"
+            ),
             text=QCoreApplication.translate(
                 "SteamStatusHandler",
                 "A Steam operation has failed.",
@@ -265,7 +269,9 @@ class SteamStatusHandler(QObject):
                 "SteamStatusHandler",
                 "Steam is required for this operation. You can enable automatic launching in Settings > Advanced.",
             ),
-            positive_text=QCoreApplication.translate("SteamStatusHandler", "Launch Steam"),
+            positive_text=QCoreApplication.translate(
+                "SteamStatusHandler", "Launch Steam"
+            ),
             negative_text=QCoreApplication.translate("SteamStatusHandler", "Cancel"),
         )
         if dialog.exec_is_positive():
@@ -282,7 +288,9 @@ class SteamStatusHandler(QObject):
         steam_path = _find_steam_executable()
         if steam_path is None:
             show_warning(
-                title=QCoreApplication.translate("SteamStatusHandler", "Steam Not Found"),
+                title=QCoreApplication.translate(
+                    "SteamStatusHandler", "Steam Not Found"
+                ),
                 text=QCoreApplication.translate(
                     "SteamStatusHandler",
                     "Could not find the Steam executable.",
@@ -320,7 +328,9 @@ class SteamStatusHandler(QObject):
         """
         logger.warning(f"Steam launch failed: {reason}")
         show_warning(
-            title=QCoreApplication.translate("SteamStatusHandler", "Steam Launch Failed"),
+            title=QCoreApplication.translate(
+                "SteamStatusHandler", "Steam Launch Failed"
+            ),
             text=QCoreApplication.translate(
                 "SteamStatusHandler",
                 "Failed to launch Steam.",

--- a/app/utils/steam_status_handler.py
+++ b/app/utils/steam_status_handler.py
@@ -1,0 +1,343 @@
+"""
+Steam status handler for detecting and launching the Steam client.
+
+Provides process-based Steam detection and optional auto-launch functionality.
+Does NOT interact with the Steamworks API or call SteamAPI_Init() -- only uses
+OS-level process detection and subprocess launching.
+"""
+
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import psutil
+from loguru import logger
+from PySide6.QtCore import QCoreApplication, QObject, QThread, Signal
+
+from app.models.settings import Settings
+from app.utils.event_bus import EventBus
+from app.views.dialogue import BinaryChoiceDialog, show_information, show_warning
+
+_STEAM_PROCESS_NAME = "steam"
+_STEAM_LAUNCH_TIMEOUT_SECONDS = 45
+_STEAM_POLL_INTERVAL_SECONDS = 2.0
+
+
+def _find_steam_executable() -> Path | None:
+    """
+    Locate the Steam executable using platform-specific heuristics.
+
+    Checks common installation paths per platform. Does not search the
+    entire filesystem.
+
+    :return: Path to the Steam executable, or None if not found.
+    """
+    candidates: list[Path] = []
+
+    if sys.platform == "darwin":
+        candidates = [
+            Path("/Applications/Steam.app/Contents/MacOS/steam_osx"),
+            Path.home() / "Applications/Steam.app/Contents/MacOS/steam_osx",
+        ]
+    elif sys.platform == "linux":
+        candidates = [
+            Path.home() / ".steam/steam/steam.sh",
+            Path("/usr/bin/steam"),
+            Path("/usr/local/bin/steam"),
+            Path.home() / ".steam/steam/ubuntu12_32/steam",
+            Path.home() / ".local/share/Steam/ubuntu12_32/steam",
+            # Flatpak Steam
+            Path("/var/lib/flatpak/exports/bin/com.valvesoftware.Steam"),
+            Path.home() / ".local/share/flatpak/exports/bin/com.valvesoftware.Steam",
+        ]
+    elif sys.platform == "win32":
+        import os
+
+        program_files_x86 = os.environ.get(
+            "ProgramFiles(x86)", r"C:\Program Files (x86)"
+        )
+        program_files = os.environ.get("ProgramFiles", r"C:\Program Files")
+        candidates = [
+            Path(program_files_x86) / "Steam" / "steam.exe",
+            Path(program_files) / "Steam" / "steam.exe",
+        ]
+
+    for candidate in candidates:
+        if candidate.exists():
+            logger.debug(f"Found Steam executable at: {candidate}")
+            return candidate
+
+    logger.debug("Steam executable not found in any standard location")
+    return None
+
+
+def _is_steam_running() -> bool:
+    """
+    Check whether the Steam client process is currently running.
+
+    Uses psutil to scan running processes. Matches by process name on
+    all platforms.
+
+    :return: True if a Steam process is detected, False otherwise.
+    """
+    target_names: set[str]
+    if sys.platform == "win32":
+        target_names = {"steam.exe", "steamservice.exe"}
+    elif sys.platform == "darwin":
+        target_names = {"steam_osx", "Steam Helper"}
+    else:
+        target_names = {"steam", "steam.sh", "steamwebhelper"}
+
+    try:
+        for proc in psutil.process_iter(["name"]):
+            try:
+                name = proc.info["name"]
+                if name and name.lower() in {t.lower() for t in target_names}:
+                    return True
+            except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+                continue
+    except Exception as e:
+        logger.warning(f"Error scanning processes for Steam: {e}")
+
+    return False
+
+
+class _SteamLaunchWorker(QThread):
+    """
+    Background worker that launches Steam and polls until it is running
+    or a timeout is reached. Runs off the UI thread to avoid blocking.
+    """
+
+    launch_succeeded = Signal()
+    launch_failed = Signal(str)  # reason
+
+    def __init__(self, steam_path: Path) -> None:
+        super().__init__()
+        self._steam_path = steam_path
+
+    def run(self) -> None:
+        """
+        Launch Steam and poll for the process to appear.
+        """
+        logger.info(f"Launching Steam from: {self._steam_path}")
+        try:
+            if sys.platform == "win32":
+                subprocess.Popen(
+                    [str(self._steam_path)],
+                    creationflags=subprocess.DETACHED_PROCESS,
+                )
+            else:
+                subprocess.Popen(
+                    [str(self._steam_path)],
+                    start_new_session=True,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+        except Exception as e:
+            reason = f"Failed to start Steam process: {e}"
+            logger.error(reason)
+            self.launch_failed.emit(reason)
+            return
+
+        deadline = time.monotonic() + _STEAM_LAUNCH_TIMEOUT_SECONDS
+        while time.monotonic() < deadline:
+            if _is_steam_running():
+                logger.info("Steam process detected after launch")
+                self.launch_succeeded.emit()
+                return
+            time.sleep(_STEAM_POLL_INTERVAL_SECONDS)
+
+        reason = f"Steam did not start within {_STEAM_LAUNCH_TIMEOUT_SECONDS} seconds"
+        logger.warning(reason)
+        self.launch_failed.emit(reason)
+
+
+class SteamStatusHandler(QObject):
+    """
+    Coordinates Steam status checks and auto-launch behavior.
+
+    Connects to ``EventBus`` signals:
+    - ``do_check_steam_connection`` -- checks if Steam is running
+    - ``do_launch_steam`` -- attempts to launch Steam
+    - ``steam_not_running`` -- emitted when a Steam operation discovers
+      Steam is not running; triggers auto-launch or a warning dialog
+      depending on the ``auto_launch_steam`` setting.
+
+    This class does **not** create any Steamworks instances or call
+    ``SteamAPI_Init()``.
+    """
+
+    def __init__(self, settings: Settings) -> None:
+        super().__init__()
+        self._settings = settings
+        self._launch_worker: _SteamLaunchWorker | None = None
+
+        event_bus = EventBus()
+        event_bus.do_check_steam_connection.connect(self._on_check_steam_connection)
+        event_bus.do_launch_steam.connect(self._on_launch_steam)
+        event_bus.steam_not_running.connect(self._on_steam_not_running)
+        event_bus.steam_operation_failed.connect(self._on_steam_operation_failed)
+
+    def _on_steam_operation_failed(self, pfid: str, reason: str) -> None:
+        """
+        Handle the ``steam_operation_failed`` signal.
+
+        :param pfid: The publishedfileid of the mod whose operation failed.
+        :param reason: Human-readable failure reason.
+        """
+        logger.warning(f"Steam operation failed for pfid={pfid}: {reason}")
+        show_warning(
+            title=QCoreApplication.translate(
+                "SteamStatusHandler", "Steam Operation Failed"
+            ),
+            text=QCoreApplication.translate(
+                "SteamStatusHandler",
+                "A Steam operation has failed.",
+            ),
+            information=reason,
+        )
+
+    def _on_check_steam_connection(self) -> None:
+        """
+        Handle explicit Steam connection check request (e.g. from the Help menu).
+        """
+        if _is_steam_running():
+            show_information(
+                title=QCoreApplication.translate("SteamStatusHandler", "Steam Status"),
+                text=QCoreApplication.translate(
+                    "SteamStatusHandler",
+                    "Steam is running.",
+                ),
+            )
+        else:
+            show_warning(
+                title=QCoreApplication.translate("SteamStatusHandler", "Steam Status"),
+                text=QCoreApplication.translate(
+                    "SteamStatusHandler",
+                    "Steam is not running.",
+                ),
+                information=QCoreApplication.translate(
+                    "SteamStatusHandler",
+                    "Some features require Steam to be running. "
+                    "You can launch Steam from Help > Launch Steam.",
+                ),
+            )
+
+    def _on_launch_steam(self) -> None:
+        """
+        Handle explicit Steam launch request (e.g. from the Help menu).
+        """
+        if _is_steam_running():
+            show_information(
+                title=QCoreApplication.translate("SteamStatusHandler", "Steam Status"),
+                text=QCoreApplication.translate(
+                    "SteamStatusHandler",
+                    "Steam is already running.",
+                ),
+            )
+            return
+
+        self._do_launch_steam()
+
+    def _on_steam_not_running(self) -> None:
+        """
+        Handle the ``steam_not_running`` signal emitted when a Steam operation
+        fails because Steam is not detected.
+
+        If ``auto_launch_steam`` is enabled, attempts to launch Steam
+        automatically. Otherwise, shows a warning dialog asking the user
+        whether to launch Steam.
+        """
+        if self._settings.auto_launch_steam:
+            logger.info("Auto-launch Steam is enabled; attempting to launch Steam")
+            self._do_launch_steam()
+        else:
+            self._show_steam_not_running_dialog()
+
+    def _show_steam_not_running_dialog(self) -> None:
+        """
+        Show a dialog informing the user that Steam is not running and
+        offering to launch it.
+        """
+        dialog = BinaryChoiceDialog(
+            title=QCoreApplication.translate("SteamStatusHandler", "Steam Not Running"),
+            text=QCoreApplication.translate(
+                "SteamStatusHandler",
+                "Steam does not appear to be running. Would you like to launch it now?",
+            ),
+            information=QCoreApplication.translate(
+                "SteamStatusHandler",
+                "Steam is required for this operation. "
+                "You can enable automatic launching in Settings > Advanced.",
+            ),
+            positive_text=QCoreApplication.translate(
+                "SteamStatusHandler", "Launch Steam"
+            ),
+            negative_text=QCoreApplication.translate("SteamStatusHandler", "Cancel"),
+        )
+        if dialog.exec_is_positive():
+            self._do_launch_steam()
+
+    def _do_launch_steam(self) -> None:
+        """
+        Find the Steam executable and launch it in a background thread.
+        """
+        if self._launch_worker is not None and self._launch_worker.isRunning():
+            logger.debug("Steam launch already in progress, ignoring duplicate request")
+            return
+
+        steam_path = _find_steam_executable()
+        if steam_path is None:
+            show_warning(
+                title=QCoreApplication.translate(
+                    "SteamStatusHandler", "Steam Not Found"
+                ),
+                text=QCoreApplication.translate(
+                    "SteamStatusHandler",
+                    "Could not find the Steam executable.",
+                ),
+                information=QCoreApplication.translate(
+                    "SteamStatusHandler",
+                    "Please ensure Steam is installed in a standard location, "
+                    "or launch it manually.",
+                ),
+            )
+            return
+
+        self._launch_worker = _SteamLaunchWorker(steam_path)
+        self._launch_worker.launch_succeeded.connect(self._on_launch_succeeded)
+        self._launch_worker.launch_failed.connect(self._on_launch_failed)
+        self._launch_worker.start()
+
+    def _on_launch_succeeded(self) -> None:
+        """
+        Called when the background worker detects that Steam has started.
+        """
+        logger.info("Steam launched successfully")
+        show_information(
+            title=QCoreApplication.translate("SteamStatusHandler", "Steam Launched"),
+            text=QCoreApplication.translate(
+                "SteamStatusHandler",
+                "Steam has been launched successfully. "
+                "You may now retry the operation.",
+            ),
+        )
+
+    def _on_launch_failed(self, reason: str) -> None:
+        """
+        Called when the background worker fails to detect Steam after launching.
+
+        :param reason: Human-readable failure reason.
+        """
+        logger.warning(f"Steam launch failed: {reason}")
+        show_warning(
+            title=QCoreApplication.translate(
+                "SteamStatusHandler", "Steam Launch Failed"
+            ),
+            text=QCoreApplication.translate(
+                "SteamStatusHandler",
+                "Failed to launch Steam.",
+            ),
+            information=reason,
+        )

--- a/app/views/menu_bar.py
+++ b/app/views/menu_bar.py
@@ -13,7 +13,9 @@ from app.utils.system_info import SystemInfo
 
 
 class MenuBar(QObject):
-    def __init__(self, menu_bar: QMenuBar, settings_controller: SettingsController) -> None:
+    def __init__(
+        self, menu_bar: QMenuBar, settings_controller: SettingsController
+    ) -> None:
         """
         Initialize the MenuBar object.
 
@@ -124,24 +126,38 @@ class MenuBar(QObject):
             QMenu: The created "File" menu.
         """
         file_menu = self.menu_bar.addMenu(self.tr("File"))
-        self.open_mod_list_action = self._add_action(file_menu, self.tr("Open Mod List…"), "Ctrl+O")
+        self.open_mod_list_action = self._add_action(
+            file_menu, self.tr("Open Mod List…"), "Ctrl+O"
+        )
         file_menu.addSeparator()
-        self.save_mod_list_action = self._add_action(file_menu, self.tr("Save Mod List As…"), "Ctrl+Shift+S")
+        self.save_mod_list_action = self._add_action(
+            file_menu, self.tr("Save Mod List As…"), "Ctrl+Shift+S"
+        )
         file_menu.addSeparator()
         self.import_submenu = QMenu(self.tr("Import"))
         file_menu.addMenu(self.import_submenu)
-        self.import_from_rentry_action = self._add_action(self.import_submenu, self.tr("From Rentry.co"))
+        self.import_from_rentry_action = self._add_action(
+            self.import_submenu, self.tr("From Rentry.co")
+        )
         self.import_from_workshop_collection_action = self._add_action(
             self.import_submenu, self.tr("From Workshop collection")
         )
-        self.import_from_save_file_action = self._add_action(self.import_submenu, self.tr("From Save file…"))
+        self.import_from_save_file_action = self._add_action(
+            self.import_submenu, self.tr("From Save file…")
+        )
         self.export_submenu = QMenu(self.tr("Export"))
         file_menu.addMenu(self.export_submenu)
-        self.export_to_clipboard_action = self._add_action(self.export_submenu, self.tr("To Clipboard…"))
-        self.export_to_rentry_action = self._add_action(self.export_submenu, self.tr("To Rentry.co…"))
+        self.export_to_clipboard_action = self._add_action(
+            self.export_submenu, self.tr("To Clipboard…")
+        )
+        self.export_to_rentry_action = self._add_action(
+            self.export_submenu, self.tr("To Rentry.co…")
+        )
         file_menu.addSeparator()
 
-        self.upload_submenu = self._create_logfile_submenu("Upload Log", self.upload_log_actions)
+        self.upload_submenu = self._create_logfile_submenu(
+            "Upload Log", self.upload_log_actions
+        )
         file_menu.addMenu(self.upload_submenu)
 
         if self.settings_controller.settings.text_editor_location:
@@ -160,7 +176,9 @@ class MenuBar(QObject):
         self.rimworld_shortcuts_submenu = QMenu(self.tr("RimWorld"))
         self.shortcuts_submenu.addMenu(self.rimworld_shortcuts_submenu)
         # Add actions to RimSort submenu
-        self.open_app_directory_action = self._add_action(self.rimsort_shortcuts_submenu, self.tr("Root Directory"))
+        self.open_app_directory_action = self._add_action(
+            self.rimsort_shortcuts_submenu, self.tr("Root Directory")
+        )
         self.open_settings_directory_action = self._add_action(
             self.rimsort_shortcuts_submenu, self.tr("Config Directory")
         )
@@ -186,7 +204,9 @@ class MenuBar(QObject):
 
         if SystemInfo().operating_system != SystemInfo.OperatingSystem.MACOS:
             file_menu.addSeparator()
-            self.settings_action = self._add_action(file_menu, self.tr("Settings…"), "Ctrl+,")
+            self.settings_action = self._add_action(
+                file_menu, self.tr("Settings…"), "Ctrl+,"
+            )
             file_menu.addSeparator()
             self.quit_action = self._add_action(file_menu, self.tr("Exit"), "Ctrl+Q")
         return file_menu
@@ -196,7 +216,9 @@ class MenuBar(QObject):
         menu_name: str,
         action_list: list[QAction],
     ) -> QMenu:
-        def create_entry(name: str, path_accessor: Callable[[], Path | None]) -> QAction:
+        def create_entry(
+            name: str, path_accessor: Callable[[], Path | None]
+        ) -> QAction:
             action = self._add_action(logfile_submenu, name)
             action.setData(path_accessor)
             action_list.append(action)
@@ -212,7 +234,9 @@ class MenuBar(QObject):
 
         logfile_submenu = QMenu(self.tr(menu_name))
         create_entry("RimSort.log", lambda: AppInfo().user_log_folder / "RimSort.log")
-        create_entry("RimSort.old.log", lambda: AppInfo().user_log_folder / "RimSort.old.log")
+        create_entry(
+            "RimSort.old.log", lambda: AppInfo().user_log_folder / "RimSort.old.log"
+        )
         create_entry(
             "RimWorld Player.log",
             partial(rimworld_log_path, "Player.log"),
@@ -237,11 +261,19 @@ class MenuBar(QObject):
         self.paste_action = self._add_action(edit_menu, self.tr("Paste"), "Ctrl+V")
         edit_menu.addSeparator()
         self.rule_editor_action = self._add_action(edit_menu, self.tr("Rule Editor…"))
-        self.ignore_json_editor_action = self._add_action(edit_menu, self.tr("Ignore JSON Editor…"))
-        self.reset_all_warnings_action = self._add_action(edit_menu, self.tr("Reset Warning Toggles"))
-        self.reset_all_mod_colors_action = self._add_action(edit_menu, self.tr("Reset Mod Colors"))
+        self.ignore_json_editor_action = self._add_action(
+            edit_menu, self.tr("Ignore JSON Editor…")
+        )
+        self.reset_all_warnings_action = self._add_action(
+            edit_menu, self.tr("Reset Warning Toggles")
+        )
+        self.reset_all_mod_colors_action = self._add_action(
+            edit_menu, self.tr("Reset Mod Colors")
+        )
         edit_menu.addSeparator()
-        self.auto_add_translations_action = self._add_action(edit_menu, self.tr("Auto-add Translations"))
+        self.auto_add_translations_action = self._add_action(
+            edit_menu, self.tr("Auto-add Translations")
+        )
         return edit_menu
 
     def _create_view_menu(self) -> QMenu:
@@ -265,13 +297,23 @@ class MenuBar(QObject):
             QMenu: The created "Download" menu.
         """
         download_menu = self.menu_bar.addMenu(self.tr("Download"))
-        self.add_git_mod_action = self._add_action(download_menu, self.tr("Add Git Mod"))
-        self.add_zip_mod_action = self._add_action(download_menu, self.tr("Add Zip Mod"))
+        self.add_git_mod_action = self._add_action(
+            download_menu, self.tr("Add Git Mod")
+        )
+        self.add_zip_mod_action = self._add_action(
+            download_menu, self.tr("Add Zip Mod")
+        )
         download_menu.addSeparator()
-        self.browse_workshop_action = self._add_action(download_menu, self.tr("Browse Workshop"))
-        self.update_workshop_mods_action = self._add_action(download_menu, self.tr("Update Workshop Mods"))
+        self.browse_workshop_action = self._add_action(
+            download_menu, self.tr("Browse Workshop")
+        )
+        self.update_workshop_mods_action = self._add_action(
+            download_menu, self.tr("Update Workshop Mods")
+        )
         download_menu.addSeparator()
-        self.steam_verify_game_files_action = self._add_action(download_menu, self.tr("Verify Game Files"))
+        self.steam_verify_game_files_action = self._add_action(
+            download_menu, self.tr("Verify Game Files")
+        )
         return download_menu
 
     def _create_instances_menu(self) -> QMenu:
@@ -285,12 +327,22 @@ class MenuBar(QObject):
         self.instances_submenu = QMenu(self.tr('Current: "Default"'))
         instances_menu.addMenu(self.instances_submenu)
         instances_menu.addSeparator()
-        self.backup_instance_action = self._add_action(instances_menu, self.tr("Backup Instance…"))
-        self.restore_instance_action = self._add_action(instances_menu, self.tr("Restore Instance…"))
+        self.backup_instance_action = self._add_action(
+            instances_menu, self.tr("Backup Instance…")
+        )
+        self.restore_instance_action = self._add_action(
+            instances_menu, self.tr("Restore Instance…")
+        )
         instances_menu.addSeparator()
-        self.clone_instance_action = self._add_action(instances_menu, self.tr("Clone Instance…"))
-        self.create_instance_action = self._add_action(instances_menu, self.tr("Create Instance…"))
-        self.delete_instance_action = self._add_action(instances_menu, self.tr("Delete Instance…"))
+        self.clone_instance_action = self._add_action(
+            instances_menu, self.tr("Clone Instance…")
+        )
+        self.create_instance_action = self._add_action(
+            instances_menu, self.tr("Create Instance…")
+        )
+        self.delete_instance_action = self._add_action(
+            instances_menu, self.tr("Delete Instance…")
+        )
         return instances_menu
 
     def _create_texture_menu(self) -> QMenu:
@@ -301,14 +353,20 @@ class MenuBar(QObject):
             QMenu: The created "Textures" menu.
         """
         texture_menu = self.menu_bar.addMenu(self.tr("Textures"))
-        self.optimize_textures_action = self._add_action(texture_menu, self.tr("Optimize Textures"))
+        self.optimize_textures_action = self._add_action(
+            texture_menu, self.tr("Optimize Textures")
+        )
         texture_menu.addSeparator()
-        self.delete_dds_textures_action = self._add_action(texture_menu, self.tr("Delete .dds Textures"))
+        self.delete_dds_textures_action = self._add_action(
+            texture_menu, self.tr("Delete .dds Textures")
+        )
         return texture_menu
 
     def _create_update_menu(self) -> QMenu:
         update_menu = self.menu_bar.addMenu(self.tr("Update"))
-        self.check_for_updates_action = self._add_action(update_menu, self.tr("Check for Updates…"))
+        self.check_for_updates_action = self._add_action(
+            update_menu, self.tr("Check for Updates…")
+        )
         self.check_for_updates_on_startup_action = self._add_action(
             update_menu, self.tr("Check for Updates on Startup"), checkable=True
         )
@@ -326,7 +384,9 @@ class MenuBar(QObject):
         self.wiki_action = self._add_action(help_menu, self.tr("RimSort Wiki…"))
         self.github_action = self._add_action(help_menu, self.tr("RimSort GitHub…"))
         help_menu.addSeparator()
-        self.check_steam_connection_action = self._add_action(help_menu, self.tr("Check Steam Connection"))
+        self.check_steam_connection_action = self._add_action(
+            help_menu, self.tr("Check Steam Connection")
+        )
         self.launch_steam_action = self._add_action(help_menu, self.tr("Launch Steam"))
         return help_menu
 

--- a/app/views/menu_bar.py
+++ b/app/views/menu_bar.py
@@ -13,9 +13,7 @@ from app.utils.system_info import SystemInfo
 
 
 class MenuBar(QObject):
-    def __init__(
-        self, menu_bar: QMenuBar, settings_controller: SettingsController
-    ) -> None:
+    def __init__(self, menu_bar: QMenuBar, settings_controller: SettingsController) -> None:
         """
         Initialize the MenuBar object.
 
@@ -126,38 +124,24 @@ class MenuBar(QObject):
             QMenu: The created "File" menu.
         """
         file_menu = self.menu_bar.addMenu(self.tr("File"))
-        self.open_mod_list_action = self._add_action(
-            file_menu, self.tr("Open Mod List…"), "Ctrl+O"
-        )
+        self.open_mod_list_action = self._add_action(file_menu, self.tr("Open Mod List…"), "Ctrl+O")
         file_menu.addSeparator()
-        self.save_mod_list_action = self._add_action(
-            file_menu, self.tr("Save Mod List As…"), "Ctrl+Shift+S"
-        )
+        self.save_mod_list_action = self._add_action(file_menu, self.tr("Save Mod List As…"), "Ctrl+Shift+S")
         file_menu.addSeparator()
         self.import_submenu = QMenu(self.tr("Import"))
         file_menu.addMenu(self.import_submenu)
-        self.import_from_rentry_action = self._add_action(
-            self.import_submenu, self.tr("From Rentry.co")
-        )
+        self.import_from_rentry_action = self._add_action(self.import_submenu, self.tr("From Rentry.co"))
         self.import_from_workshop_collection_action = self._add_action(
             self.import_submenu, self.tr("From Workshop collection")
         )
-        self.import_from_save_file_action = self._add_action(
-            self.import_submenu, self.tr("From Save file…")
-        )
+        self.import_from_save_file_action = self._add_action(self.import_submenu, self.tr("From Save file…"))
         self.export_submenu = QMenu(self.tr("Export"))
         file_menu.addMenu(self.export_submenu)
-        self.export_to_clipboard_action = self._add_action(
-            self.export_submenu, self.tr("To Clipboard…")
-        )
-        self.export_to_rentry_action = self._add_action(
-            self.export_submenu, self.tr("To Rentry.co…")
-        )
+        self.export_to_clipboard_action = self._add_action(self.export_submenu, self.tr("To Clipboard…"))
+        self.export_to_rentry_action = self._add_action(self.export_submenu, self.tr("To Rentry.co…"))
         file_menu.addSeparator()
 
-        self.upload_submenu = self._create_logfile_submenu(
-            "Upload Log", self.upload_log_actions
-        )
+        self.upload_submenu = self._create_logfile_submenu("Upload Log", self.upload_log_actions)
         file_menu.addMenu(self.upload_submenu)
 
         if self.settings_controller.settings.text_editor_location:
@@ -176,9 +160,7 @@ class MenuBar(QObject):
         self.rimworld_shortcuts_submenu = QMenu(self.tr("RimWorld"))
         self.shortcuts_submenu.addMenu(self.rimworld_shortcuts_submenu)
         # Add actions to RimSort submenu
-        self.open_app_directory_action = self._add_action(
-            self.rimsort_shortcuts_submenu, self.tr("Root Directory")
-        )
+        self.open_app_directory_action = self._add_action(self.rimsort_shortcuts_submenu, self.tr("Root Directory"))
         self.open_settings_directory_action = self._add_action(
             self.rimsort_shortcuts_submenu, self.tr("Config Directory")
         )
@@ -204,9 +186,7 @@ class MenuBar(QObject):
 
         if SystemInfo().operating_system != SystemInfo.OperatingSystem.MACOS:
             file_menu.addSeparator()
-            self.settings_action = self._add_action(
-                file_menu, self.tr("Settings…"), "Ctrl+,"
-            )
+            self.settings_action = self._add_action(file_menu, self.tr("Settings…"), "Ctrl+,")
             file_menu.addSeparator()
             self.quit_action = self._add_action(file_menu, self.tr("Exit"), "Ctrl+Q")
         return file_menu
@@ -216,9 +196,7 @@ class MenuBar(QObject):
         menu_name: str,
         action_list: list[QAction],
     ) -> QMenu:
-        def create_entry(
-            name: str, path_accessor: Callable[[], Path | None]
-        ) -> QAction:
+        def create_entry(name: str, path_accessor: Callable[[], Path | None]) -> QAction:
             action = self._add_action(logfile_submenu, name)
             action.setData(path_accessor)
             action_list.append(action)
@@ -234,9 +212,7 @@ class MenuBar(QObject):
 
         logfile_submenu = QMenu(self.tr(menu_name))
         create_entry("RimSort.log", lambda: AppInfo().user_log_folder / "RimSort.log")
-        create_entry(
-            "RimSort.old.log", lambda: AppInfo().user_log_folder / "RimSort.old.log"
-        )
+        create_entry("RimSort.old.log", lambda: AppInfo().user_log_folder / "RimSort.old.log")
         create_entry(
             "RimWorld Player.log",
             partial(rimworld_log_path, "Player.log"),
@@ -261,19 +237,11 @@ class MenuBar(QObject):
         self.paste_action = self._add_action(edit_menu, self.tr("Paste"), "Ctrl+V")
         edit_menu.addSeparator()
         self.rule_editor_action = self._add_action(edit_menu, self.tr("Rule Editor…"))
-        self.ignore_json_editor_action = self._add_action(
-            edit_menu, self.tr("Ignore JSON Editor…")
-        )
-        self.reset_all_warnings_action = self._add_action(
-            edit_menu, self.tr("Reset Warning Toggles")
-        )
-        self.reset_all_mod_colors_action = self._add_action(
-            edit_menu, self.tr("Reset Mod Colors")
-        )
+        self.ignore_json_editor_action = self._add_action(edit_menu, self.tr("Ignore JSON Editor…"))
+        self.reset_all_warnings_action = self._add_action(edit_menu, self.tr("Reset Warning Toggles"))
+        self.reset_all_mod_colors_action = self._add_action(edit_menu, self.tr("Reset Mod Colors"))
         edit_menu.addSeparator()
-        self.auto_add_translations_action = self._add_action(
-            edit_menu, self.tr("Auto-add Translations")
-        )
+        self.auto_add_translations_action = self._add_action(edit_menu, self.tr("Auto-add Translations"))
         return edit_menu
 
     def _create_view_menu(self) -> QMenu:
@@ -297,23 +265,13 @@ class MenuBar(QObject):
             QMenu: The created "Download" menu.
         """
         download_menu = self.menu_bar.addMenu(self.tr("Download"))
-        self.add_git_mod_action = self._add_action(
-            download_menu, self.tr("Add Git Mod")
-        )
-        self.add_zip_mod_action = self._add_action(
-            download_menu, self.tr("Add Zip Mod")
-        )
+        self.add_git_mod_action = self._add_action(download_menu, self.tr("Add Git Mod"))
+        self.add_zip_mod_action = self._add_action(download_menu, self.tr("Add Zip Mod"))
         download_menu.addSeparator()
-        self.browse_workshop_action = self._add_action(
-            download_menu, self.tr("Browse Workshop")
-        )
-        self.update_workshop_mods_action = self._add_action(
-            download_menu, self.tr("Update Workshop Mods")
-        )
+        self.browse_workshop_action = self._add_action(download_menu, self.tr("Browse Workshop"))
+        self.update_workshop_mods_action = self._add_action(download_menu, self.tr("Update Workshop Mods"))
         download_menu.addSeparator()
-        self.steam_verify_game_files_action = self._add_action(
-            download_menu, self.tr("Verify Game Files")
-        )
+        self.steam_verify_game_files_action = self._add_action(download_menu, self.tr("Verify Game Files"))
         return download_menu
 
     def _create_instances_menu(self) -> QMenu:
@@ -327,22 +285,12 @@ class MenuBar(QObject):
         self.instances_submenu = QMenu(self.tr('Current: "Default"'))
         instances_menu.addMenu(self.instances_submenu)
         instances_menu.addSeparator()
-        self.backup_instance_action = self._add_action(
-            instances_menu, self.tr("Backup Instance…")
-        )
-        self.restore_instance_action = self._add_action(
-            instances_menu, self.tr("Restore Instance…")
-        )
+        self.backup_instance_action = self._add_action(instances_menu, self.tr("Backup Instance…"))
+        self.restore_instance_action = self._add_action(instances_menu, self.tr("Restore Instance…"))
         instances_menu.addSeparator()
-        self.clone_instance_action = self._add_action(
-            instances_menu, self.tr("Clone Instance…")
-        )
-        self.create_instance_action = self._add_action(
-            instances_menu, self.tr("Create Instance…")
-        )
-        self.delete_instance_action = self._add_action(
-            instances_menu, self.tr("Delete Instance…")
-        )
+        self.clone_instance_action = self._add_action(instances_menu, self.tr("Clone Instance…"))
+        self.create_instance_action = self._add_action(instances_menu, self.tr("Create Instance…"))
+        self.delete_instance_action = self._add_action(instances_menu, self.tr("Delete Instance…"))
         return instances_menu
 
     def _create_texture_menu(self) -> QMenu:
@@ -353,20 +301,14 @@ class MenuBar(QObject):
             QMenu: The created "Textures" menu.
         """
         texture_menu = self.menu_bar.addMenu(self.tr("Textures"))
-        self.optimize_textures_action = self._add_action(
-            texture_menu, self.tr("Optimize Textures")
-        )
+        self.optimize_textures_action = self._add_action(texture_menu, self.tr("Optimize Textures"))
         texture_menu.addSeparator()
-        self.delete_dds_textures_action = self._add_action(
-            texture_menu, self.tr("Delete .dds Textures")
-        )
+        self.delete_dds_textures_action = self._add_action(texture_menu, self.tr("Delete .dds Textures"))
         return texture_menu
 
     def _create_update_menu(self) -> QMenu:
         update_menu = self.menu_bar.addMenu(self.tr("Update"))
-        self.check_for_updates_action = self._add_action(
-            update_menu, self.tr("Check for Updates…")
-        )
+        self.check_for_updates_action = self._add_action(update_menu, self.tr("Check for Updates…"))
         self.check_for_updates_on_startup_action = self._add_action(
             update_menu, self.tr("Check for Updates on Startup"), checkable=True
         )
@@ -384,9 +326,7 @@ class MenuBar(QObject):
         self.wiki_action = self._add_action(help_menu, self.tr("RimSort Wiki…"))
         self.github_action = self._add_action(help_menu, self.tr("RimSort GitHub…"))
         help_menu.addSeparator()
-        self.check_steam_connection_action = self._add_action(
-            help_menu, self.tr("Check Steam Connection")
-        )
+        self.check_steam_connection_action = self._add_action(help_menu, self.tr("Check Steam Connection"))
         self.launch_steam_action = self._add_action(help_menu, self.tr("Launch Steam"))
         return help_menu
 

--- a/app/views/menu_bar.py
+++ b/app/views/menu_bar.py
@@ -74,6 +74,8 @@ class MenuBar(QObject):
         self.github_action: QAction
         self.show_translation_status_action: QAction
         self.auto_add_translations_action: QAction
+        self.check_steam_connection_action: QAction
+        self.launch_steam_action: QAction
         self.check_for_updates_action: QAction | None = None
         self.check_for_updates_on_startup_action: QAction | None = None
 
@@ -382,6 +384,10 @@ class MenuBar(QObject):
         self.wiki_action = self._add_action(help_menu, self.tr("RimSort Wiki…"))
         self.github_action = self._add_action(help_menu, self.tr("RimSort GitHub…"))
         help_menu.addSeparator()
+        self.check_steam_connection_action = self._add_action(
+            help_menu, self.tr("Check Steam Connection")
+        )
+        self.launch_steam_action = self._add_action(help_menu, self.tr("Launch Steam"))
         return help_menu
 
     def _create_menu_bar(self) -> None:

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -1716,6 +1716,18 @@ This basically preserves your mod coloring, user notes etc. for this many second
         self.clear_moves_dlc_checkbox = QCheckBox(self.tr("Clear also moves DLC"))
         group_layout.addWidget(self.clear_moves_dlc_checkbox)
 
+        self.auto_launch_steam_checkbox = QCheckBox(
+            self.tr("Automatically launch Steam when needed")
+        )
+        self.auto_launch_steam_checkbox.setToolTip(
+            self.tr(
+                "If enabled, RimSort will automatically attempt to launch Steam "
+                "when a Steam operation is requested but Steam is not running. "
+                "If disabled, a warning dialog will be shown instead."
+            )
+        )
+        group_layout.addWidget(self.auto_launch_steam_checkbox)
+
         self.show_mod_updates_checkbox = QCheckBox(
             self.tr("Check for mod updates on refresh")
         )

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -52,7 +52,9 @@ class SettingsDialog(QDialog):
         main_layout.addLayout(button_layout)
 
         # Reset to defaults button
-        self.global_reset_to_defaults_button = QPushButton(self.tr("Reset to Defaults"), self)
+        self.global_reset_to_defaults_button = QPushButton(
+            self.tr("Reset to Defaults"), self
+        )
         button_layout.addWidget(self.global_reset_to_defaults_button)
 
         button_layout.addStretch()
@@ -100,7 +102,9 @@ class SettingsDialog(QDialog):
         # "Game location" → "Config location" → "Steam mods location" → "Local mods location"
         self.setTabOrder(self.game_location, self.config_folder_location)
         self.setTabOrder(self.config_folder_location, self.steam_mods_folder_location)
-        self.setTabOrder(self.steam_mods_folder_location, self.local_mods_folder_location)
+        self.setTabOrder(
+            self.steam_mods_folder_location, self.local_mods_folder_location
+        )
 
         # Push the buttons to the bottom
         tab_layout.addStretch()
@@ -147,7 +151,9 @@ class SettingsDialog(QDialog):
 
         self.game_location = QLineEdit()
         self.game_location.setPlaceholderText(
-            self.tr(r"Should be like: C:\Program Files (x86)\Steam\steamapps\common\RimWorld")
+            self.tr(
+                r"Should be like: C:\Program Files (x86)\Steam\steamapps\common\RimWorld"
+            )
         )
         self.game_location.setTextMargins(GUIInfo().text_field_margins)
         self.game_location.setFixedHeight(GUIInfo().default_font_line_height * 2)
@@ -185,7 +191,9 @@ class SettingsDialog(QDialog):
             )
         )
         self.config_folder_location.setTextMargins(GUIInfo().text_field_margins)
-        self.config_folder_location.setFixedHeight(GUIInfo().default_font_line_height * 2)
+        self.config_folder_location.setFixedHeight(
+            GUIInfo().default_font_line_height * 2
+        )
         group_layout.addWidget(self.config_folder_location)
 
     def _do_steam_mods_folder_location_area(self, tab_layout: QVBoxLayout) -> None:
@@ -197,10 +205,14 @@ class SettingsDialog(QDialog):
         header_layout = QHBoxLayout()
         group_layout.addLayout(header_layout)
 
-        self.steam_client_integration_checkbox = QCheckBox(self.tr("Enable Steam client integration"))
+        self.steam_client_integration_checkbox = QCheckBox(
+            self.tr("Enable Steam client integration")
+        )
         group_layout.addWidget(self.steam_client_integration_checkbox)
 
-        self.steam_client_integration_checkbox.stateChanged.connect(self._on_steam_integration_toggled)
+        self.steam_client_integration_checkbox.stateChanged.connect(
+            self._on_steam_integration_toggled
+        )
 
         section_label = QLabel(self.tr("Steam mods location"))
         section_label.setFont(GUIInfo().emphasis_font)
@@ -225,7 +237,9 @@ class SettingsDialog(QDialog):
             )
         )
         self.steam_mods_folder_location.setTextMargins(GUIInfo().text_field_margins)
-        self.steam_mods_folder_location.setFixedHeight(GUIInfo().default_font_line_height * 2)
+        self.steam_mods_folder_location.setFixedHeight(
+            GUIInfo().default_font_line_height * 2
+        )
         group_layout.addWidget(self.steam_mods_folder_location)
 
     def _do_local_mods_folder_location_area(self, tab_layout: QVBoxLayout) -> None:
@@ -255,10 +269,14 @@ class SettingsDialog(QDialog):
 
         self.local_mods_folder_location = QLineEdit()
         self.local_mods_folder_location.setPlaceholderText(
-            self.tr(r"should be like: C:\Program Files (x86)\Steam\steamapps\common\Rimworld\Mods")
+            self.tr(
+                r"should be like: C:\Program Files (x86)\Steam\steamapps\common\Rimworld\Mods"
+            )
         )
         self.local_mods_folder_location.setTextMargins(GUIInfo().text_field_margins)
-        self.local_mods_folder_location.setFixedHeight(GUIInfo().default_font_line_height * 2)
+        self.local_mods_folder_location.setFixedHeight(
+            GUIInfo().default_font_line_height * 2
+        )
         group_layout.addWidget(self.local_mods_folder_location)
 
     def _do_instance_folder_location_area(self, tab_layout: QVBoxLayout) -> None:
@@ -285,9 +303,13 @@ class SettingsDialog(QDialog):
 
         self.instance_folder_location = QLineEdit()
         self.instance_folder_location.setReadOnly(True)
-        self.instance_folder_location.setPlaceholderText(self.tr("Leave empty to use default location"))
+        self.instance_folder_location.setPlaceholderText(
+            self.tr("Leave empty to use default location")
+        )
         self.instance_folder_location.setTextMargins(GUIInfo().text_field_margins)
-        self.instance_folder_location.setFixedHeight(GUIInfo().default_font_line_height * 2)
+        self.instance_folder_location.setFixedHeight(
+            GUIInfo().default_font_line_height * 2
+        )
         group_layout.addWidget(self.instance_folder_location)
 
     def _do_game_launch_tab(self) -> None:
@@ -314,7 +336,9 @@ class SettingsDialog(QDialog):
             )
         )
         # Connect checkbox to disable/enable run_args group
-        self.launch_via_steam_protocol_checkbox.stateChanged.connect(self._on_steam_protocol_toggled)
+        self.launch_via_steam_protocol_checkbox.stateChanged.connect(
+            self._on_steam_protocol_toggled
+        )
         steam_protocol_layout.addWidget(self.launch_via_steam_protocol_checkbox)
 
         # Game arguments group
@@ -347,7 +371,9 @@ class SettingsDialog(QDialog):
         run_args_layout.addLayout(run_args_info_layout, 0, 0, 1, 2)
 
         run_args_label = QLabel(self.tr("Edit Game Run Arguments:"))
-        run_args_layout.addWidget(run_args_label, 1, 0, alignment=Qt.AlignmentFlag.AlignRight)
+        run_args_layout.addWidget(
+            run_args_label, 1, 0, alignment=Qt.AlignmentFlag.AlignRight
+        )
 
         self.run_args = QLineEdit()
         self.run_args.setTextMargins(GUIInfo().text_field_margins)
@@ -398,9 +424,13 @@ class SettingsDialog(QDialog):
         backup_group_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         tab_layout.addWidget(backup_group_label)
 
-        self.backup_saves_on_launch_checkbox = QCheckBox(self.tr("Automatically backup saves on first daily launch"))
+        self.backup_saves_on_launch_checkbox = QCheckBox(
+            self.tr("Automatically backup saves on first daily launch")
+        )
         self.backup_saves_on_launch_checkbox.setToolTip(
-            self.tr("If enabled, RimSort will automatically backup saves on the first daily launch.")
+            self.tr(
+                "If enabled, RimSort will automatically backup saves on the first daily launch."
+            )
         )
         tab_layout.addWidget(self.backup_saves_on_launch_checkbox)
 
@@ -408,13 +438,17 @@ class SettingsDialog(QDialog):
         retention_layout = QHBoxLayout()
         retention_label = QLabel(self.tr("Number of backups to keep:"))
         retention_label.setToolTip(
-            self.tr("The number of backups to keep. Set to -1 to keep all backups, 0 to delete all.")
+            self.tr(
+                "The number of backups to keep. Set to -1 to keep all backups, 0 to delete all."
+            )
         )
         retention_layout.addWidget(retention_label)
 
         self.auto_backup_retention_count_spinbox = QSpinBox()
         self.auto_backup_retention_count_spinbox.setRange(-1, 999)
-        self.auto_backup_retention_count_spinbox.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        self.auto_backup_retention_count_spinbox.setSizePolicy(
+            QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed
+        )
         retention_layout.addWidget(self.auto_backup_retention_count_spinbox)
         tab_layout.addLayout(retention_layout)
 
@@ -429,7 +463,9 @@ class SettingsDialog(QDialog):
         )
         self.auto_backup_compression_count_spinbox = QSpinBox()
         self.auto_backup_compression_count_spinbox.setRange(-1, 999)
-        self.auto_backup_compression_count_spinbox.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        self.auto_backup_compression_count_spinbox.setSizePolicy(
+            QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed
+        )
         compression_layout.addWidget(self.auto_backup_compression_count_spinbox)
         tab_layout.addLayout(compression_layout)
 
@@ -471,7 +507,9 @@ class SettingsDialog(QDialog):
 
         section_label = QLabel(section_lbl)
         section_label.setFont(GUIInfo().emphasis_font)
-        section_label.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
+        section_label.setSizePolicy(
+            QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed
+        )
         group_layout.addWidget(section_label)
 
         section_layout = QVBoxLayout()
@@ -536,7 +574,9 @@ class SettingsDialog(QDialog):
         url_input.setTextMargins(GUIInfo().text_field_margins)
         url_input.setClearButtonEnabled(True)
         url_input.setEnabled(False)
-        url_input.setPlaceholderText(self.tr("https://github.com/.../archive/refs/heads/main.zip"))
+        url_input.setPlaceholderText(
+            self.tr("https://github.com/.../archive/refs/heads/main.zip")
+        )
         row_layout.addWidget(url_input)
 
         url_download_button = QToolButton()
@@ -564,7 +604,9 @@ class SettingsDialog(QDialog):
         local_file_choose_button = QToolButton()
         local_file_choose_button.setText(self.tr("Choose…"))
         local_file_choose_button.setEnabled(False)
-        local_file_choose_button.setFixedWidth(github_download_button.sizeHint().width())
+        local_file_choose_button.setFixedWidth(
+            github_download_button.sizeHint().width()
+        )
         row_layout.addWidget(local_file_choose_button)
 
         section_layout.addStretch(1)
@@ -629,7 +671,9 @@ class SettingsDialog(QDialog):
             self.steam_workshop_db_local_file_choose_button,
         ) = self.__create_db_group(section_lbl, none_lbl, tab_layout)
         database_expiry_label = QLabel(
-            self.tr("Database expiry in seconds for example, 604800 for 7 days. and 0 for no expiry.")
+            self.tr(
+                "Database expiry in seconds for example, 604800 for 7 days. and 0 for no expiry."
+            )
         )
         database_expiry_label.setFont(GUIInfo().emphasis_font)
         group_layout.addWidget(database_expiry_label)
@@ -677,7 +721,9 @@ class SettingsDialog(QDialog):
 
     def _do_aux_db_time_limit_group(self, tab_layout: QBoxLayout) -> None:
         self.aux_db_time_limit_label = QLabel(
-            self.tr("Auxiliary Metadata DB deletion time limit in seconds. (Delete instantly 0, Never Delete -1)")
+            self.tr(
+                "Auxiliary Metadata DB deletion time limit in seconds. (Delete instantly 0, Never Delete -1)"
+            )
         )
         aux_db_tooltip = self.tr("""To enable editing of this time limit, enable the checkbox (Enable editing) on the right.
 After a mod is deleted, this is the time we wait until this mod item is deleted from the Auxiliary Metadata DB. 
@@ -694,9 +740,13 @@ This basically preserves your mod coloring, user notes etc. for this many second
         self.aux_db_time_limit.setFixedHeight(GUIInfo().default_font_line_height * 2)
 
         self.enable_aux_db_behavior_editing = QCheckBox(self.tr("Enable editing"))
-        self.enable_aux_db_behavior_editing.stateChanged.connect(self.enable_aux_db_time_limit_line_edit)
+        self.enable_aux_db_behavior_editing.stateChanged.connect(
+            self.enable_aux_db_time_limit_line_edit
+        )
         self.enable_aux_db_behavior_editing.setToolTip(
-            self.tr("This enables the editing of the time limit for Aux Metadata DB data deletion.")
+            self.tr(
+                "This enables the editing of the time limit for Aux Metadata DB data deletion."
+            )
         )
 
         label_layout = QHBoxLayout()
@@ -743,7 +793,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         deps_group_box_layout.addWidget(deps_label)
 
         # Use dependencies for sorting checkbox
-        self.use_moddependencies_as_loadTheseBefore = QCheckBox(self.tr("Use dependency rules for sorting."))
+        self.use_moddependencies_as_loadTheseBefore = QCheckBox(
+            self.tr("Use dependency rules for sorting.")
+        )
         self.use_moddependencies_as_loadTheseBefore.setToolTip(
             self.tr(
                 "If enabled, also uses moddependencies as loadTheseBefore, and mods will be sorted such that dependencies are loaded before the dependent mod."
@@ -752,8 +804,8 @@ This basically preserves your mod coloring, user notes etc. for this many second
         deps_group_box_layout.addWidget(self.use_moddependencies_as_loadTheseBefore)
 
         # Use alternativePackageIds as satisfying dependencies
-        self.use_alternative_package_ids_as_satisfying_dependencies_checkbox = QCheckBox(
-            self.tr("Use alternativePackageIds as satisfying dependencies")
+        self.use_alternative_package_ids_as_satisfying_dependencies_checkbox = (
+            QCheckBox(self.tr("Use alternativePackageIds as satisfying dependencies"))
         )
         self.use_alternative_package_ids_as_satisfying_dependencies_checkbox.setToolTip(
             self.tr(
@@ -761,9 +813,13 @@ This basically preserves your mod coloring, user notes etc. for this many second
                 "E.g., 'oels.vehiclemapframework', alternatives: 'oels.vehiclemapframework.dev'"
             )
         )
-        deps_group_box_layout.addWidget(self.use_alternative_package_ids_as_satisfying_dependencies_checkbox)
+        deps_group_box_layout.addWidget(
+            self.use_alternative_package_ids_as_satisfying_dependencies_checkbox
+        )
 
-        self.check_deps_checkbox = QCheckBox(self.tr("Prompt user to download dependencies when click in Sort"))
+        self.check_deps_checkbox = QCheckBox(
+            self.tr("Prompt user to download dependencies when click in Sort")
+        )
         deps_group_box_layout.addWidget(self.check_deps_checkbox)
 
         # XML parsing behavior group
@@ -777,7 +833,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         xml_parsing_explanatory_label = QLabel(self.tr("XML Parsing Behavior"))
         xml_parsing_explanatory_label.setFont(GUIInfo().emphasis_font)
         xml_parsing_group_box_layout.addWidget(xml_parsing_explanatory_label)
-        self.prefer_versioned_about_tags_checkbox = QCheckBox(self.tr("Prefer versioned About.xml tags over base tags"))
+        self.prefer_versioned_about_tags_checkbox = QCheckBox(
+            self.tr("Prefer versioned About.xml tags over base tags")
+        )
         self.prefer_versioned_about_tags_checkbox.setToolTip(
             self.tr(
                 "When enabled, *ByVersion tags take precedence over the base tags, \n"
@@ -786,7 +844,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
             )
         )
 
-        xml_parsing_group_box_layout.addWidget(self.prefer_versioned_about_tags_checkbox)
+        xml_parsing_group_box_layout.addWidget(
+            self.prefer_versioned_about_tags_checkbox
+        )
 
         # Mod list options group
         modlist_option_group_box = QGroupBox()
@@ -800,56 +860,80 @@ This basically preserves your mod coloring, user notes etc. for this many second
         modlist_option_group_box_layout.addWidget(modlist_option_label)
 
         # Download missing mods checkbox
-        self.download_missing_mods_checkbox = QCheckBox(self.tr("Download missing mods automatically"))
+        self.download_missing_mods_checkbox = QCheckBox(
+            self.tr("Download missing mods automatically")
+        )
         self.download_missing_mods_checkbox.setToolTip(
-            self.tr("Notifies to download mods that may be missing in the active modlist")
+            self.tr(
+                "Notifies to download mods that may be missing in the active modlist"
+            )
         )
         modlist_option_group_box_layout.addWidget(self.download_missing_mods_checkbox)
 
         # Duplicate mod notification checkbox
-        self.show_duplicate_mods_warning_checkbox = QCheckBox(self.tr("Show duplicate mods warning"))
+        self.show_duplicate_mods_warning_checkbox = QCheckBox(
+            self.tr("Show duplicate mods warning")
+        )
         self.show_duplicate_mods_warning_checkbox.setToolTip(
             self.tr("Notifies and displays the mods that have the same packageid")
         )
-        modlist_option_group_box_layout.addWidget(self.show_duplicate_mods_warning_checkbox)
+        modlist_option_group_box_layout.addWidget(
+            self.show_duplicate_mods_warning_checkbox
+        )
 
         # Mod type filter checkbox
         self.mod_type_filter_checkbox = QCheckBox(self.tr("Enable mod type filter"))
         self.mod_type_filter_checkbox.setToolTip(
-            self.tr("Add icons and filtering options for easy mods identification and grouping")
+            self.tr(
+                "Add icons and filtering options for easy mods identification and grouping"
+            )
         )
         modlist_option_group_box_layout.addWidget(self.mod_type_filter_checkbox)
 
         # Hide invalid mod filtering checkbox
-        self.hide_invalid_mods_when_filtering_checkbox = QCheckBox(self.tr("Hide invalid mods when filtering"))
+        self.hide_invalid_mods_when_filtering_checkbox = QCheckBox(
+            self.tr("Hide invalid mods when filtering")
+        )
         self.hide_invalid_mods_when_filtering_checkbox.setToolTip(
             self.tr("Hides invalid mods, not recommended to enable")
         )
-        modlist_option_group_box_layout.addWidget(self.hide_invalid_mods_when_filtering_checkbox)
+        modlist_option_group_box_layout.addWidget(
+            self.hide_invalid_mods_when_filtering_checkbox
+        )
 
         # Inactive mods sorting group
         self.inactive_mods_sorting_group_box = QGroupBox()
         tab_layout.addWidget(self.inactive_mods_sorting_group_box)
 
         inactive_mods_sorting_group_box_layout = QVBoxLayout()
-        self.inactive_mods_sorting_group_box.setLayout(inactive_mods_sorting_group_box_layout)
+        self.inactive_mods_sorting_group_box.setLayout(
+            inactive_mods_sorting_group_box_layout
+        )
 
         inactive_mods_sorting_label = QLabel(self.tr("Inactive Mods Sorting"))
         inactive_mods_sorting_label.setFont(GUIInfo().emphasis_font)
         inactive_mods_sorting_group_box_layout.addWidget(inactive_mods_sorting_label)
 
         # Inactive mods sorting options checkbox
-        self.enable_inactive_mods_sorting_checkbox = QCheckBox(self.tr("Enable inactive mods sorting"))
+        self.enable_inactive_mods_sorting_checkbox = QCheckBox(
+            self.tr("Enable inactive mods sorting")
+        )
         self.enable_inactive_mods_sorting_checkbox.setToolTip(
             self.tr(
                 "Additional options like name, author, folder size, modified date will be available in the mods panel for sorting inactive mods \n"
                 "Disabling this can improve performance by avoiding heavy calculations."
             )
         )
-        inactive_mods_sorting_group_box_layout.addWidget(self.enable_inactive_mods_sorting_checkbox)
+        inactive_mods_sorting_group_box_layout.addWidget(
+            self.enable_inactive_mods_sorting_checkbox
+        )
 
-        self.save_inactive_mods_sort_state_checkbox = QCheckBox(self.tr("Save inactive mods sort state"))
-        inactive_mods_sorting_group_box_layout.addWidget(self.save_inactive_mods_sort_state_checkbox)
+        self.save_inactive_mods_sort_state_checkbox = QCheckBox(
+            self.tr("Save inactive mods sort state")
+        )
+        inactive_mods_sorting_group_box_layout.addWidget(
+            self.save_inactive_mods_sort_state_checkbox
+        )
 
         tab_layout.addStretch()
 
@@ -871,7 +955,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         when_building_database_label.setFont(GUIInfo().emphasis_font)
         group_layout.addWidget(when_building_database_label)
 
-        self.db_builder_include_all_radio = QRadioButton(self.tr("Get PublishedFileIDs from locally installed mods."))
+        self.db_builder_include_all_radio = QRadioButton(
+            self.tr("Get PublishedFileIDs from locally installed mods.")
+        )
         group_layout.addWidget(self.db_builder_include_all_radio)
 
         explanatory_label = QLabel(
@@ -882,7 +968,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         )
         group_layout.addWidget(explanatory_label)
 
-        self.db_builder_include_no_local_radio = QRadioButton(self.tr("Get PublishedFileIDs from the Steam Workshop."))
+        self.db_builder_include_no_local_radio = QRadioButton(
+            self.tr("Get PublishedFileIDs from the Steam Workshop.")
+        )
         group_layout.addWidget(self.db_builder_include_no_local_radio)
 
         explanatory_label = QLabel(
@@ -900,7 +988,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         group_layout = QVBoxLayout()
         group_box.setLayout(group_layout)
 
-        self.db_builder_query_dlc_checkbox = QCheckBox(self.tr("Query DLC dependency data with Steamworks API"))
+        self.db_builder_query_dlc_checkbox = QCheckBox(
+            self.tr("Query DLC dependency data with Steamworks API")
+        )
         group_layout.addWidget(self.db_builder_query_dlc_checkbox)
 
         self.db_builder_update_instead_of_overwriting_checkbox = QCheckBox(
@@ -921,7 +1011,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         self.db_builder_steam_api_key = QLineEdit()
         self.db_builder_steam_api_key.setEchoMode(QLineEdit.EchoMode.Password)
         self.db_builder_steam_api_key.setTextMargins(GUIInfo().text_field_margins)
-        self.db_builder_steam_api_key.setFixedHeight(GUIInfo().default_font_line_height * 2)
+        self.db_builder_steam_api_key.setFixedHeight(
+            GUIInfo().default_font_line_height * 2
+        )
         grid_group_layout.addWidget(self.db_builder_steam_api_key, 1, 1)
 
         grid_group_layout.setColumnStretch(0, 0)
@@ -938,10 +1030,14 @@ This basically preserves your mod coloring, user notes etc. for this many second
         item_label = QLabel(self.tr("Download all published Workshop mods via:"))
         item_layout.addWidget(item_label)
 
-        self.db_builder_download_all_mods_via_steamcmd_button = QPushButton(self.tr("SteamCMD"))
+        self.db_builder_download_all_mods_via_steamcmd_button = QPushButton(
+            self.tr("SteamCMD")
+        )
         item_layout.addWidget(self.db_builder_download_all_mods_via_steamcmd_button)
 
-        self.db_builder_download_all_mods_via_steam_button = QPushButton(self.tr("Steam"))
+        self.db_builder_download_all_mods_via_steam_button = QPushButton(
+            self.tr("Steam")
+        )
         self.db_builder_download_all_mods_via_steam_button.setFixedWidth(
             self.db_builder_download_all_mods_via_steamcmd_button.sizeHint().width()
         )
@@ -953,7 +1049,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
 
         item_layout.addStretch()
 
-        self.db_builder_compare_databases_button = QPushButton(self.tr("Compare Databases"))
+        self.db_builder_compare_databases_button = QPushButton(
+            self.tr("Compare Databases")
+        )
         item_layout.addWidget(self.db_builder_compare_databases_button)
 
         self.db_builder_merge_databases_button = QPushButton(self.tr("Merge Databases"))
@@ -963,7 +1061,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         item_layout.addWidget(self.db_builder_merge_databases_button)
 
         self.db_builder_build_database_button = QPushButton(self.tr("Build Database"))
-        self.db_builder_build_database_button.setFixedWidth(self.db_builder_compare_databases_button.sizeHint().width())
+        self.db_builder_build_database_button.setFixedWidth(
+            self.db_builder_compare_databases_button.sizeHint().width()
+        )
         item_layout.addWidget(self.db_builder_build_database_button)
 
     def _do_steamcmd_tab(self) -> None:
@@ -979,10 +1079,14 @@ This basically preserves your mod coloring, user notes etc. for this many second
         group_layout = QVBoxLayout()
         group_box.setLayout(group_layout)
 
-        self.steamcmd_validate_downloads_checkbox = QCheckBox(self.tr("Validate downloaded mods"))
+        self.steamcmd_validate_downloads_checkbox = QCheckBox(
+            self.tr("Validate downloaded mods")
+        )
         group_layout.addWidget(self.steamcmd_validate_downloads_checkbox)
 
-        self.steamcmd_auto_clear_depot_cache_checkbox = QCheckBox(self.tr("Automatically clear depot cache"))
+        self.steamcmd_auto_clear_depot_cache_checkbox = QCheckBox(
+            self.tr("Automatically clear depot cache")
+        )
         self.steamcmd_auto_clear_depot_cache_checkbox.setToolTip(
             (
                 self.tr(
@@ -993,7 +1097,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         )
         group_layout.addWidget(self.steamcmd_auto_clear_depot_cache_checkbox)
 
-        self.steamcmd_delete_before_update_checkbox = QCheckBox(self.tr("Delete before update"))
+        self.steamcmd_delete_before_update_checkbox = QCheckBox(
+            self.tr("Delete before update")
+        )
         self.steamcmd_delete_before_update_checkbox.setToolTip(
             self.tr("This is useful if you want to ensure clean mod updates.")
         )
@@ -1018,7 +1124,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
 
         self.steamcmd_install_location = QLineEdit()
         self.steamcmd_install_location.setTextMargins(GUIInfo().text_field_margins)
-        self.steamcmd_install_location.setFixedHeight(GUIInfo().default_font_line_height * 2)
+        self.steamcmd_install_location.setFixedHeight(
+            GUIInfo().default_font_line_height * 2
+        )
         group_layout.addWidget(self.steamcmd_install_location)
 
         tab_layout.addStretch()
@@ -1028,7 +1136,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
 
         button_layout.addStretch()
 
-        self.steamcmd_clear_depot_cache_button = QPushButton(self.tr("Clear depot cache"))
+        self.steamcmd_clear_depot_cache_button = QPushButton(
+            self.tr("Clear depot cache")
+        )
         self.steamcmd_clear_depot_cache_button.setToolTip(
             self.tr(
                 "Clear the depot cache manually. This may be useful if you encounter issues with downloading mods through SteamCMD."
@@ -1062,25 +1172,33 @@ This basically preserves your mod coloring, user notes etc. for this many second
         quality_preset_label.setFont(GUIInfo().emphasis_font)
         group_layout.addWidget(quality_preset_label)
 
-        self.todds_preset_optimized_radio = QRadioButton(self.tr("Optimized - Recommended for RimWorld"))
+        self.todds_preset_optimized_radio = QRadioButton(
+            self.tr("Optimized - Recommended for RimWorld")
+        )
         group_layout.addWidget(self.todds_preset_optimized_radio)
 
         self.todds_preset_custom_radio = QRadioButton(self.tr("Custom todds command"))
         group_layout.addWidget(self.todds_preset_custom_radio)
 
         custom_command_label = QLabel(
-            self.tr("If -p as in path is not specified, path from current active or all mods selection will be used.")
+            self.tr(
+                "If -p as in path is not specified, path from current active or all mods selection will be used."
+            )
         )
         custom_command_label.setFont(GUIInfo().emphasis_font)
         group_layout.addWidget(custom_command_label)
 
         self.todds_custom_command_lineedit = QLineEdit()
-        todds_example = '-f BC1 -af BC7 -on -vf -fs -r Textures -t -p "D:\\Games\\RimWorld\\Mods"'
+        todds_example = (
+            '-f BC1 -af BC7 -on -vf -fs -r Textures -t -p "D:\\Games\\RimWorld\\Mods"'
+        )
         self.todds_custom_command_lineedit.setPlaceholderText(
             self.tr("eg: {todds_example}").format(todds_example=todds_example)
         )
         self.todds_custom_command_lineedit.setTextMargins(GUIInfo().text_field_margins)
-        self.todds_custom_command_lineedit.setFixedHeight(GUIInfo().default_font_line_height * 2)
+        self.todds_custom_command_lineedit.setFixedHeight(
+            GUIInfo().default_font_line_height * 2
+        )
         group_layout.addWidget(self.todds_custom_command_lineedit)
 
         group_box = QGroupBox()
@@ -1093,7 +1211,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         when_optimizing_label.setFont(GUIInfo().emphasis_font)
         group_layout.addWidget(when_optimizing_label)
 
-        self.todds_active_mods_only_radio = QRadioButton(self.tr("Optimize active mods only"))
+        self.todds_active_mods_only_radio = QRadioButton(
+            self.tr("Optimize active mods only")
+        )
         group_layout.addWidget(self.todds_active_mods_only_radio)
 
         self.todds_all_mods_radio = QRadioButton(self.tr("Optimize all mods"))
@@ -1108,11 +1228,15 @@ This basically preserves your mod coloring, user notes etc. for this many second
         self.todds_dry_run_checkbox = QCheckBox(self.tr("Enable dry-run mode"))
         group_layout.addWidget(self.todds_dry_run_checkbox)
 
-        self.todds_overwrite_checkbox = QCheckBox(self.tr("Overwrite existing optimized textures"))
+        self.todds_overwrite_checkbox = QCheckBox(
+            self.tr("Overwrite existing optimized textures")
+        )
         group_layout.addWidget(self.todds_overwrite_checkbox)
 
         self.auto_delete_orphaned_dds_checkbox = QCheckBox(
-            self.tr("Automatically delete .dds files if no corresponding .png file exists")
+            self.tr(
+                "Automatically delete .dds files if no corresponding .png file exists"
+            )
         )
         self.auto_delete_orphaned_dds_checkbox.setToolTip(
             self.tr(
@@ -1164,7 +1288,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         group_layout.addWidget(folder_arg_label)
         self.text_editor_folder_arg = QLineEdit()
         self.text_editor_folder_arg.setTextMargins(GUIInfo().text_field_margins)
-        self.text_editor_folder_arg.setFixedHeight(GUIInfo().default_font_line_height * 2)
+        self.text_editor_folder_arg.setFixedHeight(
+            GUIInfo().default_font_line_height * 2
+        )
         group_layout.addWidget(self.text_editor_folder_arg)
 
         file_arg_label = QLabel(self.tr("Additional Arguments (Opening Single File)"))
@@ -1211,7 +1337,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         theme_layout = QHBoxLayout()
         theme_group_box.setLayout(theme_layout)
 
-        self.enable_themes_checkbox = QCheckBox(self.tr("Enable to use theme / stylesheet instead of system Theme"))
+        self.enable_themes_checkbox = QCheckBox(
+            self.tr("Enable to use theme / stylesheet instead of system Theme")
+        )
         self.enable_themes_checkbox.setToolTip(
             self.tr(
                 "To add your own theme / stylesheet \n\n"
@@ -1227,7 +1355,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         theme_layout.addWidget(self.enable_themes_checkbox)
 
         self.themes_combobox = QComboBox()
-        self.themes_combobox.setSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred)
+        self.themes_combobox.setSizePolicy(
+            QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred
+        )
         theme_layout.addWidget(self.themes_combobox)
 
         self.theme_location_open_button = QToolButton()
@@ -1251,7 +1381,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         font_family_layout.addWidget(font_family_label)
 
         self.font_family_combobox = QFontComboBox()
-        self.font_family_combobox.setSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred)
+        self.font_family_combobox.setSizePolicy(
+            QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred
+        )
         font_family_layout.addWidget(self.font_family_combobox)
 
         font_size_layout = QHBoxLayout()
@@ -1263,11 +1395,15 @@ This basically preserves your mod coloring, user notes etc. for this many second
         self.font_size_spinbox = QSpinBox()
         self.font_size_spinbox.setRange(8, 20)
         self.font_size_spinbox.setValue(12)
-        self.font_size_spinbox.setSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred)
+        self.font_size_spinbox.setSizePolicy(
+            QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred
+        )
         font_size_layout.addWidget(self.font_size_spinbox)
 
         reset_button = QPushButton(self.tr("Reset"))
-        reset_button.setSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred)
+        reset_button.setSizePolicy(
+            QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred
+        )
 
         reset_button_layout = QHBoxLayout()
         reset_button_layout.addStretch(1)
@@ -1276,7 +1412,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         reset_button.clicked.connect(self.reset_font_settings)
 
         if self.enable_themes_checkbox.isChecked():
-            self.enable_themes_checkbox.stateChanged.connect(self.connect_populate_themes_combobox)
+            self.enable_themes_checkbox.stateChanged.connect(
+                self.connect_populate_themes_combobox
+            )
         else:
             self.themes_combobox.clear()
 
@@ -1291,11 +1429,15 @@ This basically preserves your mod coloring, user notes etc. for this many second
         language_group_layout = QHBoxLayout()
         language_group_box.setLayout(language_group_layout)
 
-        language_label = QLabel(self.tr("Select Language (Restart required to apply changes)"))
+        language_label = QLabel(
+            self.tr("Select Language (Restart required to apply changes)")
+        )
         language_group_layout.addWidget(language_label)
 
         self.language_combobox = QComboBox()
-        self.language_combobox.setSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred)
+        self.language_combobox.setSizePolicy(
+            QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred
+        )
 
         language_group_layout.addWidget(self.language_combobox)
 
@@ -1358,9 +1500,15 @@ This basically preserves your mod coloring, user notes etc. for this many second
         group_layout.addWidget(self.main_window_group)
 
         # Connect main window radio buttons to enable/disable custom size spinboxes dynamically
-        self.main_launch_maximized_radio.toggled.connect(self.disable_main_custom_size_spinboxes)
-        self.main_launch_normal_radio.toggled.connect(self.disable_main_custom_size_spinboxes)
-        self.main_launch_custom_radio.toggled.connect(self.enable_main_custom_size_spinboxes)
+        self.main_launch_maximized_radio.toggled.connect(
+            self.disable_main_custom_size_spinboxes
+        )
+        self.main_launch_normal_radio.toggled.connect(
+            self.disable_main_custom_size_spinboxes
+        )
+        self.main_launch_custom_radio.toggled.connect(
+            self.enable_main_custom_size_spinboxes
+        )
 
         # Browser Window
         (
@@ -1386,9 +1534,15 @@ This basically preserves your mod coloring, user notes etc. for this many second
         group_layout.addWidget(self.browser_window_group)
 
         # Connect browser window radio buttons to enable/disable custom size spinboxes dynamically
-        self.browser_launch_maximized_radio.toggled.connect(self.disable_browser_custom_size_spinboxes)
-        self.browser_launch_normal_radio.toggled.connect(self.disable_browser_custom_size_spinboxes)
-        self.browser_launch_custom_radio.toggled.connect(self.enable_browser_custom_size_spinboxes)
+        self.browser_launch_maximized_radio.toggled.connect(
+            self.disable_browser_custom_size_spinboxes
+        )
+        self.browser_launch_normal_radio.toggled.connect(
+            self.disable_browser_custom_size_spinboxes
+        )
+        self.browser_launch_custom_radio.toggled.connect(
+            self.enable_browser_custom_size_spinboxes
+        )
 
         # Settings Window (only custom option)
         settings_window_title_label = QLabel(self.tr("Settings Window Launch State"))
@@ -1400,7 +1554,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         settings_window_group.setLayout(settings_window_layout)
 
         self.settings_custom_width_spinbox = QSpinBox()
-        self.settings_custom_width_spinbox.setRange(Settings.MIN_SIZE, Settings.MAX_SIZE)
+        self.settings_custom_width_spinbox.setRange(
+            Settings.MIN_SIZE, Settings.MAX_SIZE
+        )
         self.settings_custom_width_spinbox.setValue(Settings.DEFAULT_WIDTH)
         self.settings_custom_width_spinbox.setSuffix(" px")
         self.settings_custom_width_spinbox.setFixedWidth(100)
@@ -1410,7 +1566,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         settings_window_layout.addWidget(self.settings_custom_width_spinbox)
 
         self.settings_custom_height_spinbox = QSpinBox()
-        self.settings_custom_height_spinbox.setRange(Settings.MIN_SIZE, Settings.MAX_SIZE)
+        self.settings_custom_height_spinbox.setRange(
+            Settings.MIN_SIZE, Settings.MAX_SIZE
+        )
         self.settings_custom_height_spinbox.setValue(Settings.DEFAULT_HEIGHT)
         self.settings_custom_height_spinbox.setSuffix(" px")
         self.settings_custom_height_spinbox.setFixedWidth(100)
@@ -1481,12 +1639,16 @@ This basically preserves your mod coloring, user notes etc. for this many second
         auth_group.setLayout(auth_group_layout)
 
         rentry_auth_label = QLabel(self.tr("Rentry Auth:"))
-        auth_group_layout.addWidget(rentry_auth_label, 0, 0, alignment=Qt.AlignmentFlag.AlignRight)
+        auth_group_layout.addWidget(
+            rentry_auth_label, 0, 0, alignment=Qt.AlignmentFlag.AlignRight
+        )
 
         self.rentry_auth_code = QLineEdit()
         self.rentry_auth_code.setTextMargins(GUIInfo().text_field_margins)
         self.rentry_auth_code.setFixedHeight(GUIInfo().default_font_line_height * 2)
-        self.rentry_auth_code.setPlaceholderText(self.tr("Obtain rentry auth code by emailing: support@rentry.co"))
+        self.rentry_auth_code.setPlaceholderText(
+            self.tr("Obtain rentry auth code by emailing: support@rentry.co")
+        )
         # TODO: If we add a rentry auth code with builds, we should change placeholder to clarify this code will be used instead of the provided one
         auth_group_layout.addWidget(self.rentry_auth_code, 0, 1)
 
@@ -1497,7 +1659,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         github_identity_group.setLayout(github_identity_layout)
 
         github_username_label = QLabel(self.tr("GitHub username:"))
-        github_identity_layout.addWidget(github_username_label, 0, 0, alignment=Qt.AlignmentFlag.AlignRight)
+        github_identity_layout.addWidget(
+            github_username_label, 0, 0, alignment=Qt.AlignmentFlag.AlignRight
+        )
 
         self.github_username = QLineEdit()
         self.github_username.setTextMargins(GUIInfo().text_field_margins)
@@ -1505,7 +1669,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         github_identity_layout.addWidget(self.github_username, 0, 1)
 
         github_token_label = QLabel(self.tr("GitHub personal access token:"))
-        github_identity_layout.addWidget(github_token_label, 1, 0, alignment=Qt.AlignmentFlag.AlignRight)
+        github_identity_layout.addWidget(
+            github_token_label, 1, 0, alignment=Qt.AlignmentFlag.AlignRight
+        )
 
         self.github_token = QLineEdit()
         self.github_token.setEchoMode(QLineEdit.EchoMode.Password)
@@ -1541,14 +1707,18 @@ This basically preserves your mod coloring, user notes etc. for this many second
         self.debug_logging_checkbox = QCheckBox(self.tr("Enable debug logging"))
         group_layout.addWidget(self.debug_logging_checkbox)
 
-        self.watchdog_checkbox = QCheckBox(self.tr("Enable watchdog file monitor daemon"))
+        self.watchdog_checkbox = QCheckBox(
+            self.tr("Enable watchdog file monitor daemon")
+        )
         group_layout.addWidget(self.watchdog_checkbox)
 
         # Clear button behavior
         self.clear_moves_dlc_checkbox = QCheckBox(self.tr("Clear also moves DLC"))
         group_layout.addWidget(self.clear_moves_dlc_checkbox)
 
-        self.auto_launch_steam_checkbox = QCheckBox(self.tr("Automatically launch Steam when needed"))
+        self.auto_launch_steam_checkbox = QCheckBox(
+            self.tr("Automatically launch Steam when needed")
+        )
         self.auto_launch_steam_checkbox.setToolTip(
             self.tr(
                 "If enabled, RimSort will automatically attempt to launch Steam "
@@ -1558,20 +1728,28 @@ This basically preserves your mod coloring, user notes etc. for this many second
         )
         group_layout.addWidget(self.auto_launch_steam_checkbox)
 
-        self.show_mod_updates_checkbox = QCheckBox(self.tr("Check for mod updates on refresh"))
+        self.show_mod_updates_checkbox = QCheckBox(
+            self.tr("Check for mod updates on refresh")
+        )
         group_layout.addWidget(self.show_mod_updates_checkbox)
 
-        self.render_unity_rich_text_checkbox = QCheckBox(self.tr("Render Unity Rich Text in mod descriptions"))
+        self.render_unity_rich_text_checkbox = QCheckBox(
+            self.tr("Render Unity Rich Text in mod descriptions")
+        )
         self.color_background_instead_of_text_checkbox = QCheckBox(
             self.tr("Apply mod coloring to background instead of text")
         )
         group_layout.addWidget(self.color_background_instead_of_text_checkbox)
         self.render_unity_rich_text_checkbox.setToolTip(
-            self.tr("Enable this option to render Unity Rich Text in mod descriptions. Images will not be displayed.")
+            self.tr(
+                "Enable this option to render Unity Rich Text in mod descriptions. Images will not be displayed."
+            )
         )
         group_layout.addWidget(self.render_unity_rich_text_checkbox)
 
-        self.update_databases_on_startup_checkbox = QCheckBox(self.tr("Update databases on startup"))
+        self.update_databases_on_startup_checkbox = QCheckBox(
+            self.tr("Update databases on startup")
+        )
         self.update_databases_on_startup_checkbox.setToolTip(
             self.tr(
                 "Enable this option to automatically update enabled databases when RimSort starts. "
@@ -1584,13 +1762,17 @@ This basically preserves your mod coloring, user notes etc. for this many second
             self.tr("Include mod notes in mod name search filter")
         )
         self.include_mod_notes_in_mod_name_filter_checkbox.setToolTip(
-            self.tr("This option will include searching mod notes when searching by mod name.")
+            self.tr(
+                "This option will include searching mod notes when searching by mod name."
+            )
         )
         group_layout.addWidget(self.include_mod_notes_in_mod_name_filter_checkbox)
 
         # Put checkbox, label and spinbox on the same horizontal line
         backup_layout = QHBoxLayout()
-        self.enable_backup_before_update_checkbox = QCheckBox(self.tr("Create backup before RimSort update"))
+        self.enable_backup_before_update_checkbox = QCheckBox(
+            self.tr("Create backup before RimSort update")
+        )
         self.enable_backup_before_update_checkbox.setToolTip(
             self.tr(
                 "Recommended to keep this enabled as it creates a backup before updating RimSort, "

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -52,9 +52,7 @@ class SettingsDialog(QDialog):
         main_layout.addLayout(button_layout)
 
         # Reset to defaults button
-        self.global_reset_to_defaults_button = QPushButton(
-            self.tr("Reset to Defaults"), self
-        )
+        self.global_reset_to_defaults_button = QPushButton(self.tr("Reset to Defaults"), self)
         button_layout.addWidget(self.global_reset_to_defaults_button)
 
         button_layout.addStretch()
@@ -102,9 +100,7 @@ class SettingsDialog(QDialog):
         # "Game location" → "Config location" → "Steam mods location" → "Local mods location"
         self.setTabOrder(self.game_location, self.config_folder_location)
         self.setTabOrder(self.config_folder_location, self.steam_mods_folder_location)
-        self.setTabOrder(
-            self.steam_mods_folder_location, self.local_mods_folder_location
-        )
+        self.setTabOrder(self.steam_mods_folder_location, self.local_mods_folder_location)
 
         # Push the buttons to the bottom
         tab_layout.addStretch()
@@ -151,9 +147,7 @@ class SettingsDialog(QDialog):
 
         self.game_location = QLineEdit()
         self.game_location.setPlaceholderText(
-            self.tr(
-                r"Should be like: C:\Program Files (x86)\Steam\steamapps\common\RimWorld"
-            )
+            self.tr(r"Should be like: C:\Program Files (x86)\Steam\steamapps\common\RimWorld")
         )
         self.game_location.setTextMargins(GUIInfo().text_field_margins)
         self.game_location.setFixedHeight(GUIInfo().default_font_line_height * 2)
@@ -191,9 +185,7 @@ class SettingsDialog(QDialog):
             )
         )
         self.config_folder_location.setTextMargins(GUIInfo().text_field_margins)
-        self.config_folder_location.setFixedHeight(
-            GUIInfo().default_font_line_height * 2
-        )
+        self.config_folder_location.setFixedHeight(GUIInfo().default_font_line_height * 2)
         group_layout.addWidget(self.config_folder_location)
 
     def _do_steam_mods_folder_location_area(self, tab_layout: QVBoxLayout) -> None:
@@ -205,14 +197,10 @@ class SettingsDialog(QDialog):
         header_layout = QHBoxLayout()
         group_layout.addLayout(header_layout)
 
-        self.steam_client_integration_checkbox = QCheckBox(
-            self.tr("Enable Steam client integration")
-        )
+        self.steam_client_integration_checkbox = QCheckBox(self.tr("Enable Steam client integration"))
         group_layout.addWidget(self.steam_client_integration_checkbox)
 
-        self.steam_client_integration_checkbox.stateChanged.connect(
-            self._on_steam_integration_toggled
-        )
+        self.steam_client_integration_checkbox.stateChanged.connect(self._on_steam_integration_toggled)
 
         section_label = QLabel(self.tr("Steam mods location"))
         section_label.setFont(GUIInfo().emphasis_font)
@@ -237,9 +225,7 @@ class SettingsDialog(QDialog):
             )
         )
         self.steam_mods_folder_location.setTextMargins(GUIInfo().text_field_margins)
-        self.steam_mods_folder_location.setFixedHeight(
-            GUIInfo().default_font_line_height * 2
-        )
+        self.steam_mods_folder_location.setFixedHeight(GUIInfo().default_font_line_height * 2)
         group_layout.addWidget(self.steam_mods_folder_location)
 
     def _do_local_mods_folder_location_area(self, tab_layout: QVBoxLayout) -> None:
@@ -269,14 +255,10 @@ class SettingsDialog(QDialog):
 
         self.local_mods_folder_location = QLineEdit()
         self.local_mods_folder_location.setPlaceholderText(
-            self.tr(
-                r"should be like: C:\Program Files (x86)\Steam\steamapps\common\Rimworld\Mods"
-            )
+            self.tr(r"should be like: C:\Program Files (x86)\Steam\steamapps\common\Rimworld\Mods")
         )
         self.local_mods_folder_location.setTextMargins(GUIInfo().text_field_margins)
-        self.local_mods_folder_location.setFixedHeight(
-            GUIInfo().default_font_line_height * 2
-        )
+        self.local_mods_folder_location.setFixedHeight(GUIInfo().default_font_line_height * 2)
         group_layout.addWidget(self.local_mods_folder_location)
 
     def _do_instance_folder_location_area(self, tab_layout: QVBoxLayout) -> None:
@@ -303,13 +285,9 @@ class SettingsDialog(QDialog):
 
         self.instance_folder_location = QLineEdit()
         self.instance_folder_location.setReadOnly(True)
-        self.instance_folder_location.setPlaceholderText(
-            self.tr("Leave empty to use default location")
-        )
+        self.instance_folder_location.setPlaceholderText(self.tr("Leave empty to use default location"))
         self.instance_folder_location.setTextMargins(GUIInfo().text_field_margins)
-        self.instance_folder_location.setFixedHeight(
-            GUIInfo().default_font_line_height * 2
-        )
+        self.instance_folder_location.setFixedHeight(GUIInfo().default_font_line_height * 2)
         group_layout.addWidget(self.instance_folder_location)
 
     def _do_game_launch_tab(self) -> None:
@@ -336,9 +314,7 @@ class SettingsDialog(QDialog):
             )
         )
         # Connect checkbox to disable/enable run_args group
-        self.launch_via_steam_protocol_checkbox.stateChanged.connect(
-            self._on_steam_protocol_toggled
-        )
+        self.launch_via_steam_protocol_checkbox.stateChanged.connect(self._on_steam_protocol_toggled)
         steam_protocol_layout.addWidget(self.launch_via_steam_protocol_checkbox)
 
         # Game arguments group
@@ -371,9 +347,7 @@ class SettingsDialog(QDialog):
         run_args_layout.addLayout(run_args_info_layout, 0, 0, 1, 2)
 
         run_args_label = QLabel(self.tr("Edit Game Run Arguments:"))
-        run_args_layout.addWidget(
-            run_args_label, 1, 0, alignment=Qt.AlignmentFlag.AlignRight
-        )
+        run_args_layout.addWidget(run_args_label, 1, 0, alignment=Qt.AlignmentFlag.AlignRight)
 
         self.run_args = QLineEdit()
         self.run_args.setTextMargins(GUIInfo().text_field_margins)
@@ -424,13 +398,9 @@ class SettingsDialog(QDialog):
         backup_group_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         tab_layout.addWidget(backup_group_label)
 
-        self.backup_saves_on_launch_checkbox = QCheckBox(
-            self.tr("Automatically backup saves on first daily launch")
-        )
+        self.backup_saves_on_launch_checkbox = QCheckBox(self.tr("Automatically backup saves on first daily launch"))
         self.backup_saves_on_launch_checkbox.setToolTip(
-            self.tr(
-                "If enabled, RimSort will automatically backup saves on the first daily launch."
-            )
+            self.tr("If enabled, RimSort will automatically backup saves on the first daily launch.")
         )
         tab_layout.addWidget(self.backup_saves_on_launch_checkbox)
 
@@ -438,17 +408,13 @@ class SettingsDialog(QDialog):
         retention_layout = QHBoxLayout()
         retention_label = QLabel(self.tr("Number of backups to keep:"))
         retention_label.setToolTip(
-            self.tr(
-                "The number of backups to keep. Set to -1 to keep all backups, 0 to delete all."
-            )
+            self.tr("The number of backups to keep. Set to -1 to keep all backups, 0 to delete all.")
         )
         retention_layout.addWidget(retention_label)
 
         self.auto_backup_retention_count_spinbox = QSpinBox()
         self.auto_backup_retention_count_spinbox.setRange(-1, 999)
-        self.auto_backup_retention_count_spinbox.setSizePolicy(
-            QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed
-        )
+        self.auto_backup_retention_count_spinbox.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         retention_layout.addWidget(self.auto_backup_retention_count_spinbox)
         tab_layout.addLayout(retention_layout)
 
@@ -463,9 +429,7 @@ class SettingsDialog(QDialog):
         )
         self.auto_backup_compression_count_spinbox = QSpinBox()
         self.auto_backup_compression_count_spinbox.setRange(-1, 999)
-        self.auto_backup_compression_count_spinbox.setSizePolicy(
-            QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed
-        )
+        self.auto_backup_compression_count_spinbox.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         compression_layout.addWidget(self.auto_backup_compression_count_spinbox)
         tab_layout.addLayout(compression_layout)
 
@@ -507,9 +471,7 @@ class SettingsDialog(QDialog):
 
         section_label = QLabel(section_lbl)
         section_label.setFont(GUIInfo().emphasis_font)
-        section_label.setSizePolicy(
-            QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed
-        )
+        section_label.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
         group_layout.addWidget(section_label)
 
         section_layout = QVBoxLayout()
@@ -574,9 +536,7 @@ class SettingsDialog(QDialog):
         url_input.setTextMargins(GUIInfo().text_field_margins)
         url_input.setClearButtonEnabled(True)
         url_input.setEnabled(False)
-        url_input.setPlaceholderText(
-            self.tr("https://github.com/.../archive/refs/heads/main.zip")
-        )
+        url_input.setPlaceholderText(self.tr("https://github.com/.../archive/refs/heads/main.zip"))
         row_layout.addWidget(url_input)
 
         url_download_button = QToolButton()
@@ -604,9 +564,7 @@ class SettingsDialog(QDialog):
         local_file_choose_button = QToolButton()
         local_file_choose_button.setText(self.tr("Choose…"))
         local_file_choose_button.setEnabled(False)
-        local_file_choose_button.setFixedWidth(
-            github_download_button.sizeHint().width()
-        )
+        local_file_choose_button.setFixedWidth(github_download_button.sizeHint().width())
         row_layout.addWidget(local_file_choose_button)
 
         section_layout.addStretch(1)
@@ -671,9 +629,7 @@ class SettingsDialog(QDialog):
             self.steam_workshop_db_local_file_choose_button,
         ) = self.__create_db_group(section_lbl, none_lbl, tab_layout)
         database_expiry_label = QLabel(
-            self.tr(
-                "Database expiry in seconds for example, 604800 for 7 days. and 0 for no expiry."
-            )
+            self.tr("Database expiry in seconds for example, 604800 for 7 days. and 0 for no expiry.")
         )
         database_expiry_label.setFont(GUIInfo().emphasis_font)
         group_layout.addWidget(database_expiry_label)
@@ -721,9 +677,7 @@ class SettingsDialog(QDialog):
 
     def _do_aux_db_time_limit_group(self, tab_layout: QBoxLayout) -> None:
         self.aux_db_time_limit_label = QLabel(
-            self.tr(
-                "Auxiliary Metadata DB deletion time limit in seconds. (Delete instantly 0, Never Delete -1)"
-            )
+            self.tr("Auxiliary Metadata DB deletion time limit in seconds. (Delete instantly 0, Never Delete -1)")
         )
         aux_db_tooltip = self.tr("""To enable editing of this time limit, enable the checkbox (Enable editing) on the right.
 After a mod is deleted, this is the time we wait until this mod item is deleted from the Auxiliary Metadata DB. 
@@ -740,13 +694,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         self.aux_db_time_limit.setFixedHeight(GUIInfo().default_font_line_height * 2)
 
         self.enable_aux_db_behavior_editing = QCheckBox(self.tr("Enable editing"))
-        self.enable_aux_db_behavior_editing.stateChanged.connect(
-            self.enable_aux_db_time_limit_line_edit
-        )
+        self.enable_aux_db_behavior_editing.stateChanged.connect(self.enable_aux_db_time_limit_line_edit)
         self.enable_aux_db_behavior_editing.setToolTip(
-            self.tr(
-                "This enables the editing of the time limit for Aux Metadata DB data deletion."
-            )
+            self.tr("This enables the editing of the time limit for Aux Metadata DB data deletion.")
         )
 
         label_layout = QHBoxLayout()
@@ -793,9 +743,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
         deps_group_box_layout.addWidget(deps_label)
 
         # Use dependencies for sorting checkbox
-        self.use_moddependencies_as_loadTheseBefore = QCheckBox(
-            self.tr("Use dependency rules for sorting.")
-        )
+        self.use_moddependencies_as_loadTheseBefore = QCheckBox(self.tr("Use dependency rules for sorting."))
         self.use_moddependencies_as_loadTheseBefore.setToolTip(
             self.tr(
                 "If enabled, also uses moddependencies as loadTheseBefore, and mods will be sorted such that dependencies are loaded before the dependent mod."
@@ -804,8 +752,8 @@ This basically preserves your mod coloring, user notes etc. for this many second
         deps_group_box_layout.addWidget(self.use_moddependencies_as_loadTheseBefore)
 
         # Use alternativePackageIds as satisfying dependencies
-        self.use_alternative_package_ids_as_satisfying_dependencies_checkbox = (
-            QCheckBox(self.tr("Use alternativePackageIds as satisfying dependencies"))
+        self.use_alternative_package_ids_as_satisfying_dependencies_checkbox = QCheckBox(
+            self.tr("Use alternativePackageIds as satisfying dependencies")
         )
         self.use_alternative_package_ids_as_satisfying_dependencies_checkbox.setToolTip(
             self.tr(
@@ -813,13 +761,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
                 "E.g., 'oels.vehiclemapframework', alternatives: 'oels.vehiclemapframework.dev'"
             )
         )
-        deps_group_box_layout.addWidget(
-            self.use_alternative_package_ids_as_satisfying_dependencies_checkbox
-        )
+        deps_group_box_layout.addWidget(self.use_alternative_package_ids_as_satisfying_dependencies_checkbox)
 
-        self.check_deps_checkbox = QCheckBox(
-            self.tr("Prompt user to download dependencies when click in Sort")
-        )
+        self.check_deps_checkbox = QCheckBox(self.tr("Prompt user to download dependencies when click in Sort"))
         deps_group_box_layout.addWidget(self.check_deps_checkbox)
 
         # XML parsing behavior group
@@ -833,9 +777,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
         xml_parsing_explanatory_label = QLabel(self.tr("XML Parsing Behavior"))
         xml_parsing_explanatory_label.setFont(GUIInfo().emphasis_font)
         xml_parsing_group_box_layout.addWidget(xml_parsing_explanatory_label)
-        self.prefer_versioned_about_tags_checkbox = QCheckBox(
-            self.tr("Prefer versioned About.xml tags over base tags")
-        )
+        self.prefer_versioned_about_tags_checkbox = QCheckBox(self.tr("Prefer versioned About.xml tags over base tags"))
         self.prefer_versioned_about_tags_checkbox.setToolTip(
             self.tr(
                 "When enabled, *ByVersion tags take precedence over the base tags, \n"
@@ -844,9 +786,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
             )
         )
 
-        xml_parsing_group_box_layout.addWidget(
-            self.prefer_versioned_about_tags_checkbox
-        )
+        xml_parsing_group_box_layout.addWidget(self.prefer_versioned_about_tags_checkbox)
 
         # Mod list options group
         modlist_option_group_box = QGroupBox()
@@ -860,80 +800,56 @@ This basically preserves your mod coloring, user notes etc. for this many second
         modlist_option_group_box_layout.addWidget(modlist_option_label)
 
         # Download missing mods checkbox
-        self.download_missing_mods_checkbox = QCheckBox(
-            self.tr("Download missing mods automatically")
-        )
+        self.download_missing_mods_checkbox = QCheckBox(self.tr("Download missing mods automatically"))
         self.download_missing_mods_checkbox.setToolTip(
-            self.tr(
-                "Notifies to download mods that may be missing in the active modlist"
-            )
+            self.tr("Notifies to download mods that may be missing in the active modlist")
         )
         modlist_option_group_box_layout.addWidget(self.download_missing_mods_checkbox)
 
         # Duplicate mod notification checkbox
-        self.show_duplicate_mods_warning_checkbox = QCheckBox(
-            self.tr("Show duplicate mods warning")
-        )
+        self.show_duplicate_mods_warning_checkbox = QCheckBox(self.tr("Show duplicate mods warning"))
         self.show_duplicate_mods_warning_checkbox.setToolTip(
             self.tr("Notifies and displays the mods that have the same packageid")
         )
-        modlist_option_group_box_layout.addWidget(
-            self.show_duplicate_mods_warning_checkbox
-        )
+        modlist_option_group_box_layout.addWidget(self.show_duplicate_mods_warning_checkbox)
 
         # Mod type filter checkbox
         self.mod_type_filter_checkbox = QCheckBox(self.tr("Enable mod type filter"))
         self.mod_type_filter_checkbox.setToolTip(
-            self.tr(
-                "Add icons and filtering options for easy mods identification and grouping"
-            )
+            self.tr("Add icons and filtering options for easy mods identification and grouping")
         )
         modlist_option_group_box_layout.addWidget(self.mod_type_filter_checkbox)
 
         # Hide invalid mod filtering checkbox
-        self.hide_invalid_mods_when_filtering_checkbox = QCheckBox(
-            self.tr("Hide invalid mods when filtering")
-        )
+        self.hide_invalid_mods_when_filtering_checkbox = QCheckBox(self.tr("Hide invalid mods when filtering"))
         self.hide_invalid_mods_when_filtering_checkbox.setToolTip(
             self.tr("Hides invalid mods, not recommended to enable")
         )
-        modlist_option_group_box_layout.addWidget(
-            self.hide_invalid_mods_when_filtering_checkbox
-        )
+        modlist_option_group_box_layout.addWidget(self.hide_invalid_mods_when_filtering_checkbox)
 
         # Inactive mods sorting group
         self.inactive_mods_sorting_group_box = QGroupBox()
         tab_layout.addWidget(self.inactive_mods_sorting_group_box)
 
         inactive_mods_sorting_group_box_layout = QVBoxLayout()
-        self.inactive_mods_sorting_group_box.setLayout(
-            inactive_mods_sorting_group_box_layout
-        )
+        self.inactive_mods_sorting_group_box.setLayout(inactive_mods_sorting_group_box_layout)
 
         inactive_mods_sorting_label = QLabel(self.tr("Inactive Mods Sorting"))
         inactive_mods_sorting_label.setFont(GUIInfo().emphasis_font)
         inactive_mods_sorting_group_box_layout.addWidget(inactive_mods_sorting_label)
 
         # Inactive mods sorting options checkbox
-        self.enable_inactive_mods_sorting_checkbox = QCheckBox(
-            self.tr("Enable inactive mods sorting")
-        )
+        self.enable_inactive_mods_sorting_checkbox = QCheckBox(self.tr("Enable inactive mods sorting"))
         self.enable_inactive_mods_sorting_checkbox.setToolTip(
             self.tr(
                 "Additional options like name, author, folder size, modified date will be available in the mods panel for sorting inactive mods \n"
                 "Disabling this can improve performance by avoiding heavy calculations."
             )
         )
-        inactive_mods_sorting_group_box_layout.addWidget(
-            self.enable_inactive_mods_sorting_checkbox
-        )
+        inactive_mods_sorting_group_box_layout.addWidget(self.enable_inactive_mods_sorting_checkbox)
 
-        self.save_inactive_mods_sort_state_checkbox = QCheckBox(
-            self.tr("Save inactive mods sort state")
-        )
-        inactive_mods_sorting_group_box_layout.addWidget(
-            self.save_inactive_mods_sort_state_checkbox
-        )
+        self.save_inactive_mods_sort_state_checkbox = QCheckBox(self.tr("Save inactive mods sort state"))
+        inactive_mods_sorting_group_box_layout.addWidget(self.save_inactive_mods_sort_state_checkbox)
 
         tab_layout.addStretch()
 
@@ -955,9 +871,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
         when_building_database_label.setFont(GUIInfo().emphasis_font)
         group_layout.addWidget(when_building_database_label)
 
-        self.db_builder_include_all_radio = QRadioButton(
-            self.tr("Get PublishedFileIDs from locally installed mods.")
-        )
+        self.db_builder_include_all_radio = QRadioButton(self.tr("Get PublishedFileIDs from locally installed mods."))
         group_layout.addWidget(self.db_builder_include_all_radio)
 
         explanatory_label = QLabel(
@@ -968,9 +882,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
         )
         group_layout.addWidget(explanatory_label)
 
-        self.db_builder_include_no_local_radio = QRadioButton(
-            self.tr("Get PublishedFileIDs from the Steam Workshop.")
-        )
+        self.db_builder_include_no_local_radio = QRadioButton(self.tr("Get PublishedFileIDs from the Steam Workshop."))
         group_layout.addWidget(self.db_builder_include_no_local_radio)
 
         explanatory_label = QLabel(
@@ -988,9 +900,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
         group_layout = QVBoxLayout()
         group_box.setLayout(group_layout)
 
-        self.db_builder_query_dlc_checkbox = QCheckBox(
-            self.tr("Query DLC dependency data with Steamworks API")
-        )
+        self.db_builder_query_dlc_checkbox = QCheckBox(self.tr("Query DLC dependency data with Steamworks API"))
         group_layout.addWidget(self.db_builder_query_dlc_checkbox)
 
         self.db_builder_update_instead_of_overwriting_checkbox = QCheckBox(
@@ -1011,9 +921,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
         self.db_builder_steam_api_key = QLineEdit()
         self.db_builder_steam_api_key.setEchoMode(QLineEdit.EchoMode.Password)
         self.db_builder_steam_api_key.setTextMargins(GUIInfo().text_field_margins)
-        self.db_builder_steam_api_key.setFixedHeight(
-            GUIInfo().default_font_line_height * 2
-        )
+        self.db_builder_steam_api_key.setFixedHeight(GUIInfo().default_font_line_height * 2)
         grid_group_layout.addWidget(self.db_builder_steam_api_key, 1, 1)
 
         grid_group_layout.setColumnStretch(0, 0)
@@ -1030,14 +938,10 @@ This basically preserves your mod coloring, user notes etc. for this many second
         item_label = QLabel(self.tr("Download all published Workshop mods via:"))
         item_layout.addWidget(item_label)
 
-        self.db_builder_download_all_mods_via_steamcmd_button = QPushButton(
-            self.tr("SteamCMD")
-        )
+        self.db_builder_download_all_mods_via_steamcmd_button = QPushButton(self.tr("SteamCMD"))
         item_layout.addWidget(self.db_builder_download_all_mods_via_steamcmd_button)
 
-        self.db_builder_download_all_mods_via_steam_button = QPushButton(
-            self.tr("Steam")
-        )
+        self.db_builder_download_all_mods_via_steam_button = QPushButton(self.tr("Steam"))
         self.db_builder_download_all_mods_via_steam_button.setFixedWidth(
             self.db_builder_download_all_mods_via_steamcmd_button.sizeHint().width()
         )
@@ -1049,9 +953,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
 
         item_layout.addStretch()
 
-        self.db_builder_compare_databases_button = QPushButton(
-            self.tr("Compare Databases")
-        )
+        self.db_builder_compare_databases_button = QPushButton(self.tr("Compare Databases"))
         item_layout.addWidget(self.db_builder_compare_databases_button)
 
         self.db_builder_merge_databases_button = QPushButton(self.tr("Merge Databases"))
@@ -1061,9 +963,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
         item_layout.addWidget(self.db_builder_merge_databases_button)
 
         self.db_builder_build_database_button = QPushButton(self.tr("Build Database"))
-        self.db_builder_build_database_button.setFixedWidth(
-            self.db_builder_compare_databases_button.sizeHint().width()
-        )
+        self.db_builder_build_database_button.setFixedWidth(self.db_builder_compare_databases_button.sizeHint().width())
         item_layout.addWidget(self.db_builder_build_database_button)
 
     def _do_steamcmd_tab(self) -> None:
@@ -1079,14 +979,10 @@ This basically preserves your mod coloring, user notes etc. for this many second
         group_layout = QVBoxLayout()
         group_box.setLayout(group_layout)
 
-        self.steamcmd_validate_downloads_checkbox = QCheckBox(
-            self.tr("Validate downloaded mods")
-        )
+        self.steamcmd_validate_downloads_checkbox = QCheckBox(self.tr("Validate downloaded mods"))
         group_layout.addWidget(self.steamcmd_validate_downloads_checkbox)
 
-        self.steamcmd_auto_clear_depot_cache_checkbox = QCheckBox(
-            self.tr("Automatically clear depot cache")
-        )
+        self.steamcmd_auto_clear_depot_cache_checkbox = QCheckBox(self.tr("Automatically clear depot cache"))
         self.steamcmd_auto_clear_depot_cache_checkbox.setToolTip(
             (
                 self.tr(
@@ -1097,9 +993,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
         )
         group_layout.addWidget(self.steamcmd_auto_clear_depot_cache_checkbox)
 
-        self.steamcmd_delete_before_update_checkbox = QCheckBox(
-            self.tr("Delete before update")
-        )
+        self.steamcmd_delete_before_update_checkbox = QCheckBox(self.tr("Delete before update"))
         self.steamcmd_delete_before_update_checkbox.setToolTip(
             self.tr("This is useful if you want to ensure clean mod updates.")
         )
@@ -1124,9 +1018,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
 
         self.steamcmd_install_location = QLineEdit()
         self.steamcmd_install_location.setTextMargins(GUIInfo().text_field_margins)
-        self.steamcmd_install_location.setFixedHeight(
-            GUIInfo().default_font_line_height * 2
-        )
+        self.steamcmd_install_location.setFixedHeight(GUIInfo().default_font_line_height * 2)
         group_layout.addWidget(self.steamcmd_install_location)
 
         tab_layout.addStretch()
@@ -1136,9 +1028,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
 
         button_layout.addStretch()
 
-        self.steamcmd_clear_depot_cache_button = QPushButton(
-            self.tr("Clear depot cache")
-        )
+        self.steamcmd_clear_depot_cache_button = QPushButton(self.tr("Clear depot cache"))
         self.steamcmd_clear_depot_cache_button.setToolTip(
             self.tr(
                 "Clear the depot cache manually. This may be useful if you encounter issues with downloading mods through SteamCMD."
@@ -1172,33 +1062,25 @@ This basically preserves your mod coloring, user notes etc. for this many second
         quality_preset_label.setFont(GUIInfo().emphasis_font)
         group_layout.addWidget(quality_preset_label)
 
-        self.todds_preset_optimized_radio = QRadioButton(
-            self.tr("Optimized - Recommended for RimWorld")
-        )
+        self.todds_preset_optimized_radio = QRadioButton(self.tr("Optimized - Recommended for RimWorld"))
         group_layout.addWidget(self.todds_preset_optimized_radio)
 
         self.todds_preset_custom_radio = QRadioButton(self.tr("Custom todds command"))
         group_layout.addWidget(self.todds_preset_custom_radio)
 
         custom_command_label = QLabel(
-            self.tr(
-                "If -p as in path is not specified, path from current active or all mods selection will be used."
-            )
+            self.tr("If -p as in path is not specified, path from current active or all mods selection will be used.")
         )
         custom_command_label.setFont(GUIInfo().emphasis_font)
         group_layout.addWidget(custom_command_label)
 
         self.todds_custom_command_lineedit = QLineEdit()
-        todds_example = (
-            '-f BC1 -af BC7 -on -vf -fs -r Textures -t -p "D:\\Games\\RimWorld\\Mods"'
-        )
+        todds_example = '-f BC1 -af BC7 -on -vf -fs -r Textures -t -p "D:\\Games\\RimWorld\\Mods"'
         self.todds_custom_command_lineedit.setPlaceholderText(
             self.tr("eg: {todds_example}").format(todds_example=todds_example)
         )
         self.todds_custom_command_lineedit.setTextMargins(GUIInfo().text_field_margins)
-        self.todds_custom_command_lineedit.setFixedHeight(
-            GUIInfo().default_font_line_height * 2
-        )
+        self.todds_custom_command_lineedit.setFixedHeight(GUIInfo().default_font_line_height * 2)
         group_layout.addWidget(self.todds_custom_command_lineedit)
 
         group_box = QGroupBox()
@@ -1211,9 +1093,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
         when_optimizing_label.setFont(GUIInfo().emphasis_font)
         group_layout.addWidget(when_optimizing_label)
 
-        self.todds_active_mods_only_radio = QRadioButton(
-            self.tr("Optimize active mods only")
-        )
+        self.todds_active_mods_only_radio = QRadioButton(self.tr("Optimize active mods only"))
         group_layout.addWidget(self.todds_active_mods_only_radio)
 
         self.todds_all_mods_radio = QRadioButton(self.tr("Optimize all mods"))
@@ -1228,15 +1108,11 @@ This basically preserves your mod coloring, user notes etc. for this many second
         self.todds_dry_run_checkbox = QCheckBox(self.tr("Enable dry-run mode"))
         group_layout.addWidget(self.todds_dry_run_checkbox)
 
-        self.todds_overwrite_checkbox = QCheckBox(
-            self.tr("Overwrite existing optimized textures")
-        )
+        self.todds_overwrite_checkbox = QCheckBox(self.tr("Overwrite existing optimized textures"))
         group_layout.addWidget(self.todds_overwrite_checkbox)
 
         self.auto_delete_orphaned_dds_checkbox = QCheckBox(
-            self.tr(
-                "Automatically delete .dds files if no corresponding .png file exists"
-            )
+            self.tr("Automatically delete .dds files if no corresponding .png file exists")
         )
         self.auto_delete_orphaned_dds_checkbox.setToolTip(
             self.tr(
@@ -1288,9 +1164,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
         group_layout.addWidget(folder_arg_label)
         self.text_editor_folder_arg = QLineEdit()
         self.text_editor_folder_arg.setTextMargins(GUIInfo().text_field_margins)
-        self.text_editor_folder_arg.setFixedHeight(
-            GUIInfo().default_font_line_height * 2
-        )
+        self.text_editor_folder_arg.setFixedHeight(GUIInfo().default_font_line_height * 2)
         group_layout.addWidget(self.text_editor_folder_arg)
 
         file_arg_label = QLabel(self.tr("Additional Arguments (Opening Single File)"))
@@ -1337,9 +1211,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
         theme_layout = QHBoxLayout()
         theme_group_box.setLayout(theme_layout)
 
-        self.enable_themes_checkbox = QCheckBox(
-            self.tr("Enable to use theme / stylesheet instead of system Theme")
-        )
+        self.enable_themes_checkbox = QCheckBox(self.tr("Enable to use theme / stylesheet instead of system Theme"))
         self.enable_themes_checkbox.setToolTip(
             self.tr(
                 "To add your own theme / stylesheet \n\n"
@@ -1355,9 +1227,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
         theme_layout.addWidget(self.enable_themes_checkbox)
 
         self.themes_combobox = QComboBox()
-        self.themes_combobox.setSizePolicy(
-            QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred
-        )
+        self.themes_combobox.setSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred)
         theme_layout.addWidget(self.themes_combobox)
 
         self.theme_location_open_button = QToolButton()
@@ -1381,9 +1251,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
         font_family_layout.addWidget(font_family_label)
 
         self.font_family_combobox = QFontComboBox()
-        self.font_family_combobox.setSizePolicy(
-            QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred
-        )
+        self.font_family_combobox.setSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred)
         font_family_layout.addWidget(self.font_family_combobox)
 
         font_size_layout = QHBoxLayout()
@@ -1395,15 +1263,11 @@ This basically preserves your mod coloring, user notes etc. for this many second
         self.font_size_spinbox = QSpinBox()
         self.font_size_spinbox.setRange(8, 20)
         self.font_size_spinbox.setValue(12)
-        self.font_size_spinbox.setSizePolicy(
-            QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred
-        )
+        self.font_size_spinbox.setSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred)
         font_size_layout.addWidget(self.font_size_spinbox)
 
         reset_button = QPushButton(self.tr("Reset"))
-        reset_button.setSizePolicy(
-            QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred
-        )
+        reset_button.setSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred)
 
         reset_button_layout = QHBoxLayout()
         reset_button_layout.addStretch(1)
@@ -1412,9 +1276,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
         reset_button.clicked.connect(self.reset_font_settings)
 
         if self.enable_themes_checkbox.isChecked():
-            self.enable_themes_checkbox.stateChanged.connect(
-                self.connect_populate_themes_combobox
-            )
+            self.enable_themes_checkbox.stateChanged.connect(self.connect_populate_themes_combobox)
         else:
             self.themes_combobox.clear()
 
@@ -1429,15 +1291,11 @@ This basically preserves your mod coloring, user notes etc. for this many second
         language_group_layout = QHBoxLayout()
         language_group_box.setLayout(language_group_layout)
 
-        language_label = QLabel(
-            self.tr("Select Language (Restart required to apply changes)")
-        )
+        language_label = QLabel(self.tr("Select Language (Restart required to apply changes)"))
         language_group_layout.addWidget(language_label)
 
         self.language_combobox = QComboBox()
-        self.language_combobox.setSizePolicy(
-            QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred
-        )
+        self.language_combobox.setSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred)
 
         language_group_layout.addWidget(self.language_combobox)
 
@@ -1500,15 +1358,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         group_layout.addWidget(self.main_window_group)
 
         # Connect main window radio buttons to enable/disable custom size spinboxes dynamically
-        self.main_launch_maximized_radio.toggled.connect(
-            self.disable_main_custom_size_spinboxes
-        )
-        self.main_launch_normal_radio.toggled.connect(
-            self.disable_main_custom_size_spinboxes
-        )
-        self.main_launch_custom_radio.toggled.connect(
-            self.enable_main_custom_size_spinboxes
-        )
+        self.main_launch_maximized_radio.toggled.connect(self.disable_main_custom_size_spinboxes)
+        self.main_launch_normal_radio.toggled.connect(self.disable_main_custom_size_spinboxes)
+        self.main_launch_custom_radio.toggled.connect(self.enable_main_custom_size_spinboxes)
 
         # Browser Window
         (
@@ -1534,15 +1386,9 @@ This basically preserves your mod coloring, user notes etc. for this many second
         group_layout.addWidget(self.browser_window_group)
 
         # Connect browser window radio buttons to enable/disable custom size spinboxes dynamically
-        self.browser_launch_maximized_radio.toggled.connect(
-            self.disable_browser_custom_size_spinboxes
-        )
-        self.browser_launch_normal_radio.toggled.connect(
-            self.disable_browser_custom_size_spinboxes
-        )
-        self.browser_launch_custom_radio.toggled.connect(
-            self.enable_browser_custom_size_spinboxes
-        )
+        self.browser_launch_maximized_radio.toggled.connect(self.disable_browser_custom_size_spinboxes)
+        self.browser_launch_normal_radio.toggled.connect(self.disable_browser_custom_size_spinboxes)
+        self.browser_launch_custom_radio.toggled.connect(self.enable_browser_custom_size_spinboxes)
 
         # Settings Window (only custom option)
         settings_window_title_label = QLabel(self.tr("Settings Window Launch State"))
@@ -1554,9 +1400,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
         settings_window_group.setLayout(settings_window_layout)
 
         self.settings_custom_width_spinbox = QSpinBox()
-        self.settings_custom_width_spinbox.setRange(
-            Settings.MIN_SIZE, Settings.MAX_SIZE
-        )
+        self.settings_custom_width_spinbox.setRange(Settings.MIN_SIZE, Settings.MAX_SIZE)
         self.settings_custom_width_spinbox.setValue(Settings.DEFAULT_WIDTH)
         self.settings_custom_width_spinbox.setSuffix(" px")
         self.settings_custom_width_spinbox.setFixedWidth(100)
@@ -1566,9 +1410,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
         settings_window_layout.addWidget(self.settings_custom_width_spinbox)
 
         self.settings_custom_height_spinbox = QSpinBox()
-        self.settings_custom_height_spinbox.setRange(
-            Settings.MIN_SIZE, Settings.MAX_SIZE
-        )
+        self.settings_custom_height_spinbox.setRange(Settings.MIN_SIZE, Settings.MAX_SIZE)
         self.settings_custom_height_spinbox.setValue(Settings.DEFAULT_HEIGHT)
         self.settings_custom_height_spinbox.setSuffix(" px")
         self.settings_custom_height_spinbox.setFixedWidth(100)
@@ -1639,16 +1481,12 @@ This basically preserves your mod coloring, user notes etc. for this many second
         auth_group.setLayout(auth_group_layout)
 
         rentry_auth_label = QLabel(self.tr("Rentry Auth:"))
-        auth_group_layout.addWidget(
-            rentry_auth_label, 0, 0, alignment=Qt.AlignmentFlag.AlignRight
-        )
+        auth_group_layout.addWidget(rentry_auth_label, 0, 0, alignment=Qt.AlignmentFlag.AlignRight)
 
         self.rentry_auth_code = QLineEdit()
         self.rentry_auth_code.setTextMargins(GUIInfo().text_field_margins)
         self.rentry_auth_code.setFixedHeight(GUIInfo().default_font_line_height * 2)
-        self.rentry_auth_code.setPlaceholderText(
-            self.tr("Obtain rentry auth code by emailing: support@rentry.co")
-        )
+        self.rentry_auth_code.setPlaceholderText(self.tr("Obtain rentry auth code by emailing: support@rentry.co"))
         # TODO: If we add a rentry auth code with builds, we should change placeholder to clarify this code will be used instead of the provided one
         auth_group_layout.addWidget(self.rentry_auth_code, 0, 1)
 
@@ -1659,9 +1497,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
         github_identity_group.setLayout(github_identity_layout)
 
         github_username_label = QLabel(self.tr("GitHub username:"))
-        github_identity_layout.addWidget(
-            github_username_label, 0, 0, alignment=Qt.AlignmentFlag.AlignRight
-        )
+        github_identity_layout.addWidget(github_username_label, 0, 0, alignment=Qt.AlignmentFlag.AlignRight)
 
         self.github_username = QLineEdit()
         self.github_username.setTextMargins(GUIInfo().text_field_margins)
@@ -1669,9 +1505,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
         github_identity_layout.addWidget(self.github_username, 0, 1)
 
         github_token_label = QLabel(self.tr("GitHub personal access token:"))
-        github_identity_layout.addWidget(
-            github_token_label, 1, 0, alignment=Qt.AlignmentFlag.AlignRight
-        )
+        github_identity_layout.addWidget(github_token_label, 1, 0, alignment=Qt.AlignmentFlag.AlignRight)
 
         self.github_token = QLineEdit()
         self.github_token.setEchoMode(QLineEdit.EchoMode.Password)
@@ -1707,18 +1541,14 @@ This basically preserves your mod coloring, user notes etc. for this many second
         self.debug_logging_checkbox = QCheckBox(self.tr("Enable debug logging"))
         group_layout.addWidget(self.debug_logging_checkbox)
 
-        self.watchdog_checkbox = QCheckBox(
-            self.tr("Enable watchdog file monitor daemon")
-        )
+        self.watchdog_checkbox = QCheckBox(self.tr("Enable watchdog file monitor daemon"))
         group_layout.addWidget(self.watchdog_checkbox)
 
         # Clear button behavior
         self.clear_moves_dlc_checkbox = QCheckBox(self.tr("Clear also moves DLC"))
         group_layout.addWidget(self.clear_moves_dlc_checkbox)
 
-        self.auto_launch_steam_checkbox = QCheckBox(
-            self.tr("Automatically launch Steam when needed")
-        )
+        self.auto_launch_steam_checkbox = QCheckBox(self.tr("Automatically launch Steam when needed"))
         self.auto_launch_steam_checkbox.setToolTip(
             self.tr(
                 "If enabled, RimSort will automatically attempt to launch Steam "
@@ -1728,28 +1558,20 @@ This basically preserves your mod coloring, user notes etc. for this many second
         )
         group_layout.addWidget(self.auto_launch_steam_checkbox)
 
-        self.show_mod_updates_checkbox = QCheckBox(
-            self.tr("Check for mod updates on refresh")
-        )
+        self.show_mod_updates_checkbox = QCheckBox(self.tr("Check for mod updates on refresh"))
         group_layout.addWidget(self.show_mod_updates_checkbox)
 
-        self.render_unity_rich_text_checkbox = QCheckBox(
-            self.tr("Render Unity Rich Text in mod descriptions")
-        )
+        self.render_unity_rich_text_checkbox = QCheckBox(self.tr("Render Unity Rich Text in mod descriptions"))
         self.color_background_instead_of_text_checkbox = QCheckBox(
             self.tr("Apply mod coloring to background instead of text")
         )
         group_layout.addWidget(self.color_background_instead_of_text_checkbox)
         self.render_unity_rich_text_checkbox.setToolTip(
-            self.tr(
-                "Enable this option to render Unity Rich Text in mod descriptions. Images will not be displayed."
-            )
+            self.tr("Enable this option to render Unity Rich Text in mod descriptions. Images will not be displayed.")
         )
         group_layout.addWidget(self.render_unity_rich_text_checkbox)
 
-        self.update_databases_on_startup_checkbox = QCheckBox(
-            self.tr("Update databases on startup")
-        )
+        self.update_databases_on_startup_checkbox = QCheckBox(self.tr("Update databases on startup"))
         self.update_databases_on_startup_checkbox.setToolTip(
             self.tr(
                 "Enable this option to automatically update enabled databases when RimSort starts. "
@@ -1762,17 +1584,13 @@ This basically preserves your mod coloring, user notes etc. for this many second
             self.tr("Include mod notes in mod name search filter")
         )
         self.include_mod_notes_in_mod_name_filter_checkbox.setToolTip(
-            self.tr(
-                "This option will include searching mod notes when searching by mod name."
-            )
+            self.tr("This option will include searching mod notes when searching by mod name.")
         )
         group_layout.addWidget(self.include_mod_notes_in_mod_name_filter_checkbox)
 
         # Put checkbox, label and spinbox on the same horizontal line
         backup_layout = QHBoxLayout()
-        self.enable_backup_before_update_checkbox = QCheckBox(
-            self.tr("Create backup before RimSort update")
-        )
+        self.enable_backup_before_update_checkbox = QCheckBox(self.tr("Create backup before RimSort update"))
         self.enable_backup_before_update_checkbox.setToolTip(
             self.tr(
                 "Recommended to keep this enabled as it creates a backup before updating RimSort, "


### PR DESCRIPTION
## Summary

- Add `SteamStatusHandler` for centralized Steam availability notifications
- When Steam isn't running and RimSort needs it, either shows a warning or auto-launches Steam (user-configurable)
- Add "Check Steam Connection" and "Launch Steam" actions to Help menu
- Steam launch polling runs on background QThread to avoid blocking UI

Part of the Steam integration refactor (decomposition of #1623).

## Changes

- `app/utils/steam_status_handler.py` — new module with:
  - Platform-specific Steam executable detection (Windows/macOS/Linux)
  - Process-based Steam running check via psutil
  - `_SteamLaunchWorker(QThread)` for non-blocking Steam launch with 45s timeout
  - `SteamStatusHandler` connecting to EventBus signals
- `app/utils/event_bus.py` — 4 new signals (`steam_not_running`, `steam_operation_failed`, `do_check_steam_connection`, `do_launch_steam`)
- `app/models/settings.py` — `auto_launch_steam` setting (default: disabled)
- `app/views/settings_dialog.py` — checkbox in Advanced tab
- `app/controllers/settings_controller.py` — setting wiring
- `app/views/menu_bar.py` — Help menu actions
- `app/controllers/menu_bar_controller.py` — action handlers
- `app/controllers/app_controller.py` — handler initialization

## Design notes

- **No STEAMWORKS instances created.** `SteamAPI_Init()` is global process state — only the future worker thread (PR 6) should call it. This PR uses process detection only.
- `steam_operation_failed` is `Signal(str, str)` — (pfid, reason) — designed for PR 7's download tracker to identify which item failed.

## Test plan

- [x] `show_information` used for success messages, `show_warning` for errors
- [x] Steam launch runs on background thread (QThread)
- [x] `steam_operation_failed` handler connected and functional
- [x] Settings persistence (checkbox state)
- [x] Menu actions wired to EventBus signals
- [ ] Manual: verify Steam detection on each platform
- [x] Manual: verify auto-launch with Steam not running

🤖 Generated with [Claude Code](https://claude.com/claude-code)