### PR TITLE
test(utils): expand test coverage for 8 untested modules

### DIFF
--- a/tests/utils/test_constants.py
+++ b/tests/utils/test_constants.py
@@ -1,0 +1,64 @@
+from app.utils.constants import (
+    DEFAULT_INSTANCE_NAME,
+    DEFAULT_MISSING_PACKAGEID,
+    KNOWN_MOD_REPLACEMENTS,
+    KNOWN_TIER_ZERO_MODS,
+    RIMWORLD_DLC_METADATA,
+    RIMWORLD_PACKAGE_IDS,
+    SEARCH_DATA_SOURCE_FILTER_INDEXES,
+    SortMethod,
+)
+
+
+class TestSortMethod:
+    def test_values(self) -> None:
+        assert SortMethod.ALPHABETICAL == "Alphabetical"
+        assert SortMethod.TOPOLOGICAL == "Topological"
+
+    def test_is_string_enum(self) -> None:
+        assert isinstance(SortMethod.ALPHABETICAL, str)
+
+
+class TestRimworldDlcMetadata:
+    def test_all_dlcs_have_required_fields(self) -> None:
+        for app_id, meta in RIMWORLD_DLC_METADATA.items():
+            assert "packageid" in meta, f"Missing packageid for {app_id}"
+            assert "name" in meta, f"Missing name for {app_id}"
+            assert "steam_url" in meta, f"Missing steam_url for {app_id}"
+
+    def test_package_ids_derived_correctly(self) -> None:
+        expected = [v["packageid"] for v in RIMWORLD_DLC_METADATA.values()]
+        assert RIMWORLD_PACKAGE_IDS == expected
+
+    def test_base_game_included(self) -> None:
+        assert "ludeon.rimworld" in RIMWORLD_PACKAGE_IDS
+
+    def test_known_dlc_count(self) -> None:
+        # Base game + 5 DLCs = 6 entries
+        assert len(RIMWORLD_DLC_METADATA) == 6
+
+
+class TestKnownMods:
+    def test_tier_zero_contains_base_game(self) -> None:
+        assert "ludeon.rimworld" in KNOWN_TIER_ZERO_MODS
+
+    def test_tier_zero_contains_harmony(self) -> None:
+        assert "brrainz.harmony" in KNOWN_TIER_ZERO_MODS
+
+    def test_replacements_keys_exist(self) -> None:
+        for key, replacements in KNOWN_MOD_REPLACEMENTS.items():
+            assert isinstance(key, str)
+            assert isinstance(replacements, set)
+            assert len(replacements) > 0
+
+
+class TestMiscConstants:
+    def test_default_instance_name(self) -> None:
+        assert DEFAULT_INSTANCE_NAME == "Default"
+
+    def test_default_missing_packageid(self) -> None:
+        assert DEFAULT_MISSING_PACKAGEID == "missing.packageid"
+
+    def test_search_filter_indexes(self) -> None:
+        assert "all" in SEARCH_DATA_SOURCE_FILTER_INDEXES
+        assert "workshop" in SEARCH_DATA_SOURCE_FILTER_INDEXES

--- a/tests/utils/test_constants.py
+++ b/tests/utils/test_constants.py
@@ -26,16 +26,23 @@ class TestRimworldDlcMetadata:
             assert "name" in meta, f"Missing name for {app_id}"
             assert "steam_url" in meta, f"Missing steam_url for {app_id}"
 
-    def test_package_ids_derived_correctly(self) -> None:
-        expected = [v["packageid"] for v in RIMWORLD_DLC_METADATA.values()]
+    def test_package_ids_match_known_values(self) -> None:
+        expected = [
+            "ludeon.rimworld",
+            "ludeon.rimworld.royalty",
+            "ludeon.rimworld.ideology",
+            "ludeon.rimworld.biotech",
+            "ludeon.rimworld.anomaly",
+            "ludeon.rimworld.odyssey",
+        ]
         assert RIMWORLD_PACKAGE_IDS == expected
 
     def test_base_game_included(self) -> None:
         assert "ludeon.rimworld" in RIMWORLD_PACKAGE_IDS
 
-    def test_known_dlc_count(self) -> None:
-        # Base game + 5 DLCs = 6 entries
-        assert len(RIMWORLD_DLC_METADATA) == 6
+    def test_no_dlcs_accidentally_removed(self) -> None:
+        # Guard against accidental deletion; update when new DLCs are added
+        assert len(RIMWORLD_DLC_METADATA) >= 6
 
 
 class TestKnownMods:

--- a/tests/utils/test_files.py
+++ b/tests/utils/test_files.py
@@ -1,0 +1,134 @@
+import time
+import zipfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from app.utils.files import (
+    cleanup_old_backups,
+    create_saves_backup,
+    subfolder_contains_candidate_path,
+)
+
+
+class TestSubfolderContainsCandidatePath:
+    def test_matching_file_in_subfolder(self, tmp_path: Path) -> None:
+        candidate = tmp_path / "Assemblies"
+        candidate.mkdir()
+        (candidate / "MyMod.dll").write_text("dll content")
+        assert (
+            subfolder_contains_candidate_path(tmp_path, "Assemblies", "*.dll") is True
+        )
+
+    def test_no_matching_file(self, tmp_path: Path) -> None:
+        candidate = tmp_path / "Assemblies"
+        candidate.mkdir()
+        (candidate / "readme.txt").write_text("text")
+        assert (
+            subfolder_contains_candidate_path(tmp_path, "Assemblies", "*.dll") is False
+        )
+
+    def test_candidate_not_exist(self, tmp_path: Path) -> None:
+        assert subfolder_contains_candidate_path(tmp_path, "Missing", "*.dll") is False
+
+    def test_none_subfolder_returns_false(self) -> None:
+        assert subfolder_contains_candidate_path(None, "test", "*.dll") is False
+
+    def test_none_candidate_uses_root(self, tmp_path: Path) -> None:
+        (tmp_path / "file.dll").write_text("data")
+        assert subfolder_contains_candidate_path(tmp_path, None, "*.dll") is True
+
+    def test_checks_immediate_subdirs(self, tmp_path: Path) -> None:
+        sub = tmp_path / "versioned"
+        sub.mkdir()
+        candidate = sub / "Assemblies"
+        candidate.mkdir()
+        (candidate / "mod.dll").write_text("dll")
+        assert (
+            subfolder_contains_candidate_path(tmp_path, "Assemblies", "*.dll") is True
+        )
+
+
+class TestCleanupOldBackups:
+    def _create_backups(self, backup_dir: Path, count: int) -> list[Path]:
+        backups = []
+        for i in range(count):
+            f = backup_dir / f"Saves_{i:04d}.zip"
+            f.write_text(f"backup {i}")
+            time.sleep(0.01)
+            backups.append(f)
+        return backups
+
+    def test_keeps_specified_number(self, tmp_path: Path) -> None:
+        self._create_backups(tmp_path, 5)
+        cleanup_old_backups(tmp_path, keep=2)
+        remaining = list(tmp_path.glob("Saves_*.zip"))
+        assert len(remaining) == 2
+
+    def test_keep_negative_one_keeps_all(self, tmp_path: Path) -> None:
+        self._create_backups(tmp_path, 5)
+        cleanup_old_backups(tmp_path, keep=-1)
+        remaining = list(tmp_path.glob("Saves_*.zip"))
+        assert len(remaining) == 5
+
+    def test_keep_zero_deletes_all(self, tmp_path: Path) -> None:
+        self._create_backups(tmp_path, 3)
+        cleanup_old_backups(tmp_path, keep=0)
+        remaining = list(tmp_path.glob("Saves_*.zip"))
+        assert len(remaining) == 0
+
+    def test_fewer_than_keep_does_nothing(self, tmp_path: Path) -> None:
+        self._create_backups(tmp_path, 2)
+        cleanup_old_backups(tmp_path, keep=5)
+        remaining = list(tmp_path.glob("Saves_*.zip"))
+        assert len(remaining) == 2
+
+
+class TestCreateSavesBackup:
+    def test_creates_backup_zip(self, tmp_path: Path) -> None:
+        saves = tmp_path / "Saves"
+        saves.mkdir()
+        (saves / "save1.rws").write_text("save data 1")
+        (saves / "save2.rws").write_text("save data 2")
+        backup_dir = tmp_path / "backups"
+
+        settings = MagicMock()
+        settings.auto_backup_compression_count = -1
+        settings.auto_backup_retention_count = 5
+
+        result = create_saves_backup(saves, backup_dir, settings)
+        assert result is not None
+        assert Path(result).exists()
+        with zipfile.ZipFile(result) as zf:
+            names = zf.namelist()
+            assert "save1.rws" in names
+            assert "save2.rws" in names
+
+    def test_nonexistent_saves_dir_returns_none(self, tmp_path: Path) -> None:
+        settings = MagicMock()
+        result = create_saves_backup(tmp_path / "nope", tmp_path / "backups", settings)
+        assert result is None
+
+    def test_compression_count_zero_returns_none(self, tmp_path: Path) -> None:
+        saves = tmp_path / "Saves"
+        saves.mkdir()
+        (saves / "save.rws").write_text("data")
+        settings = MagicMock()
+        settings.auto_backup_compression_count = 0
+        result = create_saves_backup(saves, tmp_path / "backups", settings)
+        assert result is None
+
+    def test_compression_count_limits_files(self, tmp_path: Path) -> None:
+        saves = tmp_path / "Saves"
+        saves.mkdir()
+        for i in range(5):
+            (saves / f"save{i}.rws").write_text(f"data {i}")
+            time.sleep(0.01)
+
+        settings = MagicMock()
+        settings.auto_backup_compression_count = 2
+        settings.auto_backup_retention_count = 5
+
+        result = create_saves_backup(saves, tmp_path / "backups", settings)
+        assert result is not None
+        with zipfile.ZipFile(result) as zf:
+            assert len(zf.namelist()) == 2

--- a/tests/utils/test_ignore_manager.py
+++ b/tests/utils/test_ignore_manager.py
@@ -1,0 +1,95 @@
+import json
+from collections.abc import Generator
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from app.utils.ignore_manager import IgnoreManager
+
+
+@pytest.fixture
+def ignore_file(tmp_path: Path) -> Generator[Path]:
+    file_path = tmp_path / "ignore.json"
+    with patch.object(IgnoreManager, "get_ignore_file_path", return_value=file_path):
+        yield file_path
+
+
+class TestLoadIgnoredMods:
+    def test_no_file_returns_empty(self, ignore_file: Path) -> None:
+        result = IgnoreManager.load_ignored_mods()
+        assert result == set()
+
+    def test_list_format(self, ignore_file: Path) -> None:
+        ignore_file.write_text(json.dumps(["mod.a", "mod.b"]))
+        result = IgnoreManager.load_ignored_mods()
+        assert result == {"mod.a", "mod.b"}
+
+    def test_dict_format(self, ignore_file: Path) -> None:
+        data = {"ignored_mods": ["mod.a", "mod.b"], "description": "test"}
+        ignore_file.write_text(json.dumps(data))
+        result = IgnoreManager.load_ignored_mods()
+        assert result == {"mod.a", "mod.b"}
+
+    def test_invalid_json_returns_empty(self, ignore_file: Path) -> None:
+        ignore_file.write_text("not json{{{")
+        result = IgnoreManager.load_ignored_mods()
+        assert result == set()
+
+    def test_invalid_format_returns_empty(self, ignore_file: Path) -> None:
+        ignore_file.write_text(json.dumps("just a string"))
+        result = IgnoreManager.load_ignored_mods()
+        assert result == set()
+
+
+class TestSaveIgnoredMods:
+    def test_saves_sorted_with_metadata(self, ignore_file: Path) -> None:
+        result = IgnoreManager.save_ignored_mods({"mod.b", "mod.a"})
+        assert result is True
+        data = json.loads(ignore_file.read_text())
+        assert data["ignored_mods"] == ["mod.a", "mod.b"]
+        assert "description" in data
+
+    def test_creates_parent_directory(self, tmp_path: Path) -> None:
+        nested = tmp_path / "deep" / "nested" / "ignore.json"
+        with patch.object(IgnoreManager, "get_ignore_file_path", return_value=nested):
+            result = IgnoreManager.save_ignored_mods({"mod.a"})
+        assert result is True
+        assert nested.exists()
+
+
+class TestAddRemoveMods:
+    def test_add_single_mod(self, ignore_file: Path) -> None:
+        assert IgnoreManager.add_ignored_mod("mod.a") is True
+        assert IgnoreManager.is_mod_ignored("mod.a") is True
+
+    def test_add_duplicate_is_idempotent(self, ignore_file: Path) -> None:
+        IgnoreManager.add_ignored_mod("mod.a")
+        assert IgnoreManager.add_ignored_mod("mod.a") is True
+        assert IgnoreManager.get_ignored_mods_count() == 1
+
+    def test_add_multiple_mods(self, ignore_file: Path) -> None:
+        assert IgnoreManager.add_ignored_mods(["mod.a", "mod.b", "mod.c"]) is True
+        assert IgnoreManager.get_ignored_mods_count() == 3
+
+    def test_add_empty_list(self, ignore_file: Path) -> None:
+        assert IgnoreManager.add_ignored_mods([]) is True
+
+    def test_remove_single_mod(self, ignore_file: Path) -> None:
+        IgnoreManager.add_ignored_mod("mod.a")
+        assert IgnoreManager.remove_ignored_mod("mod.a") is True
+        assert IgnoreManager.is_mod_ignored("mod.a") is False
+
+    def test_remove_nonexistent_is_noop(self, ignore_file: Path) -> None:
+        assert IgnoreManager.remove_ignored_mod("mod.nope") is True
+
+    def test_remove_multiple_mods(self, ignore_file: Path) -> None:
+        IgnoreManager.add_ignored_mods(["mod.a", "mod.b", "mod.c"])
+        assert IgnoreManager.remove_ignored_mods(["mod.a", "mod.c"]) is True
+        assert IgnoreManager.get_ignored_mods_count() == 1
+        assert IgnoreManager.is_mod_ignored("mod.b") is True
+
+    def test_clear_all(self, ignore_file: Path) -> None:
+        IgnoreManager.add_ignored_mods(["mod.a", "mod.b"])
+        assert IgnoreManager.clear_ignored_mods() is True
+        assert IgnoreManager.get_ignored_mods_count() == 0

--- a/tests/utils/test_mod_info.py
+++ b/tests/utils/test_mod_info.py
@@ -1,0 +1,227 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.utils.mod_info import DATABASE, LOCAL, STEAM, STEAM_CMD, UNKNOWN, ModInfo
+
+
+class TestModInfoInit:
+    def test_valid_construction(self) -> None:
+        info = ModInfo(
+            uuid="abc",
+            name="Test Mod",
+            authors="Author",
+            packageid="test.mod",
+            published_file_id="12345",
+            supported_versions="1.4",
+            source=LOCAL,
+            path="/mods/test",
+            downloaded_time_raw=1000000.0,
+            updated_time_raw=2000000.0,
+            workshop_url="",
+            type="Original",
+            installed_status="Installed",
+        )
+        assert info.name == "Test Mod"
+        assert info.packageid == "test.mod"
+
+    def test_empty_packageid_raises(self) -> None:
+        with pytest.raises(ValueError, match="packageid cannot be empty"):
+            ModInfo(
+                uuid="abc",
+                name="Test",
+                authors="",
+                packageid="",
+                published_file_id="",
+                supported_versions="",
+                source="",
+                path="",
+                downloaded_time_raw=None,
+                updated_time_raw=None,
+                workshop_url="",
+                type="",
+                installed_status="",
+            )
+
+    def test_whitespace_packageid_raises(self) -> None:
+        with pytest.raises(ValueError, match="packageid cannot be empty"):
+            ModInfo(
+                uuid="abc",
+                name="Test",
+                authors="",
+                packageid="   ",
+                published_file_id="",
+                supported_versions="",
+                source="",
+                path="",
+                downloaded_time_raw=None,
+                updated_time_raw=None,
+                workshop_url="",
+                type="",
+                installed_status="",
+            )
+
+    def test_empty_name_set_to_unknown(self) -> None:
+        info = ModInfo(
+            uuid="abc",
+            name="",
+            authors="",
+            packageid="valid.id",
+            published_file_id="",
+            supported_versions="",
+            source="",
+            path="",
+            downloaded_time_raw=None,
+            updated_time_raw=None,
+            workshop_url="",
+            type="",
+            installed_status="",
+        )
+        assert info.name == UNKNOWN
+
+
+class TestFromMetadata:
+    def test_basic_metadata(self) -> None:
+        metadata = {
+            "name": "Cool Mod",
+            "authors": "Author1",
+            "packageid": "cool.mod",
+            "publishedfileid": "99999",
+            "supportedversions": {"li": ["1.4", "1.5"]},
+            "data_source": "workshop",
+            "path": "/mods/cool",
+        }
+        info = ModInfo.from_metadata("uuid-1", metadata)
+        assert info.name == "Cool Mod"
+        assert info.packageid == "cool.mod"
+        assert info.source == STEAM
+        assert info.published_file_id == "99999"
+        assert "1.4" in info.supported_versions
+        assert "1.5" in info.supported_versions
+
+    def test_steamcmd_source(self) -> None:
+        metadata = {"name": "Mod", "packageid": "test.mod", "steamcmd": True}
+        info = ModInfo.from_metadata("uuid", metadata)
+        assert info.source == STEAM_CMD
+
+    def test_local_source(self) -> None:
+        metadata = {"name": "Mod", "packageid": "test.mod", "data_source": "local"}
+        info = ModInfo.from_metadata("uuid", metadata)
+        assert info.source == LOCAL
+
+    def test_database_source_fallback(self) -> None:
+        metadata = {"name": "Mod", "packageid": "test.mod"}
+        info = ModInfo.from_metadata("uuid", metadata)
+        assert info.source == DATABASE
+
+    def test_missing_packageid_raises(self) -> None:
+        metadata = {"name": "Mod", "packageid": ""}
+        with pytest.raises(ValueError, match="Failed to create ModInfo"):
+            ModInfo.from_metadata("uuid", metadata)
+
+    def test_authors_as_list(self) -> None:
+        metadata = {
+            "name": "Mod",
+            "packageid": "test.mod",
+            "authors": ["Alice", "Bob"],
+        }
+        info = ModInfo.from_metadata("uuid", metadata)
+        assert info.authors == "Alice, Bob"
+
+    def test_fallback_name_from_steamname(self) -> None:
+        metadata = {"steamName": "Steam Name", "packageid": "test.mod"}
+        info = ModInfo.from_metadata("uuid", metadata)
+        assert info.name == "Steam Name"
+
+
+class TestNormalizeVersion:
+    def test_major_minor(self) -> None:
+        assert ModInfo._normalize_version("1.4") == "1.4"
+
+    def test_major_minor_patch_truncated(self) -> None:
+        assert ModInfo._normalize_version("1.4.3") == "1.4"
+
+    def test_single_part(self) -> None:
+        assert ModInfo._normalize_version("1") == "1"
+
+    def test_non_string_returns_str(self) -> None:
+        assert ModInfo._normalize_version(42) == "42"  # type: ignore[arg-type]
+
+
+class TestParseSupportedVersions:
+    def test_dict_with_list(self) -> None:
+        result = ModInfo._parse_supported_versions_static({"li": ["1.4", "1.3"]})
+        assert result == "1.3, 1.4"
+
+    def test_dict_with_single_string(self) -> None:
+        result = ModInfo._parse_supported_versions_static({"li": "1.4"})
+        assert result == "1.4"
+
+    def test_list_input(self) -> None:
+        result = ModInfo._parse_supported_versions_static(["1.4", "1.5"])
+        assert result == "1.4, 1.5"
+
+    def test_string_input(self) -> None:
+        result = ModInfo._parse_supported_versions_static("1.4")
+        assert result == "1.4"
+
+    def test_none_returns_unknown(self) -> None:
+        result = ModInfo._parse_supported_versions_static(None)
+        assert result == UNKNOWN
+
+    def test_deduplication(self) -> None:
+        result = ModInfo._parse_supported_versions_static(["1.4", "1.4", "1.5"])
+        assert result == "1.4, 1.5"
+
+    def test_version_normalization_in_list(self) -> None:
+        result = ModInfo._parse_supported_versions_static({"li": ["1.4.3", "1.5.1"]})
+        assert result == "1.4, 1.5"
+
+
+class TestGenerateWorkshopUrl:
+    def test_valid_numeric_id(self) -> None:
+        url = ModInfo._generate_workshop_url("12345")
+        assert url == "https://steamcommunity.com/sharedfiles/filedetails/?id=12345"
+
+    def test_empty_id_returns_empty(self) -> None:
+        assert ModInfo._generate_workshop_url("") == ""
+
+    def test_non_numeric_id_returns_empty(self) -> None:
+        assert ModInfo._generate_workshop_url("abc") == ""
+
+
+class TestTimeProperties:
+    @staticmethod
+    def _make_info(
+        downloaded: float | None = None,
+        updated: float | None = None,
+    ) -> ModInfo:
+        return ModInfo(
+            uuid="a",
+            name="M",
+            authors="",
+            packageid="p.id",
+            published_file_id="",
+            supported_versions="",
+            source="",
+            path="",
+            downloaded_time_raw=downloaded,
+            updated_time_raw=updated,
+            workshop_url="",
+            type="",
+            installed_status="",
+        )
+
+    @patch("app.utils.mod_info.format_time_display")
+    def test_downloaded_time_with_value(self, mock_fmt: MagicMock) -> None:
+        mock_fmt.return_value = ("2024-01-01 00:00:00 | 1 day ago", 1000)
+        info = self._make_info(downloaded=1000.0)
+        assert info.downloaded_time == "2024-01-01 00:00:00 | 1 day ago"
+
+    def test_downloaded_time_none(self) -> None:
+        info = self._make_info()
+        assert info.downloaded_time == UNKNOWN
+
+    def test_updated_on_workshop_none(self) -> None:
+        info = self._make_info()
+        assert info.updated_on_workshop == UNKNOWN

--- a/tests/utils/test_schema.py
+++ b/tests/utils/test_schema.py
@@ -1,0 +1,70 @@
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from app.utils.schema import generate_rimworld_mods_list, validate_rimworld_mods_list
+
+
+class TestGenerateRimworldModsList:
+    def test_basic_generation(self) -> None:
+        result = generate_rimworld_mods_list(
+            "1.5",
+            ["ludeon.rimworld", "brrainz.harmony"],
+        )
+        assert result["ModsConfigData"]["version"] == "1.5"
+        active = result["ModsConfigData"]["activeMods"]["li"]
+        assert active == ["ludeon.rimworld", "brrainz.harmony"]
+
+    def test_known_expansions_excludes_base_game(self) -> None:
+        result = generate_rimworld_mods_list(
+            "1.5",
+            ["ludeon.rimworld"],
+            dlc_ids=["ludeon.rimworld", "ludeon.rimworld.royalty"],
+        )
+        known = result["ModsConfigData"]["knownExpansions"]["li"]
+        assert "ludeon.rimworld" not in known
+        assert "ludeon.rimworld.royalty" in known
+
+    def test_empty_packageids(self) -> None:
+        result = generate_rimworld_mods_list("1.5", [])
+        assert result["ModsConfigData"]["activeMods"]["li"] == []
+
+
+class TestValidateRimworldModsList:
+    @patch("app.utils.schema.show_warning")
+    def test_modsconfig_format(self, mock_warn: MagicMock, qapp: Any) -> None:
+        data = {
+            "ModsConfigData": {
+                "activeMods": {"li": ["ludeon.rimworld", "brrainz.harmony"]}
+            }
+        }
+        result = validate_rimworld_mods_list(data)
+        assert result == ["ludeon.rimworld", "brrainz.harmony"]
+        mock_warn.assert_not_called()
+
+    @patch("app.utils.schema.show_warning")
+    def test_modsconfig_single_mod_string(
+        self, mock_warn: MagicMock, qapp: Any
+    ) -> None:
+        data = {"ModsConfigData": {"activeMods": {"li": "ludeon.rimworld"}}}
+        result = validate_rimworld_mods_list(data)
+        assert result == ["ludeon.rimworld"]
+
+    @patch("app.utils.schema.show_warning")
+    def test_savegame_format(self, mock_warn: MagicMock, qapp: Any) -> None:
+        data = {"savegame": {"meta": {"modIds": {"li": ["ludeon.rimworld"]}}}}
+        result = validate_rimworld_mods_list(data)
+        assert result == ["ludeon.rimworld"]
+
+    @patch("app.utils.schema.show_warning")
+    def test_saved_mod_list_format(self, mock_warn: MagicMock, qapp: Any) -> None:
+        data = {"savedModList": {"meta": {"modIds": {"li": ["ludeon.rimworld"]}}}}
+        result = validate_rimworld_mods_list(data)
+        assert result == ["ludeon.rimworld"]
+
+    @patch("app.utils.schema.show_warning")
+    def test_invalid_format_returns_default(
+        self, mock_warn: MagicMock, qapp: Any
+    ) -> None:
+        result = validate_rimworld_mods_list({"garbage": "data"})
+        assert result == ["Ludeon.RimWorld"]
+        mock_warn.assert_called_once()

--- a/tests/utils/test_schema.py
+++ b/tests/utils/test_schema.py
@@ -48,18 +48,21 @@ class TestValidateRimworldModsList:
         data = {"ModsConfigData": {"activeMods": {"li": "ludeon.rimworld"}}}
         result = validate_rimworld_mods_list(data)
         assert result == ["ludeon.rimworld"]
+        mock_warn.assert_not_called()
 
     @patch("app.utils.schema.show_warning")
     def test_savegame_format(self, mock_warn: MagicMock, qapp: Any) -> None:
         data = {"savegame": {"meta": {"modIds": {"li": ["ludeon.rimworld"]}}}}
         result = validate_rimworld_mods_list(data)
         assert result == ["ludeon.rimworld"]
+        mock_warn.assert_not_called()
 
     @patch("app.utils.schema.show_warning")
     def test_saved_mod_list_format(self, mock_warn: MagicMock, qapp: Any) -> None:
         data = {"savedModList": {"meta": {"modIds": {"li": ["ludeon.rimworld"]}}}}
         result = validate_rimworld_mods_list(data)
         assert result == ["ludeon.rimworld"]
+        mock_warn.assert_not_called()
 
     @patch("app.utils.schema.show_warning")
     def test_invalid_format_returns_default(

--- a/tests/utils/test_symlink.py
+++ b/tests/utils/test_symlink.py
@@ -1,0 +1,139 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from app.utils.symlink import (
+    SymlinkCreationError,
+    SymlinkDstIsFileError,
+    SymlinkDstNotEmptyError,
+    SymlinkDstParentNotExistError,
+    SymlinkSrcNotDirError,
+    SymlinkSrcNotExistError,
+    create_symlink,
+    is_junction_or_link,
+)
+
+
+class TestExceptions:
+    def test_base_exception_stores_paths(self) -> None:
+        err = SymlinkCreationError("msg", "/src", "/dst")
+        assert err.src_path == Path("/src")
+        assert err.dst_path == Path("/dst")
+        assert str(err) == "msg"
+
+    def test_subclass_hierarchy(self) -> None:
+        assert issubclass(SymlinkDstNotEmptyError, SymlinkCreationError)
+        assert issubclass(SymlinkDstIsFileError, SymlinkCreationError)
+        assert issubclass(SymlinkSrcNotExistError, SymlinkCreationError)
+        assert issubclass(SymlinkSrcNotDirError, SymlinkCreationError)
+        assert issubclass(SymlinkDstParentNotExistError, SymlinkCreationError)
+
+
+class TestIsJunctionOrLink:
+    def test_regular_file_returns_false(self, tmp_path: Path) -> None:
+        f = tmp_path / "file.txt"
+        f.write_text("data")
+        assert is_junction_or_link(f) is False
+
+    def test_regular_dir_returns_false(self, tmp_path: Path) -> None:
+        d = tmp_path / "dir"
+        d.mkdir()
+        assert is_junction_or_link(d) is False
+
+    def test_symlink_returns_true(self, tmp_path: Path) -> None:
+        target = tmp_path / "target"
+        target.mkdir()
+        link = tmp_path / "link"
+        os.symlink(target, link)
+        assert is_junction_or_link(link) is True
+
+    def test_nonexistent_returns_false(self, tmp_path: Path) -> None:
+        assert is_junction_or_link(tmp_path / "nope") is False
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Unix symlink tests")
+class TestCreateSymlink:
+    def test_basic_symlink_creation(self, tmp_path: Path) -> None:
+        src = tmp_path / "source"
+        src.mkdir()
+        dst = tmp_path / "link"
+        create_symlink(str(src), str(dst))
+        assert dst.is_symlink()
+        assert os.readlink(dst) == str(src)
+
+    def test_src_not_exist_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(SymlinkSrcNotExistError):
+            create_symlink(str(tmp_path / "missing"), str(tmp_path / "link"))
+
+    def test_src_is_file_raises(self, tmp_path: Path) -> None:
+        src = tmp_path / "file.txt"
+        src.write_text("data")
+        with pytest.raises(SymlinkSrcNotDirError):
+            create_symlink(str(src), str(tmp_path / "link"))
+
+    def test_dst_existing_symlink_recreated(self, tmp_path: Path) -> None:
+        src1 = tmp_path / "src1"
+        src1.mkdir()
+        src2 = tmp_path / "src2"
+        src2.mkdir()
+        dst = tmp_path / "link"
+        os.symlink(src1, dst)
+        create_symlink(str(src2), str(dst))
+        assert os.readlink(dst) == str(src2)
+
+    def test_dst_empty_dir_removed(self, tmp_path: Path) -> None:
+        src = tmp_path / "source"
+        src.mkdir()
+        dst = tmp_path / "dest"
+        dst.mkdir()
+        create_symlink(str(src), str(dst))
+        assert dst.is_symlink()
+
+    def test_dst_nonempty_dir_raises_without_force(self, tmp_path: Path) -> None:
+        src = tmp_path / "source"
+        src.mkdir()
+        dst = tmp_path / "dest"
+        dst.mkdir()
+        (dst / "file.txt").write_text("content")
+        with pytest.raises(SymlinkDstNotEmptyError):
+            create_symlink(str(src), str(dst))
+
+    def test_dst_nonempty_dir_force(self, tmp_path: Path) -> None:
+        src = tmp_path / "source"
+        src.mkdir()
+        dst = tmp_path / "dest"
+        dst.mkdir()
+        (dst / "file.txt").write_text("content")
+        create_symlink(str(src), str(dst), force=True)
+        assert dst.is_symlink()
+
+    def test_dst_is_file_raises_without_force(self, tmp_path: Path) -> None:
+        src = tmp_path / "source"
+        src.mkdir()
+        dst = tmp_path / "dest_file"
+        dst.write_text("data")
+        with pytest.raises(SymlinkDstIsFileError):
+            create_symlink(str(src), str(dst))
+
+    def test_dst_is_file_force(self, tmp_path: Path) -> None:
+        src = tmp_path / "source"
+        src.mkdir()
+        dst = tmp_path / "dest_file"
+        dst.write_text("data")
+        create_symlink(str(src), str(dst), force=True)
+        assert dst.is_symlink()
+
+    def test_dst_parent_not_exist_raises(self, tmp_path: Path) -> None:
+        src = tmp_path / "source"
+        src.mkdir()
+        with pytest.raises(SymlinkDstParentNotExistError):
+            create_symlink(str(src), str(tmp_path / "deep" / "nested" / "link"))
+
+    def test_dst_parent_not_exist_force_creates_parents(self, tmp_path: Path) -> None:
+        src = tmp_path / "source"
+        src.mkdir()
+        dst = tmp_path / "deep" / "nested" / "link"
+        create_symlink(str(src), str(dst), force=True)
+        assert dst.is_symlink()

--- a/tests/utils/test_system_info.py
+++ b/tests/utils/test_system_info.py
@@ -1,0 +1,107 @@
+from collections.abc import Generator
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.utils.system_info import (
+    SystemInfo,
+    UnsupportedArchitectureError,
+    UnsupportedOperatingSystemError,
+)
+
+
+def _clear_singleton() -> None:
+    """Clear all singleton state from SystemInfo."""
+    instance = SystemInfo._instance
+    if instance is not None and hasattr(instance, "_is_initialized"):
+        del instance._is_initialized
+    SystemInfo._instance = None
+    SystemInfo._operating_system = None
+    SystemInfo._architecture = None
+
+
+@pytest.fixture(autouse=True)
+def reset_singleton() -> Generator[None]:
+    """Reset SystemInfo singleton between tests."""
+    _clear_singleton()
+    yield
+    _clear_singleton()
+
+
+class TestOperatingSystemDetection:
+    @patch("platform.system", return_value="Linux")
+    @patch("platform.machine", return_value="x86_64")
+    def test_linux(self, _mock_machine: MagicMock, _mock_system: MagicMock) -> None:
+        info = SystemInfo()
+        assert info.operating_system == SystemInfo.OperatingSystem.LINUX
+
+    @patch("platform.system", return_value="Windows")
+    @patch("platform.machine", return_value="AMD64")
+    def test_windows(self, _mock_machine: MagicMock, _mock_system: MagicMock) -> None:
+        info = SystemInfo()
+        assert info.operating_system == SystemInfo.OperatingSystem.WINDOWS
+
+    @patch("platform.system", return_value="Darwin")
+    @patch("platform.machine", return_value="arm64")
+    def test_macos(self, _mock_machine: MagicMock, _mock_system: MagicMock) -> None:
+        info = SystemInfo()
+        assert info.operating_system == SystemInfo.OperatingSystem.MACOS
+
+    @patch("platform.system", return_value="FreeBSD")
+    @patch("platform.machine", return_value="x86_64")
+    def test_unsupported_os_raises(
+        self, _mock_machine: MagicMock, _mock_system: MagicMock
+    ) -> None:
+        with pytest.raises(UnsupportedOperatingSystemError):
+            SystemInfo()
+
+
+class TestArchitectureDetection:
+    @patch("platform.system", return_value="Linux")
+    @patch("platform.machine", return_value="x86_64")
+    def test_x64(self, _mock_machine: MagicMock, _mock_system: MagicMock) -> None:
+        assert SystemInfo().architecture == SystemInfo.Architecture.X64
+
+    @patch("platform.system", return_value="Linux")
+    @patch("platform.machine", return_value="amd64")
+    def test_amd64(self, _mock_machine: MagicMock, _mock_system: MagicMock) -> None:
+        assert SystemInfo().architecture == SystemInfo.Architecture.X64
+
+    @patch("platform.system", return_value="Linux")
+    @patch("platform.machine", return_value="i686")
+    def test_x86(self, _mock_machine: MagicMock, _mock_system: MagicMock) -> None:
+        assert SystemInfo().architecture == SystemInfo.Architecture.X86
+
+    @patch("platform.system", return_value="Darwin")
+    @patch("platform.machine", return_value="arm64")
+    def test_arm64(self, _mock_machine: MagicMock, _mock_system: MagicMock) -> None:
+        assert SystemInfo().architecture == SystemInfo.Architecture.ARM64
+
+    @patch("platform.system", return_value="Darwin")
+    @patch("platform.machine", return_value="aarch64")
+    def test_aarch64(self, _mock_machine: MagicMock, _mock_system: MagicMock) -> None:
+        assert SystemInfo().architecture == SystemInfo.Architecture.ARM64
+
+    @patch("platform.system", return_value="Darwin")
+    @patch("platform.machine", return_value="arm64e")
+    def test_arm64e(self, _mock_machine: MagicMock, _mock_system: MagicMock) -> None:
+        assert SystemInfo().architecture == SystemInfo.Architecture.ARM64
+
+    @patch("platform.system", return_value="Linux")
+    @patch("platform.machine", return_value="mips")
+    def test_unsupported_arch_raises(
+        self, _mock_machine: MagicMock, _mock_system: MagicMock
+    ) -> None:
+        with pytest.raises(UnsupportedArchitectureError):
+            SystemInfo()
+
+
+class TestSingleton:
+    @patch("platform.system", return_value="Linux")
+    @patch("platform.machine", return_value="x86_64")
+    def test_same_instance_returned(
+        self, _mock_machine: MagicMock, _mock_system: MagicMock
+    ) -> None:
+        a = SystemInfo()
+        b = SystemInfo()
+        assert a is b

--- a/tests/utils/test_xml.py
+++ b/tests/utils/test_xml.py
@@ -1,0 +1,223 @@
+import gzip
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+import zstandard as zstd
+
+from app.utils.xml import (
+    dict_to_etree,
+    etree_to_dict,
+    extract_xml_package_ids,
+    fast_rimworld_xml_save_validation,
+    json_to_xml_write,
+    using_gzip,
+    using_zstd,
+    xml_path_to_json,
+)
+
+
+class TestEtreeToDict:
+    def test_simple_element(self) -> None:
+        root = ET.fromstring("<root><name>Test</name></root>")
+        result = etree_to_dict(root)
+        assert result == {"root": {"name": "Test"}}
+
+    def test_nested_elements(self) -> None:
+        root = ET.fromstring("<root><parent><child>value</child></parent></root>")
+        result = etree_to_dict(root)
+        assert result == {"root": {"parent": {"child": "value"}}}
+
+    def test_element_with_attributes(self) -> None:
+        root = ET.fromstring('<item id="42">content</item>')
+        result = etree_to_dict(root)
+        assert result == {"item": {"@id": "42", "#text": "content"}}
+
+    def test_duplicate_children_become_list(self) -> None:
+        root = ET.fromstring("<list><li>a</li><li>b</li><li>c</li></list>")
+        result = etree_to_dict(root)
+        assert result == {"list": {"li": ["a", "b", "c"]}}
+
+    def test_empty_element(self) -> None:
+        root = ET.fromstring("<root></root>")
+        result = etree_to_dict(root)
+        assert result == {"root": {}}
+
+    def test_text_only_element(self) -> None:
+        root = ET.fromstring("<tag>hello</tag>")
+        result = etree_to_dict(root)
+        assert result == {"tag": "hello"}
+
+
+class TestDictToEtree:
+    def test_simple_dict(self) -> None:
+        d = {"root": {"name": "Test"}}
+        elem = dict_to_etree(d)
+        assert elem.tag == "root"
+        assert elem.find("name") is not None
+        assert elem.find("name").text == "Test"
+
+    def test_dict_with_attributes(self) -> None:
+        d = {"item": {"@id": "42", "#text": "content"}}
+        elem = dict_to_etree(d)
+        assert elem.tag == "item"
+        assert elem.get("id") == "42"
+        assert elem.text == "content"
+
+    def test_list_children(self) -> None:
+        d = {"list": {"li": [{"sub": "a"}, {"sub": "b"}]}}
+        elem = dict_to_etree(d)
+        items = elem.findall("li")
+        assert len(items) == 2
+
+    def test_roundtrip(self) -> None:
+        original = {"root": {"child": "value", "nested": {"inner": "deep"}}}
+        elem = dict_to_etree(original)
+        result = etree_to_dict(elem)
+        assert result == original
+
+    def test_rejects_multi_root(self) -> None:
+        with pytest.raises(AssertionError):
+            dict_to_etree({"a": "1", "b": "2"})
+
+
+class TestXmlPathToJson:
+    def test_simple_xml_file(self, tmp_path: Path) -> None:
+        xml_file = tmp_path / "test.xml"
+        xml_file.write_text('<?xml version="1.0"?><root><name>Test</name></root>')
+        result = xml_path_to_json(str(xml_file))
+        assert result == {"root": {"name": "Test"}}
+
+    def test_nonexistent_file_returns_empty(self, tmp_path: Path) -> None:
+        result = xml_path_to_json(str(tmp_path / "missing.xml"))
+        assert result == {}
+
+    def test_gzip_compressed_xml(self, tmp_path: Path) -> None:
+        xml_content = b'<?xml version="1.0"?><root><data>gzipped</data></root>'
+        gz_file = tmp_path / "test.xml.gz"
+        with gzip.open(gz_file, "wb") as f:
+            f.write(xml_content)
+        result = xml_path_to_json(str(gz_file))
+        assert result == {"root": {"data": "gzipped"}}
+
+    def test_zstd_compressed_xml(self, tmp_path: Path) -> None:
+        xml_content = b'<?xml version="1.0"?><root><data>zstd</data></root>'
+        zstd_file = tmp_path / "test.xml.zst"
+        cctx = zstd.ZstdCompressor()
+        with open(zstd_file, "wb") as f:
+            f.write(cctx.compress(xml_content))
+        result = xml_path_to_json(str(zstd_file))
+        assert result == {"root": {"data": "zstd"}}
+
+    def test_malformed_xml_falls_back_to_beautifulsoup(self, tmp_path: Path) -> None:
+        xml_file = tmp_path / "bad.xml"
+        xml_file.write_text("<root><name>Test</name><unclosed>")
+        result = xml_path_to_json(str(xml_file))
+        assert isinstance(result, dict)
+
+
+class TestJsonToXmlWrite:
+    def test_write_and_read_roundtrip(self, tmp_path: Path) -> None:
+        data = {"config": {"setting": "value"}}
+        out_path = str(tmp_path / "output.xml")
+        json_to_xml_write(data, out_path)
+        result = xml_path_to_json(out_path)
+        assert result == data
+
+    def test_write_raises_on_error_when_requested(self, tmp_path: Path) -> None:
+        with pytest.raises(Exception):
+            json_to_xml_write(
+                {"a": "1", "b": "2"}, str(tmp_path / "out.xml"), raise_errs=True
+            )
+
+    def test_write_swallows_error_by_default(self, tmp_path: Path) -> None:
+        json_to_xml_write({"a": "1", "b": "2"}, str(tmp_path / "out.xml"))
+
+
+class TestCompressionDetection:
+    def test_using_gzip_true(self, tmp_path: Path) -> None:
+        gz_file = tmp_path / "test.gz"
+        with gzip.open(gz_file, "wb") as f:
+            f.write(b"content")
+        assert using_gzip(str(gz_file)) is True
+
+    def test_using_gzip_false(self, tmp_path: Path) -> None:
+        plain_file = tmp_path / "test.txt"
+        plain_file.write_text("plain text")
+        assert using_gzip(str(plain_file)) is False
+
+    def test_using_zstd_true(self, tmp_path: Path) -> None:
+        zstd_file = tmp_path / "test.zst"
+        cctx = zstd.ZstdCompressor()
+        with open(zstd_file, "wb") as f:
+            f.write(cctx.compress(b"content"))
+        assert using_zstd(str(zstd_file)) is True
+
+    def test_using_zstd_false(self, tmp_path: Path) -> None:
+        plain_file = tmp_path / "test.txt"
+        plain_file.write_text("plain text")
+        assert using_zstd(str(plain_file)) is False
+
+    def test_using_gzip_nonexistent(self, tmp_path: Path) -> None:
+        assert using_gzip(str(tmp_path / "nope")) is False
+
+    def test_using_zstd_nonexistent(self, tmp_path: Path) -> None:
+        assert using_zstd(str(tmp_path / "nope")) is False
+
+
+VALID_SAVEGAME_XML = """\
+<?xml version="1.0"?>
+<savegame>
+  <meta>
+    <modIds>
+      <li>ludeon.rimworld</li>
+      <li>brrainz.harmony</li>
+    </modIds>
+  </meta>
+</savegame>
+"""
+
+
+class TestExtractXmlPackageIds:
+    def test_extracts_package_ids(self, tmp_path: Path) -> None:
+        save_file = tmp_path / "save.rws"
+        save_file.write_text(VALID_SAVEGAME_XML)
+        result = extract_xml_package_ids(str(save_file))
+        assert result == {"ludeon.rimworld", "brrainz.harmony"}
+
+    def test_nonexistent_file_returns_empty(self, tmp_path: Path) -> None:
+        result = extract_xml_package_ids(str(tmp_path / "missing.rws"))
+        assert result == set()
+
+    def test_no_modIds_returns_empty(self, tmp_path: Path) -> None:
+        xml_file = tmp_path / "no_mods.xml"
+        xml_file.write_text("<savegame><meta></meta></savegame>")
+        result = extract_xml_package_ids(str(xml_file))
+        assert result == set()
+
+    def test_gzip_savefile(self, tmp_path: Path) -> None:
+        gz_file = tmp_path / "save.rws.gz"
+        with gzip.open(gz_file, "wb") as f:
+            f.write(VALID_SAVEGAME_XML.encode())
+        result = extract_xml_package_ids(str(gz_file))
+        assert result == {"ludeon.rimworld", "brrainz.harmony"}
+
+
+class TestFastRimworldXmlSaveValidation:
+    def test_valid_save(self, tmp_path: Path) -> None:
+        save_file = tmp_path / "save.rws"
+        save_file.write_text(VALID_SAVEGAME_XML)
+        assert fast_rimworld_xml_save_validation(str(save_file)) is True
+
+    def test_invalid_structure(self, tmp_path: Path) -> None:
+        save_file = tmp_path / "bad.rws"
+        save_file.write_text("<root><data>not a save</data></root>")
+        assert fast_rimworld_xml_save_validation(str(save_file)) is False
+
+    def test_nonexistent_file(self, tmp_path: Path) -> None:
+        assert fast_rimworld_xml_save_validation(str(tmp_path / "nope")) is False
+
+    def test_empty_modids(self, tmp_path: Path) -> None:
+        save_file = tmp_path / "empty.rws"
+        save_file.write_text("<savegame><meta><modIds></modIds></meta></savegame>")
+        assert fast_rimworld_xml_save_validation(str(save_file)) is False


### PR DESCRIPTION
## Summary

- Add 139 new tests across 8 previously-untested `app/utils/` source files
- Covers ~1,418 lines of source code with zero modifications to production code
- All tests pass in CI (0.55s total runtime)

## New test files

| Test File | Tests | Source Coverage |
|---|---:|---|
| `test_xml.py` | 33 | dict↔XML roundtrip, gzip/zstd compression, savegame validation |
| `test_mod_info.py` | 28 | ModInfo construction, `from_metadata`, version normalization |
| `test_symlink.py` | 17 | Exception hierarchy, `is_junction_or_link`, `create_symlink` |
| `test_ignore_manager.py` | 15 | Load/save/add/remove/clear CRUD with JSON fixtures |
| `test_files.py` | 14 | Glob matching, backup creation, retention cleanup |
| `test_system_info.py` | 12 | OS detection (3 platforms), architecture (6 variants), singleton |
| `test_constants.py` | 12 | Enum values, DLC metadata integrity, known mod sets |
| `test_schema.py` | 8 | Mod list generation, 3 validation formats, error handling |

## Test plan

- [x] `uv run pytest tests/utils/ -v --no-qt-log` — all 139 new tests pass
- [x] No production code modified — zero risk of behavioral regression
- [x] All pre-commit hooks pass (ruff, mypy, jscpd, markdownlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)