### PR TITLE
fix(settings): persist inactive mods sort key and fix sorting checkbox disable bug

### DIFF
--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -3977,7 +3977,15 @@ class ModsPanel(QWidget):
         Update the inactive mods sort UI elements from settings.
 
         Restores the saved sort key and direction to the UI combobox and button.
+        Toggles visibility of sort widgets based on whether sorting is enabled.
         """
+        sorting_enabled = self.settings_controller.settings.inactive_mods_sorting
+        self.inactive_mods_sort_combobox.setVisible(sorting_enabled)
+        self.inactive_mods_sort_order_button.setVisible(sorting_enabled)
+
+        if not sorting_enabled:
+            return
+
         self.inactive_mods_sort_key = (
             self.settings_controller.settings.inactive_mods_sort_key
         )
@@ -4519,9 +4527,9 @@ class ModsPanel(QWidget):
         self.inactive_mods_search_layout.addWidget(self.inactive_mods_sort_order_button)
 
         # Set initial visibility based on settings
-        if self.settings_controller.settings.inactive_mods_sorting:
-            self.inactive_mods_sort_combobox.setVisible(True)
-            self.inactive_mods_sort_order_button.setVisible(True)
+        sorting_enabled = self.settings_controller.settings.inactive_mods_sorting
+        self.inactive_mods_sort_combobox.setVisible(sorting_enabled)
+        self.inactive_mods_sort_order_button.setVisible(sorting_enabled)
 
         # Adding Completer.
         # self.completer = QCompleter(self.active_mods_list.get_list_items())

--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -4796,6 +4796,16 @@ class ModsPanel(QWidget):
                 thr.start()
                 self._size_progress_dialog = dlg
                 dlg.show()
+                # Save the sort key immediately if enabled (don't wait for worker)
+                if (
+                    self.settings_controller.settings.inactive_mods_sorting
+                    and self.settings_controller.settings.save_inactive_mods_sort_state
+                ):
+                    self.settings_controller.settings.inactive_mods_sort_key = (
+                        sort_key.name
+                    )
+                    self.settings_controller.settings.save()
+                self.inactive_mods_sort_key = sort_key.name
             else:
                 # Non-heavy sorts use debouncing to prevent rapid rebuilds
                 # Store pending sort parameters


### PR DESCRIPTION
## Summary

Fixes #1771

**Sort key persistence (folder size):**
- The heavy-sort (Folder Size) branch was missing save logic — the sort key was never persisted to settings even when "Save inactive mods sort state" was enabled
- Added the same save logic that already existed in the non-heavy sort branch

**Sort UI visibility:**
- The sort combobox and Asc/Desc button in the mods panel now hide/show dynamically when the "Enable inactive mods sorting" setting changes (via `EventBus.settings_have_changed`)
- Fixed init-time visibility to properly hide sort widgets when sorting is disabled at startup

**Note:** The checkbox disable-recursion fix was dropped from this PR — that was independently resolved by #2069.

## Test plan

- [x] With "Save inactive mods sort state" checked: change sort key to Folder Size → restart → sort key persists
- [x] With "Save inactive mods sort state" unchecked: change sort key → restart → resets to Modified Time / Desc
- [x] When "Enable inactive mods sorting" is unchecked, the sort combobox and Asc/Desc button in the mods panel disappear
- [x] When re-checked, the sort UI reappears immediately (no restart needed)
- [x] Full quality gate passes: `just check`
- [x] Full test suite passes: `just test` (729 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)