### PR TITLE
chore: rename Check Dependencies button to Add Missing Dependencies to clarify what it actually does.

### DIFF
--- a/app/controllers/main_window_controller.py
+++ b/app/controllers/main_window_controller.py
@@ -47,9 +47,9 @@ class MainWindowController(QObject):
         ):
             button.clicked.connect(signal.emit)
 
-        # Connect check dependencies signal from mods panel
-        self.main_window.main_content_panel.mods_panel.check_dependencies_signal.connect(
-            self.check_dependencies
+        # Connect add missing dependencies signal from mods panel
+        self.main_window.main_content_panel.mods_panel.add_missing_dependencies_signal.connect(
+            self.add_missing_dependencies
         )
 
         # Connect EventBus signals to slots
@@ -96,7 +96,7 @@ class MainWindowController(QObject):
                     return self._parse_workshop_id(workshop_url.text)
         return None
 
-    def check_dependencies(self) -> None:
+    def add_missing_dependencies(self) -> None:
         # Get the active mods list (exclude dividers)
         active_mods = {
             u

--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -3958,7 +3958,7 @@ class ModsPanel(QWidget):
 
     list_updated_signal = Signal()
     save_btn_animation_signal = Signal()
-    check_dependencies_signal = Signal()
+    add_missing_dependencies_signal = Signal()
 
     # OPTIMIZATION: Class-level constant for sort text to enum mapping
     # Centralizes the text->enum conversion logic
@@ -4083,14 +4083,21 @@ class ModsPanel(QWidget):
         )
         self.button_panel.addWidget(self.use_this_instead_button)
 
-        # Create and add Check Dependencies button
-        self.check_dependencies_button: QPushButton = QPushButton(
-            self.tr("Check Dependencies")
+        # Create and add Add Missing Dependencies button
+        self.add_missing_dependencies_button: QPushButton = QPushButton(
+            self.tr("Add Missing Dependencies")
         )
-        self.check_dependencies_button.setObjectName("CheckDependenciesButton")
-        self.button_panel.addWidget(self.check_dependencies_button)
-        self.check_dependencies_button.clicked.connect(
-            self.check_dependencies_signal.emit
+        self.add_missing_dependencies_button.setToolTip(
+            self.tr(
+                "Find and resolve missing mod dependencies by activating local mods or downloading from Steam Workshop"
+            )
+        )
+        self.add_missing_dependencies_button.setObjectName(
+            "AddMissingDependenciesButton"
+        )
+        self.button_panel.addWidget(self.add_missing_dependencies_button)
+        self.add_missing_dependencies_button.clicked.connect(
+            self.add_missing_dependencies_signal.emit
         )
         self.button_panel_frame.setLayout(self.button_panel)
 

--- a/locales/de_DE.ts
+++ b/locales/de_DE.ts
@@ -3259,8 +3259,8 @@ Alternative Dependencies:</source>
         <translation>Farbe</translation>
     </message>
     <message>
-        <source>Check Dependencies</source>
-        <translation>Überprüfen Sie die Abhängigkeiten</translation>
+        <source>Add Missing Dependencies</source>
+        <translation type="unfinished">Überprüfen Sie die Abhängigkeiten</translation>
     </message>
     <message>
         <source>Active</source>

--- a/locales/en_US.ts
+++ b/locales/en_US.ts
@@ -3137,7 +3137,7 @@ Alternative Dependencies:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Check Dependencies</source>
+        <source>Add Missing Dependencies</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/locales/es_ES.ts
+++ b/locales/es_ES.ts
@@ -3220,8 +3220,8 @@ Alternative Dependencies:</source>
         <translation>Color</translation>
     </message>
     <message>
-        <source>Check Dependencies</source>
-        <translation>Comprobar dependencias</translation>
+        <source>Add Missing Dependencies</source>
+        <translation type="unfinished">Comprobar dependencias</translation>
     </message>
     <message>
         <source>Active</source>

--- a/locales/fr_FR.ts
+++ b/locales/fr_FR.ts
@@ -3259,8 +3259,8 @@ Alternative Dependencies:</source>
         <translation>Couleur</translation>
     </message>
     <message>
-        <source>Check Dependencies</source>
-        <translation>Vérifier les dépendances</translation>
+        <source>Add Missing Dependencies</source>
+        <translation type="unfinished">Vérifier les dépendances</translation>
     </message>
     <message>
         <source>Active</source>

--- a/locales/ja_JP.ts
+++ b/locales/ja_JP.ts
@@ -3277,8 +3277,8 @@ Alternative Dependencies:</source>
         <translation>色</translation>
     </message>
     <message>
-        <source>Check Dependencies</source>
-        <translation>依存関係を確認</translation>
+        <source>Add Missing Dependencies</source>
+        <translation type="unfinished">依存関係を確認</translation>
     </message>
     <message>
         <source>Active</source>

--- a/locales/ko_KR.ts
+++ b/locales/ko_KR.ts
@@ -3277,8 +3277,8 @@ Alternative Dependencies:</source>
         <translation>색상</translation>
     </message>
     <message>
-        <source>Check Dependencies</source>
-        <translation>의존성 확인</translation>
+        <source>Add Missing Dependencies</source>
+        <translation type="unfinished">의존성 확인</translation>
     </message>
     <message>
         <source>Active</source>

--- a/locales/pt_BR.ts
+++ b/locales/pt_BR.ts
@@ -3244,8 +3244,8 @@ Um mod alternativo atualizado é recomendado:
         <translation>Cor</translation>
     </message>
     <message>
-        <source>Check Dependencies</source>
-        <translation>Verificar Dependências</translation>
+        <source>Add Missing Dependencies</source>
+        <translation type="unfinished">Verificar Dependências</translation>
     </message>
     <message>
         <source>Active</source>

--- a/locales/ru_RU.ts
+++ b/locales/ru_RU.ts
@@ -3274,8 +3274,8 @@ Alternative Dependencies:</source>
         <translation>Цвет</translation>
     </message>
     <message>
-        <source>Check Dependencies</source>
-        <translation>Проверьте зависимости</translation>
+        <source>Add Missing Dependencies</source>
+        <translation type="unfinished">Проверьте зависимости</translation>
     </message>
     <message>
         <source>Active</source>

--- a/locales/tr_TR.ts
+++ b/locales/tr_TR.ts
@@ -3225,8 +3225,8 @@ An alternative updated mod is recommended:
         <translation>Renk</translation>
     </message>
     <message>
-        <source>Check Dependencies</source>
-        <translation>Gerekli Modları Kontrol Et</translation>
+        <source>Add Missing Dependencies</source>
+        <translation type="unfinished">Gerekli Modları Kontrol Et</translation>
     </message>
     <message>
         <source>Active</source>

--- a/locales/zh_CN.ts
+++ b/locales/zh_CN.ts
@@ -3254,8 +3254,8 @@ Alternative Dependencies:</source>
         <translation>查看"替代为此"数据库</translation>
     </message>
     <message>
-        <source>Check Dependencies</source>
-        <translation>查看依赖</translation>
+        <source>Add Missing Dependencies</source>
+        <translation type="unfinished">查看依赖</translation>
     </message>
     <message>
         <source>Active</source>

--- a/locales/zh_TW.ts
+++ b/locales/zh_TW.ts
@@ -3243,8 +3243,8 @@ Alternative Dependencies:</source>
         <translation>檢查『改用此項』資料庫</translation>
     </message>
     <message>
-        <source>Check Dependencies</source>
-        <translation>檢查依賴項</translation>
+        <source>Add Missing Dependencies</source>
+        <translation type="unfinished">檢查依賴項</translation>
     </message>
     <message>
         <source>Active</source>


### PR DESCRIPTION
## Summary

Closes #2035

- Rename "Check Dependencies" button to "Add Missing Dependencies" to accurately reflect its behavior (it finds and resolves missing deps, not just checks them)
- Add tooltip: "Find and resolve missing mod dependencies by activating local mods or downloading from Steam Workshop"
- Rename internal identifiers (signal, variable, object name, handler method) for consistency
- Update source strings in all 11 translation `.ts` files, preserving existing translations as `type="unfinished"` for translator review

## Test Plan

- [x] All 367 tests pass
- [x] `just check` passes (ruff, mypy, jscpd, shfmt, markdownlint)
- [x] No stale `check_dependencies_signal`/`check_dependencies_button`/`CheckDependenciesButton` references remain in `app/`
- [x] No stale `Check Dependencies` source strings remain in `locales/`
- [x] `check_dependencies_on_sort` setting (separate concept) is untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)