### PR TITLE
fix: prevent ghost window from folder size sort progress dialog

### DIFF
--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -4628,9 +4628,8 @@ class ModsPanel(QWidget):
                 reverse=self.inactive_sort_descending,
             )
             if hasattr(self, "_size_progress_dialog") and self._size_progress_dialog:
-                self._size_progress_dialog.setLabelText(self.tr("Rebuilding list..."))
-                self._size_progress_dialog.setRange(0, len(sorted_uuids))
-                self._size_progress_dialog.setValue(0)
+                self._size_progress_dialog.close()
+                self._size_progress_dialog = None
 
             lw = self.inactive_mods_list
             # Disconnect model signals during rebuild to prevent cascading updates and duplicate items
@@ -4669,11 +4668,6 @@ class ModsPanel(QWidget):
                     data.__dict__["show_tags"] = lw.show_tags
                     list_item.setData(Qt.ItemDataRole.UserRole, data)
                     lw.addItem(list_item)
-                    if (
-                        hasattr(self, "_size_progress_dialog")
-                        and self._size_progress_dialog
-                    ):
-                        self._size_progress_dialog.setValue(idx)
             lw.uuids = sorted_uuids
 
             # Reconnect model signals
@@ -4784,15 +4778,14 @@ class ModsPanel(QWidget):
             is_heavy = sort_key == ModsPanelSortKey.FOLDER_SIZE
             if is_heavy:
                 # Background calculation required for folder size sorting
-                dlg = QProgressDialog(self)
+                dlg = QProgressDialog(self.window())
                 dlg.setLabelText(self.tr("Calculating folder sizes..."))
-                # Set up dialog without cancel button (calculation cannot be interrupted)
                 dlg.setCancelButton(None)
                 dlg.setRange(0, len(current_uuids))
-                dlg.setWindowModality(Qt.WindowModality.WindowModal)
                 dlg.setMinimumDuration(0)
                 dlg.setAutoClose(True)
-                dlg.setAutoReset(True)
+                dlg.setAutoReset(False)
+                dlg.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose)
                 dlg.setValue(0)
                 QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
                 # Start worker thread


### PR DESCRIPTION
## Summary
- Fixes ghost window left on screen after folder size sort completes
- **Root cause**: `setWindowModality(WindowModal)` on macOS creates a native modal sheet frame that persists after the dialog closes
- Removes `WindowModal` (unnecessary — no cancel button, wait cursor signals busy state)
- Parents dialog to main window instead of ModsPanel widget
- Closes dialog before list rebuild instead of repurposing it for a second "Rebuilding list..." phase
- Adds `WA_DeleteOnClose` for clean native window lifecycle

Closes #2022

## Test plan
- [x] Sort inactive mods by "Folder Size" on macOS
- [x] Verify progress dialog appears during calculation and closes cleanly
- [x] Verify no ghost/empty window remains after sort completes
- [x] Verify sort still produces correct results (descending by size)

🤖 Generated with [Claude Code](https://claude.com/claude-code)