### PR TITLE
test(infra): add shared Qt test fixtures and migrate existing tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 import subprocess
 from typing import Any, Generator, Union
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from PySide6.QtCore import QCoreApplication
@@ -57,3 +57,113 @@ def qapp() -> Generator[Union[QApplication, QCoreApplication], None, None]:
     if app is None:
         app = QApplication([])
     yield app
+
+
+@pytest.fixture(autouse=True)
+def mock_app_info(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Generator[None, None, None]:
+    """Redirect all AppInfo paths to a temp dir to prevent filesystem side effects.
+
+    Uses ``tmp_path_factory`` instead of ``tmp_path`` so the mock's
+    directories live in a *separate* temp folder, leaving the per-test
+    ``tmp_path`` completely empty for tests that need it (e.g. git clone).
+
+    Creates a real ``AppInfo`` instance (bypassing ``__init__``) so that
+    @property descriptors on the class are preserved.  This lets tests
+    override individual properties with ``PropertyMock`` as usual.
+    """
+    from app.utils.app_info import AppInfo
+
+    original_instance = AppInfo._instance
+
+    base = tmp_path_factory.mktemp("mock_app_info")
+
+    storage = base / "app_storage"
+    storage.mkdir()
+    logs = base / "logs"
+    logs.mkdir()
+
+    # Build a real AppInfo without running __init__ (which reads
+    # version.xml, creates platform dirs, etc.).
+    stub = object.__new__(AppInfo)
+    stub._is_initialized = True
+    stub._app_name = "RimSort"
+    stub._app_version = "0.0.0-test"
+    stub._app_copyright = ""
+    stub._application_folder = base / "app"
+    stub._app_storage_folder = storage
+    stub._user_log_folder = logs
+    stub._databases_folder = storage / "dbs"
+    stub._saved_modlists_folder = storage / "modlists"
+    stub._theme_data_folder = base / "app" / "themes"
+    stub._theme_storage_folder = storage / "themes"
+    stub._settings_file = storage / "settings.json"
+    stub._user_rules_file = storage / "dbs" / "userRules.json"
+    stub._ignore_mods_file = storage / "dbs" / "ignore.json"
+    stub._language_data_folder = base / "app" / "locales"
+    stub._backups_folder = storage / "backups"
+    stub._settings_backups_folder = storage / "backups" / "settings"
+    stub._game_saves_backups_folder = storage / "backups" / "saves"
+    stub._application_backups_folder = storage / "backups" / "rimsort_installation"
+    stub._browser_profile_folder = storage / "browser"
+    stub._setup_web_channel_script_file = base / "app" / "setup_web_channel_script.js"
+
+    stub._databases_folder.mkdir(parents=True, exist_ok=True)
+    (base / "app" / "themes").mkdir(parents=True, exist_ok=True)
+
+    AppInfo._instance = stub
+
+    yield
+
+    AppInfo._instance = original_instance
+
+
+@pytest.fixture
+def fresh_event_bus() -> Generator[None, None, None]:
+    """Reset the EventBus singleton so each test gets a clean instance."""
+    from app.utils.event_bus import EventBus
+
+    original_instance = EventBus._instance
+    EventBus._instance = None
+
+    yield
+
+    EventBus._instance = original_instance
+
+
+@pytest.fixture
+def mock_metadata_manager(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Patch MetadataManager.instance() to return a lightweight mock."""
+    from app.utils.metadata import MetadataManager
+
+    manager = MagicMock(spec=MetadataManager)
+    manager.internal_local_metadata = {}
+    manager.external_steam_metadata = {}
+    manager.external_community_rules = {}
+    manager.game_version = "1.5"
+    manager.mod_metadata_dir_mapper = {}
+
+    monkeypatch.setattr(
+        MetadataManager,
+        "instance",
+        classmethod(lambda cls: manager),
+    )
+    return manager
+
+
+@pytest.fixture
+def mock_steamcmd_interface(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Patch SteamcmdInterface.instance() to return a lightweight mock."""
+    from app.utils.steam.steamcmd.wrapper import SteamcmdInterface
+
+    mock_steamcmd = MagicMock(spec=SteamcmdInterface)
+    mock_steamcmd.setup = True
+    mock_steamcmd.steamcmd_appworkshop_acf_path = ""
+
+    monkeypatch.setattr(
+        SteamcmdInterface,
+        "instance",
+        classmethod(lambda cls: mock_steamcmd),
+    )
+    return mock_steamcmd

--- a/tests/views/conftest.py
+++ b/tests/views/conftest.py
@@ -1,0 +1,90 @@
+"""Shared fixtures for view and widget tests."""
+
+import uuid as uuid_module
+from typing import Any, Union
+from unittest.mock import MagicMock
+
+import pytest
+from PySide6.QtCore import QCoreApplication, QObject
+from PySide6.QtGui import QColor
+from PySide6.QtWidgets import QApplication
+
+from app.controllers.settings_controller import SettingsController
+from app.models.instance import Instance
+from app.models.settings import Settings
+
+
+@pytest.fixture
+def mock_settings_controller(
+    tmp_path: Any,
+    mock_app_info: None,
+    qapp: Union[QApplication, QCoreApplication],
+) -> MagicMock:
+    """MagicMock(spec=SettingsController) with a real Settings model."""
+    settings = Settings()
+
+    instance = Instance(
+        name="Default",
+        game_folder=str(tmp_path / "game"),
+        config_folder=str(tmp_path / "config"),
+        local_folder=str(tmp_path / "local_mods"),
+        workshop_folder=str(tmp_path / "workshop"),
+    )
+    QObject.__setattr__(settings, "instances", {"Default": instance})
+    QObject.__setattr__(settings, "current_instance", "Default")
+
+    controller = MagicMock(spec=SettingsController)
+    controller.settings = settings
+    controller.active_instance = instance
+    return controller
+
+
+def make_mod_data(
+    name: str = "Test Mod",
+    package_id: str = "test.author.testmod",
+    uuid: str | None = None,
+    data_source: str = "local",
+    authors: str = "Test Author",
+    path: str = "/fake/mods/TestMod",
+    publishedfileid: str = "",
+    version: str = "1.0",
+    supported_versions: list[str] | None = None,
+    dependencies: list[Any] | None = None,
+    load_after: list[Any] | None = None,
+    load_before: list[Any] | None = None,
+    incompatibilities: list[str] | None = None,
+    csharp: bool | None = None,
+    git_repo: bool = False,
+    steamcmd: bool = False,
+    invalid: bool = False,
+    url: str = "",
+    description: str = "A test mod.",
+    mod_color: QColor | None = None,
+) -> dict[str, Any]:
+    """Factory for mod metadata dicts matching the internal_local_metadata structure."""
+    if uuid is None:
+        uuid = str(uuid_module.uuid4())
+
+    return {
+        "uuid": uuid,
+        "name": name,
+        "packageid": package_id,
+        "authors": authors,
+        "path": path,
+        "data_source": data_source,
+        "publishedfileid": publishedfileid,
+        "version": version,
+        "supported_versions": supported_versions or ["1.5"],
+        "dependencies": dependencies or [],
+        "loadTheseBefore": load_before or [],
+        "loadTheseAfter": load_after or [],
+        "incompatibilities": incompatibilities or [],
+        "csharp": csharp,
+        "git_repo": git_repo,
+        "steamcmd": steamcmd,
+        "invalid": invalid,
+        "url": url,
+        "description": description,
+        "mod_color": mod_color,
+        "alternative": None,
+    }

--- a/tests/views/conftest.py
+++ b/tests/views/conftest.py
@@ -18,6 +18,7 @@ from app.models.settings import Settings
 def mock_settings_controller(
     tmp_path: Any,
     mock_app_info: None,
+    fresh_event_bus: None,
     qapp: Union[QApplication, QCoreApplication],
 ) -> MagicMock:
     """MagicMock(spec=SettingsController) with a real Settings model."""

--- a/tests/views/test_deletion_menu.py
+++ b/tests/views/test_deletion_menu.py
@@ -4,30 +4,10 @@ from typing import Any, Dict, Union
 from unittest.mock import MagicMock, patch
 
 import pytest
-from PySide6.QtCore import QCoreApplication
+from PySide6.QtCore import QCoreApplication, QObject
 from PySide6.QtWidgets import QApplication
 
-from app.controllers.settings_controller import SettingsController
-from app.utils.metadata import MetadataManager
 from app.views.deletion_menu import DeletionResult, ModDeletionMenu
-
-
-@pytest.fixture
-def mock_settings_controller() -> MagicMock:
-    """Mock SettingsController."""
-    controller = MagicMock(spec=SettingsController)
-    controller.settings = MagicMock()
-    controller.settings.aux_db_time_limit = 1  # Enable DB operations
-    controller.settings.current_instance_path = "/fake/path"
-    return controller
-
-
-@pytest.fixture
-def mock_metadata_manager() -> MagicMock:
-    """Mock MetadataManager."""
-    manager = MagicMock(spec=MetadataManager)
-    manager.instance.return_value = manager
-    return manager
 
 
 @pytest.fixture
@@ -49,16 +29,14 @@ def deletion_menu(
     qapp: Union[QApplication, QCoreApplication],
 ) -> ModDeletionMenu:
     """Create a ModDeletionMenu instance for testing."""
-    with patch(
-        "app.views.deletion_menu.MetadataManager.instance",
-        return_value=mock_metadata_manager,
-    ):
-        menu = ModDeletionMenu(
-            settings_controller=mock_settings_controller,
-            get_selected_mod_metadata=lambda: [],
-            menu_title="Test Menu",
-        )
-        return menu
+    # The shared fixture defaults aux_db_time_limit to -1; override to enable DB ops.
+    QObject.__setattr__(mock_settings_controller.settings, "aux_db_time_limit", 1)
+    menu = ModDeletionMenu(
+        settings_controller=mock_settings_controller,
+        get_selected_mod_metadata=lambda: [],
+        menu_title="Test Menu",
+    )
+    return menu
 
 
 class TestDeletionResult:

--- a/tests/views/test_main_content_run.py
+++ b/tests/views/test_main_content_run.py
@@ -1,52 +1,14 @@
 # tests/views/test_main_content_run.py
 from pathlib import Path
-from types import SimpleNamespace
 from typing import Generator, List, Tuple
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock
 
 import pytest
+from PySide6.QtCore import QObject
 from PySide6.QtWidgets import QApplication, QMessageBox
 
-import app.utils.metadata as metadata
-import app.utils.steam.steamcmd.wrapper as steamcmd_wrapper
 import app.views.dialogue as dialogue
 from app.views.main_content_panel import MainContent
-
-
-# Dummy settings and controller to initialize MainContent
-class DummySettings:
-    def __init__(self) -> None:
-        self.current_instance = "inst1"
-        # Mod list options
-        self.try_download_missing_mods = True
-        self.duplicate_mods_warning = True
-        self.mod_type_filter = True
-        self.hide_invalid_mods_when_filtering = False
-        self.backup_saves_on_launch = False
-        self.auto_run_todds_before_launch = False
-        # Inactive mods sort settings
-        self.inactive_mods_sorting = True
-        self.save_inactive_mods_sort_state = False
-        self.inactive_mods_sort_key = "FILESYSTEM_MODIFIED_TIME"
-        self.inactive_mods_sort_descending = True
-        self.active_mods_data_source_filter_index = 0
-        self.inactive_mods_data_source_filter_index = 0
-        self.active_mods_dividers: list[dict[str, object]] = []
-        # Instance data with dummy game_folder, config_folder and run_args
-        self.instances = {
-            "inst1": SimpleNamespace(
-                game_folder="/fake/path",
-                config_folder="/fake/config",
-                run_args="--test",
-                steam_client_integration=False,
-                launch_via_steam_protocol=False,
-            )
-        }
-
-
-class DummySettingsController:
-    def __init__(self) -> None:
-        self.settings = DummySettings()
 
 
 @pytest.fixture(autouse=True)
@@ -75,39 +37,22 @@ def patch_launch(monkeypatch: pytest.MonkeyPatch) -> List[Tuple[Path, str]]:
     return calls
 
 
-@pytest.fixture(autouse=True)
-def patch_steamcmd(monkeypatch: pytest.MonkeyPatch) -> None:
-    # Prevent SteamcmdInterface __init__ requiring args
-    monkeypatch.setattr(
-        steamcmd_wrapper.SteamcmdInterface,
-        "instance",
-        classmethod(
-            lambda cls: SimpleNamespace(setup=True, steamcmd_appworkshop_acf_path="")
-        ),
-    )
-
-
-@pytest.fixture(autouse=True)
-def patch_metadata_manager(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Patch MetadataManager to avoid initialization issues."""
-    # Create a mock MetadataManager instance
-    mock_metadata_manager = Mock()
-
-    # Patch the MetadataManager.instance method
-    monkeypatch.setattr(
-        metadata.MetadataManager,
-        "instance",
-        classmethod(lambda cls: mock_metadata_manager),
-    )
-
-
 @pytest.fixture
 def main_content(
-    monkeypatch: pytest.MonkeyPatch, qapp: QApplication
+    monkeypatch: pytest.MonkeyPatch,
+    qapp: QApplication,
+    mock_settings_controller: MagicMock,
+    mock_metadata_manager: MagicMock,
+    mock_steamcmd_interface: MagicMock,
 ) -> Generator[Tuple[MainContent, List[bool]], None, None]:
-    # Initialize MainContent with dummy settings
-    sc = DummySettingsController()
-    mc = MainContent(sc)  # type: ignore[arg-type]
+    # Ensure active_mods_dividers is set on the settings object
+    QObject.__setattr__(mock_settings_controller.settings, "active_mods_dividers", [])
+    # Set game_folder and run_args on the instance to match test expectations
+    instance = mock_settings_controller.settings.instances["Default"]
+    instance.game_folder = "/fake/path"
+    instance.run_args = "--test"
+    # Initialize MainContent with the shared mock settings controller
+    mc = MainContent(mock_settings_controller)
     # Patch _do_save to capture calls
     save_calls: List[bool] = []
     monkeypatch.setattr(mc, "_do_save", lambda: save_calls.append(True))

--- a/tests/views/test_menu_bar.py
+++ b/tests/views/test_menu_bar.py
@@ -3,24 +3,11 @@ from typing import Union
 from unittest.mock import MagicMock, patch
 
 import pytest
-from PySide6.QtCore import QCoreApplication
+from PySide6.QtCore import QCoreApplication, QObject
 from PySide6.QtWidgets import QApplication, QMenuBar
 
 from app.controllers.menu_bar_controller import MenuBarController
-from app.controllers.settings_controller import SettingsController
 from app.views.menu_bar import MenuBar
-
-
-@pytest.fixture
-def mock_settings_controller() -> MagicMock:
-    """Mock SettingsController."""
-    controller = MagicMock(spec=SettingsController)
-    controller.settings = MagicMock()
-    controller.settings.check_for_update_startup = False
-    controller.settings.text_editor_location = None
-    controller.settings.instances = {"Default": MagicMock()}
-    controller.settings.current_instance = "Default"
-    return controller
 
 
 @pytest.fixture
@@ -29,6 +16,9 @@ def menu_bar_instance(
     qapp: Union[QApplication, QCoreApplication],
 ) -> MenuBar:
     """Create a MenuBar instance for testing."""
+    QObject.__setattr__(
+        mock_settings_controller.settings, "check_for_update_startup", False
+    )
     qt_menu_bar = QMenuBar()
     menu_bar = MenuBar(qt_menu_bar, mock_settings_controller)
     return menu_bar


### PR DESCRIPTION
## Summary

- Add shared pytest-qt fixtures (`mock_app_info`, `fresh_event_bus`, `mock_metadata_manager`, `mock_steamcmd_interface`, `mock_settings_controller`, `make_mod_data`) to eliminate fixture duplication across test files
- Migrate `test_deletion_menu.py`, `test_menu_bar.py`, and `test_main_content_run.py` to use the shared fixtures
- Foundation for upcoming Qt UI test expansion (Phase 0 of [design spec](docs/superpowers/specs/2026-05-31-qt-ui-test-expansion-design.md))

### Shared fixtures added

| Fixture | Scope | autouse | Purpose |
|---------|-------|---------|---------|
| `mock_app_info` | `tests/conftest.py` | Yes | Redirects all `AppInfo` paths to temp dirs, preventing filesystem side effects |
| `fresh_event_bus` | `tests/conftest.py` | No | Resets the `EventBus` singleton for tests that need clean signal state |
| `mock_metadata_manager` | `tests/conftest.py` | No | Patches `MetadataManager.instance()` to avoid heavy init chain |
| `mock_steamcmd_interface` | `tests/conftest.py` | No | Patches `SteamcmdInterface.instance()` to avoid filesystem/network ops |
| `mock_settings_controller` | `tests/views/conftest.py` | No | `MagicMock(spec=SettingsController)` with a real `Settings` model |
| `make_mod_data` | `tests/views/conftest.py` | N/A | Factory function for mod metadata dicts (not a fixture) |

### Key design decisions

- `mock_app_info` uses `object.__new__(AppInfo)` to create a real AppInfo stub (not MagicMock) — preserves `@property` descriptor resolution
- `mock_settings_controller` uses `QObject.__setattr__` to bypass `Settings.__setattr__` which emits `EventBus().settings_have_changed` on every mutation (`object.__setattr__` crashes on QObject subclasses due to shiboken's `tp_setattro`)
- `mock_settings_controller` depends on `fresh_event_bus` because `Settings.__init__` sets ~30 public attributes, each triggering EventBus signal emission

### Net change: +230 / -116 lines (eliminated duplication)

## Test plan

- [x] All 367 existing tests pass
- [x] `just check` passes (ruff, ruff-format, mypy, pyright, jscpd, shfmt, markdownlint)
- [x] Migrated test files pass in both execution orders (no test pollution)
- [x] No new test cases — purely infrastructure refactoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)