### PR TITLE
chore: add explicit ruff config to justfile recipes

### DIFF
--- a/justfile
+++ b/justfile
@@ -24,19 +24,19 @@ test-coverage: dev-setup
 
 # Check code for linting issues
 lint:
-    uv run ruff check .
+    uv run ruff check --config pyproject.toml .
 
 # Check and automatically fix linting issues
 lint-fix:
-    uv run ruff check . --fix
+    uv run ruff check --config pyproject.toml . --fix
 
 # Check code formatting without making changes
 format:
-    uv run ruff format . --check
+    uv run ruff format --config pyproject.toml . --check
 
 # Format code automatically
 format-fix:
-    uv run ruff format .
+    uv run ruff format --config pyproject.toml .
 
 # Run type checking with mypy
 typecheck:


### PR DESCRIPTION
## Summary
- Adds `--config pyproject.toml` to all 4 ruff recipes in the justfile (`lint`, `lint-fix`, `format`, `format-fix`)
- Matches the explicit config pattern already used by the `typecheck` (mypy) recipe and the super-linter CI workflow

## Test plan
- [x] Verified `ruff check` and `ruff format` produce identical output with and without the flag
- [x] Confirmed CI already uses `PYTHON_RUFF_CONFIG_FILE: pyproject.toml` in super-linter

🤖 Generated with [Claude Code](https://claude.com/claude-code)