### PR TITLE
fix: support tar.gz release assets in auto-updater

### DIFF
--- a/app/utils/update_utils.py
+++ b/app/utils/update_utils.py
@@ -1551,7 +1551,11 @@ class UpdateManager(QObject):
                         QApplication.processEvents()
 
             logger.info(f"Extracted {total} entries from tar.gz")
+            return total
 
+        except tarfile.TarError as e:
+            raise UpdateExtractionError(f"Invalid tar.gz archive: {e}") from e
+        finally:
             try:
                 if self._progress_widget:
                     self._progress_widget.close()
@@ -1560,12 +1564,6 @@ class UpdateManager(QObject):
                         self.mod_info_panel.info_panel_frame.show()
             except Exception:
                 pass
-
-            return total
-
-        except tarfile.TarError as e:
-            raise UpdateExtractionError(f"Invalid tar.gz archive: {e}") from e
-        finally:
             if temp_tar_path.exists():
                 try:
                     temp_tar_path.unlink()

--- a/app/utils/update_utils.py
+++ b/app/utils/update_utils.py
@@ -5,6 +5,7 @@ import shlex
 import shutil
 import subprocess
 import sys
+import tarfile
 import tempfile
 import threading
 import time
@@ -44,6 +45,7 @@ DOWNLOAD_TIMEOUT = 30
 
 # File and archive constants
 ZIP_EXTENSION = ".zip"
+TAR_GZ_EXTENSION = ".tar.gz"
 MSI_EXTENSION = ".msi"
 APPIMAGE_EXTENSION = ".AppImage"
 DOWNLOAD_CHUNK_SIZE = 131072  # 128KB for better performance
@@ -134,6 +136,7 @@ class ReleaseInfo(TypedDict):
     download_url: str
     is_msi: bool
     is_appimage: bool
+    is_tar_gz: bool
 
 
 class DownloadInfo(TypedDict):
@@ -143,6 +146,7 @@ class DownloadInfo(TypedDict):
     name: str
     is_msi: bool
     is_appimage: bool
+    is_tar_gz: bool
 
 
 class PlatformPatterns(TypedDict):
@@ -635,6 +639,7 @@ class UpdateManager(QObject):
             "needs_elevation": needs_elevation,
             "is_msi": latest_release_info.get("is_msi", False),
             "is_appimage": latest_release_info.get("is_appimage", False),
+            "is_tar_gz": latest_release_info.get("is_tar_gz", False),
         }
 
     def _parse_current_version(self, current_version: str) -> version.Version:
@@ -707,9 +712,10 @@ class UpdateManager(QObject):
 
         is_msi = bool(update_info.get("is_msi", False))
         is_appimage = bool(update_info.get("is_appimage", False))
+        is_tar_gz = bool(update_info.get("is_tar_gz", False))
 
         try:
-            self._perform_update(download_url, tag_name, is_msi, is_appimage)
+            self._perform_update(download_url, tag_name, is_msi, is_appimage, is_tar_gz)
         except UpdateError as e:
             logger.error(f"Update process failed: {e}")
             raise
@@ -767,6 +773,7 @@ class UpdateManager(QObject):
                 "download_url": download_info["url"],
                 "is_msi": download_info.get("is_msi", False),
                 "is_appimage": download_info.get("is_appimage", False),
+                "is_tar_gz": download_info.get("is_tar_gz", False),
             }
 
         except requests.RequestException as e:
@@ -860,12 +867,10 @@ class UpdateManager(QObject):
         # Determine preferred extension order
         if self._system == "Windows" and self._is_in_protected_path():
             preferred_order = [MSI_EXTENSION, ZIP_EXTENSION]
+        elif self._system == "Windows":
+            preferred_order = [ZIP_EXTENSION, MSI_EXTENSION]
         else:
-            preferred_order = (
-                [ZIP_EXTENSION, MSI_EXTENSION]
-                if self._system == "Windows"
-                else [ZIP_EXTENSION]
-            )
+            preferred_order = [TAR_GZ_EXTENSION, ZIP_EXTENSION]
 
         logger.debug(
             f"Looking for asset matching system={self._system}, arch={self._arch}, patterns={system_patterns + arch_patterns}, order={preferred_order}"
@@ -930,6 +935,7 @@ class UpdateManager(QObject):
                         "name": asset_name,
                         "is_msi": preferred_extension == MSI_EXTENSION,
                         "is_appimage": False,
+                        "is_tar_gz": preferred_extension == TAR_GZ_EXTENSION,
                     },
                 )
             elif download_url and self._asset_matches(
@@ -946,6 +952,7 @@ class UpdateManager(QObject):
                             "name": asset_name,
                             "is_msi": preferred_extension == MSI_EXTENSION,
                             "is_appimage": False,
+                            "is_tar_gz": preferred_extension == TAR_GZ_EXTENSION,
                         },
                     )
 
@@ -983,6 +990,7 @@ class UpdateManager(QObject):
                         "name": asset_name,
                         "is_msi": False,
                         "is_appimage": True,
+                        "is_tar_gz": False,
                     },
                 )
 
@@ -999,6 +1007,7 @@ class UpdateManager(QObject):
                         "name": asset_name,
                         "is_msi": False,
                         "is_appimage": True,
+                        "is_tar_gz": False,
                     },
                 )
 
@@ -1015,7 +1024,12 @@ class UpdateManager(QObject):
             self.download_complete.emit(False, str(e))
 
     def _perform_update(
-        self, download_url: str, tag_name: str, is_msi: bool, is_appimage: bool = False
+        self,
+        download_url: str,
+        tag_name: str,
+        is_msi: bool,
+        is_appimage: bool = False,
+        is_tar_gz: bool = False,
     ) -> None:
         """
         Download and extract the update, then launch the update script.
@@ -1025,6 +1039,7 @@ class UpdateManager(QObject):
             tag_name: Tag name of the release
             is_msi: Whether the update is an MSI installer
             is_appimage: Whether the update is an AppImage file
+            is_tar_gz: Whether the update is a tar.gz archive
         """
         try:
             logger.debug(
@@ -1099,7 +1114,7 @@ class UpdateManager(QObject):
             else:
                 # Extract or save with progress window
                 try:
-                    self._extract_update_with_progress(is_msi)
+                    self._extract_update_with_progress(is_msi, is_tar_gz)
                 except Exception as e:
                     logger.error(f"Extraction/preparation failed: {e}")
                     raise UpdateExtractionError(f"Extraction failed: {str(e)}") from e
@@ -1484,6 +1499,79 @@ class UpdateManager(QObject):
                 except Exception as e:
                     logger.debug(f"Failed to clean up temp ZIP file: {e}")
 
+    def _extract_tar_gz(self, content: bytes, temp_base: Path) -> int:
+        """
+        Extract tar.gz content to the temporary directory with progress UI.
+
+        Args:
+            content: tar.gz file content as bytes
+            temp_base: Temporary directory to extract to
+
+        Returns:
+            Number of files extracted
+
+        Raises:
+            UpdateExtractionError: If the archive is corrupt or extraction fails
+        """
+        logger.info("Extracting update from tar.gz")
+
+        temp_tar_path = temp_base.parent / f"{temp_base.name}.tar.gz"
+        temp_tar_path.write_bytes(content)
+
+        try:
+            with tarfile.open(temp_tar_path, "r:gz") as tf:
+                members = tf.getmembers()
+                total = len(members)
+                logger.info(f"tar.gz contains {total} entries")
+
+                if total == 0:
+                    raise UpdateExtractionError("tar.gz archive is empty")
+
+                self._progress_widget = TaskProgressWindow(
+                    title="Extracting Update",
+                    show_message=True,
+                    show_percent=True,
+                )
+                self._progress_widget.set_message("Extracting files...")
+
+                if self.mod_info_panel:
+                    self.mod_info_panel.info_panel_frame.hide()
+                    self.mod_info_panel.panel.addWidget(self._progress_widget)
+                    self._progress_widget.show()
+                else:
+                    self._progress_widget.show()
+
+                for i, member in enumerate(members):
+                    tf.extract(member, temp_base, filter="data")
+                    if (i + 1) % 50 == 0 or i == total - 1:
+                        percent = int(((i + 1) / total) * 100)
+                        self._progress_widget.update_progress(
+                            percent, f"Extracting: {i + 1}/{total} files"
+                        )
+                        QApplication.processEvents()
+
+            logger.info(f"Extracted {total} entries from tar.gz")
+
+            try:
+                if self._progress_widget:
+                    self._progress_widget.close()
+                    if self.mod_info_panel:
+                        self.mod_info_panel.panel.removeWidget(self._progress_widget)
+                        self.mod_info_panel.info_panel_frame.show()
+            except Exception:
+                pass
+
+            return total
+
+        except tarfile.TarError as e:
+            raise UpdateExtractionError(f"Invalid tar.gz archive: {e}") from e
+        finally:
+            if temp_tar_path.exists():
+                try:
+                    temp_tar_path.unlink()
+                except Exception as e:
+                    logger.debug(f"Failed to clean up temp tar.gz file: {e}")
+
     def _normalize_structure(self, temp_base: Path, extracted_files: int) -> None:
         """
         Normalize the extracted structure by moving contents to root if wrapped.
@@ -1585,13 +1673,14 @@ class UpdateManager(QObject):
         logger.info(f"AppImage prepared ({len(self._update_content)} bytes)")
         return new_path
 
-    def _extract_update(self, is_msi: bool = False) -> Path:
+    def _extract_update(self, is_msi: bool = False, is_tar_gz: bool = False) -> Path:
         """
         Extract the downloaded update to a dedicated temporary directory and normalize structure,
         or save MSI file to temp location.
 
         Args:
             is_msi: Whether the update is an MSI installer (don't extract, just save)
+            is_tar_gz: Whether the update is a tar.gz archive
 
         Raises:
             UpdateExtractionError: If extraction or saving fails
@@ -1613,11 +1702,14 @@ class UpdateManager(QObject):
                 self._extracted_path = msi_path
                 return msi_path
             else:
-                # Create unique temp dir for ZIP extraction
                 temp_base = self._create_temp_dir()
 
-                # Extract ZIP content
-                extracted_files = self._extract_zip(self._update_content, temp_base)
+                if is_tar_gz:
+                    extracted_files = self._extract_tar_gz(
+                        self._update_content, temp_base
+                    )
+                else:
+                    extracted_files = self._extract_zip(self._update_content, temp_base)
                 logger.info(f"Extracted {extracted_files} files")
 
                 # Normalize structure
@@ -2257,7 +2349,9 @@ class UpdateManager(QObject):
 
         return script_path, args_repr, start_new_session, install_dir
 
-    def _extract_update_with_progress(self, is_msi: bool = False) -> None:
+    def _extract_update_with_progress(
+        self, is_msi: bool = False, is_tar_gz: bool = False
+    ) -> None:
         """
         Extract or prepare the update with a progress window.
 
@@ -2267,13 +2361,16 @@ class UpdateManager(QObject):
 
         Args:
             is_msi: Whether the update is an MSI installer
+            is_tar_gz: Whether the update is a tar.gz archive
         """
         # Run extraction on main thread (Qt operations require main thread)
-        self._extracted_path = self._extract_update_thread_worker(is_msi)
+        self._extracted_path = self._extract_update_thread_worker(is_msi, is_tar_gz)
 
-    def _extract_update_thread_worker(self, is_msi: bool = False) -> Path:
+    def _extract_update_thread_worker(
+        self, is_msi: bool = False, is_tar_gz: bool = False
+    ) -> Path:
         """Worker thread for extraction."""
-        return self._extract_update(is_msi)
+        return self._extract_update(is_msi, is_tar_gz)
 
     def _show_progress_widget(
         self, progress_widget: TaskProgressWindow, cancellable: bool = True

--- a/app/utils/update_utils.py
+++ b/app/utils/update_utils.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypedDict, Union, c
 
 import requests
 from loguru import logger
-from PySide6.QtCore import QEventLoop, QObject, Signal
+from PySide6.QtCore import QEventLoop, QObject, QThread, Signal
 from PySide6.QtWidgets import QApplication, QMessageBox
 
 import app.views.dialogue as dialogue
@@ -349,6 +349,64 @@ class ScriptConfig:
             return cmd
         else:
             raise ValueError(f"Unsupported platform: {self.platform}")
+
+
+class TarExtractThread(QThread):
+    """Extract tar.gz files in a separate thread with progress reporting.
+
+    Mirrors :class:`ZipExtractThread` so the update manager can drive both
+    archive types through the same QEventLoop pattern.
+    """
+
+    progress = Signal(int, str)
+    finished = Signal(bool, str)
+
+    def __init__(self, tar_path: str, target_path: str) -> None:
+        super().__init__()
+        self.tar_path = tar_path
+        self.target_path = target_path
+        self._should_abort = False
+
+    def run(self) -> None:
+        start = time.perf_counter()
+        try:
+            with tarfile.open(self.tar_path, "r:gz") as tf:
+                members = tf.getmembers()
+                total = len(members)
+
+                if total == 0:
+                    self.finished.emit(False, "tar.gz archive is empty")
+                    return
+
+                update_interval = max(1, total // 100)
+
+                for i, member in enumerate(members):
+                    if self._should_abort:
+                        self.finished.emit(False, "Operation aborted")
+                        return
+
+                    tf.extract(member, self.target_path, filter="data")
+
+                    if i % update_interval == 0 or i == total - 1:
+                        percent = int((i + 1) / total * 100)
+                        self.progress.emit(
+                            percent, f"Extracting: {i + 1} / {total} files"
+                        )
+
+            elapsed = time.perf_counter() - start
+            self.finished.emit(
+                True,
+                f"{self.tar_path} → {self.target_path}\n"
+                f"Time elapsed: {elapsed:.2f} seconds",
+            )
+
+        except Exception as e:
+            logger.error(f"tar.gz extraction failed: {e}")
+            self.finished.emit(False, f"Extraction error: {str(e)}")
+
+    def stop(self) -> None:
+        """Signal the thread to abort extraction on next iteration."""
+        self._should_abort = True
 
 
 class UpdateManager(QObject):
@@ -1501,14 +1559,18 @@ class UpdateManager(QObject):
 
     def _extract_tar_gz(self, content: bytes, temp_base: Path) -> int:
         """
-        Extract tar.gz content to the temporary directory with progress UI.
+        Extract tar.gz content to the temporary directory using
+        TarExtractThread with UI progress.
+
+        Mirrors the QThread + QEventLoop pattern used by :meth:`_extract_zip`
+        so the UI stays responsive and extraction can be aborted.
 
         Args:
             content: tar.gz file content as bytes
             temp_base: Temporary directory to extract to
 
         Returns:
-            Number of files extracted
+            Number of entries extracted
 
         Raises:
             UpdateExtractionError: If the archive is corrupt or extraction fails
@@ -1519,51 +1581,88 @@ class UpdateManager(QObject):
         temp_tar_path.write_bytes(content)
 
         try:
-            with tarfile.open(temp_tar_path, "r:gz") as tf:
-                members = tf.getmembers()
-                total = len(members)
-                logger.info(f"tar.gz contains {total} entries")
-
-                if total == 0:
-                    raise UpdateExtractionError("tar.gz archive is empty")
-
-                self._progress_widget = TaskProgressWindow(
-                    title="Extracting Update",
-                    show_message=True,
-                    show_percent=True,
-                )
-                self._progress_widget.set_message("Extracting files...")
-
-                if self.mod_info_panel:
-                    self.mod_info_panel.info_panel_frame.hide()
-                    self.mod_info_panel.panel.addWidget(self._progress_widget)
-                    self._progress_widget.show()
-                else:
-                    self._progress_widget.show()
-
-                for i, member in enumerate(members):
-                    tf.extract(member, temp_base, filter="data")
-                    if (i + 1) % 50 == 0 or i == total - 1:
-                        percent = int(((i + 1) / total) * 100)
-                        self._progress_widget.update_progress(
-                            percent, f"Extracting: {i + 1}/{total} files"
-                        )
-                        QApplication.processEvents()
-
-            logger.info(f"Extracted {total} entries from tar.gz")
-            return total
-
-        except tarfile.TarError as e:
-            raise UpdateExtractionError(f"Invalid tar.gz archive: {e}") from e
-        finally:
+            # Validate and count members before spawning the thread
             try:
+                with tarfile.open(temp_tar_path, "r:gz") as tf:
+                    extracted_files = len(tf.getmembers())
+            except tarfile.TarError as e:
+                raise UpdateExtractionError(f"Invalid tar.gz archive: {e}") from e
+
+            if extracted_files == 0:
+                raise UpdateExtractionError("tar.gz archive is empty")
+
+            logger.info(f"tar.gz contains {extracted_files} entries")
+
+            # Create and display extraction progress widget
+            self._progress_widget = TaskProgressWindow(
+                title="Extracting Update",
+                show_message=True,
+                show_percent=True,
+            )
+            self._progress_widget.set_message("Extracting files...")
+
+            if self.mod_info_panel:
+                self.mod_info_panel.info_panel_frame.hide()
+                self.mod_info_panel.panel.addWidget(self._progress_widget)
+                self._progress_widget.show()
+            else:
+                self._progress_widget.show()
+
+            # Create and run extraction thread
+            extraction_result: dict[str, Any] = {
+                "success": False,
+                "error": "",
+            }
+            loop = QEventLoop()
+
+            def on_extraction_progress(percent: int, message: str) -> None:
                 if self._progress_widget:
-                    self._progress_widget.close()
-                    if self.mod_info_panel:
-                        self.mod_info_panel.panel.removeWidget(self._progress_widget)
-                        self.mod_info_panel.info_panel_frame.show()
-            except Exception:
-                pass
+                    self._progress_widget.update_progress(percent, message)
+
+            def on_extraction_finished(success: bool, message: str) -> None:
+                extraction_result["success"] = success
+                extraction_result["error"] = message
+                loop.quit()
+                try:
+                    if self._progress_widget:
+                        self._progress_widget.close()
+                        if self.mod_info_panel:
+                            self.mod_info_panel.panel.removeWidget(
+                                self._progress_widget
+                            )
+                            self.mod_info_panel.info_panel_frame.show()
+                except Exception as e:
+                    logger.debug(f"Error closing progress widget: {e}")
+
+            extract_thread = TarExtractThread(
+                tar_path=str(temp_tar_path),
+                target_path=str(temp_base),
+            )
+            extract_thread.progress.connect(on_extraction_progress)
+            extract_thread.finished.connect(on_extraction_finished)
+            extract_thread.start()
+
+            # Wait for extraction to complete without blocking event loop
+            loop.exec()
+
+            # Ensure thread is properly cleaned up before continuing
+            extract_thread.wait(EXTRACTION_THREAD_TIMEOUT_MS)
+            if extract_thread.isRunning():
+                logger.warning(
+                    "Extraction thread still running after timeout, forcing quit"
+                )
+                extract_thread.quit()
+                extract_thread.wait(2000)
+
+            if not extraction_result["success"]:
+                raise UpdateExtractionError(
+                    f"Extraction failed: {extraction_result['error']}"
+                )
+
+            logger.info(f"Extracted {extracted_files} entries from tar.gz")
+            return extracted_files
+
+        finally:
             if temp_tar_path.exists():
                 try:
                     temp_tar_path.unlink()

--- a/tests/utils/test_appimage_update.py
+++ b/tests/utils/test_appimage_update.py
@@ -387,39 +387,120 @@ class TestPrepareAppImageUpdate:
 # ---------------------------------------------------------------------------
 
 
-class TestExtractTarGz:
-    @pytest.fixture(autouse=True)
-    def _mock_progress_widget(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Mock TaskProgressWindow to avoid needing a QApplication."""
-        monkeypatch.setattr("app.utils.update_utils.TaskProgressWindow", MagicMock)
+class TestTarExtractThread:
+    """Test TarExtractThread directly — no QApplication needed since we call run()."""
 
-    def _create_tar_gz(self, tmp_path: Path) -> bytes:
-        """Create a minimal tar.gz archive containing a dummy file."""
+    def _create_tar_gz_file(self, tmp_path: Path, name: str = "RimSort") -> Path:
+        """Create a tar.gz file on disk with a single entry."""
         import io
         import tarfile as tf
 
-        buf = io.BytesIO()
-        with tf.open(fileobj=buf, mode="w:gz") as tar:
+        tar_path = tmp_path / "test.tar.gz"
+        with tf.open(str(tar_path), "w:gz") as tar:
             data = b"#!/bin/sh\necho hello"
-            info = tf.TarInfo(name="RimSort")
+            info = tf.TarInfo(name=name)
             info.size = len(data)
             tar.addfile(info, io.BytesIO(data))
-        return buf.getvalue()
+        return tar_path
 
-    def test_extracts_tar_gz_content(self, tmp_path: Path) -> None:
-        content = self._create_tar_gz(tmp_path)
+    def test_extracts_content(self, tmp_path: Path) -> None:
+        from app.utils.update_utils import TarExtractThread
+
+        tar_path = self._create_tar_gz_file(tmp_path)
         extract_dir = tmp_path / "extract"
         extract_dir.mkdir()
 
-        mgr = MagicMock(spec=UpdateManager)
-        mgr.mod_info_panel = None
-        mgr._progress_widget = None
-        mgr._extract_tar_gz = UpdateManager._extract_tar_gz.__get__(mgr)
+        results: list[tuple[bool, str]] = []
+        thread = TarExtractThread(str(tar_path), str(extract_dir))
+        thread.finished.connect(lambda ok, msg: results.append((ok, msg)))
+        thread.run()
 
-        count = mgr._extract_tar_gz(content, extract_dir)
-
-        assert count == 1
+        assert len(results) == 1
+        assert results[0][0] is True
         assert (extract_dir / "RimSort").exists()
+
+    def test_reports_progress(self, tmp_path: Path) -> None:
+        from app.utils.update_utils import TarExtractThread
+
+        tar_path = self._create_tar_gz_file(tmp_path)
+        extract_dir = tmp_path / "extract"
+        extract_dir.mkdir()
+
+        progress_updates: list[tuple[int, str]] = []
+        thread = TarExtractThread(str(tar_path), str(extract_dir))
+        thread.progress.connect(lambda p, m: progress_updates.append((p, m)))
+        thread.run()
+
+        assert len(progress_updates) >= 1
+        assert progress_updates[-1][0] == 100
+
+    def test_emits_failure_on_invalid_archive(self, tmp_path: Path) -> None:
+        from app.utils.update_utils import TarExtractThread
+
+        bad_tar = tmp_path / "bad.tar.gz"
+        bad_tar.write_bytes(b"not a tarball")
+        extract_dir = tmp_path / "extract"
+        extract_dir.mkdir()
+
+        results: list[tuple[bool, str]] = []
+        thread = TarExtractThread(str(bad_tar), str(extract_dir))
+        thread.finished.connect(lambda ok, msg: results.append((ok, msg)))
+        thread.run()
+
+        assert len(results) == 1
+        assert results[0][0] is False
+
+    def test_emits_failure_on_empty_archive(self, tmp_path: Path) -> None:
+        import tarfile as tf
+
+        from app.utils.update_utils import TarExtractThread
+
+        empty_tar = tmp_path / "empty.tar.gz"
+        with tf.open(str(empty_tar), "w:gz"):
+            pass
+
+        extract_dir = tmp_path / "extract"
+        extract_dir.mkdir()
+
+        results: list[tuple[bool, str]] = []
+        thread = TarExtractThread(str(empty_tar), str(extract_dir))
+        thread.finished.connect(lambda ok, msg: results.append((ok, msg)))
+        thread.run()
+
+        assert len(results) == 1
+        assert results[0][0] is False
+        assert "empty" in results[0][1]
+
+    def test_abort_stops_extraction(self, tmp_path: Path) -> None:
+        import io
+        import tarfile as tf
+
+        from app.utils.update_utils import TarExtractThread
+
+        tar_path = tmp_path / "multi.tar.gz"
+        with tf.open(str(tar_path), "w:gz") as tar:
+            for i in range(10):
+                data = b"x" * 100
+                info = tf.TarInfo(name=f"file_{i}")
+                info.size = len(data)
+                tar.addfile(info, io.BytesIO(data))
+
+        extract_dir = tmp_path / "extract"
+        extract_dir.mkdir()
+
+        thread = TarExtractThread(str(tar_path), str(extract_dir))
+        thread.stop()  # abort before starting
+        results: list[tuple[bool, str]] = []
+        thread.finished.connect(lambda ok, msg: results.append((ok, msg)))
+        thread.run()
+
+        assert len(results) == 1
+        assert results[0][0] is False
+        assert "aborted" in results[0][1].lower()
+
+
+class TestExtractTarGzIntegration:
+    """Test _extract_tar_gz validation logic (thread interaction is mocked)."""
 
     def test_raises_on_invalid_tar_gz(self, tmp_path: Path) -> None:
         extract_dir = tmp_path / "extract"
@@ -441,7 +522,7 @@ class TestExtractTarGz:
 
         buf = io.BytesIO()
         with tf.open(fileobj=buf, mode="w:gz"):
-            pass  # empty archive
+            pass
         content = buf.getvalue()
 
         extract_dir = tmp_path / "extract"

--- a/tests/utils/test_appimage_update.py
+++ b/tests/utils/test_appimage_update.py
@@ -101,6 +101,29 @@ SAMPLE_ASSETS: list[dict[str, Any]] = [
     ),
 ]
 
+SAMPLE_ASSETS_WITH_TAR_GZ: list[dict[str, Any]] = [
+    _make_asset(
+        "RimSort-1.2.3-Ubuntu-22.04_x86_64.tar.gz",
+        "https://example.com/ubuntu.tar.gz",
+    ),
+    _make_asset(
+        "RimSort-1.2.3-Ubuntu-22.04_x86_64.zip",
+        "https://example.com/ubuntu.zip",
+    ),
+    _make_asset(
+        "RimSort-1.2.3-x86_64.AppImage",
+        "https://example.com/rimsort.AppImage",
+    ),
+    _make_asset(
+        "RimSort-1.2.3-Darwin_arm.tar.gz",
+        "https://example.com/darwin.tar.gz",
+    ),
+    _make_asset(
+        "RimSort-1.2.3-Windows_x86_64.zip",
+        "https://example.com/windows.zip",
+    ),
+]
+
 
 class TestAssetSelection:
     @pytest.fixture
@@ -177,6 +200,81 @@ class TestAssetSelection:
         assert result is not None
         assert result["is_appimage"] is False
         assert "ubuntu.zip" in result["url"]
+
+
+# ---------------------------------------------------------------------------
+# tar.gz asset selection
+# ---------------------------------------------------------------------------
+
+
+class TestTarGzAssetSelection:
+    @pytest.fixture
+    def _linux_mgr(self, monkeypatch: pytest.MonkeyPatch) -> UpdateManager:
+        monkeypatch.delenv("APPIMAGE", raising=False)
+        mgr = MagicMock(spec=UpdateManager)
+        mgr._system = "Linux"
+        mgr._arch = "64bit"
+        mgr._cached_patterns = UpdateManager._platform_patterns["Linux"]
+        mgr._find_best_asset_match = UpdateManager._find_best_asset_match.__get__(mgr)
+        mgr._get_platform_download_url = (
+            UpdateManager._get_platform_download_url.__get__(mgr)
+        )
+        mgr._asset_matches = UpdateManager._asset_matches.__get__(mgr)
+        mgr._is_in_protected_path = MagicMock(return_value=False)
+        return mgr
+
+    @pytest.fixture
+    def _darwin_mgr(self, monkeypatch: pytest.MonkeyPatch) -> UpdateManager:
+        monkeypatch.delenv("APPIMAGE", raising=False)
+        mgr = MagicMock(spec=UpdateManager)
+        mgr._system = "Darwin"
+        mgr._arch = "ARM64"
+        mgr._cached_patterns = UpdateManager._platform_patterns["Darwin"]
+        mgr._find_best_asset_match = UpdateManager._find_best_asset_match.__get__(mgr)
+        mgr._get_platform_download_url = (
+            UpdateManager._get_platform_download_url.__get__(mgr)
+        )
+        mgr._asset_matches = UpdateManager._asset_matches.__get__(mgr)
+        mgr._is_in_protected_path = MagicMock(return_value=False)
+        return mgr
+
+    def test_linux_prefers_tar_gz_over_zip(self, _linux_mgr: UpdateManager) -> None:
+        result = _linux_mgr._get_platform_download_url(SAMPLE_ASSETS_WITH_TAR_GZ)
+        assert result is not None
+        assert result["is_tar_gz"] is True
+        assert result["url"] == "https://example.com/ubuntu.tar.gz"
+
+    def test_linux_falls_back_to_zip_when_no_tar_gz(
+        self, _linux_mgr: UpdateManager
+    ) -> None:
+        result = _linux_mgr._get_platform_download_url(SAMPLE_ASSETS)
+        assert result is not None
+        assert result["is_tar_gz"] is False
+        assert result["url"] == "https://example.com/ubuntu.zip"
+
+    def test_darwin_prefers_tar_gz(self, _darwin_mgr: UpdateManager) -> None:
+        result = _darwin_mgr._get_platform_download_url(SAMPLE_ASSETS_WITH_TAR_GZ)
+        assert result is not None
+        assert result["is_tar_gz"] is True
+        assert result["url"] == "https://example.com/darwin.tar.gz"
+
+    def test_windows_ignores_tar_gz(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("APPIMAGE", raising=False)
+        mgr = MagicMock(spec=UpdateManager)
+        mgr._system = "Windows"
+        mgr._arch = "64bit"
+        mgr._cached_patterns = UpdateManager._platform_patterns["Windows"]
+        mgr._find_best_asset_match = UpdateManager._find_best_asset_match.__get__(mgr)
+        mgr._get_platform_download_url = (
+            UpdateManager._get_platform_download_url.__get__(mgr)
+        )
+        mgr._asset_matches = UpdateManager._asset_matches.__get__(mgr)
+        mgr._is_in_protected_path = MagicMock(return_value=False)
+
+        result = mgr._get_platform_download_url(SAMPLE_ASSETS_WITH_TAR_GZ)
+        assert result is not None
+        assert result["is_tar_gz"] is False
+        assert result["url"] == "https://example.com/windows.zip"
 
 
 # ---------------------------------------------------------------------------
@@ -282,3 +380,79 @@ class TestPrepareAppImageUpdate:
                 mgr._prepare_appimage_update()
         finally:
             fake.parent.chmod(0o755)
+
+
+# ---------------------------------------------------------------------------
+# _extract_tar_gz
+# ---------------------------------------------------------------------------
+
+
+class TestExtractTarGz:
+    @pytest.fixture(autouse=True)
+    def _mock_progress_widget(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Mock TaskProgressWindow to avoid needing a QApplication."""
+        monkeypatch.setattr("app.utils.update_utils.TaskProgressWindow", MagicMock)
+
+    def _create_tar_gz(self, tmp_path: Path) -> bytes:
+        """Create a minimal tar.gz archive containing a dummy file."""
+        import io
+        import tarfile as tf
+
+        buf = io.BytesIO()
+        with tf.open(fileobj=buf, mode="w:gz") as tar:
+            data = b"#!/bin/sh\necho hello"
+            info = tf.TarInfo(name="RimSort")
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+        return buf.getvalue()
+
+    def test_extracts_tar_gz_content(self, tmp_path: Path) -> None:
+        content = self._create_tar_gz(tmp_path)
+        extract_dir = tmp_path / "extract"
+        extract_dir.mkdir()
+
+        mgr = MagicMock(spec=UpdateManager)
+        mgr.mod_info_panel = None
+        mgr._progress_widget = None
+        mgr._extract_tar_gz = UpdateManager._extract_tar_gz.__get__(mgr)
+
+        count = mgr._extract_tar_gz(content, extract_dir)
+
+        assert count == 1
+        assert (extract_dir / "RimSort").exists()
+
+    def test_raises_on_invalid_tar_gz(self, tmp_path: Path) -> None:
+        extract_dir = tmp_path / "extract"
+        extract_dir.mkdir()
+
+        mgr = MagicMock(spec=UpdateManager)
+        mgr.mod_info_panel = None
+        mgr._progress_widget = None
+        mgr._extract_tar_gz = UpdateManager._extract_tar_gz.__get__(mgr)
+
+        from app.utils.update_utils import UpdateExtractionError
+
+        with pytest.raises(UpdateExtractionError, match="Invalid tar.gz"):
+            mgr._extract_tar_gz(b"not a tarball", extract_dir)
+
+    def test_raises_on_empty_tar_gz(self, tmp_path: Path) -> None:
+        import io
+        import tarfile as tf
+
+        buf = io.BytesIO()
+        with tf.open(fileobj=buf, mode="w:gz"):
+            pass  # empty archive
+        content = buf.getvalue()
+
+        extract_dir = tmp_path / "extract"
+        extract_dir.mkdir()
+
+        mgr = MagicMock(spec=UpdateManager)
+        mgr.mod_info_panel = None
+        mgr._progress_widget = None
+        mgr._extract_tar_gz = UpdateManager._extract_tar_gz.__get__(mgr)
+
+        from app.utils.update_utils import UpdateExtractionError
+
+        with pytest.raises(UpdateExtractionError, match="empty"):
+            mgr._extract_tar_gz(content, extract_dir)

--- a/tests/utils/test_appimage_update.py
+++ b/tests/utils/test_appimage_update.py
@@ -357,6 +357,27 @@ class TestPrepareAppImageUpdate:
 # ---------------------------------------------------------------------------
 
 
+def _run_tar_thread(tar_path: Path, extract_dir: Path) -> tuple[bool, str]:
+    """Run a TarExtractThread synchronously and return (success, message)."""
+    from app.utils.update_utils import TarExtractThread
+
+    results: list[tuple[bool, str]] = []
+    thread = TarExtractThread(str(tar_path), str(extract_dir))
+    thread.finished.connect(lambda ok, msg: results.append((ok, msg)))
+    thread.run()
+    assert len(results) == 1
+    return results[0]
+
+
+def _make_extract_mgr() -> UpdateManager:
+    """Build a mock UpdateManager with _extract_tar_gz bound."""
+    mgr = MagicMock(spec=UpdateManager)
+    mgr.mod_info_panel = None
+    mgr._progress_widget = None
+    mgr._extract_tar_gz = UpdateManager._extract_tar_gz.__get__(mgr)
+    return mgr
+
+
 class TestTarExtractThread:
     """Test TarExtractThread directly — no QApplication needed since we call run()."""
 
@@ -374,19 +395,12 @@ class TestTarExtractThread:
         return tar_path
 
     def test_extracts_content(self, tmp_path: Path) -> None:
-        from app.utils.update_utils import TarExtractThread
-
         tar_path = self._create_tar_gz_file(tmp_path)
         extract_dir = tmp_path / "extract"
         extract_dir.mkdir()
 
-        results: list[tuple[bool, str]] = []
-        thread = TarExtractThread(str(tar_path), str(extract_dir))
-        thread.finished.connect(lambda ok, msg: results.append((ok, msg)))
-        thread.run()
-
-        assert len(results) == 1
-        assert results[0][0] is True
+        success, _ = _run_tar_thread(tar_path, extract_dir)
+        assert success is True
         assert (extract_dir / "RimSort").exists()
 
     def test_reports_progress(self, tmp_path: Path) -> None:
@@ -405,25 +419,16 @@ class TestTarExtractThread:
         assert progress_updates[-1][0] == 100
 
     def test_emits_failure_on_invalid_archive(self, tmp_path: Path) -> None:
-        from app.utils.update_utils import TarExtractThread
-
         bad_tar = tmp_path / "bad.tar.gz"
         bad_tar.write_bytes(b"not a tarball")
         extract_dir = tmp_path / "extract"
         extract_dir.mkdir()
 
-        results: list[tuple[bool, str]] = []
-        thread = TarExtractThread(str(bad_tar), str(extract_dir))
-        thread.finished.connect(lambda ok, msg: results.append((ok, msg)))
-        thread.run()
-
-        assert len(results) == 1
-        assert results[0][0] is False
+        success, _ = _run_tar_thread(bad_tar, extract_dir)
+        assert success is False
 
     def test_emits_failure_on_empty_archive(self, tmp_path: Path) -> None:
         import tarfile as tf
-
-        from app.utils.update_utils import TarExtractThread
 
         empty_tar = tmp_path / "empty.tar.gz"
         with tf.open(str(empty_tar), "w:gz"):
@@ -432,14 +437,9 @@ class TestTarExtractThread:
         extract_dir = tmp_path / "extract"
         extract_dir.mkdir()
 
-        results: list[tuple[bool, str]] = []
-        thread = TarExtractThread(str(empty_tar), str(extract_dir))
-        thread.finished.connect(lambda ok, msg: results.append((ok, msg)))
-        thread.run()
-
-        assert len(results) == 1
-        assert results[0][0] is False
-        assert "empty" in results[0][1]
+        success, msg = _run_tar_thread(empty_tar, extract_dir)
+        assert success is False
+        assert "empty" in msg
 
     def test_abort_stops_extraction(self, tmp_path: Path) -> None:
         import io
@@ -459,7 +459,7 @@ class TestTarExtractThread:
         extract_dir.mkdir()
 
         thread = TarExtractThread(str(tar_path), str(extract_dir))
-        thread.stop()  # abort before starting
+        thread.stop()
         results: list[tuple[bool, str]] = []
         thread.finished.connect(lambda ok, msg: results.append((ok, msg)))
         thread.run()
@@ -476,15 +476,10 @@ class TestExtractTarGzIntegration:
         extract_dir = tmp_path / "extract"
         extract_dir.mkdir()
 
-        mgr = MagicMock(spec=UpdateManager)
-        mgr.mod_info_panel = None
-        mgr._progress_widget = None
-        mgr._extract_tar_gz = UpdateManager._extract_tar_gz.__get__(mgr)
-
         from app.utils.update_utils import UpdateExtractionError
 
         with pytest.raises(UpdateExtractionError, match="Invalid tar.gz"):
-            mgr._extract_tar_gz(b"not a tarball", extract_dir)
+            _make_extract_mgr()._extract_tar_gz(b"not a tarball", extract_dir)
 
     def test_raises_on_empty_tar_gz(self, tmp_path: Path) -> None:
         import io
@@ -493,17 +488,11 @@ class TestExtractTarGzIntegration:
         buf = io.BytesIO()
         with tf.open(fileobj=buf, mode="w:gz"):
             pass
-        content = buf.getvalue()
 
         extract_dir = tmp_path / "extract"
         extract_dir.mkdir()
 
-        mgr = MagicMock(spec=UpdateManager)
-        mgr.mod_info_panel = None
-        mgr._progress_widget = None
-        mgr._extract_tar_gz = UpdateManager._extract_tar_gz.__get__(mgr)
-
         from app.utils.update_utils import UpdateExtractionError
 
         with pytest.raises(UpdateExtractionError, match="empty"):
-            mgr._extract_tar_gz(content, extract_dir)
+            _make_extract_mgr()._extract_tar_gz(buf.getvalue(), extract_dir)

--- a/tests/utils/test_appimage_update.py
+++ b/tests/utils/test_appimage_update.py
@@ -125,25 +125,34 @@ SAMPLE_ASSETS_WITH_TAR_GZ: list[dict[str, Any]] = [
 ]
 
 
+def _make_platform_mgr(
+    system: str,
+    arch: str = "64bit",
+    *,
+    bind_appimage: bool = False,
+) -> UpdateManager:
+    """Build a mock UpdateManager with real asset-selection methods bound."""
+    mgr = MagicMock(spec=UpdateManager)
+    mgr._system = system
+    mgr._arch = arch
+    mgr._cached_patterns = UpdateManager._platform_patterns[system]
+    mgr._find_best_asset_match = UpdateManager._find_best_asset_match.__get__(mgr)
+    mgr._get_platform_download_url = UpdateManager._get_platform_download_url.__get__(
+        mgr
+    )
+    mgr._asset_matches = UpdateManager._asset_matches.__get__(mgr)
+    mgr._is_in_protected_path = MagicMock(return_value=False)
+    if bind_appimage:
+        mgr._find_appimage_asset = UpdateManager._find_appimage_asset.__get__(mgr)
+    return mgr
+
+
 class TestAssetSelection:
     @pytest.fixture
     def _linux_update_manager(self, monkeypatch: pytest.MonkeyPatch) -> UpdateManager:
-        """Create an UpdateManager-like object with Linux platform settings."""
+        """Create an UpdateManager-like object with Linux AppImage settings."""
         monkeypatch.setenv("APPIMAGE", "/home/user/RimSort.AppImage")
-        mgr = MagicMock(spec=UpdateManager)
-        mgr._system = "Linux"
-        mgr._arch = "64bit"
-        mgr._cached_patterns = UpdateManager._platform_patterns["Linux"]
-
-        # Bind the real methods so we can test them
-        mgr._find_appimage_asset = UpdateManager._find_appimage_asset.__get__(mgr)
-        mgr._get_platform_download_url = (
-            UpdateManager._get_platform_download_url.__get__(mgr)
-        )
-        mgr._find_best_asset_match = UpdateManager._find_best_asset_match.__get__(mgr)
-        mgr._asset_matches = UpdateManager._asset_matches.__get__(mgr)
-        mgr._is_in_protected_path = MagicMock(return_value=False)
-        return mgr
+        return _make_platform_mgr("Linux", bind_appimage=True)
 
     def test_prefers_appimage_when_running_as_appimage(
         self,
@@ -184,17 +193,7 @@ class TestAssetSelection:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.delenv("APPIMAGE", raising=False)
-
-        mgr = MagicMock(spec=UpdateManager)
-        mgr._system = "Linux"
-        mgr._arch = "64bit"
-        mgr._cached_patterns = UpdateManager._platform_patterns["Linux"]
-        mgr._find_best_asset_match = UpdateManager._find_best_asset_match.__get__(mgr)
-        mgr._get_platform_download_url = (
-            UpdateManager._get_platform_download_url.__get__(mgr)
-        )
-        mgr._asset_matches = UpdateManager._asset_matches.__get__(mgr)
-        mgr._is_in_protected_path = MagicMock(return_value=False)
+        mgr = _make_platform_mgr("Linux")
 
         result = mgr._get_platform_download_url(SAMPLE_ASSETS)
         assert result is not None
@@ -211,32 +210,12 @@ class TestTarGzAssetSelection:
     @pytest.fixture
     def _linux_mgr(self, monkeypatch: pytest.MonkeyPatch) -> UpdateManager:
         monkeypatch.delenv("APPIMAGE", raising=False)
-        mgr = MagicMock(spec=UpdateManager)
-        mgr._system = "Linux"
-        mgr._arch = "64bit"
-        mgr._cached_patterns = UpdateManager._platform_patterns["Linux"]
-        mgr._find_best_asset_match = UpdateManager._find_best_asset_match.__get__(mgr)
-        mgr._get_platform_download_url = (
-            UpdateManager._get_platform_download_url.__get__(mgr)
-        )
-        mgr._asset_matches = UpdateManager._asset_matches.__get__(mgr)
-        mgr._is_in_protected_path = MagicMock(return_value=False)
-        return mgr
+        return _make_platform_mgr("Linux")
 
     @pytest.fixture
     def _darwin_mgr(self, monkeypatch: pytest.MonkeyPatch) -> UpdateManager:
         monkeypatch.delenv("APPIMAGE", raising=False)
-        mgr = MagicMock(spec=UpdateManager)
-        mgr._system = "Darwin"
-        mgr._arch = "ARM64"
-        mgr._cached_patterns = UpdateManager._platform_patterns["Darwin"]
-        mgr._find_best_asset_match = UpdateManager._find_best_asset_match.__get__(mgr)
-        mgr._get_platform_download_url = (
-            UpdateManager._get_platform_download_url.__get__(mgr)
-        )
-        mgr._asset_matches = UpdateManager._asset_matches.__get__(mgr)
-        mgr._is_in_protected_path = MagicMock(return_value=False)
-        return mgr
+        return _make_platform_mgr("Darwin", arch="ARM64")
 
     def test_linux_prefers_tar_gz_over_zip(self, _linux_mgr: UpdateManager) -> None:
         result = _linux_mgr._get_platform_download_url(SAMPLE_ASSETS_WITH_TAR_GZ)
@@ -260,16 +239,7 @@ class TestTarGzAssetSelection:
 
     def test_windows_ignores_tar_gz(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("APPIMAGE", raising=False)
-        mgr = MagicMock(spec=UpdateManager)
-        mgr._system = "Windows"
-        mgr._arch = "64bit"
-        mgr._cached_patterns = UpdateManager._platform_patterns["Windows"]
-        mgr._find_best_asset_match = UpdateManager._find_best_asset_match.__get__(mgr)
-        mgr._get_platform_download_url = (
-            UpdateManager._get_platform_download_url.__get__(mgr)
-        )
-        mgr._asset_matches = UpdateManager._asset_matches.__get__(mgr)
-        mgr._is_in_protected_path = MagicMock(return_value=False)
+        mgr = _make_platform_mgr("Windows")
 
         result = mgr._get_platform_download_url(SAMPLE_ASSETS_WITH_TAR_GZ)
         assert result is not None


### PR DESCRIPTION
## Summary
- Since v1.1.0, Linux and macOS releases ship as `.tar.gz` instead of `.zip`. The updater only searched for `.zip` assets, causing the "Failed to find valid RimSort release for Linux 64bit" error on startup.
- Adds `.tar.gz` as the preferred archive format for Linux and macOS in the asset selection logic, with `.zip` as a fallback for backward compatibility.
- Adds `_extract_tar_gz()` method using Python's `tarfile` module with progress UI, mirroring the existing `_extract_zip()` approach.

## Test plan
- [x] Existing 16 tests continue to pass
- [x] 4 new asset selection tests: Linux prefers tar.gz, falls back to zip, Darwin prefers tar.gz, Windows ignores tar.gz
- [x] 3 new extraction tests: valid tar.gz extracts correctly, invalid content raises error, empty archive raises error

Closes #1977

🤖 Generated with [Claude Code](https://claude.com/claude-code)