### PR TITLE
Refactor Win32 scanpath into platform abstraction layer

### DIFF
--- a/app/utils/generic.py
+++ b/app/utils/generic.py
@@ -4,7 +4,6 @@ import shutil
 import subprocess
 import sys
 import webbrowser
-from collections import namedtuple
 from datetime import datetime
 from errno import EACCES
 from io import TextIOWrapper
@@ -12,7 +11,7 @@ from pathlib import Path
 from re import search, sub
 from stat import S_IRWXG, S_IRWXO, S_IRWXU
 from time import localtime, strftime
-from typing import TYPE_CHECKING, Any, Callable, Generator
+from typing import Any, Callable, Generator
 
 import requests
 import vdf  # type: ignore
@@ -24,46 +23,7 @@ import app.views.dialogue as dialogue
 from app.utils import http
 from app.utils.app_info import AppInfo
 from app.utils.launch_command_parser import parse_launch_command
-
-if TYPE_CHECKING or sys.platform == "win32":
-    import ctypes
-    from ctypes import wintypes
-
-    class WIN32_FIND_DATAW(ctypes.Structure):
-        _fields_ = [
-            ("dwFileAttributes", wintypes.DWORD),
-            ("ftCreationTime", wintypes.FILETIME),
-            ("ftLastAccessTime", wintypes.FILETIME),
-            ("ftLastWriteTime", wintypes.FILETIME),
-            ("nFileSizeHigh", wintypes.DWORD),
-            ("nFileSizeLow", wintypes.DWORD),
-            ("dwReserved0", wintypes.DWORD),
-            ("dwReserved1", wintypes.DWORD),
-            ("cFileName", wintypes.WCHAR * 260),
-            ("cAlternateFileName", wintypes.WCHAR * 14),
-        ]
-
-
-_Win32StatResult = namedtuple("_Win32StatResult", ["st_size"])
-
-
-class Win32DirEntry:
-    def __init__(self, path: Path, find_data: Any):
-        self.name = find_data.cFileName
-        self.path = str(path / self.name)
-        self.size = (find_data.nFileSizeHigh << 32) + find_data.nFileSizeLow
-        self._dwFileAttributes = find_data.dwFileAttributes
-        self.FILE_ATTRIBUTE_DIRECTORY = 0x10
-
-    def is_dir(self) -> bool:
-        return bool(self._dwFileAttributes & self.FILE_ATTRIBUTE_DIRECTORY)
-
-    def is_file(self) -> bool:
-        return not self.is_dir()
-
-    def stat(self) -> _Win32StatResult:
-        return _Win32StatResult(self.size)
-
+from app.utils.platform.windows import scanpath_win32
 
 translate = QCoreApplication.translate
 
@@ -219,50 +179,10 @@ def delete_files_only_extension(directory: Path | str, extension: str) -> bool:
 
 def scanpath(
     path: Path | str,
-) -> Generator[os.DirEntry[str] | Win32DirEntry, None, None]:
-    if sys.platform == "win32" and "ctypes" in globals():
+) -> Generator[os.DirEntry[str] | Any, None, None]:
+    if sys.platform == "win32":
         try:
-            INVALID_HANDLE_VALUE = -1
-
-            find_data = WIN32_FIND_DATAW()
-            kernel32 = ctypes.windll.kernel32
-
-            # Define function prototypes
-            kernel32.FindFirstFileW.argtypes = [
-                wintypes.LPCWSTR,
-                ctypes.POINTER(WIN32_FIND_DATAW),
-            ]
-            kernel32.FindFirstFileW.restype = wintypes.HANDLE
-            kernel32.FindNextFileW.argtypes = [
-                wintypes.HANDLE,
-                ctypes.POINTER(WIN32_FIND_DATAW),
-            ]
-            kernel32.FindNextFileW.restype = wintypes.BOOL
-            kernel32.FindClose.argtypes = [wintypes.HANDLE]
-            kernel32.FindClose.restype = wintypes.BOOL
-
-            p = Path(path)
-
-            handle = kernel32.FindFirstFileW(str(p / "*"), ctypes.byref(find_data))
-
-            if handle == INVALID_HANDLE_VALUE:
-                last_error = ctypes.get_last_error()
-                if last_error != 2:  # File not found
-                    raise ctypes.WinError(last_error)
-                return
-
-            try:
-                while True:
-                    if find_data.cFileName not in (".", ".."):
-                        yield Win32DirEntry(p, find_data)
-                    if not kernel32.FindNextFileW(handle, ctypes.byref(find_data)):
-                        last_error = ctypes.get_last_error()
-                        if last_error in (0, 18):  # No more files
-                            return
-                        else:
-                            raise ctypes.WinError(last_error)
-            finally:
-                kernel32.FindClose(handle)
+            yield from scanpath_win32(path)
         except OSError as e:
             logger.error(f"An unexpected Win32 API error for scanpath occurred: {e}")
     else:

--- a/app/utils/platform/windows.py
+++ b/app/utils/platform/windows.py
@@ -1,0 +1,93 @@
+import ctypes
+import sys
+from collections import namedtuple
+from ctypes import wintypes
+from pathlib import Path
+from typing import Any, Generator
+
+from loguru import logger
+
+
+class WIN32_FIND_DATAW(ctypes.Structure):
+    _fields_ = [
+        ("dwFileAttributes", wintypes.DWORD),
+        ("ftCreationTime", wintypes.FILETIME),
+        ("ftLastAccessTime", wintypes.FILETIME),
+        ("ftLastWriteTime", wintypes.FILETIME),
+        ("nFileSizeHigh", wintypes.DWORD),
+        ("nFileSizeLow", wintypes.DWORD),
+        ("dwReserved0", wintypes.DWORD),
+        ("dwReserved1", wintypes.DWORD),
+        ("cFileName", wintypes.WCHAR * 260),
+        ("cAlternateFileName", wintypes.WCHAR * 14),
+    ]
+
+
+class Win32DirEntry:
+    def __init__(self, path: Path, find_data: WIN32_FIND_DATAW):
+        self.name = find_data.cFileName
+        self.path = str(path / self.name)
+        self.size = (find_data.nFileSizeHigh << 32) + find_data.nFileSizeLow
+        self._dwFileAttributes = find_data.dwFileAttributes
+        self.FILE_ATTRIBUTE_DIRECTORY = 0x10
+
+    def is_dir(self) -> bool:
+        return bool(self._dwFileAttributes & self.FILE_ATTRIBUTE_DIRECTORY)
+
+    def is_file(self) -> bool:
+        return not self.is_dir()
+
+    def stat(self) -> Any:
+        _Win32StatResult = namedtuple("_Win32StatResult", ["st_size"])
+        return _Win32StatResult(self.size)
+
+
+def scanpath_win32(path: Path | str) -> Generator[Win32DirEntry, None, None]:
+    """Windows-specific scanpath implementation using Win32 API."""
+    if sys.platform != "win32":
+        return
+    try:
+        INVALID_HANDLE_VALUE = -1
+
+        find_data = WIN32_FIND_DATAW()
+        kernel32 = ctypes.windll.kernel32
+
+        # Define function prototypes
+        kernel32.FindFirstFileW.argtypes = [
+            wintypes.LPCWSTR,
+            ctypes.POINTER(WIN32_FIND_DATAW),
+        ]
+        kernel32.FindFirstFileW.restype = wintypes.HANDLE
+        kernel32.FindNextFileW.argtypes = [
+            wintypes.HANDLE,
+            ctypes.POINTER(WIN32_FIND_DATAW),
+        ]
+        kernel32.FindNextFileW.restype = wintypes.BOOL
+        kernel32.FindClose.argtypes = [wintypes.HANDLE]
+        kernel32.FindClose.restype = wintypes.BOOL
+
+        p = Path(path)
+
+        handle = kernel32.FindFirstFileW(str(p / "*"), ctypes.byref(find_data))
+
+        if handle == INVALID_HANDLE_VALUE:
+            last_error = ctypes.get_last_error()
+            if last_error != 2:  # File not found
+                raise ctypes.WinError(last_error)
+            return
+
+        try:
+            while True:
+                if find_data.cFileName not in (".", ".."):
+                    yield Win32DirEntry(p, find_data)
+                if not kernel32.FindNextFileW(handle, ctypes.byref(find_data)):
+                    last_error = ctypes.get_last_error()
+                    if last_error in (0, 18):  # No more files
+                        return
+                    else:
+                        raise ctypes.WinError(last_error)
+        finally:
+            kernel32.FindClose(handle)
+    except OSError as e:
+        logger.error(f"An unexpected Win32 API error for scanpath occurred: {e}")
+        raise


### PR DESCRIPTION
Move Windows-specific ctypes-based scanpath logic from app/utils/generic.py into app/utils/platform/windows.py to isolate OS-specific code.