### PR TITLE
fix(tests): prevent tests from launching Steam via unpatched steam:// URLs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 import subprocess
-from typing import Generator, Union
+from typing import Any, Generator, Union
 from unittest.mock import patch
 
 import pytest
@@ -18,20 +18,19 @@ def _block_steam_urls(request: pytest.FixtureRequest) -> Generator[None, None, N
     platform_specific_open is patched at the wrong import location.
     """
 
-    def _guarded_popen(
-        args: object, *a: object, **kw: object
-    ) -> subprocess.Popen[bytes]:
+    def _guarded_popen(*args: Any, **kw: Any) -> subprocess.Popen[Any]:
+        popen_args = args[0] if args else kw.get("args", "")
         cmd_str = (
-            " ".join(str(x) for x in args)
-            if isinstance(args, (list, tuple))
-            else str(args)
+            " ".join(str(x) for x in popen_args)
+            if isinstance(popen_args, (list, tuple))
+            else str(popen_args)
         )
         if "steam://" in cmd_str:
             raise RuntimeError(
                 f"Test {request.node.nodeid} tried to open a steam:// URL "
                 f"via subprocess: {cmd_str}"
             )
-        return _real_popen(args, *a, **kw)  # type: ignore[arg-type]
+        return _real_popen(*args, **kw)
 
     with patch.object(subprocess, "Popen", _guarded_popen):
         yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,40 @@
+import subprocess
 from typing import Generator, Union
+from unittest.mock import patch
 
 import pytest
 from PySide6.QtCore import QCoreApplication
 from PySide6.QtWidgets import QApplication, QDialog
+
+_real_popen = subprocess.Popen
+
+
+@pytest.fixture(autouse=True)
+def _block_steam_urls(request: pytest.FixtureRequest) -> Generator[None, None, None]:
+    """Prevent tests from opening steam:// URLs on the host machine.
+
+    Guards subprocess.Popen to block any steam:// URI regardless of
+    which Python function initiated the call. This catches cases where
+    platform_specific_open is patched at the wrong import location.
+    """
+
+    def _guarded_popen(
+        args: object, *a: object, **kw: object
+    ) -> subprocess.Popen[bytes]:
+        cmd_str = (
+            " ".join(str(x) for x in args)
+            if isinstance(args, (list, tuple))
+            else str(args)
+        )
+        if "steam://" in cmd_str:
+            raise RuntimeError(
+                f"Test {request.node.nodeid} tried to open a steam:// URL "
+                f"via subprocess: {cmd_str}"
+            )
+        return _real_popen(args, *a, **kw)  # type: ignore[arg-type]
+
+    with patch.object(subprocess, "Popen", _guarded_popen):
+        yield
 
 
 @pytest.fixture(autouse=True)

--- a/tests/controllers/test_troubleshooting.py
+++ b/tests/controllers/test_troubleshooting.py
@@ -70,7 +70,7 @@ class TestGameFilesRecovery:
 
         (game_dir / "test.txt").write_text("test")
 
-        with patch("app.utils.generic.platform_specific_open"):
+        with patch("app.controllers.troubleshooting_controller.platform_specific_open"):
             controller._delete_game_files()
             assert test_mod.exists()
             assert not (game_dir / "test.txt").exists()
@@ -90,7 +90,7 @@ class TestSteamModsRecovery:
         test_mod.mkdir()
         (test_mod / "About.xml").write_text("<ModMetaData></ModMetaData>")
 
-        with patch("app.utils.generic.platform_specific_open"):
+        with patch("app.controllers.troubleshooting_controller.platform_specific_open"):
             controller._delete_steam_mods()
             assert not test_mod.exists()
 
@@ -209,7 +209,7 @@ class TestUIInteractions:
         controller.dialog.integrity_delete_game_configs.setChecked(False)
 
         with (
-            patch("app.utils.generic.platform_specific_open"),
+            patch("app.controllers.troubleshooting_controller.platform_specific_open"),
             patch(
                 "app.controllers.troubleshooting_controller.show_dialogue_conditional",
                 return_value=True,
@@ -486,7 +486,7 @@ class TestEdgeCases:
             rmtree(path)
 
         with (
-            patch("app.utils.generic.platform_specific_open"),
+            patch("app.controllers.troubleshooting_controller.platform_specific_open"),
             patch("pathlib.Path.exists", return_value=False),
             patch("pathlib.Path.iterdir", return_value=[]),
         ):


### PR DESCRIPTION
## Summary

- Fix 4 tests in `test_troubleshooting.py` that patched `platform_specific_open` at the wrong import location (`app.utils.generic` instead of `app.controllers.troubleshooting_controller`), causing `steam://install`, `steam://validate`, and `steam://workshop_download_item` URLs to reach the real OS and launch Steam on every test run
- Add a `subprocess.Popen` safety net fixture in `conftest.py` that blocks any `steam://` URL from reaching the OS during tests, so future regressions fail loudly instead of silently launching Steam

## Test plan

- [x] All 367 tests pass
- [x] No `steam://` URLs leak through (verified with diagnostic instrumentation)
- [x] Steam no longer launches during `uv run pytest`
- [x] Ruff format and lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)