### PR TITLE
fix(ui): fix save button not blinking on mod drag-drop

### DIFF
--- a/app/controllers/main_window_controller.py
+++ b/app/controllers/main_window_controller.py
@@ -325,8 +325,6 @@ class MainWindowController(QObject):
                     self.main_window.main_content_panel.mods_panel.active_mods_list.uuids = list(
                         active_mods
                     )
-                    # Trigger list updated signal to refresh UI
-                    self.main_window.main_content_panel.mods_panel.list_updated_signal.emit()
 
                 # If there are mods to download, check SteamCMD setup first
                 if mods_to_download:

--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -1265,32 +1265,29 @@ class ModListWidget(QListWidget):
 
     def dropEvent(self, event: QDropEvent) -> None:
         super().dropEvent(event)
-        # Get source widget of dropEvent
         source_widget = event.source()
-        # Get the drop action
         drop_action = event.dropAction()
-        # Check if the drop action is MoveAction
-        if drop_action == Qt.DropAction.MoveAction:
-            # Get the new indexes of the dropped items
+        # Only manipulate UUIDs for within-list reorder (same source and dest).
+        # For cross-list drops, handle_rows_inserted (queued) handles UUID
+        # insertion exclusively — doing it here too creates duplicates that
+        # break the count guard in handle_rows_inserted.
+        if drop_action == Qt.DropAction.MoveAction and source_widget == self:
             new_indexes = [index.row() for index in self.selectedIndexes()]
-            # Get the UUIDs of the dropped items
             uuids = [
                 item.data(Qt.ItemDataRole.UserRole)["uuid"]
                 for item in self.selectedItems()
             ]
-            # Insert the UUIDs at the respective new indexes
             for idx, uuid in zip(new_indexes, uuids):
-                if uuid in self.uuids:  # Remove the uuid if it exists in the list
+                if uuid in self.uuids:
                     self.uuids.remove(uuid)
-                # Reinsert uuid at it's new index
                 self.uuids.insert(idx, uuid)
         # Re-apply divider collapse states after reorder
         self.apply_collapse_states()
-        # Update list signal
         logger.debug(
             f"Emitting {self.list_type} list update signal after rows dropped [{self.count()}]"
         )
-        # Only emit "drop" signal if a mod was dragged and dropped within the same modlist
+        # Emit signal for within-list drops. Cross-list drops will emit
+        # from handle_rows_inserted once the queued insertion completes.
         if source_widget == self:
             self.list_update_signal.emit("drop")
 
@@ -3956,8 +3953,6 @@ class ModsPanel(QWidget):
     active/inactive mods list panel on the GUI.
     """
 
-    list_updated_signal = Signal()
-    save_btn_animation_signal = Signal()
     check_dependencies_signal = Signal()
 
     # OPTIMIZATION: Class-level constant for sort text to enum mapping
@@ -4833,8 +4828,6 @@ class ModsPanel(QWidget):
         if count != "drop":
             logger.info(f"{list_type} mod count changed to: {count}")
             self.update_count(list_type=list_type)
-        # Signal save button animation
-        self.save_btn_animation_signal.emit()
         if recalculate_list_errors_warnings:
             # Update the mod list widget errors and warnings
             self.recalculate_list_errors_warnings(list_type=list_type)


### PR DESCRIPTION
## Summary

Fixes #1819

- Save button now blinks when mods are dragged between active/inactive lists (cross-list drop)
- Root cause: `dropEvent` manually inserted UUIDs into `self.uuids` AND the queued `handle_rows_inserted` also inserted them, creating duplicates that broke the `len(self.uuids) == self.count()` guard — so `list_update_signal` was never emitted
- Fix: only manipulate UUIDs in `dropEvent` for within-list reorder (`source_widget == self`); cross-list drops let `handle_rows_inserted` handle UUID insertion exclusively (same pattern as PR #1922)
- Removes unused `save_btn_animation_signal` and `list_updated_signal` from `ModsPanel` (defined and emitted but never connected to any handler)

## Test plan

- [x] Drag a mod within the active list to reorder — save button should blink
- [x] Drag a mod from inactive to active — save button should blink
- [x] Drag a mod from active to inactive — save button should blink
- [x] Click Save — save button should stop blinking
- [x] Verify full test suite passes: `uv run pytest tests/ -x -q`

🤖 Generated with [Claude Code](https://claude.com/claude-code)