### PR TITLE
Skip BinaryChoiceDialog test on macOS

### DIFF
--- a/tests/views/test_dialogue.py
+++ b/tests/views/test_dialogue.py
@@ -1,3 +1,4 @@
+import sys
 from typing import Generator
 from unittest.mock import MagicMock, patch
 
@@ -75,7 +76,9 @@ class TestBinaryChoiceDialog:
                 # Unexpected error
                 raise
 
-            assert dialog.windowTitle() == title
+            # QMessageBox.windowTitle() returns empty on macOS (native dialogs don't use it)
+            if sys.platform != "darwin":
+                assert dialog.windowTitle() == title
             if dialog.textFormat() == Qt.TextFormat.RichText:
                 assert dialog.text() == f"<b>{text}</b>"
             else:


### PR DESCRIPTION
## Summary
- Skip `windowTitle()` assertion on macOS in `TestBinaryChoiceDialog::test_initialization`
- `QMessageBox.windowTitle()` always returns empty on macOS because Qt uses native message box styling that doesn't track the window title
- CI only runs on `ubuntu-latest` so this was never caught — fails locally on macOS

## Test plan
- [x] All 367 tests pass locally on macOS
- [x] Lint and format checks pass
- [x] CI passes on Linux (no behavior change there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)