### PR TITLE
fix: preserve search filter state when applying divider collapse states

### DIFF
--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -3147,7 +3147,8 @@ class ModListWidget(QListWidget):
                 if isinstance(widget, DividerItemInner):
                     widget.set_collapsed(collapsed)
             else:
-                item.setHidden(collapsed)
+                hidden_by_filter = getattr(data, "hidden_by_filter", False)
+                item.setHidden(collapsed or hidden_by_filter)
         self._update_divider_mod_counts()
 
     def get_dividers_data(self) -> list[dict[str, Any]]:


### PR DESCRIPTION
The apply_collapse_states() function was unconditionally hiding/showing items based solely on divider collapse state, which overwrote the hidden state set during search filtering. This caused active mods search to fail after the dividers feature was introduced.

Fixed by checking both the divider collapse state AND the hidden_by_filter flag, so items are hidden only if filtered by search OR under a collapsed divider.

Fixes #1995