### PR TITLE
fix: use platform.machine() for arch detection

### DIFF
--- a/app/utils/update_utils.py
+++ b/app/utils/update_utils.py
@@ -816,7 +816,7 @@ class UpdateManager(QObject):
                 release_data.get("assets", []), needs_elevation
             )
             if not download_info:
-                system_info = f"{platform.system()} {platform.architecture()[0]} {platform.processor()}"
+                system_info = f"{platform.system()} {platform.architecture()[0]} {platform.machine()}"
                 dialogue.show_warning(
                     title=self.tr(ERR_NO_VALID_RELEASE_TITLE),
                     text=self.tr(ERR_NO_VALID_RELEASE_TEXT).format(

--- a/distribute.py
+++ b/distribute.py
@@ -28,11 +28,13 @@ Setup environment
 
 _ARCH = platform.architecture()[0]
 _CWD = os.getcwd()
-_PROCESSOR = platform.machine()
-if _PROCESSOR == "":
-    _PROCESSOR = platform.processor()
-
 _SYSTEM = platform.system()
+_MACHINE = platform.machine() or platform.processor()
+# Normalize to match pre-built binary and todds asset naming on macOS
+if _SYSTEM == "Darwin":
+    _PROCESSOR = {"arm64": "arm", "x86_64": "i386"}.get(_MACHINE, _MACHINE)
+else:
+    _PROCESSOR = _MACHINE
 
 PY_CMD = sys.executable
 

--- a/distribute.py
+++ b/distribute.py
@@ -28,9 +28,9 @@ Setup environment
 
 _ARCH = platform.architecture()[0]
 _CWD = os.getcwd()
-_PROCESSOR = platform.processor()
+_PROCESSOR = platform.machine()
 if _PROCESSOR == "":
-    _PROCESSOR = platform.machine()
+    _PROCESSOR = platform.processor()
 
 _SYSTEM = platform.system()
 


### PR DESCRIPTION
## Summary
- Swaps `platform.processor()` → `platform.machine()` in `distribute.py` and `app/utils/update_utils.py`
- `platform.processor()` returns the full CPU model name on Linux (e.g., "AMD Ryzen 5 8400F 6-Core Processor") instead of the architecture (`x86_64`), breaking SteamworksPy library filename construction and showing incorrect info in update error messages

Closes #1680

## Test plan
- [x] Verify `distribute.py` constructs correct `SteamworksPy_{arch}.so` filenames on Linux
- [x] Verify update error dialog shows architecture string, not CPU model name

🤖 Generated with [Claude Code](https://claude.com/claude-code)