### PR TITLE
chore: add jscpd and shfmt just recipes, update contributor docs

### DIFF
--- a/docs/development-guide/contributor-guidelines.md
+++ b/docs/development-guide/contributor-guidelines.md
@@ -102,13 +102,14 @@ Key recipes for contributors:
 
 | Command | Description |
 | :--- | :--- |
-| `just check` | Run all code quality checks (lint, format, typecheck, jscpd) |
+| `just check` | Run all code quality checks (lint, format, typecheck, jscpd, shfmt) |
 | `just fix` | Auto-fix linting and formatting issues |
 | `just test` | Run tests with coverage reporting |
 | `just lint` | Check for linting issues with ruff |
 | `just format` | Check code formatting with ruff |
 | `just typecheck` | Run mypy type checking |
 | `just jscpd` | Detect copy-paste code duplication |
+| `just shfmt` | Check shell script formatting |
 
 **Run `just check` before submitting a PR.** CI runs all of these checks and will fail if any report issues.
 

--- a/docs/development-guide/contributor-guidelines.md
+++ b/docs/development-guide/contributor-guidelines.md
@@ -94,18 +94,42 @@ To mitigate this issue, the version info for the release pipeline is grabbed fir
 
 Please ensure if you have any feature request to check if there is already something planned. We are tracking features and issues related to RimSort in the GitHub repo's "Issues" tab. If it is not already in the issues tab, you can discuss this with maintainers first through the RimSort Discord server.
 
-## Misc Coding Style
+## Task Runner
 
-- The preferred Python formatter is: [ruff](https://docs.astral.sh/ruff/) (`pip install ruff`)
-  - Here is the Ruff extension for [VS Code](https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff)
-  - Note that Ruff replaces isort, flake8 as well as black. If you have these, make sure to disable them to prevent conflicts.
+We use [just](https://just.systems/) as our task runner. Run `just` with no arguments to list all available recipes.
+
+Key recipes for contributors:
+
+| Command | Description |
+| :--- | :--- |
+| `just check` | Run all code quality checks (lint, format, typecheck, jscpd) |
+| `just fix` | Auto-fix linting and formatting issues |
+| `just test` | Run tests with coverage reporting |
+| `just lint` | Check for linting issues with ruff |
+| `just format` | Check code formatting with ruff |
+| `just typecheck` | Run mypy type checking |
+| `just jscpd` | Detect copy-paste code duplication |
+
+**Run `just check` before submitting a PR.** CI runs all of these checks and will fail if any report issues.
+
+## Coding Style
+
+### Linting and Formatting
+
+- **[Ruff](https://docs.astral.sh/ruff/)** is used for both linting and formatting (`just lint`, `just format`).
+  - [VS Code extension](https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff)
+  - Ruff replaces isort, flake8, and black. Disable those if you have them installed.
+  - Configuration is in `pyproject.toml`.
+- **[mypy](https://mypy.readthedocs.io/en/stable/)** is used for static type checking (`just typecheck`).
+  - [VS Code extension](https://marketplace.visualstudio.com/items?itemName=matangover.mypy)
+- **[JSCPD](https://github.com/kucherenko/jscpd)** is used for copy-paste detection (`just jscpd`).
+  - CI enforces a 0% duplication threshold. If you have similar code blocks, extract a shared helper.
+- For shell scripts, we use [shfmt](https://github.com/mvdan/sh#shfmt).
+  - [VS Code extension](https://marketplace.visualstudio.com/items?itemName=mkhl.shfmt)
+
+### Conventions
+
 - The preferred docstring format is: [Sphinx reST](https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html)
 - Type annotations should be added to function/method signatures.
-  - Use Python 3.10+ standards. (Avoid importing Typing. [Pep604](https://peps.python.org/pep-0604/) instead of Optional)
-- We use [mypy](https://mypy.readthedocs.io/en/stable/) for static type checking.
-  - Grab [this extension](https://marketplace.visualstudio.com/items?itemName=matangover.mypy) for VS Code/VS Codium!
-- For quick setup, you can install some of the dependencies described above along with additional modules for typing to automate your development:
-  - `pip install -r requirements_develop.txt`
+  - Use Python 3.10+ standards. (Avoid importing Typing. [PEP 604](https://peps.python.org/pep-0604/) instead of Optional)
 - VS Code workspace settings are included
-- For shell scripts, we use [shfmt](https://github.com/mvdan/sh#shfmt)
-  - [VS Code Extension](https://marketplace.visualstudio.com/items?itemName=mkhl.shfmt)

--- a/docs/development-guide/development-setup.md
+++ b/docs/development-guide/development-setup.md
@@ -34,9 +34,17 @@ Your OS needs to be one that PySide6 supports. As an example, we use the followi
 
 ### Tools and Software 
 
+**Required:**
 - [git](https://git-scm.com/)
 - [Python](https://python.org/) 3.12 (Can be installed with uv if you'd like)
 - [uv](https://docs.astral.sh/uv/getting-started/installation/)
+- [just](https://just.systems/man/en/installation.html) — task runner for development commands
+
+**For code quality checks** (used by `just check` and CI):
+- [Node.js / npx](https://nodejs.org/) — needed for [JSCPD](https://github.com/kucherenko/jscpd) copy-paste detection (`just jscpd`)
+- [shfmt](https://github.com/mvdan/sh#shfmt) — shell script formatter (`just shfmt`)
+
+Python linters (ruff, mypy) are installed automatically by `uv sync` — no manual setup needed.
 
 ### Cloning the repository
 RimSort uses submodules that are hosted in other repositories that need to be cloned. 

--- a/docs/development-guide/development-setup.md
+++ b/docs/development-guide/development-setup.md
@@ -67,16 +67,17 @@ git submodule update --init --recursive
 
 RimSort uses the Python package and project manager [uv](https://docs.astral.sh/uv/).
 
-To get started, in the project root, simply run: 
+The easiest way to set up everything (submodules, venv, dev + build dependencies) is:
 ```shell
-uv sync
+just dev-setup
 ```
 
-Note that by default, `uv` will also install the dev dependency group.
+This runs `uv sync --locked --dev --group build`, which installs all runtime, dev, and build dependencies (including linters like ruff and mypy).
 
-If you wish to also build the executables locally, you'll need to also install the `build` dependency group:
+If you prefer to do it manually:
 ```shell
-uv sync --group build
+uv sync --dev            # install runtime + dev dependencies (linters, test tools)
+uv sync --group build    # also install build dependencies (nuitka, etc.)
 ```
 
 ## Automated build process

--- a/justfile
+++ b/justfile
@@ -46,8 +46,12 @@ typecheck:
 jscpd:
     npx jscpd@latest app/ tests/ --threshold 0
 
-# Run all code quality checks (lint, format, typecheck, jscpd)
-check: lint format typecheck jscpd
+# Check shell script formatting
+shfmt:
+    shfmt -d update.sh packaging/
+
+# Run all code quality checks (lint, format, typecheck, jscpd, shfmt)
+check: lint format typecheck jscpd shfmt
 
 # Automatically fix linting and formatting issues
 fix: lint-fix format-fix

--- a/justfile
+++ b/justfile
@@ -46,8 +46,8 @@ typecheck:
 jscpd:
     npx jscpd@latest app/ tests/ --threshold 0
 
-# Run all code quality checks (lint, format, typecheck)
-check: lint format typecheck
+# Run all code quality checks (lint, format, typecheck, jscpd)
+check: lint format typecheck jscpd
 
 # Automatically fix linting and formatting issues
 fix: lint-fix format-fix

--- a/justfile
+++ b/justfile
@@ -42,6 +42,10 @@ format-fix:
 typecheck:
     uv run mypy --config-file pyproject.toml .
 
+# Detect copy-paste code duplication (matches CI's jscpd check)
+jscpd:
+    npx jscpd@latest app/ tests/ --threshold 0
+
 # Run all code quality checks (lint, format, typecheck)
 check: lint format typecheck
 


### PR DESCRIPTION
## Summary
- Add `just jscpd` recipe — runs `npx jscpd@latest` with CI's zero-tolerance threshold
- Add `just shfmt` recipe — checks shell script formatting
- Include both in `just check` so all CI checks run locally
- Update contributor guidelines with a task runner section and restructured coding style docs
- Add linter/formatter prerequisites (just, npx, shfmt) to the development setup guide

## Test plan
- [x] `just jscpd` runs and reports 0 clones
- [x] `just shfmt` runs against `update.sh` and `packaging/`
- [x] `just check` includes all quality checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)