### PR TITLE
feat(sort): soft-deprecate alphabetical sort

### DIFF
--- a/app/controllers/sort_controller.py
+++ b/app/controllers/sort_controller.py
@@ -28,6 +28,10 @@ class Sorter:
             logger.info(f"Created sorter instance with {sort_method} sort method")
 
             if sort_method == SortMethod.ALPHABETICAL:
+                logger.warning(
+                    "Alphabetical sort is deprecated and may produce incorrect results "
+                    "with complex mod lists. Consider switching to Topological sort."
+                )
                 self.sort_method = do_alphabetical_sort
             elif sort_method == SortMethod.TOPOLOGICAL:
                 self.sort_method = do_topo_sort

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -776,6 +776,12 @@ This basically preserves your mod coloring, user notes etc. for this many second
         sort_group_box_layout.addWidget(sorting_label)
 
         self.sorting_alphabetical_radio = QRadioButton(self.tr("Alphabetically"))
+        self.sorting_alphabetical_radio.setToolTip(
+            self.tr(
+                "Alphabetical sorting may produce incorrect results with complex mod lists. "
+                "Topological sorting is recommended."
+            )
+        )
         sort_group_box_layout.addWidget(self.sorting_alphabetical_radio)
 
         self.sorting_topological_radio = QRadioButton(self.tr("Topologically"))


### PR DESCRIPTION
## Summary

- Add deprecation tooltip to the Alphabetical sorting radio button in settings: *"Alphabetical sorting may produce incorrect results with complex mod lists. Topological sorting is recommended."*
- Log `logger.warning()` when alphabetical sort is selected

## Context

Investigation of #1676 found that the alphabetical sort has no cycle detection — when conflicting load order rules from different metadata sources create dependency cycles, it silently produces incorrect results. The topological sort already detects and reports these cycles via `CircularDependencyError`. Since the topological sort also sorts alphabetically within each dependency level, it provides similar ordering with correctness guarantees.

This is a soft deprecation — the alphabetical sort option remains functional. No UI banners, no blocking, no removal.

Ref #1676

## Test plan

- [x] All 367 tests pass
- [x] Lint, format, mypy, jscpd all clean
- [x] Tooltip appears on hover over "Alphabetically" radio button in settings
- [x] Warning logged when alphabetical sort is selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)