### PR TITLE
refactor: replace multiprocessing Steamworks wrapper with QThread worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,7 @@ ltex.dictionary*
 # Translation cache
 .translation_cache.json
 nuitka-crash-report.xml
+
+# Tool caches
+.ruff_cache
+.uv-cache

--- a/app/__main__.py
+++ b/app/__main__.py
@@ -145,6 +145,13 @@ def main_thread() -> None:
                 logger.warning(
                     f"watchdog received the following exception while exiting: {stacktrace}"
                 )
+            try:
+                from app.views.main_content_panel import MainContent
+
+                if MainContent._instance is not None:
+                    MainContent._instance.cleanup()
+            except Exception as e:
+                logger.warning(f"Error during MainContent cleanup: {e}")
         logger.info("Exiting application!")
         sys.exit()
 

--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -972,6 +972,11 @@ class SettingsController(QObject):
             self.settings.steam_apikey
         )
 
+        # Steam API
+        self.settings_dialog.steam_api_idle_timeout_spinbox.setValue(
+            self.settings.steam_api_idle_timeout
+        )
+
         # SteamCMD tab
         self.settings_dialog.steamcmd_validate_downloads_checkbox.setChecked(
             self.settings.steamcmd_validate_downloads
@@ -1367,6 +1372,11 @@ class SettingsController(QObject):
         self.settings.build_steam_database_update_toggle = self.settings_dialog.db_builder_update_instead_of_overwriting_checkbox.isChecked()
         self.settings.steam_apikey = (
             self.settings_dialog.db_builder_steam_api_key.text()
+        )
+
+        # Steam API
+        self.settings.steam_api_idle_timeout = (
+            self.settings_dialog.steam_api_idle_timeout_spinbox.value()
         )
 
         # SteamCMD tab

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -133,6 +133,9 @@ class Settings(QObject):
         self.build_steam_database_update_toggle: bool = False
         self.steam_apikey: str = ""
 
+        # Steam API
+        self.steam_api_idle_timeout: int = 15
+
         # SteamCMD
         self.steamcmd_validate_downloads: bool = True
         self.steamcmd_delete_before_update: bool = False

--- a/app/utils/event_bus.py
+++ b/app/utils/event_bus.py
@@ -105,6 +105,8 @@ class EventBus(QObject):
     do_save_active_mods_list = Signal()
     do_run_game = Signal()
     do_steamworks_api_call = Signal(list)
+    workshop_item_installed = Signal(str)
+    do_refresh_steamcmd_acf = Signal()
     do_steamcmd_download = Signal(list)
     do_delete_outdated_entries_in_aux_db = Signal()
     do_set_all_entries_in_aux_db_as_outdated = Signal()

--- a/app/utils/steam/steambrowser/js_bridge.py
+++ b/app/utils/steam/steambrowser/js_bridge.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from PySide6.QtCore import QObject, Slot
 
@@ -13,7 +13,7 @@ class JavaScriptBridge(QObject):
     """
 
     def __init__(
-        self, browser_instance: "SteamBrowser", parent: Optional[QObject] = None
+        self, browser_instance: "SteamBrowser", parent: QObject | None = None
     ) -> None:
         super().__init__(parent)
         self._browser_instance = browser_instance

--- a/app/utils/steam/steamcmd/wrapper.py
+++ b/app/utils/steam/steamcmd/wrapper.py
@@ -49,19 +49,20 @@ class SteamcmdInterface:
         return cls._instance
 
     def __init__(self, steamcmd_prefix: str, validate: bool) -> None:
-        if not hasattr(self, "initialized"):
-            self.initialized = True
-            self.setup = False
-            self.steamcmd_prefix = steamcmd_prefix
-            super(SteamcmdInterface, self).__init__()
-            logger.debug("Initializing SteamcmdInterface")
-            self.initialize_prefix(steamcmd_prefix, validate)
+        if hasattr(self, "initialized"):
+            return
+        self.initialized = True
+        self.setup = False
+        self.steamcmd_prefix = steamcmd_prefix
+        super(SteamcmdInterface, self).__init__()
+        logger.debug("Initializing SteamcmdInterface")
+        self.initialize_prefix(steamcmd_prefix, validate)
 
-            EventBus().do_clear_steamcmd_depot_cache.connect(
-                lambda: self.clear_depot_cache()
-            )
-            self.translate = QCoreApplication.translate
-            logger.debug("Finished SteamcmdInterface initialization")
+        EventBus().do_clear_steamcmd_depot_cache.connect(
+            lambda: self.clear_depot_cache()
+        )
+        self.translate = QCoreApplication.translate
+        logger.debug("Finished SteamcmdInterface initialization")
 
     def initialize_prefix(self, steamcmd_prefix: str, validate: bool) -> None:
         self.steamcmd_prefix = steamcmd_prefix

--- a/app/utils/steam/steamworks/wrapper.py
+++ b/app/utils/steam/steamworks/wrapper.py
@@ -20,6 +20,7 @@ Reference:
 
 import concurrent.futures
 import sys
+import threading
 import time
 from dataclasses import dataclass, field
 from os import getcwd
@@ -118,12 +119,13 @@ class SteamworksWorker(QThread):
         self._libs_path = libs_path
         self._last_activity = time.monotonic()
         self._pending_callbacks = 0
-        self._shutdown_requested = False
+        self._callback_generation = 0
+        self._shutdown_event = threading.Event()
 
     def run(self) -> None:
         """Main loop: dequeue ops, pump callbacks, check idle timeout."""
         logger.info("SteamworksWorker thread started")
-        while not self._shutdown_requested:
+        while not self._shutdown_event.is_set():
             # 1. Check queue for new operations
             try:
                 op = self._queue.get(timeout=_LOOP_INTERVAL)
@@ -165,7 +167,7 @@ class SteamworksWorker(QThread):
     def shutdown(self) -> None:
         """Signal shutdown and wait for the thread to finish."""
         logger.info("SteamworksWorker shutdown requested")
-        self._shutdown_requested = True
+        self._shutdown_event.set()
         self.wait(10000)
 
     def update_idle_timeout(self, timeout: int) -> None:
@@ -263,7 +265,7 @@ class SteamworksWorker(QThread):
         deadline = time.monotonic() + timeout
         while (
             self._pending_callbacks > 0
-            and not self._shutdown_requested
+            and not self._shutdown_event.is_set()
             and time.monotonic() < deadline
         ):
             self._pump_callbacks()
@@ -278,7 +280,7 @@ class SteamworksWorker(QThread):
     def _wait_with_callbacks(self, duration: float) -> None:
         """Wait for a duration while continuing to pump callbacks."""
         deadline = time.monotonic() + duration
-        while time.monotonic() < deadline and not self._shutdown_requested:
+        while time.monotonic() < deadline and not self._shutdown_event.is_set():
             self._pump_callbacks()
             time.sleep(_LOOP_INTERVAL)
 
@@ -305,9 +307,13 @@ class SteamworksWorker(QThread):
             self.operation_complete.emit("subscribe", False)
             return
 
+        self._callback_generation += 1
+        gen = self._callback_generation
         self._pending_callbacks = len(op.pfids)
 
         def on_subscribed(*args: Any, **kwargs: Any) -> None:
+            if gen != self._callback_generation:
+                return
             self._pending_callbacks = max(0, self._pending_callbacks - 1)
             self._last_activity = time.monotonic()
             try:
@@ -342,9 +348,13 @@ class SteamworksWorker(QThread):
             self.operation_complete.emit("unsubscribe", False)
             return
 
+        self._callback_generation += 1
+        gen = self._callback_generation
         self._pending_callbacks = len(op.pfids)
 
         def on_unsubscribed(*args: Any, **kwargs: Any) -> None:
+            if gen != self._callback_generation:
+                return
             self._pending_callbacks = max(0, self._pending_callbacks - 1)
             self._last_activity = time.monotonic()
             try:
@@ -386,9 +396,13 @@ class SteamworksWorker(QThread):
             return
 
         # 2 callbacks per pfid: 1 unsub + 1 sub (download callbacks unreliable)
+        self._callback_generation += 1
+        gen = self._callback_generation
         self._pending_callbacks = len(op.pfids) * 2
 
         def on_unsubscribed(*args: Any, **kwargs: Any) -> None:
+            if gen != self._callback_generation:
+                return
             self._pending_callbacks = max(0, self._pending_callbacks - 1)
             self._last_activity = time.monotonic()
             try:
@@ -407,6 +421,8 @@ class SteamworksWorker(QThread):
                 logger.error(f"Error in resubscribe unsub callback: {e}")
 
         def on_subscribed(*args: Any, **kwargs: Any) -> None:
+            if gen != self._callback_generation:
+                return
             self._pending_callbacks = max(0, self._pending_callbacks - 1)
             self._last_activity = time.monotonic()
             try:
@@ -507,10 +523,14 @@ class SteamworksWorker(QThread):
             op.result_future.set_result(None)
             return
 
+        self._callback_generation += 1
+        gen = self._callback_generation
         self._pending_callbacks = len(op.pfids)
         results: dict[int, Any] = {}
 
         def on_result(*args: Any, **kwargs: Any) -> None:
+            if gen != self._callback_generation:
+                return
             self._pending_callbacks = max(0, self._pending_callbacks - 1)
             self._last_activity = time.monotonic()
             try:

--- a/app/utils/steam/steamworks/wrapper.py
+++ b/app/utils/steam/steamworks/wrapper.py
@@ -29,7 +29,7 @@ from queue import Empty, Queue
 from typing import Any
 
 from loguru import logger
-from PySide6.QtCore import QThread, Signal
+from PySide6.QtCore import QThread, Signal, SignalInstance
 
 from app.utils.generic import launch_game_process
 
@@ -228,7 +228,7 @@ class SteamworksWorker(QThread):
         if self._steamworks is None or not self._steamworks.loaded():
             return None
         try:
-            return self._steamworks.Workshop.GetItemDownloadInfo(pfid)  # type: ignore[no-any-return]
+            return self._steamworks.Workshop.GetItemDownloadInfo(pfid)
         except Exception:
             return None
 
@@ -296,6 +296,52 @@ class SteamworksWorker(QThread):
             self._pump_callbacks()
             time.sleep(_LOOP_INTERVAL)
 
+    def _tick_callback(self, gen: int) -> bool:
+        """Shared preamble for Steamworks callbacks: check generation, decrement
+        pending count, and refresh last-activity timestamp.
+
+        :return: True if callback is current and should be processed.
+        """
+        if gen != self._callback_generation:
+            return False
+        self._pending_callbacks = max(0, self._pending_callbacks - 1)
+        self._last_activity = time.monotonic()
+        return True
+
+    def _make_callback(
+        self,
+        gen: int,
+        op_label: str,
+        success_signal: SignalInstance | None = None,
+    ) -> Any:
+        """Build a Steamworks callback closure that handles generation checks,
+        pending-count bookkeeping, result logging, and signal emission.
+
+        :param gen: callback generation at time of registration
+        :param op_label: human-readable label for log lines (e.g. "Subscribe")
+        :param success_signal: optional signal(str) emitted on result==1
+        """
+
+        def _cb(*args: Any, **kwargs: Any) -> None:
+            if not self._tick_callback(gen):
+                return
+            try:
+                pfid = args[0].publishedFileId
+                result = args[0].result
+                if result == 1:
+                    logger.info(f"{op_label} succeeded for {pfid}")
+                    if success_signal is not None:
+                        success_signal.emit(str(pfid))
+                else:
+                    logger.error(f"{op_label} failed for {pfid}: result={result}")
+                    self.steam_operation_failed.emit(
+                        str(pfid), f"{op_label.lower()} failed"
+                    )
+            except Exception as e:
+                logger.error(f"Error in {op_label} callback: {e}")
+
+        return _cb
+
     def _execute_operation(self, op: SteamworksOperation) -> None:
         if isinstance(op, SubscribeOp):
             self._handle_subscribe(op)
@@ -320,29 +366,15 @@ class SteamworksWorker(QThread):
         if not self._ensure_initialized():
             self.operation_complete.emit("subscribe", False)
             return
+        assert self._steamworks is not None
 
         self._callback_generation += 1
         gen = self._callback_generation
         self._pending_callbacks = len(op.pfids)
 
-        def on_subscribed(*args: Any, **kwargs: Any) -> None:
-            if gen != self._callback_generation:
-                return
-            self._pending_callbacks = max(0, self._pending_callbacks - 1)
-            self._last_activity = time.monotonic()
-            try:
-                pfid = args[0].publishedFileId
-                result = args[0].result
-                if result == 1:
-                    logger.info(f"Subscribe succeeded for {pfid}")
-                    self.item_subscribed.emit(str(pfid))
-                else:
-                    logger.error(f"Subscribe failed for {pfid}: result={result}")
-                    self.steam_operation_failed.emit(str(pfid), "subscribe failed")
-            except Exception as e:
-                logger.error(f"Error in subscribe callback: {e}")
-
-        self._steamworks.Workshop.SetItemSubscribedCallback(on_subscribed)
+        self._steamworks.Workshop.SetItemSubscribedCallback(
+            self._make_callback(gen, "Subscribe", self.item_subscribed)
+        )
 
         for idx, pfid in enumerate(op.pfids):
             logger.debug(f"SubscribeItem({pfid})")
@@ -361,29 +393,15 @@ class SteamworksWorker(QThread):
         if not self._ensure_initialized():
             self.operation_complete.emit("unsubscribe", False)
             return
+        assert self._steamworks is not None
 
         self._callback_generation += 1
         gen = self._callback_generation
         self._pending_callbacks = len(op.pfids)
 
-        def on_unsubscribed(*args: Any, **kwargs: Any) -> None:
-            if gen != self._callback_generation:
-                return
-            self._pending_callbacks = max(0, self._pending_callbacks - 1)
-            self._last_activity = time.monotonic()
-            try:
-                pfid = args[0].publishedFileId
-                result = args[0].result
-                if result == 1:
-                    logger.info(f"Unsubscribe succeeded for {pfid}")
-                    self.item_unsubscribed.emit(str(pfid))
-                else:
-                    logger.error(f"Unsubscribe failed for {pfid}: result={result}")
-                    self.steam_operation_failed.emit(str(pfid), "unsubscribe failed")
-            except Exception as e:
-                logger.error(f"Error in unsubscribe callback: {e}")
-
-        self._steamworks.Workshop.SetItemUnsubscribedCallback(on_unsubscribed)
+        self._steamworks.Workshop.SetItemUnsubscribedCallback(
+            self._make_callback(gen, "Unsubscribe", self.item_unsubscribed)
+        )
 
         for idx, pfid in enumerate(op.pfids):
             logger.debug(f"UnsubscribeItem({pfid})")
@@ -408,53 +426,19 @@ class SteamworksWorker(QThread):
         if not self._ensure_initialized():
             self.operation_complete.emit("resubscribe", False)
             return
+        assert self._steamworks is not None
 
         # 2 callbacks per pfid: 1 unsub + 1 sub (download callbacks unreliable)
         self._callback_generation += 1
         gen = self._callback_generation
         self._pending_callbacks = len(op.pfids) * 2
 
-        def on_unsubscribed(*args: Any, **kwargs: Any) -> None:
-            if gen != self._callback_generation:
-                return
-            self._pending_callbacks = max(0, self._pending_callbacks - 1)
-            self._last_activity = time.monotonic()
-            try:
-                pfid = args[0].publishedFileId
-                result = args[0].result
-                if result == 1:
-                    logger.info(f"Resubscribe unsub succeeded for {pfid}")
-                else:
-                    logger.error(
-                        f"Resubscribe unsub failed for {pfid}: result={result}"
-                    )
-                    self.steam_operation_failed.emit(
-                        str(pfid), "resubscribe unsub failed"
-                    )
-            except Exception as e:
-                logger.error(f"Error in resubscribe unsub callback: {e}")
-
-        def on_subscribed(*args: Any, **kwargs: Any) -> None:
-            if gen != self._callback_generation:
-                return
-            self._pending_callbacks = max(0, self._pending_callbacks - 1)
-            self._last_activity = time.monotonic()
-            try:
-                pfid = args[0].publishedFileId
-                result = args[0].result
-                if result == 1:
-                    logger.info(f"Resubscribe sub succeeded for {pfid}")
-                    self.item_subscribed.emit(str(pfid))
-                else:
-                    logger.error(f"Resubscribe sub failed for {pfid}: result={result}")
-                    self.steam_operation_failed.emit(
-                        str(pfid), "resubscribe sub failed"
-                    )
-            except Exception as e:
-                logger.error(f"Error in resubscribe sub callback: {e}")
-
-        self._steamworks.Workshop.SetItemUnsubscribedCallback(on_unsubscribed)
-        self._steamworks.Workshop.SetItemSubscribedCallback(on_subscribed)
+        self._steamworks.Workshop.SetItemUnsubscribedCallback(
+            self._make_callback(gen, "Resubscribe unsub")
+        )
+        self._steamworks.Workshop.SetItemSubscribedCallback(
+            self._make_callback(gen, "Resubscribe sub", self.item_subscribed)
+        )
 
         # Stage 1: Unsubscribe ALL
         logger.info(f"RESUBSCRIBE Stage 1: Unsubscribing {len(op.pfids)} mod(s)")
@@ -480,40 +464,21 @@ class SteamworksWorker(QThread):
 
         # Stage 5: Force download ALL (preserving PR #1918 hasattr guard)
         logger.info(f"RESUBSCRIBE Stage 5: Downloading {len(op.pfids)} mod(s)")
-        if hasattr(self._steamworks.Workshop, "DownloadItem"):
-            for pfid in op.pfids:
-                try:
-                    self._steamworks.Workshop.DownloadItem(
-                        pfid,
-                        high_priority=True,
-                        callback=lambda *a, **kw: None,
-                        override_callback=True,
-                    )
-                except Exception as e:
-                    logger.error(f"Failed to trigger download for {pfid}: {e}")
-        else:
-            logger.warning(
-                "DownloadItem skipped: not supported by SteamworksPy library."
-            )
+        self._try_download_items(op.pfids)
 
         success = self._wait_for_pending_callbacks(timeout=60)
         self.operation_complete.emit("resubscribe", success)
 
-    def _handle_force_download(self, op: ForceDownloadOp) -> None:
-        if not op.pfids:
-            self.operation_complete.emit("force_download", True)
-            return
-        logger.info(f"FORCE DOWNLOAD: {len(op.pfids)} mod(s)")
-        if not self._ensure_initialized():
-            self.operation_complete.emit("force_download", False)
-            return
-
-        if not hasattr(self._steamworks.Workshop, "DownloadItem"):
-            logger.warning("DownloadItem not supported by SteamworksPy library.")
-            self.operation_complete.emit("force_download", False)
-            return
-
-        for pfid in op.pfids:
+    def _try_download_items(self, pfids: list[int]) -> bool:
+        """Attempt DownloadItem for each pfid. Returns False if unsupported."""
+        if self._steamworks is None or not hasattr(
+            self._steamworks.Workshop, "DownloadItem"
+        ):
+            logger.warning(
+                "DownloadItem skipped: not supported by SteamworksPy library."
+            )
+            return False
+        for pfid in pfids:
             try:
                 self._steamworks.Workshop.DownloadItem(
                     pfid,
@@ -524,9 +489,20 @@ class SteamworksWorker(QThread):
             except Exception as e:
                 logger.error(f"Failed to trigger download for {pfid}: {e}")
                 self.steam_operation_failed.emit(str(pfid), f"download failed: {e}")
+        return True
 
+    def _handle_force_download(self, op: ForceDownloadOp) -> None:
+        if not op.pfids:
+            self.operation_complete.emit("force_download", True)
+            return
+        logger.info(f"FORCE DOWNLOAD: {len(op.pfids)} mod(s)")
+        if not self._ensure_initialized():
+            self.operation_complete.emit("force_download", False)
+            return
+
+        success = self._try_download_items(op.pfids)
         # No callback counting — download callbacks are unreliable
-        self.operation_complete.emit("force_download", True)
+        self.operation_complete.emit("force_download", success)
 
     def _handle_game_launch(self, op: GameLaunchOp) -> None:
         """Initialize Steamworks for Steam overlay, launch the game, then unload."""
@@ -545,6 +521,7 @@ class SteamworksWorker(QThread):
         if not self._ensure_initialized():
             op.result_future.set_result(None)
             return
+        assert self._steamworks is not None
 
         self._callback_generation += 1
         gen = self._callback_generation
@@ -552,10 +529,8 @@ class SteamworksWorker(QThread):
         results: dict[int, Any] = {}
 
         def on_result(*args: Any, **kwargs: Any) -> None:
-            if gen != self._callback_generation:
+            if not self._tick_callback(gen):
                 return
-            self._pending_callbacks = max(0, self._pending_callbacks - 1)
-            self._last_activity = time.monotonic()
             try:
                 pfid = args[0].publishedFileId
                 app_dependencies_list = args[0].get_app_dependencies_list()

--- a/app/utils/steam/steamworks/wrapper.py
+++ b/app/utils/steam/steamworks/wrapper.py
@@ -31,6 +31,8 @@ from typing import Any
 from loguru import logger
 from PySide6.QtCore import QThread, Signal
 
+from app.utils.generic import launch_game_process
+
 # Ensure SteamworksPy module is in Python path when running from interpreter
 if "__compiled__" not in globals():
     sys.path.append(str((Path(getcwd()) / "submodules" / "SteamworksPy")))
@@ -73,6 +75,12 @@ class ResubscribeOp(SteamworksOperation):
 @dataclass
 class ForceDownloadOp(SteamworksOperation):
     pfids: list[int] = field(default_factory=list)
+
+
+@dataclass
+class GameLaunchOp(SteamworksOperation):
+    game_install_path: str = ""
+    args: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -187,6 +195,9 @@ class SteamworksWorker(QThread):
     def force_download(self, pfids: list[int]) -> None:
         self.submit(ForceDownloadOp(pfids=pfids))
 
+    def launch_game(self, game_install_path: str, args: list[str]) -> None:
+        self.submit(GameLaunchOp(game_install_path=game_install_path, args=args))
+
     def query_app_dependencies(
         self, pfids: list[int]
     ) -> concurrent.futures.Future[dict[int, Any] | None]:
@@ -242,6 +253,7 @@ class SteamworksWorker(QThread):
 
     def _unload(self) -> None:
         if self._steamworks is not None:
+            self._callback_generation += 1
             try:
                 self._steamworks.unload()
             except Exception as e:
@@ -293,6 +305,8 @@ class SteamworksWorker(QThread):
             self._handle_resubscribe(op)
         elif isinstance(op, ForceDownloadOp):
             self._handle_force_download(op)
+        elif isinstance(op, GameLaunchOp):
+            self._handle_game_launch(op)
         elif isinstance(op, AppDependenciesOp):
             self._handle_app_dependencies(op)
         else:
@@ -513,6 +527,15 @@ class SteamworksWorker(QThread):
 
         # No callback counting — download callbacks are unreliable
         self.operation_complete.emit("force_download", True)
+
+    def _handle_game_launch(self, op: GameLaunchOp) -> None:
+        """Initialize Steamworks for Steam overlay, launch the game, then unload."""
+        logger.info("GAME LAUNCH: initializing Steamworks before launch")
+        self._ensure_initialized()
+        launch_game_process(game_install_path=Path(op.game_install_path), args=op.args)
+        # Unload immediately — don't hold the handle while the game runs
+        self._unload()
+        self.operation_complete.emit("game_launch", True)
 
     def _handle_app_dependencies(self, op: AppDependenciesOp) -> None:
         if not op.pfids:

--- a/app/utils/steam/steamworks/wrapper.py
+++ b/app/utils/steam/steamworks/wrapper.py
@@ -549,7 +549,7 @@ class SteamworksWorker(QThread):
             logger.debug(f"GetAppDependencies({pfid})")
             self._steamworks.Workshop.GetAppDependencies(pfid)
             if idx < len(op.pfids) - 1:
-                time.sleep(1)
+                self._wait_with_callbacks(1)
 
         self._wait_for_pending_callbacks(timeout=60)
         op.result_future.set_result(results)

--- a/app/utils/steam/steamworks/wrapper.py
+++ b/app/utils/steam/steamworks/wrapper.py
@@ -1,678 +1,537 @@
 """
-Steamworks API Wrapper Module
+Steamworks API Worker Thread Module
 
-Provides Python wrappers for Steamworks API interactions including:
-- Workshop mod subscription/unsubscription (ISteamUGC)
-- Game launching with Steamworks integration
-- App dependency queries
-- Callback-based async event handling
+Provides a QThread-based worker that owns the STEAMWORKS instance lifecycle.
+Operations are submitted via a thread-safe queue; results are communicated
+back via Qt Signals. The worker auto-unloads the Steamworks API after a
+configurable idle timeout to avoid Steam reporting the game as running.
 
-Key features:
-- Proper sequencing for resubscribe operations (unsub → wait → sub → download)
-- Sequential processing for subscribe/unsubscribe operations
-- Thread-safe callback handling with timeout management
-- Comprehensive logging for debugging and monitoring
-
-Usage:
-    - SteamworksSubscriptionHandler: Handle mod subscription operations
-    - SteamworksGameLaunch: Launch RimWorld with Steamworks initialized
-    - SteamworksAppDependenciesQuery: Query mod dependencies
+Key classes:
+    SteamworksWorker: QThread worker owning STEAMWORKS lifecycle
+    SteamworksOperation: Base dataclass for operation submission
+    SubscribeOp, UnsubscribeOp, ResubscribeOp: Subscription operations
+    AppDependenciesOp: DLC dependency query operation
+    ForceDownloadOp: Direct download trigger operation
 
 Reference:
     https://partner.steamgames.com/doc/api/ISteamUGC
     https://github.com/philippj/SteamworksPy
-    https://philippj.github.io/SteamworksPy
-    https://github.com/philippj/SteamworksPy/issues/62
-    https://github.com/philippj/SteamworksPy/issues/75
-    https://github.com/philippj/SteamworksPy/pull/76
 """
 
+import concurrent.futures
 import sys
-from multiprocessing import Process
+import time
+from dataclasses import dataclass, field
 from os import getcwd
 from pathlib import Path
-from threading import Thread
-from time import sleep, time
-from typing import Any, Callable, Union
+from queue import Empty, Queue
+from typing import Any
 
 from loguru import logger
+from PySide6.QtCore import QThread, Signal
 
-# If we're running from a Python interpreter, Ensure SteamworksPy module is in Python path, sys.path ($PYTHONPATH)
-# Ensure that this is available by running via: git submodule update --init --recursive
-# You can automatically ensure this is done by utilizing distribute.py
+# Ensure SteamworksPy module is in Python path when running from interpreter
 if "__compiled__" not in globals():
     sys.path.append(str((Path(getcwd()) / "submodules" / "SteamworksPy")))
 
-from app.utils.generic import launch_game_process
 from steamworks import STEAMWORKS  # type: ignore
 
-# Timing constants for subscription operations
-RESUBSCRIBE_UNSUBSCRIBE_WAIT = 4  # Seconds to wait for Steam to uninstall files
-RESUBSCRIBE_SUBSCRIBE_WAIT = 2  # Seconds to wait for Steam to register subscriptions
-API_CALL_GAP = 0.5  # Seconds between API calls to space them out
-SUBSCRIBE_UNSUBSCRIBE_INTERVAL = (
-    0.5  # Seconds between operations in subscribe/unsubscribe
-)
+# Timing constants for subscription operations (preserved from original)
+RESUBSCRIBE_UNSUBSCRIBE_WAIT = 4
+RESUBSCRIBE_SUBSCRIBE_WAIT = 2
+API_CALL_GAP = 0.5
+SUBSCRIBE_UNSUBSCRIBE_INTERVAL = 0.5
+
+# Worker loop interval (seconds) — controls callback pump rate (~10 Hz)
+_LOOP_INTERVAL = 0.1
 
 
-class SteamworksInterface:
+# --- Operation dataclasses ---
+
+
+@dataclass
+class SteamworksOperation:
+    """Base class for all operations submitted to the worker."""
+
+
+@dataclass
+class SubscribeOp(SteamworksOperation):
+    pfids: list[int] = field(default_factory=list)
+
+
+@dataclass
+class UnsubscribeOp(SteamworksOperation):
+    pfids: list[int] = field(default_factory=list)
+
+
+@dataclass
+class ResubscribeOp(SteamworksOperation):
+    pfids: list[int] = field(default_factory=list)
+
+
+@dataclass
+class ForceDownloadOp(SteamworksOperation):
+    pfids: list[int] = field(default_factory=list)
+
+
+@dataclass
+class AppDependenciesOp(SteamworksOperation):
+    pfids: list[int] = field(default_factory=list)
+    result_future: concurrent.futures.Future[dict[int, Any] | None] = field(
+        default_factory=concurrent.futures.Future
+    )
+    # NOTE: Always pass result_future explicitly via query_app_dependencies().
+    # The default_factory exists only to satisfy dataclass field ordering.
+
+
+# --- Worker thread ---
+
+
+class SteamworksWorker(QThread):
     """
-    Low-level Steamworks API interface wrapper.
+    QThread worker that owns the STEAMWORKS instance lifecycle.
 
-    Manages Steamworks SDK initialization, callback threading, and lifecycle.
-    Provides callback-based async event handling for Steam operations.
+    Operations are submitted via a thread-safe queue. The worker pumps
+    Steamworks callbacks in its run loop and auto-unloads the API after
+    an idle timeout (default 15s) to prevent Steam from showing the game
+    as running while RimSort is open.
 
-    Attributes:
-        callbacks (bool): Whether to enable callback-based event handling
-        callbacks_count (int): Number of callbacks received so far
-        callbacks_total (int | None): Total callbacks expected (for multi-operation batches)
-        multiple_queries (bool): Whether multiple async operations are in flight
-        end_callbacks (bool): Signal to end the callback thread
-        steam_not_running (bool): Whether Steam was unavailable during init
-        steamworks: STEAMWORKS SDK instance
-        steamworks_thread (Thread): Background thread running callback loop
-        get_app_deps_query_result (dict): Cached AppDependencies query results
-
-    Reference:
-    https://partner.steamgames.com/doc/api/ISteamUGC
-    https://github.com/philippj/SteamworksPy
-    https://philippj.github.io/SteamworksPy
-    https://github.com/philippj/SteamworksPy/issues/62
-    https://github.com/philippj/SteamworksPy/issues/75
-    https://github.com/philippj/SteamworksPy/pull/76
+    Signals:
+        operation_complete: (op_type: str, success: bool)
+        steam_not_running: Emitted when STEAMWORKS.initialize() fails
+        steam_operation_failed: (pfid: str, reason: str)
+        item_subscribed: (pfid: str)
+        item_unsubscribed: (pfid: str)
     """
 
-    def __init__(
-        self,
-        callbacks: bool,
-        callbacks_total: int | None = None,
-        _libs: str | None = None,
-    ) -> None:
-        """
-        Initialize Steamworks API interface.
+    operation_complete = Signal(str, bool)
+    steam_not_running = Signal()
+    steam_operation_failed = Signal(str, str)
+    item_subscribed = Signal(str)
+    item_unsubscribed = Signal(str)
 
-        Args:
-            callbacks: Enable callback-based async event handling
-            callbacks_total: Expected number of callbacks (for multi-op batches)
-            _libs: Optional path to prebuilt Steamworks libraries
-        """
-        logger.info("SteamworksInterface initializing...")
-        self.callbacks = callbacks
-        self.callbacks_count = 0
-        self.callbacks_total = callbacks_total
-        if self.callbacks:
-            logger.debug("Callbacks enabled!")
-            self.end_callbacks = False  # Signal used to end the _callbacks Thread
+    def __init__(self, idle_timeout: int = 15, libs_path: str | None = None) -> None:
+        super().__init__()
+        self._queue: Queue[SteamworksOperation] = Queue()
+        self._steamworks: STEAMWORKS | None = None
+        self._idle_timeout = idle_timeout
+        self._libs_path = libs_path
+        self._last_activity = time.monotonic()
+        self._pending_callbacks = 0
+        self._shutdown_requested = False
+
+    def run(self) -> None:
+        """Main loop: dequeue ops, pump callbacks, check idle timeout."""
+        logger.info("SteamworksWorker thread started")
+        while not self._shutdown_requested:
+            # 1. Check queue for new operations
+            try:
+                op = self._queue.get(timeout=_LOOP_INTERVAL)
+                self._last_activity = time.monotonic()
+                self._execute_operation(op)
+            except Empty:
+                pass
+
+            # 2. Pump callbacks if Steamworks is loaded
+            self._pump_callbacks()
+
+            # 3. Check idle timeout (only when no pending work)
             if (
-                self.callbacks_total
-            ):  # Pass this if you want to do multiple actions with 1 initialization
-                logger.debug(f"Callbacks total : {self.callbacks_total}")
-                self.multiple_queries = True
-            else:
-                self.multiple_queries = False
-        # Used for GetAppDependencies data
-        self.get_app_deps_query_result: dict[int, Any] = {}
-        self.steam_not_running = False  # Skip action if True. Log occurrences.
-        self.steamworks = STEAMWORKS(_libs=_libs)
+                self._steamworks is not None
+                and self._pending_callbacks <= 0
+                and self._queue.empty()
+                and time.monotonic() - self._last_activity > self._idle_timeout
+            ):
+                logger.info("Idle timeout reached, unloading Steamworks API")
+                self._unload()
+
+        # Drain pending callbacks before final unload (max 5s grace period)
+        if self._steamworks is not None:
+            if self._pending_callbacks > 0:
+                logger.info(
+                    f"Draining {self._pending_callbacks} pending callback(s) before shutdown..."
+                )
+                deadline = time.monotonic() + 5.0
+                while self._pending_callbacks > 0 and time.monotonic() < deadline:
+                    self._pump_callbacks()
+                    time.sleep(_LOOP_INTERVAL)
+            self._unload()
+        logger.info("SteamworksWorker thread stopped")
+
+    def submit(self, op: SteamworksOperation) -> None:
+        """Thread-safe enqueue from any thread."""
+        self._queue.put(op)
+
+    def shutdown(self) -> None:
+        """Signal shutdown and wait for the thread to finish."""
+        logger.info("SteamworksWorker shutdown requested")
+        self._shutdown_requested = True
+        self.wait(10000)
+
+    def update_idle_timeout(self, timeout: int) -> None:
+        self._idle_timeout = timeout
+
+    # --- Convenience methods (submit typed operations) ---
+
+    def subscribe(self, pfids: list[int]) -> None:
+        self.submit(SubscribeOp(pfids=pfids))
+
+    def unsubscribe(self, pfids: list[int]) -> None:
+        self.submit(UnsubscribeOp(pfids=pfids))
+
+    def resubscribe(self, pfids: list[int]) -> None:
+        self.submit(ResubscribeOp(pfids=pfids))
+
+    def force_download(self, pfids: list[int]) -> None:
+        self.submit(ForceDownloadOp(pfids=pfids))
+
+    def query_app_dependencies(
+        self, pfids: list[int]
+    ) -> concurrent.futures.Future[dict[int, Any] | None]:
+        future: concurrent.futures.Future[dict[int, Any] | None] = (
+            concurrent.futures.Future()
+        )
+        self.submit(AppDependenciesOp(pfids=pfids, result_future=future))
+        return future
+
+    # --- Query methods (called cross-thread) ---
+    # These read _steamworks without synchronization. Safe under CPython's
+    # GIL for simple attribute reads; the try/except guards against TOCTOU
+    # races if _unload() sets _steamworks to None between the check and call.
+    # If PR 7 needs heavy use of these, route through the operation queue.
+
+    def health_check(self) -> bool:
+        return self._steamworks is not None and self._steamworks.loaded()
+
+    def get_item_state(self, pfid: int) -> int | None:
+        if self._steamworks is None or not self._steamworks.loaded():
+            return None
         try:
-            self.steamworks.initialize()  # Init the Steamworks API
+            return int(self._steamworks.Workshop.GetItemState(pfid))
+        except Exception:
+            return None
+
+    def get_item_download_info(self, pfid: int) -> dict[str, Any] | None:
+        if self._steamworks is None or not self._steamworks.loaded():
+            return None
+        try:
+            return self._steamworks.Workshop.GetItemDownloadInfo(pfid)  # type: ignore[no-any-return]
+        except Exception:
+            return None
+
+    # --- Internal methods (run on worker thread only) ---
+
+    def _ensure_initialized(self) -> bool:
+        if self._steamworks is not None and self._steamworks.loaded():
+            return True
+
+        try:
+            self._steamworks = STEAMWORKS(_libs=self._libs_path)
+            self._steamworks.initialize()
+            logger.info("Steamworks API initialized")
+            return True
         except Exception as e:
             logger.warning(
-                f"Unable to initialize Steamworks API due to exception: {e.__class__.__name__}"
+                f"Unable to initialize Steamworks API: {e.__class__.__name__}: {e}"
             )
-            logger.warning(
-                "If you are a Steam user, please check that Steam running and that you are logged in..."
-            )
-            self.steam_not_running = True
-        if not self.steam_not_running:  # Skip if True
-            if self.callbacks:
-                # Start the thread
-                logger.debug("Starting thread")
-                self.steamworks_thread = self._daemon()
-                self.steamworks_thread.start()
+            self.steam_not_running.emit()
+            self._steamworks = None
+            return False
 
-    def _callbacks(self) -> None:
+    def _unload(self) -> None:
+        if self._steamworks is not None:
+            try:
+                self._steamworks.unload()
+            except Exception as e:
+                logger.warning(f"Error unloading Steamworks: {e}")
+            self._steamworks = None
+            self._pending_callbacks = 0
+            logger.info("Steamworks API unloaded")
+
+    def _pump_callbacks(self) -> None:
+        if self._steamworks is not None and self._steamworks.loaded():
+            try:
+                self._steamworks.run_callbacks()
+            except Exception as e:
+                logger.debug(f"run_callbacks error: {e}")
+
+    def _wait_for_pending_callbacks(self, timeout: float) -> bool:
+        """Wait for _pending_callbacks to reach zero while pumping callbacks.
+
+        :return: True if all callbacks completed, False if timed out.
         """
-        Background thread target for processing Steamworks callbacks.
-
-        Runs in a daemon thread, calling steamworks.run_callbacks() repeatedly
-        until self.end_callbacks is set. Callbacks fire asynchronously and
-        invoke handlers registered via SetItemSubscribedCallback, etc.
-        """
-        logger.debug("Starting _callbacks")
-        # Wait for Steamworks to be fully loaded
-        while not self.steamworks.loaded():
-            logger.warning("Waiting for Steamworks...")
-        else:
-            logger.info("Steamworks loaded!")
-
-        # Main callback loop - process events every 100ms until signaled to stop
-        while not self.end_callbacks:
-            self.steamworks.run_callbacks()
-            sleep(0.1)
-        else:
-            logger.info(
-                f"{self.callbacks_count} callback(s) received. Ending thread..."
-            )
-
-    # TODO: Rework this for proper static type checking
-    def _cb_app_dependencies_result_callback(self, *args: Any, **kwargs: Any) -> None:
-        """
-        Executes upon Steamworks API callback response
-        """
-        # Add to callbacks count
-        self.callbacks_count = self.callbacks_count + 1
-        # Debug prints
-        logger.debug(f"GetAppDependencies query callback: {args}, {kwargs}")
-        logger.debug(f"result : {args[0].result}")
-        pfid = args[0].publishedFileId
-        logger.debug(f"publishedFileId : {pfid}")
-        app_dependencies_list = args[0].get_app_dependencies_list()
-        logger.debug(f"app_dependencies_list : {app_dependencies_list}")
-        # Collect data for our query if dependencies were returned
-        if len(app_dependencies_list) > 0:
-            self.get_app_deps_query_result[pfid] = app_dependencies_list
-        # Check for multiple actions
-        if self.multiple_queries and self.callbacks_count == self.callbacks_total:
-            # Set flag so that _callbacks cease
-            self.end_callbacks = True
-        elif not self.multiple_queries:
-            # Set flag so that _callbacks cease
-            self.end_callbacks = True
-
-    def _daemon(self) -> Thread:
-        """
-        Returns a Thread pointing to our _callbacks daemon
-        """
-        return Thread(target=self._callbacks, daemon=True)
-
-    def _wait_for_callbacks(self, timeout: int) -> None:
-        """
-        Waits for the Steamworks API callbacks to complete within a specified time interval.
-
-        Args:
-            timeout (int): Maximum time to wait in seconds.
-
-        Returns:
-            None
-        """
-        start_time = time()
-        logger.debug(f"Waiting {timeout} seconds for Steamworks API callbacks...")
-        while self.steamworks_thread.is_alive():
-            elapsed_time = time() - start_time
-            if elapsed_time >= timeout:
-                self.end_callbacks = True
-                break
-            sleep(1)
-
-
-class SteamworksAppDependenciesQuery:
-    def __init__(
-        self,
-        pfid_or_pfids: Union[int, list[int]],
-        interval: int = 1,
-        _libs: str | None = None,
-    ) -> None:
-        self._libs = _libs
-        self.interval = interval
-        self.pfid_or_pfids = pfid_or_pfids
-
-    def run(self) -> None | dict[int, Any]:
-        """
-        Query PublishedFileIDs for AppID dependency data
-        :param pfid_or_pfids: is an int that corresponds with a subscribed Steam mod's PublishedFileId
-                            OR is a list of int that corresponds with multiple Steam mod PublishedFileIds
-        :param interval: time in seconds to sleep between multiple subsequent API calls
-        """
-        logger.info(
-            f"Creating SteamworksInterface and passing PublishedFileID(s) {self.pfid_or_pfids}"
-        )
-        # If the chunk passed is a single int, convert it into a list in an effort to simplify procedure
-        if isinstance(self.pfid_or_pfids, int):
-            self.pfid_or_pfids = [self.pfid_or_pfids]
-        # Create our Steamworks interface and initialize Steamworks API
-        steamworks_interface = SteamworksInterface(
-            callbacks=True, callbacks_total=len(self.pfid_or_pfids), _libs=self._libs
-        )
-        if not steamworks_interface.steam_not_running:  # Skip if True
-            while not steamworks_interface.steamworks.loaded():  # Ensure that Steamworks API is initialized before attempting any instruction
-                break
-            else:
-                for pfid in self.pfid_or_pfids:
-                    logger.debug(f"ISteamUGC/GetAppDependencies Query: {pfid}")
-                    steamworks_interface.steamworks.Workshop.SetGetAppDependenciesResultCallback(
-                        steamworks_interface._cb_app_dependencies_result_callback
-                    )
-                    steamworks_interface.steamworks.Workshop.GetAppDependencies(pfid)
-                    # Sleep for the interval if we have more than one pfid to action on
-                    if len(self.pfid_or_pfids) > 1:
-                        sleep(self.interval)
-                # Patience, but don't wait forever
-                steamworks_interface._wait_for_callbacks(timeout=60)
-                # This means that the callbacks thread has ended. We are done with Steamworks API now, so we dispose of everything.
-                logger.info("Thread completed. Unloading Steamworks...")
-                steamworks_interface.steamworks_thread.join()
-                # Grab the data and return it
-                logger.warning(
-                    f"Returning {len(steamworks_interface.get_app_deps_query_result.keys())} results..."
-                )
-                return steamworks_interface.get_app_deps_query_result
-        else:
-            steamworks_interface.steamworks.unload()
-
-        return None
-
-
-class SteamworksGameLaunch(Process):
-    def __init__(
-        self, game_install_path: str, args: list[str], _libs: str | None = None
-    ) -> None:
-        Process.__init__(self)
-        self._libs = _libs
-        self.game_install_path = game_install_path
-        self.args = args
-
-    def run(self) -> None:
-        """
-        Handle SW game launch; instructions received from connected signals
-
-        :param game_install_path: is a string path to the game folder
-        :param args: is a string representing the args to pass to the generated executable path
-        """
-        logger.info("Creating SteamworksInterface and launching game executable")
-        # Try to initialize the SteamWorks API, but allow game to launch if Steam not found
-        steamworks_interface = SteamworksInterface(callbacks=False, _libs=self._libs)
-
-        # Launch the game
-        launch_game_process(
-            game_install_path=Path(self.game_install_path), args=self.args
-        )
-        # If we had an API initialization, try to unload it
-        if (
-            not steamworks_interface.steam_not_running
-            and steamworks_interface.steamworks
+        deadline = time.monotonic() + timeout
+        while (
+            self._pending_callbacks > 0
+            and not self._shutdown_requested
+            and time.monotonic() < deadline
         ):
-            # Unload Steamworks API
-            steamworks_interface.steamworks.unload()
+            self._pump_callbacks()
+            time.sleep(_LOOP_INTERVAL)
+        if self._pending_callbacks > 0:
+            logger.warning(
+                f"Callback wait timed out with {self._pending_callbacks} pending"
+            )
+            return False
+        return True
 
+    def _wait_with_callbacks(self, duration: float) -> None:
+        """Wait for a duration while continuing to pump callbacks."""
+        deadline = time.monotonic() + duration
+        while time.monotonic() < deadline and not self._shutdown_requested:
+            self._pump_callbacks()
+            time.sleep(_LOOP_INTERVAL)
 
-class SteamworksSubscriptionHandler(Process):
-    """
-    Handles Steam Workshop mod subscription operations.
-
-    Supports three operations:
-    - "subscribe": Subscribe to mods (ISteamUGC::SubscribeItem)
-    - "unsubscribe": Unsubscribe from mods (ISteamUGC::UnsubscribeItem)
-    - "resubscribe": Unsub then resub with proper delays (forces Steam to re-download)
-
-    Resubscribe timing is critical for fixing GitHub issue #1460 (missing mods):
-    1. UnsubscribeItem() → Steam marks as unsubscribed
-    2. Wait 4 seconds → Steam uninstalls mod files
-    3. SubscribeItem() → Steam marks as subscribed
-    4. Wait 2 seconds → Steam registers subscription
-    5. DownloadItem(high_priority=True) → Forces Steam to queue re-download
-
-    Without proper spacing, Steam can queue operations in wrong order,
-    resulting in mods being subscribed but not downloaded.
-
-    Uses callback-based async event handling with configurable timeouts.
-
-    Attributes:
-        action (str): Operation to perform
-        pfid_or_pfids (list[int]): Published file IDs (Steam Workshop mod IDs)
-        interval (float): Delay in seconds between processing multiple mods
-        _libs (str | None): Optional path to prebuilt Steamworks libraries
-    """
-
-    def __init__(
-        self,
-        action: str,
-        pfid_or_pfids: Union[int, list[int]],
-        interval: float = SUBSCRIBE_UNSUBSCRIBE_INTERVAL,
-        _libs: str | None = None,
-    ):
-        """
-        Initialize subscription handler.
-
-        Args:
-            action: Operation type ("subscribe", "unsubscribe", or "resubscribe")
-            pfid_or_pfids: Single mod ID or list of mod IDs to process
-            interval: Seconds to wait between operations (only used for subscribe/unsubscribe)
-            _libs: Optional custom path to Steamworks libraries
-        """
-        Process.__init__(self)
-        self._libs = _libs
-        self.action = action
-        # Normalize to list for consistent handling
-        self.pfid_or_pfids = (
-            pfid_or_pfids if isinstance(pfid_or_pfids, list) else [pfid_or_pfids]
-        )
-        self.interval = interval
-
-    def run(self) -> None:
-        """
-        Main entry point for handling subscription operations.
-
-        Initializes Steamworks API, sets up callbacks, executes the operation
-        (subscribe/unsubscribe/resubscribe), and waits for all callbacks.
-
-        Expected callbacks:
-        - resubscribe: 2 per mod (unsub + resub)
-        - subscribe: 1 per mod
-        - unsubscribe: 1 per mod
-
-        Timeouts:
-        - resubscribe: 60 seconds (due to 4s + 2s + 3s delays)
-        - subscribe/unsubscribe: 30 seconds
-        """
-        logger.warning(
-            f"=== SteamworksSubscriptionHandler START: action={self.action}, mods={len(self.pfid_or_pfids)} ==="
-        )
-
-        # Calculate expected callbacks - used to know when all operations complete
-        if self.action == "resubscribe":
-            # Each mod: 1 unsub callback + 1 resub callback = 2
-            # Note: DownloadItem callback unreliable, not counted
-            callbacks_total = len(self.pfid_or_pfids) * 2
+    def _execute_operation(self, op: SteamworksOperation) -> None:
+        if isinstance(op, SubscribeOp):
+            self._handle_subscribe(op)
+        elif isinstance(op, UnsubscribeOp):
+            self._handle_unsubscribe(op)
+        elif isinstance(op, ResubscribeOp):
+            self._handle_resubscribe(op)
+        elif isinstance(op, ForceDownloadOp):
+            self._handle_force_download(op)
+        elif isinstance(op, AppDependenciesOp):
+            self._handle_app_dependencies(op)
         else:
-            # subscribe/unsubscribe: Each mod gets exactly one callback
-            callbacks_total = len(self.pfid_or_pfids)
+            logger.error(f"Unknown operation type: {type(op)}")
 
-        logger.warning(f"Expected {callbacks_total} callback(s)")
-
-        steamworks_interface = SteamworksInterface(
-            callbacks=True, callbacks_total=callbacks_total, _libs=self._libs
-        )
-
-        if steamworks_interface.steam_not_running:
-            logger.error("Steam is not running. Aborting subscription handler.")
-            steamworks_interface.steamworks.unload()
+    def _handle_subscribe(self, op: SubscribeOp) -> None:
+        if not op.pfids:
+            self.operation_complete.emit("subscribe", True)
+            return
+        logger.info(f"SUBSCRIBE: {len(op.pfids)} mod(s)")
+        if not self._ensure_initialized():
+            self.operation_complete.emit("subscribe", False)
             return
 
-        # Wait for Steamworks to be ready
-        logger.warning("Waiting for Steamworks to load...")
-        while not steamworks_interface.steamworks.loaded():
-            sleep(0.1)
-        logger.warning("Steamworks loaded and ready")
+        self._pending_callbacks = len(op.pfids)
 
-        try:
-            if self.action == "resubscribe":
-                self._handle_resubscribe(steamworks_interface)
-            elif self.action == "subscribe":
-                self._handle_subscribe(steamworks_interface)
-            elif self.action == "unsubscribe":
-                self._handle_unsubscribe(steamworks_interface)
-            else:
-                logger.error(f"Unknown action: {self.action}")
-                return
-
-            # Wait for all callbacks to complete
-            # Resubscribe may take longer due to unsub + resub per mod
-            timeout = 60 if self.action == "resubscribe" else 30
-            logger.warning(
-                f"Waiting up to {timeout}s for callbacks to complete (expecting {callbacks_total})..."
-            )
-            steamworks_interface._wait_for_callbacks(timeout=timeout)
-            logger.warning(
-                f"✓ All callbacks completed! ({steamworks_interface.callbacks_count}/{callbacks_total})"
-            )
-
-        except Exception as e:
-            logger.error(
-                f"✗ Error during subscription action {self.action}: {e}", exc_info=True
-            )
-        finally:
-            # Cleanup
-            logger.warning(
-                "=== SteamworksSubscriptionHandler END: Unloading Steamworks ==="
-            )
-            if (
-                hasattr(steamworks_interface, "steamworks_thread")
-                and steamworks_interface.steamworks_thread.is_alive()
-            ):
-                steamworks_interface.steamworks_thread.join(timeout=5)
-            steamworks_interface.steamworks.unload()
-
-    def _handle_resubscribe(self, steamworks_interface: SteamworksInterface) -> None:
-        """
-        Resubscribe to mods with batched sequencing (fixes GitHub issue #1460).
-
-        Process all mods in three stages to ensure proper Steam sequencing:
-
-        Stage 1: Unsubscribe ALL mods (small delays between API calls)
-        Stage 2: Wait 4 seconds (let Steam uninstall all mod files)
-        Stage 3: Subscribe ALL mods (small delays between API calls)
-        Stage 4: Wait 2 seconds (let Steam register all subscriptions)
-        Stage 5: Download ALL mods (force Steam to queue downloads)
-
-        This batched approach is more efficient than per-mod sequencing:
-        - Faster: Reduces total time from 27+ seconds (per-mod) to ~6 seconds (batched)
-        - More stable: All unsubs complete before any subs start
-        - Clearer: Better matches Steam's async queue expectations
-
-        Without proper staging, Steam may queue subscribe before unsubscribe
-        completes, resulting in mods subscribed but not downloaded.
-        """
-        logger.warning(
-            f">>> RESUBSCRIBE: Starting for {len(self.pfid_or_pfids)} mod(s)"
-        )
-
-        # Register callbacks for all unsub/resub operations
-        # These fire asynchronously as Steam processes each operation
-        steamworks_interface.steamworks.Workshop.SetItemUnsubscribedCallback(
-            self._create_unsub_callback(steamworks_interface)
-        )
-        steamworks_interface.steamworks.Workshop.SetItemSubscribedCallback(
-            self._create_resub_callback(steamworks_interface)
-        )
-        logger.warning("Callbacks registered for unsub and resub")
-
-        # STAGE 1: Unsubscribe ALL mods
-        logger.warning(f">>> STAGE 1: Unsubscribing {len(self.pfid_or_pfids)} mod(s)")
-        for idx, pfid in enumerate(self.pfid_or_pfids, 1):
-            logger.warning(f"  [{idx}] Unsubscribing: {pfid}")
-            steamworks_interface.steamworks.Workshop.UnsubscribeItem(pfid)
-            # Small gap between API calls to space them out
-            if len(self.pfid_or_pfids) > 1 and idx < len(self.pfid_or_pfids):
-                sleep(API_CALL_GAP)
-
-        # STAGE 2: Wait for Steam to uninstall all mod files
-        logger.warning(
-            f"  Waiting {RESUBSCRIBE_UNSUBSCRIBE_WAIT}s for all unsubscribes to complete..."
-        )
-        sleep(RESUBSCRIBE_UNSUBSCRIBE_WAIT)
-
-        # STAGE 3: Subscribe ALL mods
-        logger.warning(f">>> STAGE 2: Subscribing {len(self.pfid_or_pfids)} mod(s)")
-        for idx, pfid in enumerate(self.pfid_or_pfids, 1):
-            logger.warning(f"  [{idx}] Subscribing: {pfid}")
-            steamworks_interface.steamworks.Workshop.SubscribeItem(pfid)
-            # Small gap between API calls to space them out
-            if len(self.pfid_or_pfids) > 1 and idx < len(self.pfid_or_pfids):
-                sleep(API_CALL_GAP)
-
-        # STAGE 4: Wait for Steam to register all subscriptions
-        logger.warning(
-            f"  Waiting {RESUBSCRIBE_SUBSCRIBE_WAIT}s for all subscribes to register..."
-        )
-        sleep(RESUBSCRIBE_SUBSCRIBE_WAIT)
-
-        # STAGE 5: Force download ALL mods with high priority
-        logger.warning(
-            f">>> STAGE 3: Initiating downloads for {len(self.pfid_or_pfids)} mod(s)"
-        )
-        for idx, pfid in enumerate(self.pfid_or_pfids, 1):
+        def on_subscribed(*args: Any, **kwargs: Any) -> None:
+            self._pending_callbacks = max(0, self._pending_callbacks - 1)
+            self._last_activity = time.monotonic()
             try:
-                logger.warning(f"  [{idx}] Download: {pfid}")
-                # Call DownloadItem to force Steam to queue the mod for download
-                # high_priority=True makes Steam skip other queued downloads
-                # Note: callback may not fire, but the download is still queued
-                if hasattr(steamworks_interface.steamworks.Workshop, "DownloadItem"):
-                    steamworks_interface.steamworks.Workshop.DownloadItem(
-                        pfid,
-                        high_priority=True,
-                        callback=self._create_download_callback(steamworks_interface),
-                        override_callback=True,
-                    )
+                pfid = args[0].publishedFileId
+                result = args[0].result
+                if result == 1:
+                    logger.info(f"Subscribe succeeded for {pfid}")
+                    self.item_subscribed.emit(str(pfid))
                 else:
-                    logger.warning(
-                        "DownloadItem skipped: not supported by SteamworksPy library."
+                    logger.error(f"Subscribe failed for {pfid}: result={result}")
+                    self.steam_operation_failed.emit(str(pfid), "subscribe failed")
+            except Exception as e:
+                logger.error(f"Error in subscribe callback: {e}")
+
+        self._steamworks.Workshop.SetItemSubscribedCallback(on_subscribed)
+
+        for idx, pfid in enumerate(op.pfids):
+            logger.debug(f"SubscribeItem({pfid})")
+            self._steamworks.Workshop.SubscribeItem(pfid)
+            if idx < len(op.pfids) - 1:
+                time.sleep(SUBSCRIBE_UNSUBSCRIBE_INTERVAL)
+
+        success = self._wait_for_pending_callbacks(timeout=30)
+        self.operation_complete.emit("subscribe", success)
+
+    def _handle_unsubscribe(self, op: UnsubscribeOp) -> None:
+        if not op.pfids:
+            self.operation_complete.emit("unsubscribe", True)
+            return
+        logger.info(f"UNSUBSCRIBE: {len(op.pfids)} mod(s)")
+        if not self._ensure_initialized():
+            self.operation_complete.emit("unsubscribe", False)
+            return
+
+        self._pending_callbacks = len(op.pfids)
+
+        def on_unsubscribed(*args: Any, **kwargs: Any) -> None:
+            self._pending_callbacks = max(0, self._pending_callbacks - 1)
+            self._last_activity = time.monotonic()
+            try:
+                pfid = args[0].publishedFileId
+                result = args[0].result
+                if result == 1:
+                    logger.info(f"Unsubscribe succeeded for {pfid}")
+                    self.item_unsubscribed.emit(str(pfid))
+                else:
+                    logger.error(f"Unsubscribe failed for {pfid}: result={result}")
+                    self.steam_operation_failed.emit(str(pfid), "unsubscribe failed")
+            except Exception as e:
+                logger.error(f"Error in unsubscribe callback: {e}")
+
+        self._steamworks.Workshop.SetItemUnsubscribedCallback(on_unsubscribed)
+
+        for idx, pfid in enumerate(op.pfids):
+            logger.debug(f"UnsubscribeItem({pfid})")
+            self._steamworks.Workshop.UnsubscribeItem(pfid)
+            if idx < len(op.pfids) - 1:
+                time.sleep(SUBSCRIBE_UNSUBSCRIBE_INTERVAL)
+
+        success = self._wait_for_pending_callbacks(timeout=30)
+        self.operation_complete.emit("unsubscribe", success)
+
+    def _handle_resubscribe(self, op: ResubscribeOp) -> None:
+        """
+        Batched resubscribe preserving the timing from PR #1719:
+        Stage 1: UnsubscribeItem all → Stage 2: wait 4s →
+        Stage 3: SubscribeItem all → Stage 4: wait 2s →
+        Stage 5: DownloadItem all (if available)
+        """
+        if not op.pfids:
+            self.operation_complete.emit("resubscribe", True)
+            return
+        logger.info(f"RESUBSCRIBE: {len(op.pfids)} mod(s)")
+        if not self._ensure_initialized():
+            self.operation_complete.emit("resubscribe", False)
+            return
+
+        # 2 callbacks per pfid: 1 unsub + 1 sub (download callbacks unreliable)
+        self._pending_callbacks = len(op.pfids) * 2
+
+        def on_unsubscribed(*args: Any, **kwargs: Any) -> None:
+            self._pending_callbacks = max(0, self._pending_callbacks - 1)
+            self._last_activity = time.monotonic()
+            try:
+                pfid = args[0].publishedFileId
+                result = args[0].result
+                if result == 1:
+                    logger.info(f"Resubscribe unsub succeeded for {pfid}")
+                else:
+                    logger.error(
+                        f"Resubscribe unsub failed for {pfid}: result={result}"
+                    )
+                    self.steam_operation_failed.emit(
+                        str(pfid), "resubscribe unsub failed"
                     )
             except Exception as e:
+                logger.error(f"Error in resubscribe unsub callback: {e}")
+
+        def on_subscribed(*args: Any, **kwargs: Any) -> None:
+            self._pending_callbacks = max(0, self._pending_callbacks - 1)
+            self._last_activity = time.monotonic()
+            try:
+                pfid = args[0].publishedFileId
+                result = args[0].result
+                if result == 1:
+                    logger.info(f"Resubscribe sub succeeded for {pfid}")
+                    self.item_subscribed.emit(str(pfid))
+                else:
+                    logger.error(f"Resubscribe sub failed for {pfid}: result={result}")
+                    self.steam_operation_failed.emit(
+                        str(pfid), "resubscribe sub failed"
+                    )
+            except Exception as e:
+                logger.error(f"Error in resubscribe sub callback: {e}")
+
+        self._steamworks.Workshop.SetItemUnsubscribedCallback(on_unsubscribed)
+        self._steamworks.Workshop.SetItemSubscribedCallback(on_subscribed)
+
+        # Stage 1: Unsubscribe ALL
+        logger.info(f"RESUBSCRIBE Stage 1: Unsubscribing {len(op.pfids)} mod(s)")
+        for idx, pfid in enumerate(op.pfids):
+            self._steamworks.Workshop.UnsubscribeItem(pfid)
+            if idx < len(op.pfids) - 1:
+                time.sleep(API_CALL_GAP)
+
+        # Stage 2: Wait for Steam to uninstall files
+        logger.info(f"RESUBSCRIBE Stage 2: Waiting {RESUBSCRIBE_UNSUBSCRIBE_WAIT}s")
+        self._wait_with_callbacks(RESUBSCRIBE_UNSUBSCRIBE_WAIT)
+
+        # Stage 3: Subscribe ALL
+        logger.info(f"RESUBSCRIBE Stage 3: Subscribing {len(op.pfids)} mod(s)")
+        for idx, pfid in enumerate(op.pfids):
+            self._steamworks.Workshop.SubscribeItem(pfid)
+            if idx < len(op.pfids) - 1:
+                time.sleep(API_CALL_GAP)
+
+        # Stage 4: Wait for Steam to register subscriptions
+        logger.info(f"RESUBSCRIBE Stage 4: Waiting {RESUBSCRIBE_SUBSCRIBE_WAIT}s")
+        self._wait_with_callbacks(RESUBSCRIBE_SUBSCRIBE_WAIT)
+
+        # Stage 5: Force download ALL (preserving PR #1918 hasattr guard)
+        logger.info(f"RESUBSCRIBE Stage 5: Downloading {len(op.pfids)} mod(s)")
+        if hasattr(self._steamworks.Workshop, "DownloadItem"):
+            for pfid in op.pfids:
+                try:
+                    self._steamworks.Workshop.DownloadItem(
+                        pfid,
+                        high_priority=True,
+                        callback=lambda *a, **kw: None,
+                        override_callback=True,
+                    )
+                except Exception as e:
+                    logger.error(f"Failed to trigger download for {pfid}: {e}")
+        else:
+            logger.warning(
+                "DownloadItem skipped: not supported by SteamworksPy library."
+            )
+
+        success = self._wait_for_pending_callbacks(timeout=60)
+        self.operation_complete.emit("resubscribe", success)
+
+    def _handle_force_download(self, op: ForceDownloadOp) -> None:
+        if not op.pfids:
+            self.operation_complete.emit("force_download", True)
+            return
+        logger.info(f"FORCE DOWNLOAD: {len(op.pfids)} mod(s)")
+        if not self._ensure_initialized():
+            self.operation_complete.emit("force_download", False)
+            return
+
+        if not hasattr(self._steamworks.Workshop, "DownloadItem"):
+            logger.warning("DownloadItem not supported by SteamworksPy library.")
+            self.operation_complete.emit("force_download", False)
+            return
+
+        for pfid in op.pfids:
+            try:
+                self._steamworks.Workshop.DownloadItem(
+                    pfid,
+                    high_priority=True,
+                    callback=lambda *a, **kw: None,
+                    override_callback=True,
+                )
+            except Exception as e:
                 logger.error(f"Failed to trigger download for {pfid}: {e}")
+                self.steam_operation_failed.emit(str(pfid), f"download failed: {e}")
 
-        logger.warning(">>> All mods queued. Waiting for callbacks...")
+        # No callback counting — download callbacks are unreliable
+        self.operation_complete.emit("force_download", True)
 
-    def _handle_subscribe(self, steamworks_interface: SteamworksInterface) -> None:
-        """
-        Subscribe to mods
-        """
-        logger.warning(f">>> SUBSCRIBE: Starting for {len(self.pfid_or_pfids)} mod(s)")
+    def _handle_app_dependencies(self, op: AppDependenciesOp) -> None:
+        if not op.pfids:
+            op.result_future.set_result({})
+            return
+        logger.info(f"APP DEPENDENCIES: querying {len(op.pfids)} mod(s)")
+        if not self._ensure_initialized():
+            op.result_future.set_result(None)
+            return
 
-        steamworks_interface.steamworks.Workshop.SetItemSubscribedCallback(
-            self._create_resub_callback(steamworks_interface)
-        )
-        logger.warning("Callback registered for subscribe")
+        self._pending_callbacks = len(op.pfids)
+        results: dict[int, Any] = {}
 
-        for idx, pfid in enumerate(self.pfid_or_pfids, 1):
-            logger.warning(
-                f">>> Subscribing to mod {idx}/{len(self.pfid_or_pfids)}: {pfid}"
-            )
-            steamworks_interface.steamworks.Workshop.SubscribeItem(pfid)
+        def on_result(*args: Any, **kwargs: Any) -> None:
+            self._pending_callbacks = max(0, self._pending_callbacks - 1)
+            self._last_activity = time.monotonic()
+            try:
+                pfid = args[0].publishedFileId
+                app_dependencies_list = args[0].get_app_dependencies_list()
+                logger.debug(
+                    f"AppDependencies callback: pfid={pfid}, "
+                    f"deps={app_dependencies_list}"
+                )
+                if len(app_dependencies_list) > 0:
+                    results[pfid] = app_dependencies_list
+            except Exception as e:
+                logger.error(f"Error in AppDependencies callback: {e}")
 
-            if len(self.pfid_or_pfids) > 1 and idx < len(self.pfid_or_pfids):
-                logger.warning(f"Waiting {self.interval}s before next mod...")
-                sleep(self.interval)
+        self._steamworks.Workshop.SetGetAppDependenciesResultCallback(on_result)
 
-        logger.warning(">>> All mods queued. Waiting for callbacks...")
+        for idx, pfid in enumerate(op.pfids):
+            logger.debug(f"GetAppDependencies({pfid})")
+            self._steamworks.Workshop.GetAppDependencies(pfid)
+            if idx < len(op.pfids) - 1:
+                time.sleep(1)
 
-    def _handle_unsubscribe(self, steamworks_interface: SteamworksInterface) -> None:
-        """
-        Unsubscribe from mods
-        """
-        logger.warning(
-            f">>> UNSUBSCRIBE: Starting for {len(self.pfid_or_pfids)} mod(s)"
-        )
-
-        steamworks_interface.steamworks.Workshop.SetItemUnsubscribedCallback(
-            self._create_unsub_callback(steamworks_interface)
-        )
-        logger.warning("Callback registered for unsubscribe")
-
-        for idx, pfid in enumerate(self.pfid_or_pfids, 1):
-            logger.warning(
-                f">>> Unsubscribing from mod {idx}/{len(self.pfid_or_pfids)}: {pfid}"
-            )
-            steamworks_interface.steamworks.Workshop.UnsubscribeItem(pfid)
-
-            if len(self.pfid_or_pfids) > 1 and idx < len(self.pfid_or_pfids):
-                logger.warning(f"Waiting {self.interval}s before next mod...")
-                sleep(self.interval)
-
-        logger.warning(">>> All mods queued. Waiting for callbacks...")
-
-    def _create_unsub_callback(
-        self, steamworks_interface: SteamworksInterface
-    ) -> Callable[[Any, Any], None]:
-        """
-        Create unsubscribe callback handler.
-
-        Returns a callable that increments callback count and signals
-        completion when all expected callbacks have fired.
-        """
-
-        def callback(*args: Any, **kwargs: Any) -> None:
-            steamworks_interface.callbacks_count += 1
-            result = args[0].result
-            pfid = args[0].publishedFileId
-
-            if result == 1:
-                logger.warning(f"✓ Unsubscribe succeeded for {pfid}")
-            else:
-                logger.error(f"✗ Unsubscribe failed for {pfid}: result={result}")
-
-            # Check if all expected callbacks have completed
-            if (
-                steamworks_interface.multiple_queries
-                and steamworks_interface.callbacks_total is not None
-                and steamworks_interface.callbacks_count
-                >= steamworks_interface.callbacks_total
-            ):
-                steamworks_interface.end_callbacks = True
-            elif not steamworks_interface.multiple_queries:
-                steamworks_interface.end_callbacks = True
-
-        return callback
-
-    def _create_resub_callback(
-        self, steamworks_interface: SteamworksInterface
-    ) -> Callable[[Any, Any], None]:
-        """
-        Create subscribe callback handler.
-
-        Returns a callable that increments callback count and signals
-        completion when all expected callbacks have fired.
-        """
-
-        def callback(*args: Any, **kwargs: Any) -> None:
-            steamworks_interface.callbacks_count += 1
-            result = args[0].result
-            pfid = args[0].publishedFileId
-
-            if result == 1:
-                logger.warning(f"✓ Subscribe succeeded for {pfid}")
-            else:
-                logger.error(f"✗ Subscribe failed for {pfid}: result={result}")
-
-            # Check if all expected callbacks have completed
-            if (
-                steamworks_interface.multiple_queries
-                and steamworks_interface.callbacks_total is not None
-                and steamworks_interface.callbacks_count
-                >= steamworks_interface.callbacks_total
-            ):
-                steamworks_interface.end_callbacks = True
-            elif not steamworks_interface.multiple_queries:
-                steamworks_interface.end_callbacks = True
-
-        return callback
-
-    def _create_download_callback(
-        self, steamworks_interface: SteamworksInterface
-    ) -> Callable[[Any, Any], None]:
-        """
-        Create download callback handler.
-
-        Returns a callable that increments callback count and signals
-        completion when all expected callbacks have fired.
-
-        Note: DownloadItem callbacks are unreliable and may not fire,
-        so this is primarily used for logging purposes.
-        """
-
-        def callback(*args: Any, **kwargs: Any) -> None:
-            steamworks_interface.callbacks_count += 1
-            result = args[0].result
-            pfid = args[0].publishedFileId
-
-            if result == 1:
-                logger.warning(f"✓ Download succeeded for {pfid}")
-            else:
-                logger.error(f"✗ Download failed for {pfid}: result={result}")
-
-            # Check if all expected callbacks have completed
-            if (
-                steamworks_interface.multiple_queries
-                and steamworks_interface.callbacks_total is not None
-                and steamworks_interface.callbacks_count
-                >= steamworks_interface.callbacks_total
-            ):
-                steamworks_interface.end_callbacks = True
-            elif not steamworks_interface.multiple_queries:
-                steamworks_interface.end_callbacks = True
-
-        return callback
-
-
-if __name__ == "__main__":
-    sys.exit()
+        self._wait_for_pending_callbacks(timeout=60)
+        op.result_future.set_result(results)

--- a/app/utils/steam/webapi/wrapper.py
+++ b/app/utils/steam/webapi/wrapper.py
@@ -2,7 +2,7 @@ import sys
 import traceback
 from logging import WARNING, getLogger
 from math import ceil
-from multiprocessing import Pool, cpu_count
+from multiprocessing import cpu_count
 from pathlib import Path
 from time import time
 from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
@@ -18,7 +18,7 @@ from app.utils import http
 from app.utils.app_info import AppInfo
 from app.utils.constants import RIMWORLD_DLC_METADATA
 from app.utils.generic import chunks
-from app.utils.steam.steamworks.wrapper import SteamworksAppDependenciesQuery
+from app.utils.steam.steamworks.wrapper import SteamworksWorker
 from app.views.dialogue import show_warning
 
 STEAM_THERE_WAS_A_PROBLEM_FLAG = "There was a problem accessing the item. "
@@ -719,64 +719,80 @@ class DynamicQuery(QObject):
         self, publishedfileids: list[str], query: Dict[str, Any]
     ) -> None:
         """
-        Given a list of PublishedFileIds and a query, return the query after looking up
-        and appending DLC dependency data from the Steamworks API.
+        Query DLC dependency data via Steamworks API through the worker thread.
 
-        https://partner.steamgames.com/doc/api/ISteamUGC#GetAppDependencies
+        Replaces the previous multiprocessing.Pool approach with sequential
+        chunk submissions to SteamworksWorker, which serializes all Steamworks
+        API calls through a single handle.
 
         :param publishedfileids: a list of PublishedFileIds to query metadata for
-        :param json_to_update: a Dict of json data, containing a query to update in
-        RimPy db_data["database"] format, or the skeleton of one from local_metadata
-        :return: Dict containing the updated json data from PublishedFileIds query
+        :param query: a Dict containing a database to update with dependency data
         """
         self._emit_message(
-            f"\nSteamworks API: ISteamUGC/GetAppDependencies initializing for {len(publishedfileids)} mods\n\nThis may take a while. Please wait..."
+            f"\nSteamworks API: ISteamUGC/GetAppDependencies initializing "
+            f"for {len(publishedfileids)} mods\n\nThis may take a while. Please wait..."
         )
-        # Maximum processes
-        num_processes = cpu_count()
-        # Create a pool of worker processes
-        with Pool(processes=num_processes) as pool:
-            # Create instances of SteamworksAppDependenciesQuery for each chunk
-            queries = [
-                SteamworksAppDependenciesQuery(
-                    pfid_or_pfids=[int(str_pfid) for str_pfid in chunk],
-                    interval=1,
-                    _libs=str((AppInfo().application_folder / "libs")),
-                )
-                for chunk in list(
-                    chunks(
-                        _list=publishedfileids,
-                        limit=ceil(len(publishedfileids) / num_processes),
-                    )
-                )
-            ]
-            # Map the execution of the queries to the pool of processes
-            results = pool.map(SteamworksAppDependenciesQuery.run, queries)
-        # Merge the results from all processes into a single dictionary
-        self._emit_message("Processes completed!\nCollecting results")
-        pfids_appid_deps: dict[int, list[int]] = {}
-        for result in results:
-            if result is not None:
-                pfids_appid_deps.update(result)
-        self._emit_message(f"\nTotal: {len(pfids_appid_deps.keys())}")
-        # Uncomment to see the total metadata returned from all Processes
-        # logger.debug(pfids_appid_deps)
-        # Add our metadata to the query...
-        logger.debug("Populating AppID dependency information into database from query")
-        for pfid in query["database"].keys():
-            if int(pfid) in pfids_appid_deps:
-                for appid in pfids_appid_deps[int(pfid)]:
-                    if str(appid) in RIMWORLD_DLC_METADATA.keys():
-                        if not query["database"][pfid].get("dependencies"):
-                            query["database"][pfid]["dependencies"] = {}
-                        query["database"][pfid]["dependencies"].update(
-                            {
-                                str(appid): [
-                                    RIMWORLD_DLC_METADATA[str(appid)]["name"],
-                                    RIMWORLD_DLC_METADATA[str(appid)]["steam_url"],
-                                ]
-                            }
-                        )
+
+        # Get or create a SteamworksWorker
+        worker: SteamworksWorker | None = None
+        temporary_worker = False
+        try:
+            from app.views.main_content_panel import MainContent
+
+            if MainContent._instance is not None:
+                worker = MainContent._instance._steamworks_worker
+        except Exception:
+            pass
+
+        if worker is None:
+            # CLI mode or no MainContent — create a temporary worker
+            if QCoreApplication.instance() is None:
+                QCoreApplication([])
+            worker = SteamworksWorker(
+                idle_timeout=300,
+                libs_path=str(AppInfo().application_folder / "libs"),
+            )
+            worker.start()
+            temporary_worker = True
+
+        try:
+            # Process in chunks for progress reporting
+            num_chunks = max(1, cpu_count())
+            chunk_size = max(1, ceil(len(publishedfileids) / num_chunks))
+            pfids_appid_deps: dict[int, list[int]] = {}
+
+            for chunk in chunks(_list=publishedfileids, limit=chunk_size):
+                int_chunk = [int(str_pfid) for str_pfid in chunk]
+                future = worker.query_app_dependencies(int_chunk)
+                try:
+                    result = future.result(timeout=120)
+                    if result is not None:
+                        pfids_appid_deps.update(result)
+                except Exception as e:
+                    logger.error(f"AppDependencies query failed for chunk: {e}")
+
+            self._emit_message(f"\nTotal: {len(pfids_appid_deps.keys())}")
+
+            logger.debug(
+                "Populating AppID dependency information into database from query"
+            )
+            for pfid in query["database"].keys():
+                if int(pfid) in pfids_appid_deps:
+                    for appid in pfids_appid_deps[int(pfid)]:
+                        if str(appid) in RIMWORLD_DLC_METADATA.keys():
+                            if not query["database"][pfid].get("dependencies"):
+                                query["database"][pfid]["dependencies"] = {}
+                            query["database"][pfid]["dependencies"].update(
+                                {
+                                    str(appid): [
+                                        RIMWORLD_DLC_METADATA[str(appid)]["name"],
+                                        RIMWORLD_DLC_METADATA[str(appid)]["steam_url"],
+                                    ]
+                                }
+                            )
+        finally:
+            if temporary_worker:
+                worker.shutdown()
 
 
 def ISteamRemoteStorage_GetCollectionDetails(

--- a/app/utils/steam/webapi/wrapper.py
+++ b/app/utils/steam/webapi/wrapper.py
@@ -2,7 +2,6 @@ import sys
 import traceback
 from logging import WARNING, getLogger
 from math import ceil
-from multiprocessing import cpu_count
 from pathlib import Path
 from time import time
 from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
@@ -756,20 +755,29 @@ class DynamicQuery(QObject):
             temporary_worker = True
 
         try:
-            # Process in chunks for progress reporting
-            num_chunks = max(1, cpu_count())
-            chunk_size = max(1, ceil(len(publishedfileids) / num_chunks))
+            # Process in chunks for progress reporting.
+            # Each mod takes ~1s (sleep between API calls), so timeout
+            # must scale with chunk size. Use small chunks for responsive
+            # progress updates and reasonable per-chunk timeouts.
+            chunk_size = 200
             pfids_appid_deps: dict[int, list[int]] = {}
+            total = len(publishedfileids)
+            processed = 0
 
             for chunk in chunks(_list=publishedfileids, limit=chunk_size):
                 int_chunk = [int(str_pfid) for str_pfid in chunk]
                 future = worker.query_app_dependencies(int_chunk)
                 try:
-                    result = future.result(timeout=120)
+                    chunk_timeout = len(int_chunk) + 120
+                    result = future.result(timeout=chunk_timeout)
                     if result is not None:
                         pfids_appid_deps.update(result)
                 except Exception as e:
                     logger.error(f"AppDependencies query failed for chunk: {e}")
+                processed += len(int_chunk)
+                self._emit_message(
+                    f"ISteamUGC/GetAppDependencies progress [{processed}/{total}]"
+                )
 
             self._emit_message(f"\nTotal: {len(pfids_appid_deps.keys())}")
 

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -2595,11 +2595,23 @@ class MainContent(QObject):
 
     def _on_steam_not_running(self) -> None:
         logger.warning("Steam is not running — Steamworks operations unavailable")
+        dialogue.show_warning(
+            title=self.tr("Steam Not Running"),
+            text=self.tr("Steam does not appear to be running."),
+            information=self.tr("Please start Steam and try again."),
+        )
 
     def _on_steamworks_operation_complete(self, op_type: str, success: bool) -> None:
-        logger.info(
-            f"Steamworks '{op_type}' completed: {'success' if success else 'failure'}"
-        )
+        status = "completed" if success else "failed"
+        logger.info(f"Steamworks '{op_type}' {status}")
+        if not success:
+            dialogue.show_warning(
+                title=self.tr("Steam Operation Failed"),
+                text=self.tr(
+                    "The Steam {op_type} operation did not complete successfully."
+                ).format(op_type=op_type),
+                information=self.tr("Check the log for details."),
+            )
 
     def _on_item_subscribed(self, pfid: str) -> None:
         EventBus().workshop_item_installed.emit(pfid)
@@ -3691,9 +3703,14 @@ class MainContent(QObject):
                 "Launching game via Steam protocol URI (steam://rungameid/294100)..."
             )
             platform_specific_open("steam://rungameid/294100")
+        elif steam_client_integration:
+            # Launch with Steamworks API initialized for Steam overlay
+            logger.info("Launching game process with Steamworks API...")
+            self._steamworks_worker.launch_game(
+                game_install_path=str(game_install_path), args=run_args
+            )
         else:
-            # Launch game executable directly
-            # This method ignores Steam overlay but respects custom run arguments
+            # Launch game executable directly without Steam integration
             logger.info("Launching game process without Steamworks API...")
             launch_game_process(game_install_path=game_install_path, args=run_args)
 

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -59,10 +59,7 @@ from app.utils.rentry.wrapper import RentryImport, RentryUpload
 from app.utils.schema import generate_rimworld_mods_list
 from app.utils.steam.steambrowser.browser import SteamBrowser
 from app.utils.steam.steamcmd.wrapper import SteamcmdInterface
-from app.utils.steam.steamworks.wrapper import (
-    SteamworksGameLaunch,
-    SteamworksSubscriptionHandler,
-)
+from app.utils.steam.steamworks.wrapper import SteamworksWorker
 from app.utils.steam.webapi.wrapper import (
     CollectionImport,
     ISteamRemoteStorage_GetPublishedFileDetails,
@@ -340,8 +337,19 @@ class MainContent(QObject):
             # Instantiate query runner
             self.query_runner: RunnerPanel | None = None
 
-            # Steamworks bool - use this to check any Steamworks processes you try to initialize
-            self.steamworks_in_use = False
+            # Steamworks worker thread (deferred init — no Steam API call until first operation)
+            self._steamworks_worker = SteamworksWorker(
+                idle_timeout=self.settings_controller.settings.steam_api_idle_timeout,
+                libs_path=str(AppInfo().application_folder / "libs"),
+            )
+            self._steamworks_worker.steam_not_running.connect(
+                self._on_steam_not_running
+            )
+            self._steamworks_worker.operation_complete.connect(
+                self._on_steamworks_operation_complete
+            )
+            self._steamworks_worker.item_subscribed.connect(self._on_item_subscribed)
+            self._steamworks_worker.start()
 
             # Instantiate todds runner
             self.todds_runner: RunnerPanel | None = None
@@ -2523,101 +2531,43 @@ class MainContent(QObject):
                 ),
             )
 
-    def _handle_steamworks_resubscribe(self, instruction: list[Any]) -> None:
-        """
-        Handle mod revalidation by forcing Steam to validate and redownload mods.
-
-        This bypasses the Steamworks API because the native resubscribe process is broken.
-        Instead, we use the Steam URI protocol to trigger validation directly.
-        This approach is more efficient than the Steamworks API implementation, which
-        would unsubscribe then subscribe again.
-
-        :param instruction: List where instruction[0] = "resubscribe" and
-                           instruction[1] = list of PublishedFileIds (int)
-        """
-        logger.info(f"Validating mods with instruction: {instruction}")
-        # Steam URI protocol: steam://validate/{APP_ID}/{PublishedFileIds}
-        # APP_ID 294100 is RimWorld
-        platform_specific_open(f"steam://validate/294100/{instruction[1]}")
-
     def _do_steamworks_api_call(self, instruction: list[Any]) -> None:
         """
-        Create & launch Steamworks API process to handle instructions received from connected signals
+        Bridge: parse instruction list and submit typed operation to the worker.
 
-        FOR subscription_actions[]...
-        :param instruction: a list where:
-            instruction[0] is a string that corresponds with the following supported_actions[]
-            instruction[1] is an int that corresponds with a subscribed Steam mod's PublishedFileId
-                        OR is a list of int that corresponds with multiple subscribed Steam mod's PublishedFileId
-        FOR "launch_game_process"...
-        :param instruction: a list where:
-            instruction[0] is a string that corresponds with the following supported_actions[]
-            instruction[1] is a list containing [game_folder_path: str, args: list] respectively
+        The do_steamworks_api_call Signal(list) is kept for backward compatibility.
+        This translates the legacy format into typed SteamworksOperation submissions.
         """
         logger.info(f"Received Steamworks API instruction: {instruction}")
-        # use prebuilt libs path
-        libs_path = str((AppInfo().application_folder / "libs"))
-        if not self.steamworks_in_use:
-            subscription_actions = ["resubscribe", "subscribe", "unsubscribe"]
-            supported_actions = ["launch_game_process"]
-            supported_actions.extend(subscription_actions)
-            if (
-                instruction[0] in supported_actions
-            ):  # Actions can be added as multiprocessing.Process; implemented in util.steam.steamworks.wrapper
-                if instruction[0] == "launch_game_process":  # SW API init + game launch
-                    self.steamworks_in_use = True
-                    steamworks_api_process = SteamworksGameLaunch(
-                        game_install_path=instruction[1][0],
-                        args=instruction[1][1],
-                        _libs=libs_path,
-                    )
-                    # Start the Steamworks API Process
-                    steamworks_api_process.start()
-                    logger.info(
-                        f"Steamworks API process wrapper started with PID: {steamworks_api_process.pid}"
-                    )
-                    steamworks_api_process.join()
-                    logger.info(
-                        f"Steamworks API process wrapper completed for PID: {steamworks_api_process.pid}"
-                    )
-                    self.steamworks_in_use = False
-                elif (
-                    instruction[0] in subscription_actions and len(instruction[1]) >= 1
-                ):  # ISteamUGC/{SubscribeItem/UnsubscribeItem}
-                    logger.info(
-                        f"Creating Steamworks API process with instruction {instruction}"
-                    )
-                    self.steamworks_in_use = True
-                    # Process all mods in a single handler to ensure proper sequencing and avoid parallel processing issues
-                    logger.debug(
-                        f"Processing {instruction[0]} sequentially for {len(instruction[1])} mod(s)"
-                    )
-                    handler = SteamworksSubscriptionHandler(
-                        action=instruction[0],
-                        pfid_or_pfids=instruction[1],
-                        _libs=libs_path,
-                    )
-                    handler.start()
-                    handler.join()
-                    # Clean up after processing
-                    self.steamworks_in_use = False
-                else:
-                    logger.warning(
-                        "Skipping Steamworks API call - only 1 Steamworks API initialization allowed at a time!!"
-                    )
-            else:
-                logger.error(f"Unsupported instruction {instruction}")
-                return
+        action = instruction[0]
+        pfids = instruction[1]
+
+        # Normalize pfids to list[int]
+        if isinstance(pfids, int):
+            pfids = [pfids]
         else:
-            logger.warning(
-                "Steamworks API is already initialized! We do NOT want multiple interactions. Skipping instruction..."
-            )
+            pfids = [int(p) for p in pfids]
+
+        if not pfids:
+            logger.warning("Empty pfids list, skipping Steamworks API call")
+            return
+
+        if action == "subscribe":
+            self._steamworks_worker.subscribe(pfids)
+        elif action == "unsubscribe":
+            self._steamworks_worker.unsubscribe(pfids)
+        elif action == "resubscribe":
+            self._steamworks_worker.resubscribe(pfids)
+        elif action == "force_download":
+            self._steamworks_worker.force_download(pfids)
+        else:
+            logger.error(f"Unsupported steamworks instruction: {action}")
 
     def _do_steamworks_api_call_animated(
         self, instruction: list[list[str] | str]
     ) -> None:
         publishedfileids = instruction[1]
-        logger.debug(f"Attempting to download {len(publishedfileids)} mods with Steam")
+        logger.debug(f"Attempting to process {len(publishedfileids)} mods with Steam")
         steamdb = self.metadata_manager.external_steam_metadata
         if steamdb is None:
             steamdb = {}
@@ -2628,7 +2578,6 @@ class MainContent(QObject):
                 publishedfileids=publishedfileids,
                 steamdb=steamdb,
             )
-        # No empty publishedfileids
         if len(publishedfileids) == 0:
             dialogue.show_warning(
                 title=self.tr("RimSort"),
@@ -2641,21 +2590,25 @@ class MainContent(QObject):
         # Close browser if open
         if self.steam_browser:
             self.steam_browser.close()
-        # Process API call
-        self.do_threaded_loading_animation(
-            gif_path=str(AppInfo().theme_data_folder / "default-icons" / "steam.gif"),
-            target=partial(self._do_steamworks_api_call, instruction=instruction),
-            text=self.tr(
-                "Processing Steam subscription action(s) via Steamworks API..."
-            ),
+        # Submit to worker (non-blocking — GUI doesn't freeze)
+        self._do_steamworks_api_call([instruction[0], publishedfileids])
+
+    def _on_steam_not_running(self) -> None:
+        logger.warning("Steam is not running — Steamworks operations unavailable")
+
+    def _on_steamworks_operation_complete(self, op_type: str, success: bool) -> None:
+        logger.info(
+            f"Steamworks '{op_type}' completed: {'success' if success else 'failure'}"
         )
-        # Do a full refresh of metadata and UI
-        # self._do_refresh()
-        # TODO  check if this is necessary
-        """       
-        Disabled refresh since steam downloads are not instant and in the background in its own time
-        Refreshing metadata and UI here could tag mods as invalid or cause crashes due to key errors etc
-        """
+
+    def _on_item_subscribed(self, pfid: str) -> None:
+        EventBus().workshop_item_installed.emit(pfid)
+
+    def cleanup(self) -> None:
+        """Clean up resources before application exit."""
+        if hasattr(self, "_steamworks_worker"):
+            logger.info("Shutting down Steamworks worker thread...")
+            self._steamworks_worker.shutdown()
 
         # GIT MOD ACTIONS
 
@@ -3591,6 +3544,11 @@ class MainContent(QObject):
         self.steamcmd_wrapper.validate_downloads = (
             self.settings_controller.settings.steamcmd_validate_downloads
         )
+
+        if hasattr(self, "_steamworks_worker"):
+            self._steamworks_worker.update_idle_timeout(
+                self.settings_controller.settings.steam_api_idle_timeout
+            )
 
     @Slot()
     def _on_do_download_all_mods_via_steamcmd(self) -> None:

--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -1693,6 +1693,7 @@ class ModListWidget(QListWidget):
             re_git_action = None
             re_steamcmd_action = None
             re_steam_action = None
+            force_download_steam_action = None
             # Unsubscribe mod
             unsubscribe_mod_steam_action = None
             # Change mod color
@@ -1829,6 +1830,11 @@ class ModListWidget(QListWidget):
                             re_steam_action = QAction()
                             re_steam_action.setText(
                                 self.tr("Re-subscribe mod with Steam")
+                            )
+                            # Force download steam mods
+                            force_download_steam_action = QAction()
+                            force_download_steam_action.setText(
+                                self.tr("Force download with Steam")
                             )
                             # Unsubscribe steam mods
                             unsubscribe_mod_steam_action = QAction()
@@ -2003,6 +2009,12 @@ class ModListWidget(QListWidget):
                                     re_steam_action.setText(
                                         self.tr("Re-subscribe mod(s) with Steam")
                                     )
+                                # Force download steam mods
+                                if not force_download_steam_action:
+                                    force_download_steam_action = QAction()
+                                    force_download_steam_action.setText(
+                                        self.tr("Force download mod(s) with Steam")
+                                    )
                                 # Unsubscribe steam mods
                                 if not unsubscribe_mod_steam_action:
                                     unsubscribe_mod_steam_action = QAction()
@@ -2065,6 +2077,7 @@ class ModListWidget(QListWidget):
                 or convert_workshop_local_action
                 or re_steamcmd_action
                 or re_steam_action
+                or force_download_steam_action
                 or unsubscribe_mod_steam_action
                 or add_to_steamdb_blacklist_action
                 or remove_from_steamdb_blacklist_action
@@ -2083,6 +2096,8 @@ class ModListWidget(QListWidget):
                     workshop_actions_menu.addAction(re_steamcmd_action)
                 if re_steam_action:
                     workshop_actions_menu.addAction(re_steam_action)
+                if force_download_steam_action:
+                    workshop_actions_menu.addAction(force_download_steam_action)
                 if unsubscribe_mod_steam_action:
                     workshop_actions_menu.addAction(unsubscribe_mod_steam_action)
                 if (
@@ -2338,6 +2353,21 @@ class ModListWidget(QListWidget):
                                 [int(str_pfid) for str_pfid in publishedfileids],
                             ]
                         )
+                    return True
+                elif (  # ACTION: Force download mod(s) with steam
+                    action == force_download_steam_action
+                    and len(steam_publishedfileid_to_name) > 0
+                ):
+                    publishedfileids = steam_publishedfileid_to_name.keys()
+                    logger.debug(
+                        f"Force downloading {len(publishedfileids)} mod(s) with Steam"
+                    )
+                    EventBus().do_steamworks_api_call.emit(
+                        [
+                            "force_download",
+                            [int(str_pfid) for str_pfid in publishedfileids],
+                        ]
+                    )
                     return True
                 elif (  # ACTION: Unsubscribe mod(s) with steam
                     action == unsubscribe_mod_steam_action

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -242,6 +242,27 @@ class SettingsDialog(QDialog):
         )
         group_layout.addWidget(self.steam_mods_folder_location)
 
+        # Steam API idle timeout
+        idle_timeout_layout = QHBoxLayout()
+        idle_timeout_label = QLabel(self.tr("Steam API idle timeout (seconds)"))
+        idle_timeout_label.setToolTip(
+            self.tr(
+                "How long to keep the Steamworks API handle open after the last "
+                "operation completes. Lower values release Steam faster; higher "
+                "values avoid re-initialization for rapid operations."
+            )
+        )
+        idle_timeout_layout.addWidget(idle_timeout_label)
+        self.steam_api_idle_timeout_spinbox = QSpinBox()
+        self.steam_api_idle_timeout_spinbox.setMinimum(5)
+        self.steam_api_idle_timeout_spinbox.setMaximum(300)
+        self.steam_api_idle_timeout_spinbox.setSingleStep(5)
+        self.steam_api_idle_timeout_spinbox.setSizePolicy(
+            QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed
+        )
+        idle_timeout_layout.addWidget(self.steam_api_idle_timeout_spinbox)
+        group_layout.addLayout(idle_timeout_layout)
+
     def _do_local_mods_folder_location_area(self, tab_layout: QVBoxLayout) -> None:
         group_box = QGroupBox()
         tab_layout.addWidget(group_box)

--- a/app/windows/runner_panel.py
+++ b/app/windows/runner_panel.py
@@ -567,6 +567,7 @@ class RunnerPanel(QWidget):
 
     def _handle_steamcmd_completion(self) -> None:
         """Handle SteamCMD-specific completion tasks."""
+        EventBus().do_refresh_steamcmd_acf.emit()
         # Check if there are any failed downloads to report
         if len(self.steamcmd_download_tracking) == 0:
             self.change_progress_bar_color("success")

--- a/tests/utils/steam/test_steamworks_worker.py
+++ b/tests/utils/steam/test_steamworks_worker.py
@@ -1,0 +1,346 @@
+"""
+Tests for SteamworksWorker lifecycle and operation handling.
+
+All tests mock the STEAMWORKS class at the import boundary to avoid
+requiring a real Steam client.
+"""
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+from PySide6.QtCore import QCoreApplication
+from PySide6.QtTest import QSignalSpy
+
+from app.utils.steam.steamworks.wrapper import SteamworksWorker
+
+
+@pytest.fixture(autouse=True)
+def _ensure_qapp() -> None:
+    if QCoreApplication.instance() is None:
+        QCoreApplication([])
+
+
+def _make_mock_steamworks(loaded: bool = True) -> MagicMock:
+    """Create a mock STEAMWORKS instance with Workshop methods."""
+    sw = MagicMock()
+    sw.loaded.return_value = loaded
+    # Use spec to control which Workshop attributes exist.
+    # DownloadItem is intentionally absent unless explicitly added by tests.
+    sw.Workshop = MagicMock(
+        spec=[
+            "SubscribeItem",
+            "UnsubscribeItem",
+            "SetItemSubscribedCallback",
+            "SetItemUnsubscribedCallback",
+            "SetGetAppDependenciesResultCallback",
+            "GetAppDependencies",
+            "GetItemState",
+            "GetItemDownloadInfo",
+        ]
+    )
+    return sw
+
+
+@pytest.fixture
+def mock_steamworks_class() -> MagicMock:
+    """Patch the STEAMWORKS class constructor."""
+    with patch("app.utils.steam.steamworks.wrapper.STEAMWORKS") as cls:
+        mock_sw = _make_mock_steamworks()
+        cls.return_value = mock_sw
+        cls._mock_instance = mock_sw
+        yield cls
+
+
+class TestWorkerLifecycle:
+    def test_worker_starts_idle(self, mock_steamworks_class: MagicMock) -> None:
+        worker = SteamworksWorker(idle_timeout=15)
+        worker.start()
+        time.sleep(0.3)
+
+        assert worker.health_check() is False
+        mock_steamworks_class.assert_not_called()
+
+        worker.shutdown()
+
+    def test_first_operation_triggers_init(
+        self, mock_steamworks_class: MagicMock
+    ) -> None:
+        mock_sw = mock_steamworks_class._mock_instance
+
+        # Make callbacks fire immediately by side-effecting the callback registration
+        def fire_subscribe_callback(*args, **kwargs):
+            cb = args[0]
+            result_obj = MagicMock()
+            result_obj.publishedFileId = 12345
+            result_obj.result = 1
+            cb(result_obj)
+
+        mock_sw.Workshop.SetItemSubscribedCallback.side_effect = fire_subscribe_callback
+
+        worker = SteamworksWorker(idle_timeout=60)
+        worker.start()
+        time.sleep(0.2)
+
+        worker.subscribe([12345])
+        time.sleep(1.0)
+
+        mock_sw.initialize.assert_called_once()
+        mock_sw.Workshop.SubscribeItem.assert_called_once_with(12345)
+
+        worker.shutdown()
+
+    def test_idle_timeout_triggers_unload(
+        self, mock_steamworks_class: MagicMock
+    ) -> None:
+        mock_sw = mock_steamworks_class._mock_instance
+
+        def fire_subscribe_callback(*args, **kwargs):
+            cb = args[0]
+            result_obj = MagicMock()
+            result_obj.publishedFileId = 111
+            result_obj.result = 1
+            cb(result_obj)
+
+        mock_sw.Workshop.SetItemSubscribedCallback.side_effect = fire_subscribe_callback
+
+        worker = SteamworksWorker(idle_timeout=1)
+        worker.start()
+        time.sleep(0.2)
+
+        worker.subscribe([111])
+        time.sleep(0.5)
+
+        # Not yet unloaded
+        mock_sw.unload.assert_not_called()
+
+        # Wait for idle timeout
+        time.sleep(1.5)
+
+        mock_sw.unload.assert_called_once()
+
+        worker.shutdown()
+
+    def test_reinit_after_idle_shutdown(self, mock_steamworks_class: MagicMock) -> None:
+        mock_sw = mock_steamworks_class._mock_instance
+
+        def fire_subscribe_callback(*args, **kwargs):
+            cb = args[0]
+            result_obj = MagicMock()
+            result_obj.publishedFileId = 222
+            result_obj.result = 1
+            cb(result_obj)
+
+        mock_sw.Workshop.SetItemSubscribedCallback.side_effect = fire_subscribe_callback
+
+        worker = SteamworksWorker(idle_timeout=1)
+        worker.start()
+        time.sleep(0.2)
+
+        # First operation
+        worker.subscribe([222])
+        time.sleep(2.0)  # Wait for idle unload
+        mock_sw.unload.assert_called_once()
+
+        # Second operation should re-init
+        worker.subscribe([333])
+        time.sleep(1.0)
+        assert mock_sw.initialize.call_count == 2
+
+        worker.shutdown()
+
+    def test_steam_not_running_signal(self, mock_steamworks_class: MagicMock) -> None:
+        mock_sw = mock_steamworks_class._mock_instance
+        mock_sw.initialize.side_effect = Exception("Steam not running")
+
+        worker = SteamworksWorker(idle_timeout=60)
+        spy = QSignalSpy(worker.steam_not_running)
+        worker.start()
+        time.sleep(0.2)
+
+        worker.subscribe([999])
+        time.sleep(1.0)
+
+        assert spy.count() >= 1
+        mock_sw.Workshop.SubscribeItem.assert_not_called()
+
+        worker.shutdown()
+
+    def test_operation_complete_signal(self, mock_steamworks_class: MagicMock) -> None:
+        mock_sw = mock_steamworks_class._mock_instance
+
+        def fire_subscribe_callback(*args, **kwargs):
+            cb = args[0]
+            result_obj = MagicMock()
+            result_obj.publishedFileId = 555
+            result_obj.result = 1
+            cb(result_obj)
+
+        mock_sw.Workshop.SetItemSubscribedCallback.side_effect = fire_subscribe_callback
+
+        worker = SteamworksWorker(idle_timeout=60)
+        spy = QSignalSpy(worker.operation_complete)
+        worker.start()
+        time.sleep(0.2)
+
+        worker.subscribe([555])
+        time.sleep(1.0)
+
+        assert spy.count() >= 1
+        assert spy.at(0) == ["subscribe", True]
+
+        worker.shutdown()
+
+    def test_shutdown_is_clean(self, mock_steamworks_class: MagicMock) -> None:
+        worker = SteamworksWorker(idle_timeout=60)
+        worker.start()
+        time.sleep(0.2)
+        assert worker.isRunning()
+
+        worker.shutdown()
+        assert not worker.isRunning()
+
+
+class TestOperationHandling:
+    def test_unsubscribe_emits_item_unsubscribed(
+        self, mock_steamworks_class: MagicMock
+    ) -> None:
+        mock_sw = mock_steamworks_class._mock_instance
+
+        def fire_unsub_callback(*args, **kwargs):
+            cb = args[0]
+            result_obj = MagicMock()
+            result_obj.publishedFileId = 777
+            result_obj.result = 1
+            cb(result_obj)
+
+        mock_sw.Workshop.SetItemUnsubscribedCallback.side_effect = fire_unsub_callback
+
+        worker = SteamworksWorker(idle_timeout=60)
+        spy = QSignalSpy(worker.item_unsubscribed)
+        worker.start()
+        time.sleep(0.2)
+
+        worker.unsubscribe([777])
+        time.sleep(1.0)
+
+        assert spy.count() >= 1
+        assert spy.at(0) == ["777"]
+
+        worker.shutdown()
+
+    def test_hasattr_check_for_download_item(
+        self, mock_steamworks_class: MagicMock
+    ) -> None:
+        """DownloadItem is absent (not in Workshop spec) — force_download should not crash."""
+        worker = SteamworksWorker(idle_timeout=60)
+        spy = QSignalSpy(worker.operation_complete)
+        worker.start()
+        time.sleep(0.2)
+
+        worker.force_download([888])
+        time.sleep(1.0)
+
+        # Should emit operation_complete with False (DownloadItem not supported)
+        assert spy.count() >= 1
+        assert spy.at(0) == ["force_download", False]
+
+        worker.shutdown()
+
+    def test_force_download_with_download_item(
+        self, mock_steamworks_class: MagicMock
+    ) -> None:
+        """When DownloadItem is present, it should be called."""
+        mock_sw = mock_steamworks_class._mock_instance
+        mock_sw.Workshop.DownloadItem = MagicMock()
+
+        worker = SteamworksWorker(idle_timeout=60)
+        spy = QSignalSpy(worker.operation_complete)
+        worker.start()
+        time.sleep(0.2)
+
+        worker.force_download([999])
+        time.sleep(1.0)
+
+        mock_sw.Workshop.DownloadItem.assert_called_once()
+        assert spy.count() >= 1
+        assert spy.at(0) == ["force_download", True]
+
+        worker.shutdown()
+
+    def test_app_dependencies_returns_via_future(
+        self, mock_steamworks_class: MagicMock
+    ) -> None:
+        mock_sw = mock_steamworks_class._mock_instance
+
+        def fire_deps_callback(*args, **kwargs):
+            cb = args[0]
+            result_obj = MagicMock()
+            result_obj.publishedFileId = 444
+            result_obj.get_app_dependencies_list.return_value = [294100]
+            cb(result_obj)
+
+        mock_sw.Workshop.SetGetAppDependenciesResultCallback.side_effect = (
+            fire_deps_callback
+        )
+
+        worker = SteamworksWorker(idle_timeout=60)
+        worker.start()
+        time.sleep(0.2)
+
+        future = worker.query_app_dependencies([444])
+        result = future.result(timeout=10)
+
+        assert result is not None
+        assert 444 in result
+        assert result[444] == [294100]
+
+        worker.shutdown()
+
+    def test_queue_serialization(self, mock_steamworks_class: MagicMock) -> None:
+        """Multiple operations submitted rapidly should execute in order."""
+        mock_sw = mock_steamworks_class._mock_instance
+        call_order: list[str] = []
+
+        def track_subscribe(*args, **kwargs):
+            cb = args[0]
+            result_obj = MagicMock()
+            result_obj.result = 1
+
+            def on_subscribe_item(pfid):
+                call_order.append(f"sub-{pfid}")
+                result_obj.publishedFileId = pfid
+                cb(result_obj)
+
+            mock_sw.Workshop.SubscribeItem.side_effect = on_subscribe_item
+
+        def track_unsubscribe(*args, **kwargs):
+            cb = args[0]
+            result_obj = MagicMock()
+            result_obj.result = 1
+
+            def on_unsubscribe_item(pfid):
+                call_order.append(f"unsub-{pfid}")
+                result_obj.publishedFileId = pfid
+                cb(result_obj)
+
+            mock_sw.Workshop.UnsubscribeItem.side_effect = on_unsubscribe_item
+
+        mock_sw.Workshop.SetItemSubscribedCallback.side_effect = track_subscribe
+        mock_sw.Workshop.SetItemUnsubscribedCallback.side_effect = track_unsubscribe
+
+        worker = SteamworksWorker(idle_timeout=60)
+        worker.start()
+        time.sleep(0.2)
+
+        # Submit subscribe then unsubscribe rapidly
+        worker.subscribe([100])
+        worker.unsubscribe([200])
+        time.sleep(2.0)
+
+        assert "sub-100" in call_order
+        assert "unsub-200" in call_order
+        # Subscribe should come before unsubscribe
+        assert call_order.index("sub-100") < call_order.index("unsub-200")
+
+        worker.shutdown()

--- a/tests/utils/steam/test_steamworks_worker.py
+++ b/tests/utils/steam/test_steamworks_worker.py
@@ -6,6 +6,8 @@ requiring a real Steam client.
 """
 
 import time
+from collections.abc import Generator
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -43,7 +45,7 @@ def _make_mock_steamworks(loaded: bool = True) -> MagicMock:
 
 
 @pytest.fixture
-def mock_steamworks_class() -> MagicMock:
+def mock_steamworks_class() -> Generator[MagicMock]:
     """Patch the STEAMWORKS class constructor."""
     with patch("app.utils.steam.steamworks.wrapper.STEAMWORKS") as cls:
         mock_sw = _make_mock_steamworks()
@@ -69,7 +71,7 @@ class TestWorkerLifecycle:
         mock_sw = mock_steamworks_class._mock_instance
 
         # Make callbacks fire immediately by side-effecting the callback registration
-        def fire_subscribe_callback(*args, **kwargs):
+        def fire_subscribe_callback(*args: Any, **kwargs: Any) -> None:
             cb = args[0]
             result_obj = MagicMock()
             result_obj.publishedFileId = 12345
@@ -95,7 +97,7 @@ class TestWorkerLifecycle:
     ) -> None:
         mock_sw = mock_steamworks_class._mock_instance
 
-        def fire_subscribe_callback(*args, **kwargs):
+        def fire_subscribe_callback(*args: Any, **kwargs: Any) -> None:
             cb = args[0]
             result_obj = MagicMock()
             result_obj.publishedFileId = 111
@@ -124,7 +126,7 @@ class TestWorkerLifecycle:
     def test_reinit_after_idle_shutdown(self, mock_steamworks_class: MagicMock) -> None:
         mock_sw = mock_steamworks_class._mock_instance
 
-        def fire_subscribe_callback(*args, **kwargs):
+        def fire_subscribe_callback(*args: Any, **kwargs: Any) -> None:
             cb = args[0]
             result_obj = MagicMock()
             result_obj.publishedFileId = 222
@@ -169,7 +171,7 @@ class TestWorkerLifecycle:
     def test_operation_complete_signal(self, mock_steamworks_class: MagicMock) -> None:
         mock_sw = mock_steamworks_class._mock_instance
 
-        def fire_subscribe_callback(*args, **kwargs):
+        def fire_subscribe_callback(*args: Any, **kwargs: Any) -> None:
             cb = args[0]
             result_obj = MagicMock()
             result_obj.publishedFileId = 555
@@ -207,7 +209,7 @@ class TestOperationHandling:
     ) -> None:
         mock_sw = mock_steamworks_class._mock_instance
 
-        def fire_unsub_callback(*args, **kwargs):
+        def fire_unsub_callback(*args: Any, **kwargs: Any) -> None:
             cb = args[0]
             result_obj = MagicMock()
             result_obj.publishedFileId = 777
@@ -273,7 +275,7 @@ class TestOperationHandling:
     ) -> None:
         mock_sw = mock_steamworks_class._mock_instance
 
-        def fire_deps_callback(*args, **kwargs):
+        def fire_deps_callback(*args: Any, **kwargs: Any) -> None:
             cb = args[0]
             result_obj = MagicMock()
             result_obj.publishedFileId = 444
@@ -302,24 +304,24 @@ class TestOperationHandling:
         mock_sw = mock_steamworks_class._mock_instance
         call_order: list[str] = []
 
-        def track_subscribe(*args, **kwargs):
+        def track_subscribe(*args: Any, **kwargs: Any) -> None:
             cb = args[0]
             result_obj = MagicMock()
             result_obj.result = 1
 
-            def on_subscribe_item(pfid):
+            def on_subscribe_item(pfid: int) -> None:
                 call_order.append(f"sub-{pfid}")
                 result_obj.publishedFileId = pfid
                 cb(result_obj)
 
             mock_sw.Workshop.SubscribeItem.side_effect = on_subscribe_item
 
-        def track_unsubscribe(*args, **kwargs):
+        def track_unsubscribe(*args: Any, **kwargs: Any) -> None:
             cb = args[0]
             result_obj = MagicMock()
             result_obj.result = 1
 
-            def on_unsubscribe_item(pfid):
+            def on_unsubscribe_item(pfid: int) -> None:
                 call_order.append(f"unsub-{pfid}")
                 result_obj.publishedFileId = pfid
                 cb(result_obj)
@@ -350,10 +352,10 @@ class TestOperationHandling:
         mock_sw = mock_steamworks_class._mock_instance
         subscribed_pfids: list[int] = []
 
-        def fire_subscribe_callback(*args, **kwargs):
+        def fire_subscribe_callback(*args: Any, **kwargs: Any) -> None:
             cb = args[0]
 
-            def on_item(pfid):
+            def on_item(pfid: int) -> None:
                 subscribed_pfids.append(pfid)
                 result_obj = MagicMock()
                 result_obj.publishedFileId = pfid
@@ -386,7 +388,7 @@ class TestOperationHandling:
         """Callback with result != 1 should emit steam_operation_failed."""
         mock_sw = mock_steamworks_class._mock_instance
 
-        def fire_failed_callback(*args, **kwargs):
+        def fire_failed_callback(*args: Any, **kwargs: Any) -> None:
             cb = args[0]
             result_obj = MagicMock()
             result_obj.publishedFileId = 666
@@ -417,10 +419,10 @@ class TestOperationHandling:
         mock_sw = mock_steamworks_class._mock_instance
         stage_log: list[str] = []
 
-        def track_unsub_callback(*args, **kwargs):
+        def track_unsub_callback(*args: Any, **kwargs: Any) -> None:
             cb = args[0]
 
-            def on_unsub(pfid):
+            def on_unsub(pfid: int) -> None:
                 stage_log.append(f"unsub-{pfid}")
                 result_obj = MagicMock()
                 result_obj.publishedFileId = pfid
@@ -429,10 +431,10 @@ class TestOperationHandling:
 
             mock_sw.Workshop.UnsubscribeItem.side_effect = on_unsub
 
-        def track_sub_callback(*args, **kwargs):
+        def track_sub_callback(*args: Any, **kwargs: Any) -> None:
             cb = args[0]
 
-            def on_sub(pfid):
+            def on_sub(pfid: int) -> None:
                 stage_log.append(f"sub-{pfid}")
                 result_obj = MagicMock()
                 result_obj.publishedFileId = pfid
@@ -472,12 +474,12 @@ class TestOperationHandling:
     ) -> None:
         """Late callbacks from a previous operation should not affect the next one."""
         mock_sw = mock_steamworks_class._mock_instance
-        stored_callbacks: list = []
+        stored_callbacks: list[Any] = []
 
-        def capture_subscribe_callback(*args, **kwargs):
+        def capture_subscribe_callback(*args: Any, **kwargs: Any) -> None:
             stored_callbacks.append(args[0])
 
-            def on_item(pfid):
+            def on_item(pfid: int) -> None:
                 if pfid == 200:
                     cb = stored_callbacks[-1]
                     result_obj = MagicMock()

--- a/tests/utils/steam/test_steamworks_worker.py
+++ b/tests/utils/steam/test_steamworks_worker.py
@@ -344,3 +344,174 @@ class TestOperationHandling:
         assert call_order.index("sub-100") < call_order.index("unsub-200")
 
         worker.shutdown()
+
+    def test_subscribe_multiple_pfids(self, mock_steamworks_class: MagicMock) -> None:
+        """Subscribe with multiple pfids should call SubscribeItem for each."""
+        mock_sw = mock_steamworks_class._mock_instance
+        subscribed_pfids: list[int] = []
+
+        def fire_subscribe_callback(*args, **kwargs):
+            cb = args[0]
+
+            def on_item(pfid):
+                subscribed_pfids.append(pfid)
+                result_obj = MagicMock()
+                result_obj.publishedFileId = pfid
+                result_obj.result = 1
+                cb(result_obj)
+
+            mock_sw.Workshop.SubscribeItem.side_effect = on_item
+
+        mock_sw.Workshop.SetItemSubscribedCallback.side_effect = fire_subscribe_callback
+
+        worker = SteamworksWorker(idle_timeout=60)
+        spy = QSignalSpy(worker.item_subscribed)
+        worker.start()
+        time.sleep(0.2)
+
+        worker.subscribe([100, 200, 300])
+        time.sleep(3.0)
+
+        assert subscribed_pfids == [100, 200, 300]
+        assert spy.count() == 3
+        assert spy.at(0) == ["100"]
+        assert spy.at(1) == ["200"]
+        assert spy.at(2) == ["300"]
+
+        worker.shutdown()
+
+    def test_subscribe_callback_failure_emits_operation_failed(
+        self, mock_steamworks_class: MagicMock
+    ) -> None:
+        """Callback with result != 1 should emit steam_operation_failed."""
+        mock_sw = mock_steamworks_class._mock_instance
+
+        def fire_failed_callback(*args, **kwargs):
+            cb = args[0]
+            result_obj = MagicMock()
+            result_obj.publishedFileId = 666
+            result_obj.result = 2  # failure
+            cb(result_obj)
+
+        mock_sw.Workshop.SetItemSubscribedCallback.side_effect = fire_failed_callback
+
+        worker = SteamworksWorker(idle_timeout=60)
+        fail_spy = QSignalSpy(worker.steam_operation_failed)
+        sub_spy = QSignalSpy(worker.item_subscribed)
+        worker.start()
+        time.sleep(0.2)
+
+        worker.subscribe([666])
+        time.sleep(1.0)
+
+        assert fail_spy.count() >= 1
+        assert fail_spy.at(0) == ["666", "subscribe failed"]
+        assert sub_spy.count() == 0
+
+        worker.shutdown()
+
+    def test_resubscribe_batched_sequencing(
+        self, mock_steamworks_class: MagicMock
+    ) -> None:
+        """Resubscribe should follow the 5-stage batched pattern."""
+        mock_sw = mock_steamworks_class._mock_instance
+        stage_log: list[str] = []
+
+        def track_unsub_callback(*args, **kwargs):
+            cb = args[0]
+
+            def on_unsub(pfid):
+                stage_log.append(f"unsub-{pfid}")
+                result_obj = MagicMock()
+                result_obj.publishedFileId = pfid
+                result_obj.result = 1
+                cb(result_obj)
+
+            mock_sw.Workshop.UnsubscribeItem.side_effect = on_unsub
+
+        def track_sub_callback(*args, **kwargs):
+            cb = args[0]
+
+            def on_sub(pfid):
+                stage_log.append(f"sub-{pfid}")
+                result_obj = MagicMock()
+                result_obj.publishedFileId = pfid
+                result_obj.result = 1
+                cb(result_obj)
+
+            mock_sw.Workshop.SubscribeItem.side_effect = on_sub
+
+        mock_sw.Workshop.SetItemUnsubscribedCallback.side_effect = track_unsub_callback
+        mock_sw.Workshop.SetItemSubscribedCallback.side_effect = track_sub_callback
+
+        worker = SteamworksWorker(idle_timeout=60)
+        spy = QSignalSpy(worker.operation_complete)
+        worker.start()
+        time.sleep(0.2)
+
+        worker.resubscribe([10, 20])
+        # Resubscribe takes: API calls + 4s wait + API calls + 2s wait + download
+        time.sleep(10.0)
+
+        # All unsubs should come before all subs
+        assert "unsub-10" in stage_log
+        assert "unsub-20" in stage_log
+        assert "sub-10" in stage_log
+        assert "sub-20" in stage_log
+        unsub_end = max(stage_log.index("unsub-10"), stage_log.index("unsub-20"))
+        sub_start = min(stage_log.index("sub-10"), stage_log.index("sub-20"))
+        assert unsub_end < sub_start
+
+        assert spy.count() >= 1
+        assert spy.at(0)[0] == "resubscribe"
+
+        worker.shutdown()
+
+    def test_stale_callback_ignored_across_operations(
+        self, mock_steamworks_class: MagicMock
+    ) -> None:
+        """Late callbacks from a previous operation should not affect the next one."""
+        mock_sw = mock_steamworks_class._mock_instance
+        stored_callbacks: list = []
+
+        def capture_subscribe_callback(*args, **kwargs):
+            stored_callbacks.append(args[0])
+
+            def on_item(pfid):
+                if pfid == 200:
+                    cb = stored_callbacks[-1]
+                    result_obj = MagicMock()
+                    result_obj.publishedFileId = pfid
+                    result_obj.result = 1
+                    cb(result_obj)
+
+            mock_sw.Workshop.SubscribeItem.side_effect = on_item
+
+        mock_sw.Workshop.SetItemSubscribedCallback.side_effect = (
+            capture_subscribe_callback
+        )
+
+        worker = SteamworksWorker(idle_timeout=60)
+        worker.start()
+        time.sleep(0.2)
+
+        # First operation — callback won't fire (simulating dropped callback)
+        worker.subscribe([100])
+        time.sleep(2.0)
+
+        # Second operation — callback fires normally
+        worker.subscribe([200])
+        time.sleep(2.0)
+
+        # Fire the stale callback from op 1 — should be ignored by generation check
+        if len(stored_callbacks) >= 1:
+            stale_cb = stored_callbacks[0]
+            result_obj = MagicMock()
+            result_obj.publishedFileId = 100
+            result_obj.result = 1
+            stale_cb(result_obj)
+
+        time.sleep(0.5)
+        assert worker._pending_callbacks >= 0
+
+        worker.shutdown()

--- a/tests/views/test_main_content_run.py
+++ b/tests/views/test_main_content_run.py
@@ -32,6 +32,10 @@ class DummySettings:
         self.active_mods_data_source_filter_index = 0
         self.inactive_mods_data_source_filter_index = 0
         self.active_mods_dividers: list[dict[str, object]] = []
+        # Steam API
+        self.steam_api_idle_timeout = 15
+        # SteamCMD
+        self.steamcmd_validate_downloads = True
         # Instance data with dummy game_folder, config_folder and run_args
         self.instances = {
             "inst1": SimpleNamespace(
@@ -40,6 +44,7 @@ class DummySettings:
                 run_args=["--test"],
                 steam_client_integration=False,
                 launch_via_steam_protocol=False,
+                steamcmd_install_path="",
             )
         }
 
@@ -85,6 +90,19 @@ def patch_steamcmd(monkeypatch: pytest.MonkeyPatch) -> None:
             lambda cls: SimpleNamespace(setup=True, steamcmd_appworkshop_acf_path="")
         ),
     )
+
+
+@pytest.fixture(autouse=True)
+def patch_steamworks_worker(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Prevent SteamworksWorker from initializing the Steamworks API during tests."""
+    from unittest.mock import MagicMock
+
+    from app.views import main_content_panel
+
+    mock_worker_cls = MagicMock()
+    mock_worker_instance = MagicMock()
+    mock_worker_cls.return_value = mock_worker_instance
+    monkeypatch.setattr(main_content_panel, "SteamworksWorker", mock_worker_cls)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary

Replace the multiprocessing-based Steamworks API wrapper with a single `SteamworksWorker(QThread)` that owns the `STEAMWORKS` instance lifecycle. The worker accepts operations via a thread-safe queue, pumps callbacks in its run loop, and auto-unloads the Steam API after a configurable idle timeout (default 15s). This solves three problems:

- **Steam showing "game running"** whenever RimSort is open (singleton approach from #1623)
- **GUI freezing** during subscribe/unsubscribe operations (blocking `Process.join()`)
- **Multiple conflicting STEAMWORKS handles** from `multiprocessing.Pool`

Part of the Steam integration refactor series (PR 6/8). See #1623 for the original monolithic PR this was decomposed from.

## Changes

### Core refactor
- **`app/utils/steam/steamworks/wrapper.py`**: Complete rewrite. Removed `SteamworksInterface`, `SteamworksSubscriptionHandler(Process)`, `SteamworksGameLaunch(Process)`, `SteamworksAppDependenciesQuery`. Added `SteamworksWorker(QThread)` with typed operation dataclasses (`SubscribeOp`, `UnsubscribeOp`, `ResubscribeOp`, `ForceDownloadOp`, `GameLaunchOp`, `AppDependenciesOp`).
- **`app/views/main_content_panel.py`**: Replaced Process-based API calls with non-blocking worker submissions. Removed `steamworks_in_use` boolean gate. Added UI feedback (warning dialogs for failures).
- **`app/utils/steam/webapi/wrapper.py`**: Replaced `multiprocessing.Pool` for `ISteamUGC_GetAppDependencies` with sequential worker submissions via `Future`.

### Thread safety
- `threading.Event` for shutdown signaling (proper cross-thread visibility)
- Callback generation counter prevents stale callbacks from previous operations from corrupting pending counts
- Shutdown path drains pending callbacks (5s grace) before destroying the STEAMWORKS handle

### New features
- Configurable Steam API idle timeout (Settings > Locations, 5-300s)
- "Force download with Steam" context menu action for workshop mods
- Game launch with Steamworks API initialization (Steam overlay for direct-launch users)
- `workshop_item_installed` and `do_refresh_steamcmd_acf` EventBus signals (infrastructure for PRs 7-8)

### Housekeeping
- SteamCMD wrapper init guard flip to early-return style
- PEP 604 type hints in `js_bridge.py`
- `.gitignore` entries for `.ruff_cache`, `.uv-cache`
- ACF refresh signal emission on SteamCMD completion
- Fixes pre-existing blacklist filtering bug where filtered pfids were not passed to the API call

### Preserved behaviors
- PR #1719 resubscribe batched sequencing (unsub all → 4s → sub all → 2s → download)
- PR #1918 `hasattr` check for `DownloadItem`
- All timing constants unchanged

## Test plan
- [x] 16 new tests in `tests/utils/steam/test_steamworks_worker.py` (lifecycle, operations, signals, thread safety)
- [x] All 343 existing tests pass
- [x] Static analysis clean (`ruff check`, `ruff format`)
- [x] Manual: Subscribe/unsubscribe mod via context menu
- [x] Manual: Verify Steam API idle timeout unloads (check logs)
- [ ] Manual: Verify "Force download with Steam" context menu works
- [ ] Manual: Settings > Steam API idle timeout spinbox saves/loads
- [ ] Manual: Game launch with Steam overlay (steam_client_integration enabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)