### PR TITLE
test(sort): add test suite for sorting algorithms

### DIFF
--- a/tests/sort/conftest.py
+++ b/tests/sort/conftest.py
@@ -31,6 +31,43 @@ def make_mod(
     return mod
 
 
+def three_mod_alpha_fixture() -> tuple[dict[str, Any], dict[str, set[str]], set[str]]:
+    """Metadata, graph, and active_mods for a 3-mod alphabetical test."""
+    metadata = {
+        "uuid_z": make_mod("mod.z", name="Zebra"),
+        "uuid_a": make_mod("mod.a", name="Alpha"),
+        "uuid_m": make_mod("mod.m", name="Middle"),
+    }
+    graph: dict[str, set[str]] = {"mod.z": set(), "mod.a": set(), "mod.m": set()}
+    return metadata, graph, {"uuid_z", "uuid_a", "uuid_m"}
+
+
+def diamond_fixture() -> tuple[dict[str, Any], dict[str, set[str]], set[str]]:
+    """Metadata, graph, and active_mods for a diamond dependency test."""
+    metadata = {
+        "uuid_a": make_mod("mod.a", name="Alpha"),
+        "uuid_b": make_mod("mod.b", name="Beta"),
+        "uuid_c": make_mod("mod.c", name="Charlie"),
+        "uuid_d": make_mod("mod.d", name="Delta"),
+    }
+    graph: dict[str, set[str]] = {
+        "mod.a": set(),
+        "mod.b": {"mod.a"},
+        "mod.c": {"mod.a"},
+        "mod.d": {"mod.b", "mod.c"},
+    }
+    return metadata, graph, {"uuid_a", "uuid_b", "uuid_c", "uuid_d"}
+
+
+def assert_diamond_ordering(result: list[str]) -> None:
+    """Verify diamond dependency ordering: A before B,C before D."""
+    assert len(result) == 4
+    assert result.index("uuid_a") < result.index("uuid_b")
+    assert result.index("uuid_a") < result.index("uuid_c")
+    assert result.index("uuid_b") < result.index("uuid_d")
+    assert result.index("uuid_c") < result.index("uuid_d")
+
+
 @pytest.fixture
 def metadata_manager_mock() -> Generator[MagicMock, None, None]:
     """Mock MetadataManager.instance() for sorting tests.

--- a/tests/sort/conftest.py
+++ b/tests/sort/conftest.py
@@ -1,0 +1,45 @@
+from typing import Any, Generator
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def make_mod(
+    packageid: str,
+    name: str | None = None,
+    load_these_before: list[tuple[str, bool]] | None = None,
+    load_these_after: list[tuple[str, bool]] | None = None,
+    load_top: bool = False,
+    load_bottom: bool = False,
+    dependencies: list[str | tuple[str, dict[str, Any]]] | None = None,
+) -> dict[str, Any]:
+    """Build a mod metadata dict for sorting tests."""
+    mod: dict[str, Any] = {
+        "packageid": packageid,
+        "name": name or packageid,
+    }
+    if load_these_before is not None:
+        mod["loadTheseBefore"] = set(load_these_before)
+    if load_these_after is not None:
+        mod["loadTheseAfter"] = set(load_these_after)
+    if load_top:
+        mod["loadTop"] = True
+    if load_bottom:
+        mod["loadBottom"] = True
+    if dependencies is not None:
+        mod["dependencies"] = dependencies
+    return mod
+
+
+@pytest.fixture
+def metadata_manager_mock() -> Generator[MagicMock, None, None]:
+    """Mock MetadataManager.instance() for sorting tests.
+
+    Sets up an empty internal_local_metadata dict. Tests should populate
+    it via the returned mock: mock.internal_local_metadata = {...}
+    """
+    with patch("app.utils.metadata.MetadataManager.instance") as mock_instance:
+        mock = MagicMock()
+        mock.internal_local_metadata = {}
+        mock_instance.return_value = mock
+        yield mock

--- a/tests/sort/test_alphabetical_sort.py
+++ b/tests/sort/test_alphabetical_sort.py
@@ -102,7 +102,7 @@ class TestDoAlphabeticalSort:
         assert result == ["uuid_lower", "uuid_upper"]
 
     def test_non_string_name_handled(self, metadata_manager_mock: MagicMock) -> None:
-        """Mods with non-string name values don't crash the sort."""
+        """Mods with non-string name values don't crash and sort after valid names."""
         metadata_manager_mock.internal_local_metadata = {
             "uuid_a": {"packageid": "mod.a", "name": None},
             "uuid_b": make_mod("mod.b", name="Beta"),
@@ -113,3 +113,6 @@ class TestDoAlphabeticalSort:
         }
         result = do_alphabetical_sort(graph, {"uuid_a", "uuid_b"})
         assert len(result) == 2
+        # "Beta" sorts before the fallback "name error in mod about.xml"
+        assert result[0] == "uuid_b"
+        assert result[1] == "uuid_a"

--- a/tests/sort/test_alphabetical_sort.py
+++ b/tests/sort/test_alphabetical_sort.py
@@ -1,0 +1,132 @@
+from unittest.mock import MagicMock
+
+from app.sort.alphabetical_sort import do_alphabetical_sort
+from tests.sort.conftest import make_mod
+
+
+class TestDoAlphabeticalSort:
+    def test_single_mod(self, metadata_manager_mock: MagicMock) -> None:
+        metadata_manager_mock.internal_local_metadata = {
+            "uuid_a": make_mod("mod.a", name="Alpha"),
+        }
+        result = do_alphabetical_sort({"mod.a": set()}, {"uuid_a"})
+        assert result == ["uuid_a"]
+
+    def test_alphabetical_no_dependencies(
+        self, metadata_manager_mock: MagicMock
+    ) -> None:
+        """Without dependencies, mods are sorted alphabetically by name."""
+        metadata_manager_mock.internal_local_metadata = {
+            "uuid_z": make_mod("mod.z", name="Zebra"),
+            "uuid_a": make_mod("mod.a", name="Alpha"),
+            "uuid_m": make_mod("mod.m", name="Middle"),
+        }
+        graph: dict[str, set[str]] = {
+            "mod.z": set(),
+            "mod.a": set(),
+            "mod.m": set(),
+        }
+        result = do_alphabetical_sort(graph, {"uuid_z", "uuid_a", "uuid_m"})
+        names = [
+            metadata_manager_mock.internal_local_metadata[u]["name"] for u in result
+        ]
+        assert names == ["Alpha", "Middle", "Zebra"]
+
+    def test_dependency_placed_before_dependent(
+        self, metadata_manager_mock: MagicMock
+    ) -> None:
+        """A mod's dependency appears before it even if alphabetically later."""
+        metadata_manager_mock.internal_local_metadata = {
+            "uuid_a": make_mod("mod.a", name="Alpha"),
+            "uuid_z": make_mod("mod.z", name="Zebra"),
+        }
+        # Alpha depends on Zebra
+        graph: dict[str, set[str]] = {
+            "mod.a": {"mod.z"},
+            "mod.z": set(),
+        }
+        result = do_alphabetical_sort(graph, {"uuid_a", "uuid_z"})
+        assert result.index("uuid_z") < result.index("uuid_a")
+
+    def test_transitive_deps_placed_before(
+        self, metadata_manager_mock: MagicMock
+    ) -> None:
+        metadata_manager_mock.internal_local_metadata = {
+            "uuid_a": make_mod("mod.a", name="Alpha"),
+            "uuid_b": make_mod("mod.b", name="Beta"),
+            "uuid_c": make_mod("mod.c", name="Charlie"),
+        }
+        # Alpha -> Beta -> Charlie
+        graph: dict[str, set[str]] = {
+            "mod.a": {"mod.b"},
+            "mod.b": {"mod.c"},
+            "mod.c": set(),
+        }
+        result = do_alphabetical_sort(graph, {"uuid_a", "uuid_b", "uuid_c"})
+        assert result.index("uuid_c") < result.index("uuid_b")
+        assert result.index("uuid_b") < result.index("uuid_a")
+
+    def test_graph_entries_not_in_active_mods_excluded(
+        self, metadata_manager_mock: MagicMock
+    ) -> None:
+        metadata_manager_mock.internal_local_metadata = {
+            "uuid_a": make_mod("mod.a", name="Alpha"),
+        }
+        graph: dict[str, set[str]] = {
+            "mod.a": set(),
+            "mod.ghost": set(),
+        }
+        result = do_alphabetical_sort(graph, {"uuid_a"})
+        assert result == ["uuid_a"]
+
+    def test_empty_graph(self, metadata_manager_mock: MagicMock) -> None:
+        metadata_manager_mock.internal_local_metadata = {}
+        result = do_alphabetical_sort({}, set())
+        assert result == []
+
+    def test_diamond_dependency(self, metadata_manager_mock: MagicMock) -> None:
+        """Diamond: D depends on B and C, both depend on A. A appears once and first."""
+        metadata_manager_mock.internal_local_metadata = {
+            "uuid_a": make_mod("mod.a", name="Alpha"),
+            "uuid_b": make_mod("mod.b", name="Beta"),
+            "uuid_c": make_mod("mod.c", name="Charlie"),
+            "uuid_d": make_mod("mod.d", name="Delta"),
+        }
+        graph: dict[str, set[str]] = {
+            "mod.a": set(),
+            "mod.b": {"mod.a"},
+            "mod.c": {"mod.a"},
+            "mod.d": {"mod.b", "mod.c"},
+        }
+        result = do_alphabetical_sort(graph, {"uuid_a", "uuid_b", "uuid_c", "uuid_d"})
+        assert len(result) == 4
+        assert result.index("uuid_a") < result.index("uuid_b")
+        assert result.index("uuid_a") < result.index("uuid_c")
+        assert result.index("uuid_b") < result.index("uuid_d")
+        assert result.index("uuid_c") < result.index("uuid_d")
+
+    def test_case_insensitive_sort(self, metadata_manager_mock: MagicMock) -> None:
+        """Alphabetical sorting is case-insensitive."""
+        metadata_manager_mock.internal_local_metadata = {
+            "uuid_upper": make_mod("mod.upper", name="ZEBRA"),
+            "uuid_lower": make_mod("mod.lower", name="alpha"),
+        }
+        graph: dict[str, set[str]] = {
+            "mod.upper": set(),
+            "mod.lower": set(),
+        }
+        result = do_alphabetical_sort(graph, {"uuid_upper", "uuid_lower"})
+        assert result == ["uuid_lower", "uuid_upper"]
+
+    def test_non_string_name_handled(self, metadata_manager_mock: MagicMock) -> None:
+        """Mods with non-string name values don't crash the sort."""
+        metadata_manager_mock.internal_local_metadata = {
+            "uuid_a": {"packageid": "mod.a", "name": None},
+            "uuid_b": make_mod("mod.b", name="Beta"),
+        }
+        graph: dict[str, set[str]] = {
+            "mod.a": set(),
+            "mod.b": set(),
+        }
+        result = do_alphabetical_sort(graph, {"uuid_a", "uuid_b"})
+        assert len(result) == 2

--- a/tests/sort/test_alphabetical_sort.py
+++ b/tests/sort/test_alphabetical_sort.py
@@ -1,7 +1,12 @@
 from unittest.mock import MagicMock
 
 from app.sort.alphabetical_sort import do_alphabetical_sort
-from tests.sort.conftest import make_mod
+from tests.sort.conftest import (
+    assert_diamond_ordering,
+    diamond_fixture,
+    make_mod,
+    three_mod_alpha_fixture,
+)
 
 
 class TestDoAlphabeticalSort:
@@ -16,17 +21,9 @@ class TestDoAlphabeticalSort:
         self, metadata_manager_mock: MagicMock
     ) -> None:
         """Without dependencies, mods are sorted alphabetically by name."""
-        metadata_manager_mock.internal_local_metadata = {
-            "uuid_z": make_mod("mod.z", name="Zebra"),
-            "uuid_a": make_mod("mod.a", name="Alpha"),
-            "uuid_m": make_mod("mod.m", name="Middle"),
-        }
-        graph: dict[str, set[str]] = {
-            "mod.z": set(),
-            "mod.a": set(),
-            "mod.m": set(),
-        }
-        result = do_alphabetical_sort(graph, {"uuid_z", "uuid_a", "uuid_m"})
+        metadata, graph, active = three_mod_alpha_fixture()
+        metadata_manager_mock.internal_local_metadata = metadata
+        result = do_alphabetical_sort(graph, active)
         names = [
             metadata_manager_mock.internal_local_metadata[u]["name"] for u in result
         ]
@@ -86,24 +83,10 @@ class TestDoAlphabeticalSort:
 
     def test_diamond_dependency(self, metadata_manager_mock: MagicMock) -> None:
         """Diamond: D depends on B and C, both depend on A. A appears once and first."""
-        metadata_manager_mock.internal_local_metadata = {
-            "uuid_a": make_mod("mod.a", name="Alpha"),
-            "uuid_b": make_mod("mod.b", name="Beta"),
-            "uuid_c": make_mod("mod.c", name="Charlie"),
-            "uuid_d": make_mod("mod.d", name="Delta"),
-        }
-        graph: dict[str, set[str]] = {
-            "mod.a": set(),
-            "mod.b": {"mod.a"},
-            "mod.c": {"mod.a"},
-            "mod.d": {"mod.b", "mod.c"},
-        }
-        result = do_alphabetical_sort(graph, {"uuid_a", "uuid_b", "uuid_c", "uuid_d"})
-        assert len(result) == 4
-        assert result.index("uuid_a") < result.index("uuid_b")
-        assert result.index("uuid_a") < result.index("uuid_c")
-        assert result.index("uuid_b") < result.index("uuid_d")
-        assert result.index("uuid_c") < result.index("uuid_d")
+        metadata, graph, active = diamond_fixture()
+        metadata_manager_mock.internal_local_metadata = metadata
+        result = do_alphabetical_sort(graph, active)
+        assert_diamond_ordering(result)
 
     def test_case_insensitive_sort(self, metadata_manager_mock: MagicMock) -> None:
         """Alphabetical sorting is case-insensitive."""

--- a/tests/sort/test_dependencies.py
+++ b/tests/sort/test_dependencies.py
@@ -1,0 +1,562 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.sort.dependencies import (
+    gen_deps_graph,
+    gen_rev_deps_graph,
+    gen_tier_one_deps_graph,
+    gen_tier_three_deps_graph,
+    gen_tier_two_deps_graph,
+    gen_tier_zero_deps_graph,
+    get_dependencies_recursive,
+    get_reverse_dependencies_recursive,
+)
+from tests.sort.conftest import make_mod
+
+# ---------------------------------------------------------------------------
+# get_dependencies_recursive — pure graph traversal, no MetadataManager
+# ---------------------------------------------------------------------------
+
+
+class TestGetDependenciesRecursive:
+    def test_no_dependencies(self) -> None:
+        graph: dict[str, set[str]] = {"mod_a": set()}
+        result = get_dependencies_recursive("mod_a", graph, set())
+        assert result == set()
+
+    def test_direct_dependencies(self) -> None:
+        graph: dict[str, set[str]] = {
+            "mod_a": {"mod_b", "mod_c"},
+            "mod_b": set(),
+            "mod_c": set(),
+        }
+        result = get_dependencies_recursive("mod_a", graph, set())
+        assert result == {"mod_b", "mod_c"}
+
+    def test_transitive_dependencies(self) -> None:
+        graph: dict[str, set[str]] = {
+            "mod_a": {"mod_b"},
+            "mod_b": {"mod_c"},
+            "mod_c": {"mod_d"},
+            "mod_d": set(),
+        }
+        result = get_dependencies_recursive("mod_a", graph, set())
+        assert result == {"mod_b", "mod_c", "mod_d"}
+
+    def test_diamond_dependency(self) -> None:
+        """A depends on B and C, both depend on D."""
+        graph: dict[str, set[str]] = {
+            "mod_a": {"mod_b", "mod_c"},
+            "mod_b": {"mod_d"},
+            "mod_c": {"mod_d"},
+            "mod_d": set(),
+        }
+        result = get_dependencies_recursive("mod_a", graph, set())
+        assert result == {"mod_b", "mod_c", "mod_d"}
+
+    def test_circular_dependency_terminates(self) -> None:
+        """Circular deps don't infinite-loop thanks to processed_ids tracking."""
+        graph: dict[str, set[str]] = {
+            "mod_a": {"mod_b"},
+            "mod_b": {"mod_a"},
+        }
+        result = get_dependencies_recursive("mod_a", graph, set())
+        assert result == {"mod_b", "mod_a"}
+
+    def test_unknown_package_returns_empty(self) -> None:
+        graph: dict[str, set[str]] = {"mod_a": set()}
+        result = get_dependencies_recursive("nonexistent", graph, set())
+        assert result == set()
+
+    def test_processed_ids_prevents_revisit(self) -> None:
+        """If mod_b is already processed, it and its deps are skipped."""
+        graph: dict[str, set[str]] = {
+            "mod_a": {"mod_b"},
+            "mod_b": {"mod_c"},
+            "mod_c": set(),
+        }
+        already_processed = {"mod_b"}
+        result = get_dependencies_recursive("mod_a", graph, already_processed)
+        assert result == set()
+
+
+# ---------------------------------------------------------------------------
+# get_reverse_dependencies_recursive — reverse graph traversal
+# ---------------------------------------------------------------------------
+
+
+class TestGetReverseDependenciesRecursive:
+    def test_no_reverse_deps(self) -> None:
+        graph: dict[str, set[str]] = {"mod_a": set()}
+        result = get_reverse_dependencies_recursive("mod_a", graph)
+        assert result == set()
+
+    def test_direct_reverse_deps(self) -> None:
+        graph: dict[str, set[str]] = {
+            "mod_a": {"mod_b", "mod_c"},
+            "mod_b": set(),
+            "mod_c": set(),
+        }
+        result = get_reverse_dependencies_recursive("mod_a", graph)
+        assert result == {"mod_b", "mod_c"}
+
+    def test_transitive_reverse_deps(self) -> None:
+        graph: dict[str, set[str]] = {
+            "mod_a": {"mod_b"},
+            "mod_b": {"mod_c"},
+            "mod_c": set(),
+        }
+        result = get_reverse_dependencies_recursive("mod_a", graph)
+        assert result == {"mod_b", "mod_c"}
+
+    def test_unknown_package_returns_empty(self) -> None:
+        graph: dict[str, set[str]] = {"mod_a": set()}
+        result = get_reverse_dependencies_recursive("nonexistent", graph)
+        assert result == set()
+
+    def test_circular_reverse_deps_causes_recursion_error(self) -> None:
+        """Circular reverse deps cause infinite recursion — no processed_ids guard.
+
+        Unlike get_dependencies_recursive, this function has no cycle protection.
+        This test documents the production bug: if reverse dependency data ever
+        contains a cycle, the app will crash with RecursionError.
+        """
+        graph: dict[str, set[str]] = {
+            "mod_a": {"mod_b"},
+            "mod_b": {"mod_a"},
+        }
+        with pytest.raises(RecursionError):
+            get_reverse_dependencies_recursive("mod_a", graph)
+
+
+# ---------------------------------------------------------------------------
+# gen_deps_graph — builds forward dependency graph from loadTheseBefore
+# ---------------------------------------------------------------------------
+
+
+class TestGenDepsGraph:
+    def test_no_dependencies(self, metadata_manager_mock: MagicMock) -> None:
+        metadata_manager_mock.internal_local_metadata = {
+            "uuid_a": make_mod("mod.a"),
+            "uuid_b": make_mod("mod.b"),
+        }
+        graph = gen_deps_graph({"uuid_a", "uuid_b"}, ["mod.a", "mod.b"])
+        assert graph == {"mod.a": set(), "mod.b": set()}
+
+    def test_single_dependency(self, metadata_manager_mock: MagicMock) -> None:
+        metadata_manager_mock.internal_local_metadata = {
+            "uuid_a": make_mod("mod.a", load_these_before=[("mod.b", True)]),
+            "uuid_b": make_mod("mod.b"),
+        }
+        graph = gen_deps_graph({"uuid_a", "uuid_b"}, ["mod.a", "mod.b"])
+        assert graph["mod.a"] == {"mod.b"}
+        assert graph["mod.b"] == set()
+
+    def test_dependency_not_in_active_mods_excluded(
+        self, metadata_manager_mock: MagicMock
+    ) -> None:
+        metadata_manager_mock.internal_local_metadata = {
+            "uuid_a": make_mod("mod.a", load_these_before=[("mod.inactive", True)]),
+        }
+        graph = gen_deps_graph({"uuid_a"}, ["mod.a"])
+        assert graph["mod.a"] == set()
+
+    def test_multiple_dependencies(self, metadata_manager_mock: MagicMock) -> None:
+        metadata_manager_mock.internal_local_metadata = {
+            "uuid_a": make_mod(
+                "mod.a", load_these_before=[("mod.b", True), ("mod.c", False)]
+            ),
+            "uuid_b": make_mod("mod.b"),
+            "uuid_c": make_mod("mod.c"),
+        }
+        graph = gen_deps_graph(
+            {"uuid_a", "uuid_b", "uuid_c"}, ["mod.a", "mod.b", "mod.c"]
+        )
+        assert graph["mod.a"] == {"mod.b", "mod.c"}
+
+
+# ---------------------------------------------------------------------------
+# gen_rev_deps_graph — builds reverse dependency graph from loadTheseAfter
+# ---------------------------------------------------------------------------
+
+
+class TestGenRevDepsGraph:
+    def test_no_reverse_dependencies(self, metadata_manager_mock: MagicMock) -> None:
+        metadata_manager_mock.internal_local_metadata = {
+            "uuid_a": make_mod("mod.a"),
+        }
+        graph = gen_rev_deps_graph({"uuid_a"}, ["mod.a"])
+        assert graph == {"mod.a": set()}
+
+    def test_single_reverse_dependency(self, metadata_manager_mock: MagicMock) -> None:
+        metadata_manager_mock.internal_local_metadata = {
+            "uuid_a": make_mod("mod.a", load_these_after=[("mod.b", True)]),
+            "uuid_b": make_mod("mod.b"),
+        }
+        graph = gen_rev_deps_graph({"uuid_a", "uuid_b"}, ["mod.a", "mod.b"])
+        assert graph["mod.a"] == {"mod.b"}
+
+    def test_inactive_reverse_dep_excluded(
+        self, metadata_manager_mock: MagicMock
+    ) -> None:
+        metadata_manager_mock.internal_local_metadata = {
+            "uuid_a": make_mod("mod.a", load_these_after=[("mod.inactive", True)]),
+        }
+        graph = gen_rev_deps_graph({"uuid_a"}, ["mod.a"])
+        assert graph["mod.a"] == set()
+
+
+# ---------------------------------------------------------------------------
+# gen_tier_zero_deps_graph — filters to essential mods (Core, DLCs, Harmony)
+# ---------------------------------------------------------------------------
+
+
+class TestGenTierZeroDepsGraph:
+    def test_known_tier_zero_mod_included(self) -> None:
+        graph: dict[str, set[str]] = {
+            "ludeon.rimworld": set(),
+            "some.regular.mod": set(),
+        }
+        tier_zero_graph, tier_zero_mods = gen_tier_zero_deps_graph(graph)
+        assert "ludeon.rimworld" in tier_zero_mods
+        assert "some.regular.mod" not in tier_zero_mods
+        assert "ludeon.rimworld" in tier_zero_graph
+
+    def test_tier_zero_deps_included_transitively(self) -> None:
+        graph: dict[str, set[str]] = {
+            "brrainz.harmony": {"some.dep"},
+            "some.dep": set(),
+            "regular.mod": set(),
+        }
+        _, tier_zero_mods = gen_tier_zero_deps_graph(graph)
+        assert "brrainz.harmony" in tier_zero_mods
+        assert "some.dep" in tier_zero_mods
+        assert "regular.mod" not in tier_zero_mods
+
+    def test_inactive_known_tier_zero_mod_excluded(self) -> None:
+        graph: dict[str, set[str]] = {"some.regular.mod": set()}
+        _, tier_zero_mods = gen_tier_zero_deps_graph(graph)
+        assert len(tier_zero_mods) == 0
+
+    def test_empty_graph(self) -> None:
+        tier_zero_graph, tier_zero_mods = gen_tier_zero_deps_graph({})
+        assert tier_zero_graph == {}
+        assert tier_zero_mods == set()
+
+    def test_circular_deps_in_tier_zero_handled(self) -> None:
+        graph: dict[str, set[str]] = {
+            "brrainz.harmony": {"zetrith.prepatcher"},
+            "zetrith.prepatcher": {"brrainz.harmony"},
+        }
+        _, tier_zero_mods = gen_tier_zero_deps_graph(graph)
+        assert "brrainz.harmony" in tier_zero_mods
+        assert "zetrith.prepatcher" in tier_zero_mods
+
+
+# ---------------------------------------------------------------------------
+# gen_tier_one_deps_graph — framework mods (KNOWN_TIER_ONE_MODS + loadTop)
+# ---------------------------------------------------------------------------
+
+
+class TestGenTierOneDepsGraph:
+    @pytest.fixture(autouse=True)
+    def _protect_known_tier_one_mods(self) -> None:
+        """Snapshot and restore KNOWN_TIER_ONE_MODS.
+
+        gen_tier_one_deps_graph mutates the module-level constant via alias
+        (production bug). This fixture prevents cross-test pollution.
+        """
+        from app.utils.constants import KNOWN_TIER_ONE_MODS
+
+        original = KNOWN_TIER_ONE_MODS.copy()
+        yield  # type: ignore[misc]
+        KNOWN_TIER_ONE_MODS.clear()
+        KNOWN_TIER_ONE_MODS.update(original)
+
+    def test_known_tier_one_mod_included(
+        self, metadata_manager_mock: MagicMock
+    ) -> None:
+        metadata_manager_mock.internal_local_metadata = {}
+        graph: dict[str, set[str]] = {
+            "unlimitedhugs.hugslib": set(),
+            "some.regular.mod": set(),
+        }
+        _, tier_one_mods = gen_tier_one_deps_graph(graph)
+        assert "unlimitedhugs.hugslib" in tier_one_mods
+        assert "some.regular.mod" not in tier_one_mods
+
+    def test_load_top_mod_included(self, metadata_manager_mock: MagicMock) -> None:
+        metadata_manager_mock.internal_local_metadata = {
+            "uuid_custom": make_mod("custom.framework", load_top=True),
+        }
+        graph: dict[str, set[str]] = {
+            "custom.framework": set(),
+            "some.regular.mod": set(),
+        }
+        _, tier_one_mods = gen_tier_one_deps_graph(graph)
+        assert "custom.framework" in tier_one_mods
+
+    def test_transitive_deps_of_tier_one_included(
+        self, metadata_manager_mock: MagicMock
+    ) -> None:
+        metadata_manager_mock.internal_local_metadata = {}
+        graph: dict[str, set[str]] = {
+            "unlimitedhugs.hugslib": {"some.hugslib.dep"},
+            "some.hugslib.dep": set(),
+        }
+        _, tier_one_mods = gen_tier_one_deps_graph(graph)
+        assert "some.hugslib.dep" in tier_one_mods
+
+    def test_empty_graph(self, metadata_manager_mock: MagicMock) -> None:
+        metadata_manager_mock.internal_local_metadata = {}
+        tier_one_graph, tier_one_mods = gen_tier_one_deps_graph({})
+        assert tier_one_graph == {}
+        assert tier_one_mods == set()
+
+
+# ---------------------------------------------------------------------------
+# gen_tier_three_deps_graph — bottom-loading mods (loadBottom + rocketman)
+# ---------------------------------------------------------------------------
+
+
+class TestGenTierThreeDepsGraph:
+    def test_hardcoded_rocketman_included(
+        self, metadata_manager_mock: MagicMock
+    ) -> None:
+        metadata_manager_mock.internal_local_metadata = {
+            "uuid_rocket": make_mod("krkr.rocketman"),
+        }
+        deps_graph: dict[str, set[str]] = {
+            "krkr.rocketman": set(),
+            "some.mod": set(),
+        }
+        rev_graph: dict[str, set[str]] = {
+            "krkr.rocketman": set(),
+            "some.mod": set(),
+        }
+        _, tier_three_mods = gen_tier_three_deps_graph(
+            deps_graph, rev_graph, {"uuid_rocket"}
+        )
+        assert "krkr.rocketman" in tier_three_mods
+        assert "some.mod" not in tier_three_mods
+
+    def test_load_bottom_mod_included(self, metadata_manager_mock: MagicMock) -> None:
+        metadata_manager_mock.internal_local_metadata = {
+            "uuid_bottom": make_mod("custom.bottom", load_bottom=True),
+        }
+        deps_graph: dict[str, set[str]] = {"custom.bottom": set()}
+        rev_graph: dict[str, set[str]] = {"custom.bottom": set()}
+        _, tier_three_mods = gen_tier_three_deps_graph(
+            deps_graph, rev_graph, {"uuid_bottom"}
+        )
+        assert "custom.bottom" in tier_three_mods
+
+    def test_reverse_deps_pulled_into_tier_three(
+        self, metadata_manager_mock: MagicMock
+    ) -> None:
+        """Mods that depend on tier three mods (via reverse graph) are also tier three."""
+        metadata_manager_mock.internal_local_metadata = {
+            "uuid_rocket": make_mod("krkr.rocketman"),
+            "uuid_addon": make_mod("rocket.addon"),
+        }
+        deps_graph: dict[str, set[str]] = {
+            "krkr.rocketman": set(),
+            "rocket.addon": {"krkr.rocketman"},
+        }
+        rev_graph: dict[str, set[str]] = {
+            "krkr.rocketman": {"rocket.addon"},
+            "rocket.addon": set(),
+        }
+        tier_three_graph, tier_three_mods = gen_tier_three_deps_graph(
+            deps_graph, rev_graph, {"uuid_rocket", "uuid_addon"}
+        )
+        assert "rocket.addon" in tier_three_mods
+        assert tier_three_graph["rocket.addon"] == {"krkr.rocketman"}
+
+    def test_non_tier_three_deps_trimmed(
+        self, metadata_manager_mock: MagicMock
+    ) -> None:
+        """Dependencies on non-tier-three mods are removed from the tier three graph."""
+        metadata_manager_mock.internal_local_metadata = {
+            "uuid_rocket": make_mod("krkr.rocketman"),
+            "uuid_regular": make_mod("some.regular"),
+        }
+        deps_graph: dict[str, set[str]] = {
+            "krkr.rocketman": {"some.regular"},
+            "some.regular": set(),
+        }
+        rev_graph: dict[str, set[str]] = {
+            "krkr.rocketman": set(),
+            "some.regular": set(),
+        }
+        tier_three_graph, _ = gen_tier_three_deps_graph(
+            deps_graph, rev_graph, {"uuid_rocket", "uuid_regular"}
+        )
+        assert tier_three_graph["krkr.rocketman"] == set()
+
+
+# ---------------------------------------------------------------------------
+# gen_tier_two_deps_graph — everything else, with conflict resolution
+# ---------------------------------------------------------------------------
+
+
+class TestGenTierTwoDepsGraph:
+    def test_basic_from_load_these_before(
+        self, metadata_manager_mock: MagicMock
+    ) -> None:
+        metadata_manager_mock.internal_local_metadata = {
+            "uuid_a": make_mod("mod.a", load_these_before=[("mod.b", True)]),
+            "uuid_b": make_mod("mod.b"),
+        }
+        graph = gen_tier_two_deps_graph(
+            {"uuid_a", "uuid_b"}, ["mod.a", "mod.b"], set(), set()
+        )
+        assert graph["mod.a"] == {"mod.b"}
+        assert graph["mod.b"] == set()
+
+    def test_tier_one_mods_excluded(self, metadata_manager_mock: MagicMock) -> None:
+        metadata_manager_mock.internal_local_metadata = {
+            "uuid_a": make_mod("mod.a"),
+            "uuid_fw": make_mod("framework.mod"),
+        }
+        graph = gen_tier_two_deps_graph(
+            {"uuid_a", "uuid_fw"},
+            ["mod.a", "framework.mod"],
+            {"framework.mod"},
+            set(),
+        )
+        assert "framework.mod" not in graph
+        assert "mod.a" in graph
+
+    def test_tier_three_mods_excluded(self, metadata_manager_mock: MagicMock) -> None:
+        metadata_manager_mock.internal_local_metadata = {
+            "uuid_a": make_mod("mod.a"),
+            "uuid_bottom": make_mod("bottom.mod"),
+        }
+        graph = gen_tier_two_deps_graph(
+            {"uuid_a", "uuid_bottom"},
+            ["mod.a", "bottom.mod"],
+            set(),
+            {"bottom.mod"},
+        )
+        assert "bottom.mod" not in graph
+
+    def test_deps_referencing_tier_one_stripped(
+        self, metadata_manager_mock: MagicMock
+    ) -> None:
+        metadata_manager_mock.internal_local_metadata = {
+            "uuid_a": make_mod(
+                "mod.a", load_these_before=[("framework.mod", True), ("mod.b", True)]
+            ),
+            "uuid_b": make_mod("mod.b"),
+        }
+        graph = gen_tier_two_deps_graph(
+            {"uuid_a", "uuid_b"},
+            ["mod.a", "mod.b", "framework.mod"],
+            {"framework.mod"},
+            set(),
+        )
+        assert graph["mod.a"] == {"mod.b"}
+
+    def test_inferred_deps_from_about_xml(
+        self, metadata_manager_mock: MagicMock
+    ) -> None:
+        """About.xml dependencies become load order rules when enabled."""
+        metadata_manager_mock.internal_local_metadata = {
+            "uuid_a": make_mod("mod.a", dependencies=["mod.b"]),
+            "uuid_b": make_mod("mod.b"),
+        }
+        metadata_manager_mock.settings_controller.settings.use_alternative_package_ids_as_satisfying_dependencies = False
+        graph = gen_tier_two_deps_graph(
+            {"uuid_a", "uuid_b"},
+            ["mod.a", "mod.b"],
+            set(),
+            set(),
+            use_moddependencies_as_loadTheseBefore=True,
+        )
+        assert "mod.b" in graph["mod.a"]
+
+    def test_explicit_rules_override_inferred(
+        self, metadata_manager_mock: MagicMock
+    ) -> None:
+        """Explicit loadTheseBefore takes precedence over conflicting inferred deps."""
+        # mod.a has inferred dep on mod.b (from About.xml dependencies)
+        # mod.b explicitly says mod.a loads before it (mod.b -> mod.a)
+        # The inferred mod.a -> mod.b would create a cycle, so it's dropped
+        metadata_manager_mock.internal_local_metadata = {
+            "uuid_a": make_mod("mod.a", dependencies=["mod.b"]),
+            "uuid_b": make_mod("mod.b", load_these_before=[("mod.a", True)]),
+        }
+        metadata_manager_mock.settings_controller.settings.use_alternative_package_ids_as_satisfying_dependencies = False
+        graph = gen_tier_two_deps_graph(
+            {"uuid_a", "uuid_b"},
+            ["mod.a", "mod.b"],
+            set(),
+            set(),
+            use_moddependencies_as_loadTheseBefore=True,
+        )
+        assert "mod.b" not in graph["mod.a"]
+        assert "mod.a" in graph["mod.b"]
+
+    def test_empty_active_mods(self, metadata_manager_mock: MagicMock) -> None:
+        metadata_manager_mock.internal_local_metadata = {}
+        graph = gen_tier_two_deps_graph(set(), [], set(), set())
+        assert graph == {}
+
+    def test_inferred_deps_disabled_by_default(
+        self, metadata_manager_mock: MagicMock
+    ) -> None:
+        """Without use_moddependencies_as_loadTheseBefore, About.xml deps are ignored."""
+        metadata_manager_mock.internal_local_metadata = {
+            "uuid_a": make_mod("mod.a", dependencies=["mod.b"]),
+            "uuid_b": make_mod("mod.b"),
+        }
+        graph = gen_tier_two_deps_graph(
+            {"uuid_a", "uuid_b"}, ["mod.a", "mod.b"], set(), set()
+        )
+        assert graph["mod.a"] == set()
+
+    def test_tuple_dependency_with_alternatives(
+        self, metadata_manager_mock: MagicMock
+    ) -> None:
+        """Tuple-format About.xml deps with alternatives are handled."""
+        metadata_manager_mock.internal_local_metadata = {
+            "uuid_a": make_mod(
+                "mod.a",
+                dependencies=[("mod.primary", {"alternatives": {"mod.alt"}})],
+            ),
+            "uuid_alt": make_mod("mod.alt"),
+        }
+        metadata_manager_mock.settings_controller.settings.use_alternative_package_ids_as_satisfying_dependencies = True
+        graph = gen_tier_two_deps_graph(
+            {"uuid_a", "uuid_alt"},
+            ["mod.a", "mod.alt"],
+            set(),
+            set(),
+            use_moddependencies_as_loadTheseBefore=True,
+        )
+        # mod.primary is not active, but mod.alt is an active alternative
+        assert "mod.alt" in graph["mod.a"]
+
+    def test_alternative_deps_disabled_by_setting(
+        self, metadata_manager_mock: MagicMock
+    ) -> None:
+        """Alternative package IDs are ignored when the setting is disabled."""
+        metadata_manager_mock.internal_local_metadata = {
+            "uuid_a": make_mod(
+                "mod.a",
+                dependencies=[("mod.primary", {"alternatives": {"mod.alt"}})],
+            ),
+            "uuid_alt": make_mod("mod.alt"),
+        }
+        metadata_manager_mock.settings_controller.settings.use_alternative_package_ids_as_satisfying_dependencies = False
+        graph = gen_tier_two_deps_graph(
+            {"uuid_a", "uuid_alt"},
+            ["mod.a", "mod.alt"],
+            set(),
+            set(),
+            use_moddependencies_as_loadTheseBefore=True,
+        )
+        # Alternative resolution disabled — mod.alt should not appear
+        assert graph["mod.a"] == set()

--- a/tests/sort/test_dependencies.py
+++ b/tests/sort/test_dependencies.py
@@ -1,3 +1,4 @@
+from collections.abc import Generator
 from unittest.mock import MagicMock
 
 import pytest
@@ -261,7 +262,7 @@ class TestGenTierZeroDepsGraph:
 
 class TestGenTierOneDepsGraph:
     @pytest.fixture(autouse=True)
-    def _protect_known_tier_one_mods(self) -> None:
+    def _protect_known_tier_one_mods(self) -> Generator[None]:
         """Snapshot and restore KNOWN_TIER_ONE_MODS.
 
         gen_tier_one_deps_graph mutates the module-level constant via alias
@@ -270,7 +271,7 @@ class TestGenTierOneDepsGraph:
         from app.utils.constants import KNOWN_TIER_ONE_MODS
 
         original = KNOWN_TIER_ONE_MODS.copy()
-        yield  # type: ignore[misc]
+        yield
         KNOWN_TIER_ONE_MODS.clear()
         KNOWN_TIER_ONE_MODS.update(original)
 

--- a/tests/sort/test_mod_sorting.py
+++ b/tests/sort/test_mod_sorting.py
@@ -1,0 +1,678 @@
+"""Tests for app.sort.mod_sorting — inactive mods list sorting helpers."""
+
+from collections.abc import Generator
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.sort.mod_sorting import (
+    DEFAULT_REVERSE_FLAGS,
+    ModsPanelSortKey,
+    _build_sort_key_map,
+    get_cached_metadata_for_batch,
+    get_dir_size,
+    get_mod_metadata,
+    sort_uuids,
+    uuid_no_key,
+    uuid_to_author,
+    uuid_to_filesystem_modified_time,
+    uuid_to_folder_size,
+    uuid_to_mod_color,
+    uuid_to_mod_name,
+    uuid_to_mod_tags,
+    uuid_to_packageid,
+    uuid_to_version,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_folder_size_cache() -> Generator[None, None, None]:
+    """Clear the module-level folder size cache between tests."""
+    yield
+    from app.sort.mod_sorting import _FOLDER_SIZE_CACHE
+
+    _FOLDER_SIZE_CACHE.clear()
+
+
+# ---------------------------------------------------------------------------
+# uuid_no_key — identity function
+# ---------------------------------------------------------------------------
+
+
+class TestUuidNoKey:
+    def test_returns_uuid_unchanged(self) -> None:
+        assert uuid_no_key("some-uuid-123") == "some-uuid-123"
+
+    def test_empty_string(self) -> None:
+        assert uuid_no_key("") == ""
+
+
+# ---------------------------------------------------------------------------
+# uuid_to_mod_name
+# ---------------------------------------------------------------------------
+
+
+class TestUuidToModName:
+    def test_cached_metadata_with_name(self) -> None:
+        cached: dict[str, Any] = {"uuid1": {"name": "MyMod"}}
+        assert uuid_to_mod_name("uuid1", cached) == "mymod"
+
+    def test_cached_metadata_missing_uuid(self) -> None:
+        cached: dict[str, Any] = {}
+        assert uuid_to_mod_name("missing", cached) == "name error in mod about.xml"
+
+    def test_cached_metadata_name_is_none(self) -> None:
+        cached: dict[str, Any] = {"uuid1": {"name": None}}
+        assert uuid_to_mod_name("uuid1", cached) == "name error in mod about.xml"
+
+    def test_cached_metadata_name_is_non_string(self) -> None:
+        cached: dict[str, Any] = {"uuid1": {"name": 42}}
+        assert uuid_to_mod_name("uuid1", cached) == "name error in mod about.xml"
+
+    def test_uncached_path(self, metadata_manager_mock: MagicMock) -> None:
+        metadata_manager_mock.internal_local_metadata = {
+            "uuid1": {"name": "TestMod"},
+        }
+        assert uuid_to_mod_name("uuid1") == "testmod"
+
+    def test_name_preserves_lowercase(self) -> None:
+        cached: dict[str, Any] = {"uuid1": {"name": "ALLCAPS"}}
+        assert uuid_to_mod_name("uuid1", cached) == "allcaps"
+
+    def test_metadata_is_none(self) -> None:
+        cached: dict[str, Any] = {"uuid1": None}
+        assert uuid_to_mod_name("uuid1", cached) == "name error in mod about.xml"
+
+
+# ---------------------------------------------------------------------------
+# uuid_to_packageid
+# ---------------------------------------------------------------------------
+
+
+class TestUuidToPackageid:
+    def test_cached_with_packageid(self) -> None:
+        cached: dict[str, Any] = {"uuid1": {"packageid": "author.ModName"}}
+        assert uuid_to_packageid("uuid1", cached) == "author.modname"
+
+    def test_cached_missing_uuid(self) -> None:
+        cached: dict[str, Any] = {}
+        assert uuid_to_packageid("missing", cached) == ""
+
+    def test_packageid_is_non_string(self) -> None:
+        cached: dict[str, Any] = {"uuid1": {"packageid": 123}}
+        assert uuid_to_packageid("uuid1", cached) == ""
+
+    def test_packageid_is_none(self) -> None:
+        cached: dict[str, Any] = {"uuid1": {"packageid": None}}
+        assert uuid_to_packageid("uuid1", cached) == ""
+
+    def test_uncached_path(self, metadata_manager_mock: MagicMock) -> None:
+        metadata_manager_mock.internal_local_metadata = {
+            "uuid1": {"packageid": "Author.Mod"},
+        }
+        assert uuid_to_packageid("uuid1") == "author.mod"
+
+
+# ---------------------------------------------------------------------------
+# uuid_to_version
+# ---------------------------------------------------------------------------
+
+
+class TestUuidToVersion:
+    def test_cached_with_version(self) -> None:
+        cached: dict[str, Any] = {"uuid1": {"modversion": "1.2.3"}}
+        assert uuid_to_version("uuid1", cached) == "1.2.3"
+
+    def test_cached_missing_uuid(self) -> None:
+        cached: dict[str, Any] = {}
+        assert uuid_to_version("missing", cached) == ""
+
+    def test_version_is_non_string(self) -> None:
+        cached: dict[str, Any] = {"uuid1": {"modversion": 100}}
+        assert uuid_to_version("uuid1", cached) == ""
+
+    def test_uncached_path(self, metadata_manager_mock: MagicMock) -> None:
+        metadata_manager_mock.internal_local_metadata = {
+            "uuid1": {"modversion": "2.0.0-BETA"},
+        }
+        assert uuid_to_version("uuid1") == "2.0.0-beta"
+
+
+# ---------------------------------------------------------------------------
+# uuid_to_mod_color
+# ---------------------------------------------------------------------------
+
+
+class TestUuidToModColor:
+    def test_cached_with_color_hex(self) -> None:
+        cached: dict[str, Any] = {"uuid1": {"color_hex": "#FF00AA"}}
+        assert uuid_to_mod_color("uuid1", cached) == "#ff00aa"
+
+    def test_cached_missing_uuid(self) -> None:
+        cached: dict[str, Any] = {}
+        assert uuid_to_mod_color("missing", cached) == ""
+
+    def test_color_hex_is_non_string(self) -> None:
+        cached: dict[str, Any] = {"uuid1": {"color_hex": 0xFF00AA}}
+        assert uuid_to_mod_color("uuid1", cached) == ""
+
+    def test_uncached_path(self, metadata_manager_mock: MagicMock) -> None:
+        metadata_manager_mock.internal_local_metadata = {
+            "uuid1": {"color_hex": "#AABBCC"},
+        }
+        assert uuid_to_mod_color("uuid1") == "#aabbcc"
+
+
+# ---------------------------------------------------------------------------
+# uuid_to_author — complex multi-format extractor
+# ---------------------------------------------------------------------------
+
+
+class TestUuidToAuthor:
+    def test_dict_li_list(self) -> None:
+        """{'li': ['Author1', 'Author2']} → first author lowercased."""
+        cached: dict[str, Any] = {"uuid1": {"authors": {"li": ["Author1", "Author2"]}}}
+        assert uuid_to_author("uuid1", cached) == "author1"
+
+    def test_dict_li_string(self) -> None:
+        """{'li': 'SingleAuthor'} → lowercased."""
+        cached: dict[str, Any] = {"uuid1": {"authors": {"li": "SingleAuthor"}}}
+        assert uuid_to_author("uuid1", cached) == "singleauthor"
+
+    def test_list_format(self) -> None:
+        """['Author1', 'Author2'] → first author lowercased."""
+        cached: dict[str, Any] = {"uuid1": {"authors": ["Author1", "Author2"]}}
+        assert uuid_to_author("uuid1", cached) == "author1"
+
+    def test_string_format(self) -> None:
+        """'JustAString' → lowercased."""
+        cached: dict[str, Any] = {"uuid1": {"authors": "JustAString"}}
+        assert uuid_to_author("uuid1", cached) == "justastring"
+
+    def test_none_authors(self) -> None:
+        """None → empty string."""
+        cached: dict[str, Any] = {"uuid1": {"authors": None}}
+        assert uuid_to_author("uuid1", cached) == ""
+
+    def test_missing_authors_key(self) -> None:
+        """No 'authors' key at all → empty string."""
+        cached: dict[str, Any] = {"uuid1": {"name": "SomeMod"}}
+        assert uuid_to_author("uuid1", cached) == ""
+
+    def test_empty_list(self) -> None:
+        """[] → empty string."""
+        cached: dict[str, Any] = {"uuid1": {"authors": []}}
+        assert uuid_to_author("uuid1", cached) == ""
+
+    def test_empty_dict(self) -> None:
+        """{} → empty string (no 'li' key)."""
+        cached: dict[str, Any] = {"uuid1": {"authors": {}}}
+        assert uuid_to_author("uuid1", cached) == ""
+
+    def test_dict_li_empty_list(self) -> None:
+        """{'li': []} → empty string."""
+        cached: dict[str, Any] = {"uuid1": {"authors": {"li": []}}}
+        assert uuid_to_author("uuid1", cached) == ""
+
+    def test_missing_uuid(self) -> None:
+        cached: dict[str, Any] = {}
+        assert uuid_to_author("missing", cached) == ""
+
+    def test_metadata_is_none(self) -> None:
+        cached: dict[str, Any] = {"uuid1": None}
+        assert uuid_to_author("uuid1", cached) == ""
+
+    def test_uncached_path(self, metadata_manager_mock: MagicMock) -> None:
+        metadata_manager_mock.internal_local_metadata = {
+            "uuid1": {"authors": "UncachedAuthor"},
+        }
+        assert uuid_to_author("uuid1") == "uncachedauthor"
+
+
+# ---------------------------------------------------------------------------
+# uuid_to_filesystem_modified_time
+# ---------------------------------------------------------------------------
+
+
+class TestUuidToFilesystemModifiedTime:
+    def test_path_exists(self) -> None:
+        cached: dict[str, Any] = {"uuid1": {"path": "/mods/mymod", "name": "MyMod"}}
+        with (
+            patch("app.sort.mod_sorting.os.path.exists", return_value=True),
+            patch("app.sort.mod_sorting.os.path.getmtime", return_value=1700000000.5),
+        ):
+            result = uuid_to_filesystem_modified_time("uuid1", cached)
+        assert result == 1700000000
+
+    def test_path_does_not_exist(self) -> None:
+        cached: dict[str, Any] = {"uuid1": {"path": "/mods/gone", "name": "Gone"}}
+        with patch("app.sort.mod_sorting.os.path.exists", return_value=False):
+            result = uuid_to_filesystem_modified_time("uuid1", cached)
+        assert result == 0
+
+    def test_no_metadata(self) -> None:
+        cached: dict[str, Any] = {}
+        assert uuid_to_filesystem_modified_time("missing", cached) == 0
+
+    def test_path_is_none(self) -> None:
+        cached: dict[str, Any] = {"uuid1": {"path": None}}
+        assert uuid_to_filesystem_modified_time("uuid1", cached) == 0
+
+    def test_uncached_path(self, metadata_manager_mock: MagicMock) -> None:
+        metadata_manager_mock.internal_local_metadata = {
+            "uuid1": {"path": "/mods/test", "name": "Test"},
+        }
+        with (
+            patch("app.sort.mod_sorting.os.path.exists", return_value=True),
+            patch("app.sort.mod_sorting.os.path.getmtime", return_value=1600000000.0),
+        ):
+            result = uuid_to_filesystem_modified_time("uuid1")
+        assert result == 1600000000
+
+
+# ---------------------------------------------------------------------------
+# uuid_to_folder_size
+# ---------------------------------------------------------------------------
+
+
+class TestUuidToFolderSize:
+    def test_directory_exists(self) -> None:
+        cached: dict[str, Any] = {"uuid1": {"path": "/mods/mymod"}}
+        with (
+            patch("app.sort.mod_sorting.os.path.isdir", return_value=True),
+            patch("app.sort.mod_sorting.os.path.getmtime", return_value=12345.0),
+            patch("app.sort.mod_sorting.get_dir_size", return_value=4096),
+        ):
+            result = uuid_to_folder_size("uuid1", cached)
+        assert result == 4096
+
+    def test_path_not_a_directory(self) -> None:
+        cached: dict[str, Any] = {"uuid1": {"path": "/mods/file.txt"}}
+        with patch("app.sort.mod_sorting.os.path.isdir", return_value=False):
+            result = uuid_to_folder_size("uuid1", cached)
+        assert result == 0
+
+    def test_no_metadata(self) -> None:
+        cached: dict[str, Any] = {}
+        assert uuid_to_folder_size("missing", cached) == 0
+
+    def test_path_is_none(self) -> None:
+        cached: dict[str, Any] = {"uuid1": {"path": None}}
+        assert uuid_to_folder_size("uuid1", cached) == 0
+
+    def test_cache_hit_same_mtime(self) -> None:
+        """Second call with same mtime returns cached value without calling get_dir_size."""
+        cached: dict[str, Any] = {"uuid1": {"path": "/mods/mymod"}}
+        with (
+            patch("app.sort.mod_sorting.os.path.isdir", return_value=True),
+            patch("app.sort.mod_sorting.os.path.getmtime", return_value=12345.0),
+            patch("app.sort.mod_sorting.get_dir_size", return_value=8192) as mock_size,
+        ):
+            first = uuid_to_folder_size("uuid1", cached)
+            second = uuid_to_folder_size("uuid1", cached)
+
+        assert first == 8192
+        assert second == 8192
+        # get_dir_size should only be called once (cache hit on second call)
+        mock_size.assert_called_once()
+
+    def test_cache_miss_different_mtime(self) -> None:
+        """Different mtime forces recalculation."""
+        from app.sort.mod_sorting import _FOLDER_SIZE_CACHE
+
+        # Pre-populate cache with old mtime
+        _FOLDER_SIZE_CACHE["/mods/mymod"] = (10000, 1024)
+
+        cached: dict[str, Any] = {"uuid1": {"path": "/mods/mymod"}}
+        with (
+            patch("app.sort.mod_sorting.os.path.isdir", return_value=True),
+            patch(
+                "app.sort.mod_sorting.os.path.getmtime", return_value=99999.0
+            ),  # different mtime
+            patch("app.sort.mod_sorting.get_dir_size", return_value=2048) as mock_size,
+        ):
+            result = uuid_to_folder_size("uuid1", cached)
+
+        assert result == 2048
+        mock_size.assert_called_once_with("/mods/mymod")
+
+    def test_oserror_on_getmtime(self) -> None:
+        """OSError during getmtime returns 0."""
+        cached: dict[str, Any] = {"uuid1": {"path": "/mods/mymod"}}
+        with (
+            patch("app.sort.mod_sorting.os.path.isdir", return_value=True),
+            patch(
+                "app.sort.mod_sorting.os.path.getmtime", side_effect=OSError("denied")
+            ),
+        ):
+            result = uuid_to_folder_size("uuid1", cached)
+        assert result == 0
+
+    def test_metadata_is_none(self) -> None:
+        cached: dict[str, Any] = {"uuid1": None}
+        assert uuid_to_folder_size("uuid1", cached) == 0
+
+
+# ---------------------------------------------------------------------------
+# get_dir_size — real filesystem via tmp_path
+# ---------------------------------------------------------------------------
+
+
+class TestGetDirSize:
+    def test_empty_directory(self, tmp_path: Path) -> None:
+        assert get_dir_size(str(tmp_path)) == 0
+
+    def test_single_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "file.txt"
+        f.write_bytes(b"hello")  # 5 bytes
+        assert get_dir_size(str(tmp_path)) == 5
+
+    def test_multiple_files(self, tmp_path: Path) -> None:
+        (tmp_path / "a.txt").write_bytes(b"aaa")  # 3
+        (tmp_path / "b.txt").write_bytes(b"bb")  # 2
+        assert get_dir_size(str(tmp_path)) == 5
+
+    def test_nested_directories(self, tmp_path: Path) -> None:
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        (tmp_path / "top.txt").write_bytes(b"top")  # 3
+        (sub / "nested.txt").write_bytes(b"nested")  # 6
+        assert get_dir_size(str(tmp_path)) == 9
+
+    def test_deeply_nested(self, tmp_path: Path) -> None:
+        deep = tmp_path / "a" / "b" / "c"
+        deep.mkdir(parents=True)
+        (deep / "deep.txt").write_bytes(b"deep")  # 4
+        assert get_dir_size(str(tmp_path)) == 4
+
+    def test_oserror_on_inaccessible_subdir(self, tmp_path: Path) -> None:
+        """OSError on a subdirectory is silently skipped."""
+        (tmp_path / "file.txt").write_bytes(b"ok")  # 2
+        # Patch scanpath to raise OSError for a specific subdirectory
+        with patch(
+            "app.sort.mod_sorting.scanpath", side_effect=OSError("permission denied")
+        ):
+            # OSError is caught, returns 0
+            result = get_dir_size(str(tmp_path))
+        assert result == 0
+
+
+# ---------------------------------------------------------------------------
+# uuid_to_mod_tags
+# ---------------------------------------------------------------------------
+
+
+class TestUuidToModTags:
+    def test_no_settings_controller(self) -> None:
+        assert uuid_to_mod_tags("uuid1", settings_controller=None) == ""
+
+    def test_normal_tags(self) -> None:
+        mock_sc = MagicMock()
+        with patch(
+            "app.sort.mod_sorting.auxdb_get_mod_tags",
+            return_value=["Zebra", "Alpha", "Beta"],
+        ):
+            result = uuid_to_mod_tags("uuid1", settings_controller=mock_sc)
+        assert result == "alpha, beta, zebra"
+
+    def test_empty_tags(self) -> None:
+        mock_sc = MagicMock()
+        with patch("app.sort.mod_sorting.auxdb_get_mod_tags", return_value=[]):
+            result = uuid_to_mod_tags("uuid1", settings_controller=mock_sc)
+        assert result == ""
+
+    def test_exception_returns_empty(self) -> None:
+        mock_sc = MagicMock()
+        with patch(
+            "app.sort.mod_sorting.auxdb_get_mod_tags",
+            side_effect=RuntimeError("db error"),
+        ):
+            result = uuid_to_mod_tags("uuid1", settings_controller=mock_sc)
+        assert result == ""
+
+    def test_single_tag(self) -> None:
+        mock_sc = MagicMock()
+        with patch("app.sort.mod_sorting.auxdb_get_mod_tags", return_value=["OnlyTag"]):
+            result = uuid_to_mod_tags("uuid1", settings_controller=mock_sc)
+        assert result == "onlytag"
+
+
+# ---------------------------------------------------------------------------
+# get_mod_metadata
+# ---------------------------------------------------------------------------
+
+
+class TestGetModMetadata:
+    def test_uuid_exists(self, metadata_manager_mock: MagicMock) -> None:
+        metadata_manager_mock.internal_local_metadata = {
+            "uuid1": {"name": "TestMod"},
+        }
+        result = get_mod_metadata("uuid1")
+        assert result == {"name": "TestMod"}
+
+    def test_uuid_missing(self, metadata_manager_mock: MagicMock) -> None:
+        metadata_manager_mock.internal_local_metadata = {}
+        result = get_mod_metadata("nonexistent")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# get_cached_metadata_for_batch
+# ---------------------------------------------------------------------------
+
+
+class TestGetCachedMetadataForBatch:
+    def test_basic_batch_fetch(self, metadata_manager_mock: MagicMock) -> None:
+        metadata_manager_mock.internal_local_metadata = {
+            "uuid1": {"name": "Mod1"},
+            "uuid2": {"name": "Mod2"},
+        }
+        result = get_cached_metadata_for_batch(["uuid1", "uuid2"])
+        assert result["uuid1"] == {"name": "Mod1"}
+        assert result["uuid2"] == {"name": "Mod2"}
+
+    def test_missing_uuids_map_to_none(self, metadata_manager_mock: MagicMock) -> None:
+        metadata_manager_mock.internal_local_metadata = {
+            "uuid1": {"name": "Mod1"},
+        }
+        result = get_cached_metadata_for_batch(["uuid1", "uuid_missing"])
+        assert result["uuid1"] == {"name": "Mod1"}
+        assert result["uuid_missing"] is None
+
+    def test_empty_uuids(self, metadata_manager_mock: MagicMock) -> None:
+        metadata_manager_mock.internal_local_metadata = {}
+        result = get_cached_metadata_for_batch([])
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# _build_sort_key_map
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSortKeyMap:
+    def test_modname_key(self) -> None:
+        cached: dict[str, Any] = {
+            "uuid1": {"name": "Bravo"},
+            "uuid2": {"name": "Alpha"},
+        }
+        result = _build_sort_key_map(
+            ["uuid1", "uuid2"], ModsPanelSortKey.MODNAME, cached
+        )
+        assert result["uuid1"] == "bravo"
+        assert result["uuid2"] == "alpha"
+
+    def test_nokey_returns_uuid(self) -> None:
+        cached: dict[str, Any] = {"uuid1": {"name": "Irrelevant"}}
+        result = _build_sort_key_map(["uuid1"], ModsPanelSortKey.NOKEY, cached)
+        assert result["uuid1"] == "uuid1"
+
+    def test_packageid_key(self) -> None:
+        cached: dict[str, Any] = {"uuid1": {"packageid": "Author.Pkg"}}
+        result = _build_sort_key_map(["uuid1"], ModsPanelSortKey.PACKAGEID, cached)
+        assert result["uuid1"] == "author.pkg"
+
+    def test_version_key(self) -> None:
+        cached: dict[str, Any] = {"uuid1": {"modversion": "1.0.0"}}
+        result = _build_sort_key_map(["uuid1"], ModsPanelSortKey.VERSION, cached)
+        assert result["uuid1"] == "1.0.0"
+
+    def test_author_key(self) -> None:
+        cached: dict[str, Any] = {"uuid1": {"authors": "SomeAuthor"}}
+        result = _build_sort_key_map(["uuid1"], ModsPanelSortKey.AUTHOR, cached)
+        assert result["uuid1"] == "someauthor"
+
+    def test_mod_color_key(self) -> None:
+        cached: dict[str, Any] = {"uuid1": {"color_hex": "#ABC123"}}
+        result = _build_sort_key_map(["uuid1"], ModsPanelSortKey.MOD_COLOR, cached)
+        assert result["uuid1"] == "#abc123"
+
+    def test_filesystem_modified_time_key(self) -> None:
+        cached: dict[str, Any] = {"uuid1": {"path": "/mods/m", "name": "M"}}
+        with (
+            patch("app.sort.mod_sorting.os.path.exists", return_value=True),
+            patch("app.sort.mod_sorting.os.path.getmtime", return_value=1700000000.0),
+        ):
+            result = _build_sort_key_map(
+                ["uuid1"], ModsPanelSortKey.FILESYSTEM_MODIFIED_TIME, cached
+            )
+        assert result["uuid1"] == 1700000000
+
+    def test_folder_size_key(self) -> None:
+        cached: dict[str, Any] = {"uuid1": {"path": "/mods/m"}}
+        with (
+            patch("app.sort.mod_sorting.os.path.isdir", return_value=True),
+            patch("app.sort.mod_sorting.os.path.getmtime", return_value=100.0),
+            patch("app.sort.mod_sorting.get_dir_size", return_value=999),
+        ):
+            result = _build_sort_key_map(
+                ["uuid1"], ModsPanelSortKey.FOLDER_SIZE, cached
+            )
+        assert result["uuid1"] == 999
+
+    def test_mod_tags_key(self) -> None:
+        cached: dict[str, Any] = {"uuid1": {"name": "M"}}
+        mock_sc = MagicMock()
+        with patch(
+            "app.sort.mod_sorting.auxdb_get_mod_tags",
+            return_value=["Tag2", "Tag1"],
+        ):
+            result = _build_sort_key_map(
+                ["uuid1"],
+                ModsPanelSortKey.MOD_TAGS,
+                cached,
+                settings_controller=mock_sc,
+            )
+        assert result["uuid1"] == "tag1, tag2"
+
+
+# ---------------------------------------------------------------------------
+# sort_uuids — orchestration
+# ---------------------------------------------------------------------------
+
+
+class TestSortUuids:
+    _three_mod_cached: dict[str, Any] = {
+        "uuid_z": {"name": "Zebra"},
+        "uuid_a": {"name": "Alpha"},
+        "uuid_m": {"name": "Middle"},
+    }
+    _three_mod_uuids = ["uuid_z", "uuid_a", "uuid_m"]
+
+    def test_sort_by_modname_ascending(self) -> None:
+        result = sort_uuids(
+            self._three_mod_uuids,
+            ModsPanelSortKey.MODNAME,
+            descending=False,
+            cached_metadata=self._three_mod_cached,
+        )
+        assert result == ["uuid_a", "uuid_m", "uuid_z"]
+
+    def test_sort_by_modname_descending(self) -> None:
+        result = sort_uuids(
+            self._three_mod_uuids,
+            ModsPanelSortKey.MODNAME,
+            descending=True,
+            cached_metadata=self._three_mod_cached,
+        )
+        assert result == ["uuid_z", "uuid_m", "uuid_a"]
+
+    def test_descending_none_uses_default_flags(self) -> None:
+        """When descending=None, uses DEFAULT_REVERSE_FLAGS (all False = ascending)."""
+        cached: dict[str, Any] = {
+            "uuid_b": {"name": "Bravo"},
+            "uuid_a": {"name": "Alpha"},
+        }
+        result = sort_uuids(
+            ["uuid_b", "uuid_a"],
+            ModsPanelSortKey.MODNAME,
+            descending=None,
+            cached_metadata=cached,
+        )
+        # Default is ascending (False)
+        assert result == ["uuid_a", "uuid_b"]
+
+    def test_sort_preserves_original_list(self) -> None:
+        """sort_uuids returns a new list; original is not mutated."""
+        cached: dict[str, Any] = {
+            "uuid_b": {"name": "Bravo"},
+            "uuid_a": {"name": "Alpha"},
+        }
+        original = ["uuid_b", "uuid_a"]
+        result = sort_uuids(
+            original,
+            ModsPanelSortKey.MODNAME,
+            cached_metadata=cached,
+        )
+        assert result == ["uuid_a", "uuid_b"]
+        assert original == ["uuid_b", "uuid_a"]
+
+    def test_sort_empty_list(self) -> None:
+        result = sort_uuids(
+            [],
+            ModsPanelSortKey.MODNAME,
+            cached_metadata={},
+        )
+        assert result == []
+
+    def test_sort_single_item(self) -> None:
+        cached: dict[str, Any] = {"uuid1": {"name": "Only"}}
+        result = sort_uuids(
+            ["uuid1"],
+            ModsPanelSortKey.MODNAME,
+            cached_metadata=cached,
+        )
+        assert result == ["uuid1"]
+
+    def test_sort_by_nokey_preserves_relative_order(self) -> None:
+        """NOKEY sorts by UUID string value (lexicographic)."""
+        cached: dict[str, Any] = {
+            "uuid_c": {"name": "C"},
+            "uuid_a": {"name": "A"},
+            "uuid_b": {"name": "B"},
+        }
+        result = sort_uuids(
+            ["uuid_c", "uuid_a", "uuid_b"],
+            ModsPanelSortKey.NOKEY,
+            cached_metadata=cached,
+        )
+        assert result == ["uuid_a", "uuid_b", "uuid_c"]
+
+
+# ---------------------------------------------------------------------------
+# DEFAULT_REVERSE_FLAGS and ModsPanelSortKey
+# ---------------------------------------------------------------------------
+
+
+class TestModsPanelSortKeyEnum:
+    def test_all_enum_values_have_default_reverse_flag(self) -> None:
+        """Every enum member should have an entry in DEFAULT_REVERSE_FLAGS."""
+        for member in ModsPanelSortKey:
+            assert member in DEFAULT_REVERSE_FLAGS
+
+    def test_all_defaults_are_false(self) -> None:
+        """All default reverse flags are False (ascending)."""
+        for member in ModsPanelSortKey:
+            assert DEFAULT_REVERSE_FLAGS[member] is False

--- a/tests/sort/test_topo_sort.py
+++ b/tests/sort/test_topo_sort.py
@@ -1,0 +1,121 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from toposort import CircularDependencyError
+
+from app.sort.topo_sort import do_topo_sort
+from tests.sort.conftest import make_mod
+
+
+class TestDoTopoSort:
+    def test_single_mod(self, metadata_manager_mock: MagicMock) -> None:
+        metadata_manager_mock.internal_local_metadata = {
+            "uuid_a": make_mod("mod.a", name="Alpha"),
+        }
+        result = do_topo_sort({"mod.a": set()}, {"uuid_a"})
+        assert result == ["uuid_a"]
+
+    def test_linear_chain(self, metadata_manager_mock: MagicMock) -> None:
+        """A -> B -> C produces dependencies-first ordering."""
+        metadata_manager_mock.internal_local_metadata = {
+            "uuid_a": make_mod("mod.a", name="A"),
+            "uuid_b": make_mod("mod.b", name="B"),
+            "uuid_c": make_mod("mod.c", name="C"),
+        }
+        graph: dict[str, set[str]] = {
+            "mod.a": {"mod.b"},
+            "mod.b": {"mod.c"},
+            "mod.c": set(),
+        }
+        result = do_topo_sort(graph, {"uuid_a", "uuid_b", "uuid_c"})
+        assert result.index("uuid_c") < result.index("uuid_b")
+        assert result.index("uuid_b") < result.index("uuid_a")
+
+    def test_alphabetical_within_same_level(
+        self, metadata_manager_mock: MagicMock
+    ) -> None:
+        """Mods at the same topological level are sorted alphabetically by name."""
+        metadata_manager_mock.internal_local_metadata = {
+            "uuid_z": make_mod("mod.z", name="Zebra"),
+            "uuid_a": make_mod("mod.a", name="Alpha"),
+            "uuid_m": make_mod("mod.m", name="Middle"),
+        }
+        graph: dict[str, set[str]] = {
+            "mod.z": set(),
+            "mod.a": set(),
+            "mod.m": set(),
+        }
+        result = do_topo_sort(graph, {"uuid_z", "uuid_a", "uuid_m"})
+        assert result == ["uuid_a", "uuid_m", "uuid_z"]
+
+    def test_graph_entry_not_in_active_mods_skipped(
+        self, metadata_manager_mock: MagicMock
+    ) -> None:
+        metadata_manager_mock.internal_local_metadata = {
+            "uuid_a": make_mod("mod.a", name="A"),
+        }
+        graph: dict[str, set[str]] = {
+            "mod.a": set(),
+            "mod.inactive": set(),
+        }
+        result = do_topo_sort(graph, {"uuid_a"})
+        assert result == ["uuid_a"]
+
+    def test_missing_packageid_skipped(self, metadata_manager_mock: MagicMock) -> None:
+        metadata_manager_mock.internal_local_metadata = {
+            "uuid_a": make_mod("mod.a", name="A"),
+            "uuid_bad": {"name": "Bad Mod"},  # missing packageid
+        }
+        result = do_topo_sort({"mod.a": set()}, {"uuid_a", "uuid_bad"})
+        assert "uuid_a" in result
+        assert "uuid_bad" not in result
+
+    @patch("app.sort.topo_sort.show_warning")
+    def test_circular_dependency_raises(
+        self, mock_warning: MagicMock, metadata_manager_mock: MagicMock
+    ) -> None:
+        metadata_manager_mock.internal_local_metadata = {
+            "uuid_a": make_mod("mod.a", name="A"),
+            "uuid_b": make_mod("mod.b", name="B"),
+        }
+        graph: dict[str, set[str]] = {
+            "mod.a": {"mod.b"},
+            "mod.b": {"mod.a"},
+        }
+        with pytest.raises(CircularDependencyError):
+            do_topo_sort(graph, {"uuid_a", "uuid_b"})
+        mock_warning.assert_called_once()
+
+    def test_complex_dag(self, metadata_manager_mock: MagicMock) -> None:
+        """Diamond: D depends on B and C, both depend on A."""
+        metadata_manager_mock.internal_local_metadata = {
+            "uuid_a": make_mod("mod.a", name="Alpha"),
+            "uuid_b": make_mod("mod.b", name="Beta"),
+            "uuid_c": make_mod("mod.c", name="Charlie"),
+            "uuid_d": make_mod("mod.d", name="Delta"),
+        }
+        graph: dict[str, set[str]] = {
+            "mod.a": set(),
+            "mod.b": {"mod.a"},
+            "mod.c": {"mod.a"},
+            "mod.d": {"mod.b", "mod.c"},
+        }
+        result = do_topo_sort(graph, {"uuid_a", "uuid_b", "uuid_c", "uuid_d"})
+        assert result.index("uuid_a") < result.index("uuid_b")
+        assert result.index("uuid_a") < result.index("uuid_c")
+        assert result.index("uuid_b") < result.index("uuid_d")
+        assert result.index("uuid_c") < result.index("uuid_d")
+
+    def test_empty_graph(self, metadata_manager_mock: MagicMock) -> None:
+        metadata_manager_mock.internal_local_metadata = {}
+        result = do_topo_sort({}, set())
+        assert result == []
+
+    def test_non_string_name_handled(self, metadata_manager_mock: MagicMock) -> None:
+        """Mods with non-string name values don't crash the sort."""
+        metadata_manager_mock.internal_local_metadata = {
+            "uuid_a": {"packageid": "mod.a", "name": None},
+            "uuid_b": make_mod("mod.b", name="Beta"),
+        }
+        result = do_topo_sort({"mod.a": set(), "mod.b": set()}, {"uuid_a", "uuid_b"})
+        assert len(result) == 2

--- a/tests/sort/test_topo_sort.py
+++ b/tests/sort/test_topo_sort.py
@@ -4,7 +4,12 @@ import pytest
 from toposort import CircularDependencyError
 
 from app.sort.topo_sort import do_topo_sort
-from tests.sort.conftest import make_mod
+from tests.sort.conftest import (
+    assert_diamond_ordering,
+    diamond_fixture,
+    make_mod,
+    three_mod_alpha_fixture,
+)
 
 
 class TestDoTopoSort:
@@ -35,17 +40,9 @@ class TestDoTopoSort:
         self, metadata_manager_mock: MagicMock
     ) -> None:
         """Mods at the same topological level are sorted alphabetically by name."""
-        metadata_manager_mock.internal_local_metadata = {
-            "uuid_z": make_mod("mod.z", name="Zebra"),
-            "uuid_a": make_mod("mod.a", name="Alpha"),
-            "uuid_m": make_mod("mod.m", name="Middle"),
-        }
-        graph: dict[str, set[str]] = {
-            "mod.z": set(),
-            "mod.a": set(),
-            "mod.m": set(),
-        }
-        result = do_topo_sort(graph, {"uuid_z", "uuid_a", "uuid_m"})
+        metadata, graph, active = three_mod_alpha_fixture()
+        metadata_manager_mock.internal_local_metadata = metadata
+        result = do_topo_sort(graph, active)
         assert result == ["uuid_a", "uuid_m", "uuid_z"]
 
     def test_graph_entry_not_in_active_mods_skipped(
@@ -88,23 +85,10 @@ class TestDoTopoSort:
 
     def test_complex_dag(self, metadata_manager_mock: MagicMock) -> None:
         """Diamond: D depends on B and C, both depend on A."""
-        metadata_manager_mock.internal_local_metadata = {
-            "uuid_a": make_mod("mod.a", name="Alpha"),
-            "uuid_b": make_mod("mod.b", name="Beta"),
-            "uuid_c": make_mod("mod.c", name="Charlie"),
-            "uuid_d": make_mod("mod.d", name="Delta"),
-        }
-        graph: dict[str, set[str]] = {
-            "mod.a": set(),
-            "mod.b": {"mod.a"},
-            "mod.c": {"mod.a"},
-            "mod.d": {"mod.b", "mod.c"},
-        }
-        result = do_topo_sort(graph, {"uuid_a", "uuid_b", "uuid_c", "uuid_d"})
-        assert result.index("uuid_a") < result.index("uuid_b")
-        assert result.index("uuid_a") < result.index("uuid_c")
-        assert result.index("uuid_b") < result.index("uuid_d")
-        assert result.index("uuid_c") < result.index("uuid_d")
+        metadata, graph, active = diamond_fixture()
+        metadata_manager_mock.internal_local_metadata = metadata
+        result = do_topo_sort(graph, active)
+        assert_diamond_ordering(result)
 
     def test_empty_graph(self, metadata_manager_mock: MagicMock) -> None:
         metadata_manager_mock.internal_local_metadata = {}


### PR DESCRIPTION
## Summary

- Add 141 tests covering the entire `app/sort/` module — previously at 0–21% coverage, now at **92%**
- Tests cover dependency graph generation, tier classification, recursive traversal, topological and alphabetical sorting algorithms, and all inactive mods list sorting helpers
- Documents a production bug: `get_reverse_dependencies_recursive` lacks cycle protection and will crash with `RecursionError` on circular data
- Adds guard fixture for `KNOWN_TIER_ONE_MODS` global mutation bug to prevent cross-test pollution

## Coverage improvement

| Module | Before | After |
|--------|--------|-------|
| `dependencies.py` | 7% | **97%** |
| `topo_sort.py` | 15% | **96%** |
| `alphabetical_sort.py` | 8% | **94%** |
| `mod_sorting.py` | 0% | **86%** |
| **Combined `app/sort/`** | **~13%** | **92%** |

## Test plan

- [x] All 141 sort tests pass
- [x] Full suite (508 tests) passes with no regressions
- [x] Lint, format, mypy, jscpd all clean
- [x] Code reviewed by independent subagent

🤖 Generated with [Claude Code](https://claude.com/claude-code)