### PR TITLE
fix(instances): use forward slashes in auto-generated Steam launch args

### DIFF
--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -986,8 +986,8 @@ class MainWindow(QMainWindow):
                 # Generate preview of run args
                 preview_generated_run_args = [
                     "-logfile",
-                    str(instance_path / "RimWorld.log"),
-                    f"-savedatafolder={str(instance_path / 'InstanceData')}",
+                    (instance_path / "RimWorld.log").as_posix(),
+                    f"-savedatafolder={(instance_path / 'InstanceData').as_posix()}",
                 ]
                 preview_text = " ".join(preview_generated_run_args)
                 # Prompt the user if they would like to automatically generate run args for the instance


### PR DESCRIPTION
## Summary
- Fixes #1648
- Auto-generated Steam launch arguments (`-logfile`, `-savedatafolder`) used `str(Path(...))` which produces backslashes on Windows
- Steam/Unity requires forward slashes — backslashes cause the game to launch without mods
- Replace `str()` with `Path.as_posix()` to produce forward slashes on all platforms (no-op on Linux/macOS)

## Test plan
- [ ] On Windows: create a new instance with game/config folders set, accept auto-generated run args — verify paths use forward slashes
- [ ] On Windows: launch game from the new instance — verify mods load correctly
- [x] On Linux/macOS: verify no behavioral change (paths already use forward slashes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)