### PR TITLE
docs(development): update contributor guidelines + justfile recipes

### DIFF
--- a/docs/development-guide/contributor-guidelines.md
+++ b/docs/development-guide/contributor-guidelines.md
@@ -8,17 +8,20 @@ permalink: development-guide/contributor-guidelines
 
 
 # Contributor Guidelines
+
 {: .no_toc}
 
 Please follow the following guidelines when contributing to RimSort.
 
 ## Table of Contents
+
 {: .no_toc .text-delta }
 
 1. TOC
 {:toc}
 
 ## Basic Guidelines
+
 1. Pull Requests need to be made AFTER all guidelines are met. It's OK to miss some stuff because we can catch it in review, but we should be proactive with docstrings, code formatting, etc. If not ready, use a draft.
 
 2. Please submit Pull Requests which contain feature-specific changes only. PRs should not lump multiple changes into one thing. This so we can be more selective in discussion. This is a requirement, and deviation will cause PR to be closed.
@@ -102,14 +105,28 @@ Key recipes for contributors:
 
 | Command | Description |
 | :--- | :--- |
-| `just check` | Run all code quality checks (lint, format, typecheck, jscpd, shfmt) |
+| `just check` | Run all code quality checks (ruff, ruff-format, typecheck, jscpd, shfmt) |
 | `just fix` | Auto-fix linting and formatting issues |
-| `just test` | Run tests with coverage reporting |
-| `just lint` | Check for linting issues with ruff |
-| `just format` | Check code formatting with ruff |
-| `just typecheck` | Run mypy type checking |
-| `just jscpd` | Detect copy-paste code duplication |
-| `just shfmt` | Format + check shell script formatting (shfmt) |
+| `just test` | Run tests with doctest modules enabled |
+| `just test-coverage` | Run tests with coverage reports (XML, HTML, terminal) |
+| `just test-verbose` | Run tests with verbose output and short tracebacks |
+| `just ruff` | Check code for linting issues (ruff check) |
+| `just ruff-format` | Check code for formatting issues (ruff format) |
+| `just ruff-fix` | Auto-fix linting issues (ruff check --fix) |
+| `just ruff-format-fix` | Auto-fix formatting issues (ruff format) |
+| `just typecheck` | Run static type checking (mypy) |
+| `just jscpd` | Detect copy-paste code duplication (zero-tolerance) |
+| `just shfmt` | Check shell script formatting (shfmt, diff-only) |
+| `just shfmt-fix` | Auto-fix shell script formatting issues (shfmt -w) |
+| `just clean` | Remove build artifacts, caches, and generated files |
+| `just run` | Run the RimSort application |
+| `just dev-setup` | Install all dependencies including dev and build groups |
+| `just build` | Build RimSort executable (inits submodules, runs checks) |
+| `just build-version VERSION` | Build with a specific version string, e.g. "1.2.3.4" |
+| `just update` | Update all dependencies to latest compatible versions |
+| `just submodules-init` | Initialize and update git submodules (after cloning) |
+| `just build-help` | Show help for distribute.py build script |
+| `just ci` | Run full CI pipeline locally (checks + tests + coverage) |
 
 **Run `just check` before submitting a PR.** CI runs all of these checks and will fail if any report issues.
 
@@ -117,7 +134,7 @@ Key recipes for contributors:
 
 ### Linting and Formatting
 
-- **[Ruff](https://docs.astral.sh/ruff/)** is used for both linting and formatting (`just lint`, `just format`).
+- **[Ruff](https://docs.astral.sh/ruff/)** is used for both linting and formatting (`just ruff` + `just ruff-format`).
   - [VS Code extension](https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff)
   - Ruff replaces isort, flake8, and black. Disable those if you have them installed.
   - Configuration is in `pyproject.toml`.
@@ -134,4 +151,3 @@ Key recipes for contributors:
 - Type annotations should be added to function/method signatures.
   - Use Python 3.10+ standards. (Avoid importing Typing. [PEP 604](https://peps.python.org/pep-0604/) instead of Optional)
 - VS Code workspace settings are included
-

--- a/docs/development-guide/contributor-guidelines.zh-cn.md
+++ b/docs/development-guide/contributor-guidelines.zh-cn.md
@@ -9,17 +9,20 @@ lang: zh-cn
 
 
 # 贡献指南
+
 {: .no_toc}
 
 为 Rimsort 做出贡献时，请遵循以下准则。
 
 ## 目录
+
 {: .no_toc .text-delta }
 
 1. TOC
 {:toc}
 
 ## 基本准则
+
 1. 请在满足所有准则要求后再提交 Pull Request。允许存在少量疏漏（我们会在审核时修正），但请确保文档注释、代码格式等基础事项已妥善处理。如未准备就绪，请使用草案（Draft）模式提交。
 
 2. Pull Request 必须仅包含单一功能的相关改动。请勿将多项改动混杂在一个 PR 中，这有助于更高效地开展讨论。未遵守此要求的 PR 将被关闭。
@@ -60,7 +63,7 @@ lang: zh-cn
 | :--------: | :-----------------------------------------------------------: | :-----: | :----------------------------------------------------------------------------------------------------------------------------------------------- |
 |  Release   |                v\${major}.\${minor}.\${patch}                 | 手动  | 可以安全使用，被认为稳定的版本。                                                                                      |
 |    Edge    | v\${major}.\${minor}.\${patch}-edge\${increment}+${short-sha} | 手动  | 这些版本发布频繁，包含最新功能和修复，但可能存在显著的破坏性 Bug。                      |
-| Auto-Build | v\${major}.\${minor}.\${patch}-auto\${increment}+${short-sha} |  自动   | 自动构建流水线在每个 Pull Request 和向 main 分支推送时触发生成的版本。不会正式发布，构建产物以 artifact 形式保留。 | 
+| Auto-Build | v\${major}.\${minor}.\${patch}-auto\${increment}+${short-sha} |  自动   | 自动构建流水线在每个 Pull Request 和向 main 分支推送时触发生成的版本。不会正式发布，构建产物以 artifact 形式保留。 |
 
 正式版通过手动触发相关 GitHub 工作流操作创建。为保证安全，建议将发布流程设置为仅创建草稿。
 
@@ -102,17 +105,30 @@ lang: zh-cn
 
 给贡献者的关键命令：
 
-| Command | Description |
+| 命令 | 描述 |
 | :--- | :--- |
-| `just check` | 运行所有代码质量检查（lint、format、typecheck、jscpd、shfmt） |
+| `just check` | 运行所有代码质量检查（ruff、ruff-format、typecheck、jscpd、shfmt） |
 | `just fix` | 自动修复 lint 和格式化问题 |
-| `just test` | 运行测试并生成覆盖率报告 |
-| `just lint` | 检查 ruff 的 lint 问题 |
-| `just format` | 使用 ruff 检查代码格式 |
-| `just typecheck` | 运行 mypy 的类型检查 |
-| `just jscpd` | 检测代码拷贝粘贴重复 |
-| `just shfmt` | 格式化并检查 Shell 脚本格式（shfmt） |
-
+| `just test` | 运行测试（启用 doctest 模块） |
+| `just test-coverage` | 运行测试并生成覆盖率报告（XML、HTML、终端） |
+| `just test-verbose` | 运行测试（详细输出和简短回溯） |
+| `just ruff` | 检查代码 lint 问题（ruff check） |
+| `just ruff-format` | 检查代码格式问题（ruff format） |
+| `just ruff-fix` | 自动修复 lint 问题（ruff check --fix） |
+| `just ruff-format-fix` | 自动修复格式问题（ruff format） |
+| `just typecheck` | 运行静态类型检查（mypy） |
+| `just jscpd` | 检测代码拷贝粘贴重复（零容忍） |
+| `just shfmt` | 检查 Shell 脚本格式（shfmt，仅显示差异） |
+| `just shfmt-fix` | 自动修复 Shell 脚本格式问题（shfmt -w） |
+| `just clean` | 删除构建产物、缓存和生成的文件 |
+| `just run` | 运行 RimSort 应用程序 |
+| `just dev-setup` | 安装所有依赖（包括 dev 和 build 组） |
+| `just build` | 构建 RimSort 可执行文件（初始化子模块并运行检查） |
+| `just build-version VERSION` | 使用指定版本字符串构建，例如 "1.2.3.4" |
+| `just update` | 将所有依赖更新至最新兼容版本 |
+| `just submodules-init` | 初始化和更新 git 子模块（克隆后需要运行） |
+| `just build-help` | 显示 distribute.py 构建脚本的帮助信息 |
+| `just ci` | 本地运行完整 CI 流水线（检查 + 测试 + 覆盖率） |
 
 **提交 PR 前请先运行 `just check`。**CI 会执行全部这些检查，并且若检测到问题将失败。
 
@@ -120,7 +136,7 @@ lang: zh-cn
 
 ### Linting 与格式化
 
-- **[Ruff](https://docs.astral.sh/ruff/)** 同时用于 lint 和格式化（`just lint`、`just format`）。
+- **[Ruff](https://docs.astral.sh/ruff/)** 同时用于 lint 和格式化（`just ruff` + `just ruff-format`）。
   - VS Code 扩展：<https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff>
   - Ruff 替代 isort、flake8 和 black。请确保禁用这些工具以避免冲突。
   - 配置位于 `pyproject.toml`。
@@ -140,4 +156,3 @@ lang: zh-cn
 - 函数/方法的签名需要添加类型注解。
   - 使用 Python 3.10+ 标准。（避免导入 Typing；使用 [PEP 604](https://peps.python.org/pep-0604/) 的 `| None` 代替 Optional）
 - 已包含 VS Code 工作区设置
-

--- a/justfile
+++ b/justfile
@@ -1,105 +1,139 @@
-# Configure shell for Windows to avoid requiring `sh` (just's default on some setups)
-set shell := ["powershell", "-NoProfile", "-Command"]
+# ─── Shell Configuration ─────────────────────────────────────────────────
+# Use PowerShell 7 (pwsh) as the default shell — it's cross-platform
+# (available on Windows, Linux, and macOS). If pwsh is not installed on
+# your system, change to: set shell := ["sh", "-c"]
+set shell := ["pwsh", "-NoProfile", "-Command"]
 
-# List all available recipes (default)
+# ─── Global Variables ────────────────────────────────────────────────────
+# Shared flag values to keep recipes DRY and consistent.
+ruff_config := "--config pyproject.toml"
+pytest_opts := "--doctest-modules --no-qt-log"
+
+# ─── Default Target (lists all available recipes) ────────────────────────
 @default:
     just --list
 
+# ═══════════════════════════════════════════════════════════════════════════
 # Core Development
+# ═══════════════════════════════════════════════════════════════════════════
 
 # Run the RimSort application
 run: dev-setup
     uv run python -m app
 
-# Run tests with coverage reporting to terminal
+# Run tests with doctest modules enabled
 test: dev-setup
-    uv run pytest --doctest-modules -s --no-qt-log
+    uv run pytest {{pytest_opts}} -s
 
 # Run tests with verbose output and short tracebacks
 test-verbose: dev-setup
-    uv run pytest --doctest-modules -v --tb=short -s --no-qt-log
+    uv run pytest {{pytest_opts}} -v --tb=short -s
 
 # Run tests with full coverage reports (XML, HTML, and terminal)
 test-coverage: dev-setup
-    uv run pytest --doctest-modules --junitxml=junit/test-results.xml --cov=app --cov-report=xml --cov-report=html --cov-report=term-missing --no-qt-log
+    uv run pytest {{pytest_opts}} --junitxml=junit/test-results.xml --cov=app --cov-report=xml --cov-report=html --cov-report=term-missing
 
+# ═══════════════════════════════════════════════════════════════════════════
 # Code Quality
+# ═══════════════════════════════════════════════════════════════════════════
 
-# Check code for linting issues
-lint:
-    uv run ruff check --config pyproject.toml .
+# Check code for linting issues (ruff check)
+ruff:
+    uv run ruff check {{ruff_config}} .
 
-# Check and automatically fix linting issues
-lint-fix:
-    uv run ruff check --config pyproject.toml . --fix
+# Check code for formatting issues (ruff format)
+ruff-format:
+    uv run ruff format {{ruff_config}} . --check
 
-# Check code formatting without making changes
-format:
-    uv run ruff format --config pyproject.toml . --check
+# Check and automatically fix linting issues (ruff check --fix)
+ruff-fix:
+    uv run ruff check {{ruff_config}} . --fix
 
-# Format code automatically
-format-fix:
-    uv run ruff format --config pyproject.toml .
+# Automatically fix formatting issues (ruff format)
+ruff-format-fix:
+    uv run ruff format {{ruff_config}} .
 
-# Run type checking with mypy
+# Run static type checking (mypy)
 typecheck:
     uv run mypy --config-file pyproject.toml .
 
-# Detect copy-paste code duplication (matches CI's jscpd check)
+# Detect copy-paste code duplication (jscpd) — exits with error if any
+# clones are found (--threshold 0 means zero tolerance for duplicates).
+# Matches the CI's jscpd check configuration.
 jscpd:
     npx jscpd@latest app/ tests/ --threshold 0
 
-# Check shell script formatting
+# Check shell script (.sh) formatting (shfmt) — diff-only, no changes made
 shfmt:
-    shfmt -w .
     shfmt -d .
 
+# Automatically fix shell script formatting issues (shfmt)
+shfmt-fix:
+    shfmt -w .
 
-# Run all code quality checks (lint, format, typecheck, jscpd, shfmt)
-check: lint format typecheck jscpd shfmt
+# Run all code quality checks: ruff + ruff-format + typecheck + jscpd + shfmt
+check: ruff ruff-format typecheck jscpd shfmt
+    @echo "Use 'just fix' to automatically fix linting and formatting issues!"
 
-# Automatically fix linting and formatting issues
-fix: lint-fix format-fix
+# Automatically fix linting and formatting issues (ruff-fix + ruff-format-fix + shfmt -w)
+fix: ruff-fix ruff-format-fix shfmt-fix
     @echo "Auto-fixes applied!"
 
-# Run full CI pipeline (all checks + tests with coverage)
+# Run full CI pipeline locally: all quality checks + tests with coverage
 ci: check test-coverage
     @echo "CI simulation complete!"
 
-## Dependency Management
-# Install all dependencies including dev and build groups
+# ═══════════════════════════════════════════════════════════════════════════
+# Dependency Management
+# ═══════════════════════════════════════════════════════════════════════════
+
+# Install all dependencies (including dev and build groups) after ensuring
+# git submodules are initialized.
 dev-setup: submodules-init
     uv venv --allow-existing
     uv sync --locked --dev --group build
 
-# Update all dependencies to latest compatible versions
+# Update all dependencies to their latest compatible versions
 update:
     uv lock --upgrade
 
 # Remove all build artifacts, caches, and generated files
+[unix]
 clean:
+    #!/usr/bin/env bash
+    set -euo pipefail
     rm -rf build/ dist/ *.egg-info
     rm -rf .pytest_cache .mypy_cache .ruff_cache
     rm -rf htmlcov .coverage coverage.xml
     rm -rf junit/
     find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
 
-# Build/Distribution
+[windows]
+clean:
+    Remove-Item -Recurse -Force -ErrorAction SilentlyContinue build, dist, *.egg-info, .pytest_cache, .mypy_cache, .ruff_cache, htmlcov, .coverage, coverage.xml, junit
+    Get-ChildItem -Recurse -Directory -Filter __pycache__ | Remove-Item -Recurse -Force
 
-# Build RimSort executable
+# ═══════════════════════════════════════════════════════════════════════════
+# Build / Distribution
+# ═══════════════════════════════════════════════════════════════════════════
+
+# Build RimSort executable (inits submodules and runs all checks first)
 build *ARGS='': submodules-init check
     uv run python distribute.py {{ARGS}}
 
-# Build RimSort executable with specific version (e.g., "1.2.3.4")
+# Build RimSort executable with a specific version string, e.g. "1.2.3.4"
+# (inits submodules and runs all checks first)
 build-version VERSION: submodules-init check
     uv run python distribute.py --product-version="{{VERSION}}"
 
-# Create source tarball with submodules for RPM building
+# Create source tarball including submodules for RPM building
+[linux]
 rpm-tarball VERSION='1.0.0':
     #!/usr/bin/env bash
     set -euo pipefail
 
-    # Auto-append .1 if version has only 3 parts (for Nuitka compatibility)
+    # Nuitka requires a 4-part version (e.g. "1.0.0.1"), so auto-append ".1"
+    # when only 3 parts are provided.
     PART_COUNT=$(echo "{{VERSION}}" | tr '.' '\n' | wc -l)
     if [ "$PART_COUNT" -eq 3 ]; then
         FULL_VERSION="{{VERSION}}.1"
@@ -107,33 +141,36 @@ rpm-tarball VERSION='1.0.0':
         FULL_VERSION="{{VERSION}}"
     fi
 
-    TARBALL="$HOME/rpmbuild/SOURCES/rimsort-$FULL_VERSION.tar.gz"
+    TARBALL="$HOME/rpmbuild/SOURCES/rimsort-${FULL_VERSION}.tar.gz"
 
-    echo "Creating source tarball with submodules for version $FULL_VERSION..."
+    echo "Creating source tarball with submodules for version ${FULL_VERSION}..."
 
-    # Create temporary directory
     TMPDIR=$(mktemp -d)
     trap 'rm -rf "$TMPDIR"' EXIT
 
     # Archive main repository
-    git archive --prefix="RimSort-$FULL_VERSION/" HEAD | tar -x -C "$TMPDIR"
+    git archive --prefix="RimSort-${FULL_VERSION}/" HEAD | tar -x -C "$TMPDIR"
 
-    # Archive submodules
-    git submodule foreach --quiet "git archive --prefix=\"RimSort-$FULL_VERSION/\$displaypath/\" HEAD | tar -x -C \"$TMPDIR\""
+    # Archive each git submodule into the correct path under the prefix
+    git submodule foreach --quiet \
+        "git archive --prefix=\"RimSort-${FULL_VERSION}/\$displaypath/\" HEAD \
+         | tar -x -C \"$TMPDIR\""
 
-    # Create the final tarball
-    cd "$TMPDIR"
-    tar -czf "$TARBALL" "RimSort-$FULL_VERSION"
+    # Package everything into a single tarball
+    tar -czf "$TARBALL" -C "$TMPDIR" "RimSort-${FULL_VERSION}"
 
-    echo "Tarball created: $TARBALL"
+    echo "Tarball created: ${TARBALL}"
     ls -lh "$TARBALL"
 
-# Build RPM package for Fedora/RHEL (e.g., just build-rpm 1.0.63 or just build-rpm 1.0.63.1)
+# Build RPM package for Fedora/RHEL (e.g. "just build-rpm 1.0.63" or "just build-rpm 1.0.63.1")
+# Note: version normalization logic is duplicated from rpm-tarball because
+# bash shebang recipes cannot invoke other just recipes.
+[linux]
 build-rpm VERSION='1.0.0': check (rpm-tarball VERSION)
     #!/usr/bin/env bash
     set -euo pipefail
 
-    # Auto-append .1 if version has only 3 parts (for Nuitka compatibility)
+    # Auto-append ".1" if version has only 3 parts (Nuitka compatibility)
     PART_COUNT=$(echo "{{VERSION}}" | tr '.' '\n' | wc -l)
     if [ "$PART_COUNT" -eq 3 ]; then
         FULL_VERSION="{{VERSION}}.1"
@@ -144,25 +181,28 @@ build-rpm VERSION='1.0.0': check (rpm-tarball VERSION)
     echo "Setting up RPM build environment..."
     mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
 
-    echo "Building RPM package for version $FULL_VERSION..."
-    rpmbuild -bb packaging/rpm/rimsort.spec --define "version $FULL_VERSION"
+    echo "Building RPM package for version ${FULL_VERSION}..."
+    rpmbuild -bb packaging/rpm/rimsort.spec --define "version ${FULL_VERSION}"
 
     echo "RPM build complete!"
-    RPM_FILE=$(find ~/rpmbuild/RPMS/x86_64/ -name "rimsort-$FULL_VERSION-*.rpm" | head -n 1)
+    RPM_FILE=$(find ~/rpmbuild/RPMS/x86_64/ -name "rimsort-${FULL_VERSION}-*.rpm" | head -n 1)
     if [ -n "$RPM_FILE" ]; then
-        echo "Built RPM: $RPM_FILE"
+        echo "Built RPM: ${RPM_FILE}"
         ls -lh "$RPM_FILE"
     else
         echo "Warning: Could not find built RPM"
     fi
 
 # Build AppImage from existing Nuitka output (Linux only)
+[linux]
 build-appimage VERSION='1.0.0':
     bash packaging/appimage/build-appimage.sh build/app.dist "{{VERSION}}"
 
+# ═══════════════════════════════════════════════════════════════════════════
 # Utilities
+# ═══════════════════════════════════════════════════════════════════════════
 
-# Initialize and update git submodules (run after cloning)
+# Initialize and update git submodules (required after the first clone)
 submodules-init:
     git submodule update --init --recursive
 


### PR DESCRIPTION
Align contributor guideline docs with current just recipe names/descriptions, and refresh justfile to provide canonical commands for lint/format/typecheck/tests/CI. Verified with: just check and just test (366 passed, 1 skipped).