### PR TITLE
chore: add shared git pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -4,9 +4,22 @@
 
 set -euo pipefail
 
+if ! command -v just &>/dev/null; then
+	echo "BLOCKED: 'just' is not installed or not on PATH."
+	echo "Install it: https://just.systems/man/en/installation.html"
+	exit 1
+fi
+
+if ! command -v pwsh &>/dev/null; then
+	echo "BLOCKED: 'pwsh' (PowerShell 7) is not installed or not on PATH."
+	echo "The justfile requires pwsh. Install it: https://aka.ms/install-powershell"
+	echo "Or change the justfile shell: set shell := [\"sh\", \"-c\"]"
+	exit 1
+fi
+
 echo "Running pre-commit quality checks..."
 
-if ! just check 2>&1; then
+if ! just check; then
 	echo ""
 	echo "BLOCKED: quality checks failed. Run 'just fix' to auto-fix what's fixable."
 	exit 1

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Pre-commit hook: run full quality gate before allowing a commit.
+# Install with: just install-hooks
+
+set -euo pipefail
+
+echo "Running pre-commit quality checks..."
+
+if ! just check 2>&1; then
+	echo ""
+	echo "BLOCKED: quality checks failed. Run 'just fix' to auto-fix what's fixable."
+	exit 1
+fi
+
+echo "All pre-commit checks passed."

--- a/docs/development-guide/development-setup.md
+++ b/docs/development-guide/development-setup.md
@@ -86,6 +86,12 @@ just dev-setup
 
 This runs `uv sync --locked --dev --group build`, which installs all runtime, dev, and build dependencies (including linters like ruff and mypy).
 
+After setup, install the shared git hooks so that `just check` runs automatically before each commit:
+
+```shell
+just install-hooks
+```
+
 If you prefer to do it manually:
 
 ```shell

--- a/justfile
+++ b/justfile
@@ -210,6 +210,11 @@ build-appimage VERSION='1.0.0':
 # Utilities
 # ═══════════════════════════════════════════════════════════════════════════
 
+# Install shared git hooks (pre-commit quality gate)
+install-hooks:
+    git config core.hooksPath .githooks
+    @echo "Git hooks installed — commits will run 'just check' automatically."
+
 # Initialize and update git submodules (required after the first clone)
 submodules-init:
     git submodule update --init --recursive


### PR DESCRIPTION
## Summary

- Add a shared git pre-commit hook (`.githooks/pre-commit`) that runs `just check` before each commit
- Add `just install-hooks` recipe to configure `core.hooksPath`
- Document hook installation in the development setup guide
- Pre-flight checks for `just` and `pwsh` with clear diagnostics if missing

## Details

The hook runs the full quality gate (`just check` — ruff, mypy, jscpd, shfmt, markdownlint) before allowing a commit. If any check fails, the commit is blocked with a message pointing to `just fix`.

Dependency checks catch missing `just` or `pwsh` early with actionable install instructions instead of opaque errors.

## Test plan

- [x] Run `just install-hooks` and verify `git config core.hooksPath` returns `.githooks`
- [x] Make a commit with clean code — hook should pass
- [x] Introduce a lint error and attempt to commit — hook should block with clear message

🤖 Generated with [Claude Code](https://claude.com/claude-code)