### PR TITLE
feat: Rewrite dependency checking to show full overview per mod

### DIFF
--- a/app/controllers/main_window_controller.py
+++ b/app/controllers/main_window_controller.py
@@ -104,14 +104,23 @@ class MainWindowController(QObject):
             if not is_divider_uuid(u)
         }
 
-        # Create a dictionary to store missing dependencies
-        missing_deps: dict[str, set[str]] = {}
-
         # Precompute active package IDs for quick lookup
         active_ids = {
             self.metadata_manager.internal_local_metadata[u].get("packageid")
             for u in active_mods
         }
+
+        # Build a full deps summary and missing deps dict
+        deps_summary: dict[str, dict[str, set[str]]] = {}
+        missing_deps: dict[str, set[str]] = {}
+
+        # Precompute all local package IDs (for "local" classification)
+        all_local_package_ids = {
+            mod_data.get("packageid")
+            for mod_data in self.metadata_manager.internal_local_metadata.values()
+        }
+
+        consider_alternatives = self.metadata_manager.settings_controller.settings.use_alternative_package_ids_as_satisfying_dependencies
 
         # Check each active mod's dependencies
         for uuid in active_mods:
@@ -125,10 +134,12 @@ class MainWindowController(QObject):
             if not dependencies:
                 continue
 
+            satisfied: set[str] = set()
+            local: set[str] = set()
+            download: set[str] = set()
+
             # Check each dependency, honoring alternativePackageIds
             # E.g. [], ['brrainz.harmony'], [('oels.vehiclemapframework', {'alternatives': {'oels.vehiclemapframework.dev'}})]
-            missing = set()
-            consider_alternatives = self.metadata_manager.settings_controller.settings.use_alternative_package_ids_as_satisfying_dependencies
             for dep in dependencies:
                 if isinstance(dep, tuple):
                     dep_id = dep[0]
@@ -143,226 +154,230 @@ class MainWindowController(QObject):
                     dep_id = dep
                     alt_ids = set()
 
-                # Check if the dependency is in the active mods list; optionally consider alternatives
-                satisfied = dep_id in active_ids
-                if not satisfied and consider_alternatives:
-                    satisfied = any(alt in active_ids for alt in alt_ids)
-                if not satisfied:
-                    missing.add(dep_id)
+                # Check if the dependency is satisfied (in active mods)
+                is_satisfied = dep_id in active_ids
+                if not is_satisfied and consider_alternatives:
+                    is_satisfied = any(alt in active_ids for alt in alt_ids)
 
-            if missing:
-                missing_deps[mod_id] = missing
+                if is_satisfied:
+                    satisfied.add(dep_id)
+                else:
+                    # Classify missing deps: local vs download
+                    is_local = dep_id in all_local_package_ids or (
+                        consider_alternatives
+                        and any(alt in all_local_package_ids for alt in alt_ids)
+                    )
+                    if is_local:
+                        local.add(dep_id)
+                    else:
+                        download.add(dep_id)
 
-        if missing_deps:
-            # Show the missing dependencies dialog
-            dialog = MissingDependenciesDialog(self.main_window)
-            selected_deps = dialog.show_dialog(missing_deps)
+            deps_summary[mod_id] = {
+                "satisfied": satisfied,
+                "local": local,
+                "download": download,
+            }
 
-            if selected_deps:
-                # Create lists to track local mods and mods that need to be downloaded
-                local_mods = []
-                mods_to_download = []
+            if local or download:
+                missing_deps[mod_id] = local | download
 
-                # Check each selected dependency
-                for dep_id in selected_deps:
-                    # First check if it exists locally
-                    found_locally = False
-                    for (
-                        mod_data
-                    ) in self.metadata_manager.internal_local_metadata.values():
-                        if mod_data.get("packageid") == dep_id:
-                            local_mods.append(dep_id)
-                            found_locally = True
-                            break
+        # Always show the dialog (even if no missing deps)
+        dialog = MissingDependenciesDialog(self.main_window)
+        selected_deps = dialog.show_dialog(deps_summary, missing_deps)
 
-                    if not found_locally:
-                        # If not found locally, we need to find its Workshop ID
-                        # First check if we have it in our Steam metadata
-                        workshop_id = None
-                        if self.metadata_manager.external_steam_metadata:
-                            for (
-                                pfid,
-                                metadata,
-                            ) in self.metadata_manager.external_steam_metadata.items():
-                                if (
-                                    metadata.get("packageId", "").lower()
-                                    == dep_id.lower()
-                                ):
-                                    workshop_id = pfid
-                                    break
+        if not missing_deps:
+            # No missing deps at all - user was shown an informational dialog
+            logger.info("No missing dependencies found.")
+            return
 
-                        if workshop_id:
-                            mods_to_download.append(workshop_id)
-                        else:
-                            # If not in Steam metadata, try to find it in the mod's About.xml
-                            # search through all active mods' About.xml files
-                            for active_uuid in active_mods:
-                                active_mod_data = (
-                                    self.metadata_manager.internal_local_metadata[
-                                        active_uuid
-                                    ]
-                                )
-                                mod_path = active_mod_data.get("path")
-                                if not mod_path:
-                                    continue
+        if selected_deps:
+            # Create lists to track local mods and mods that need to be downloaded
+            local_mods = []
+            mods_to_download = []
 
-                                about_path = os.path.join(
-                                    mod_path, "About", "About.xml"
-                                )
-                                if os.path.exists(about_path):
-                                    try:
-                                        import xml.etree.ElementTree as ET
+            # Check each selected dependency
+            for dep_id in selected_deps:
+                # First check if it exists locally
+                found_locally = False
+                for mod_data in self.metadata_manager.internal_local_metadata.values():
+                    if mod_data.get("packageid") == dep_id:
+                        local_mods.append(dep_id)
+                        found_locally = True
+                        break
 
-                                        tree = ET.parse(about_path)
-                                        root = tree.getroot()
-
-                                        prefer_versioned = False
-                                        try:
-                                            prefer_versioned = self.metadata_manager.settings_controller.settings.prefer_versioned_about_tags
-                                        except Exception:
-                                            prefer_versioned = False
-
-                                        # First check versioned deps if preference enabled
-                                        # ByVersion precedence here mirrors MetadataManager.compile_metadata:
-                                        # - If ON and matching version key exists:
-                                        #   * empty → suppress base (no fallback)
-                                        #   * non-empty → use versioned only (no additive merge)
-                                        # - If ON and no matching key → fall back to base
-                                        # - If OFF → skip ByVersion entirely and use base only
-                                        used_versioned = False
-                                        if prefer_versioned:
-                                            try:
-                                                major, minor = (
-                                                    self.metadata_manager.game_version.split(
-                                                        "."
-                                                    )[:2]
-                                                )
-                                                target_keys = [
-                                                    f"v{major}.{minor}",
-                                                    f"{major}.{minor}",
-                                                ]
-                                            except Exception:
-                                                target_keys = []
-
-                                            deps_by_version = root.find(
-                                                "modDependenciesByVersion"
-                                            )
-                                            if (
-                                                deps_by_version is not None
-                                                and target_keys
-                                            ):
-                                                # Try exact matches, then prefix matches
-                                                candidate = None
-                                                for child in list(deps_by_version):
-                                                    if child.tag in target_keys:
-                                                        candidate = child
-                                                        break
-                                                if candidate is None:
-                                                    for child in list(deps_by_version):
-                                                        if any(
-                                                            child.tag.startswith(k)
-                                                            for k in target_keys
-                                                            if k
-                                                        ):
-                                                            candidate = child
-                                                            break
-
-                                                if candidate is not None:
-                                                    used_versioned = True
-                                                    lis = candidate.findall("li")
-                                                    if not lis:
-                                                        logger.debug(
-                                                            f"Prefer versioned tags: {candidate.tag} is present but empty; suppressing base modDependencies for {about_path}"
-                                                        )
-                                                    else:
-                                                        logger.debug(
-                                                            f"Prefer versioned tags: using dependencies from {candidate.tag} in {about_path}"
-                                                        )
-                                                        workshop_id = self._find_workshop_id_in_deps(
-                                                            candidate, dep_id
-                                                        )
-                                                        if workshop_id:
-                                                            mods_to_download.append(
-                                                                workshop_id
-                                                            )
-                                                            break
-
-                                        if used_versioned:
-                                            # If versioned key existed (even if empty), don't fall back to base
-                                            pass
-                                        else:
-                                            # Fall back to base modDependencies
-                                            deps = root.find("modDependencies")
-                                            if deps is None:
-                                                continue
-
-                                            workshop_id = (
-                                                self._find_workshop_id_in_deps(
-                                                    deps, dep_id
-                                                )
-                                            )
-                                            if workshop_id:
-                                                mods_to_download.append(workshop_id)
-                                                break
-                                        if workshop_id:
-                                            break  # Found the workshop ID, no need to check other mods
-                                    except Exception:
-                                        continue
-
-                # First add any local mods to the active list
-                if local_mods:
-                    for mod_id in local_mods:
-                        # Find the UUID for this package ID
+                if not found_locally:
+                    # If not found locally, we need to find its Workshop ID
+                    # First check if we have it in our Steam metadata
+                    workshop_id = None
+                    if self.metadata_manager.external_steam_metadata:
                         for (
-                            uuid,
-                            mod_data,
-                        ) in self.metadata_manager.internal_local_metadata.items():
-                            if mod_data.get("packageid") == mod_id:
-                                active_mods.add(uuid)
+                            pfid,
+                            metadata,
+                        ) in self.metadata_manager.external_steam_metadata.items():
+                            if metadata.get("packageId", "").lower() == dep_id.lower():
+                                workshop_id = pfid
                                 break
 
-                    # Update the active mods list with local mods
-                    self.main_window.main_content_panel.mods_panel.active_mods_list.uuids = list(
-                        active_mods
-                    )
-
-                # If there are mods to download, check SteamCMD setup first
-                if mods_to_download:
-                    # Check if SteamCMD is set up
-                    steamcmd_wrapper = (
-                        self.main_window.main_content_panel.steamcmd_wrapper
-                    )
-
-                    if not steamcmd_wrapper.setup:
-                        # Set up SteamCMD first
-                        self.main_window.main_content_panel._do_setup_steamcmd()
-                        # After setup, try downloading again if setup was successful
-                        if steamcmd_wrapper.setup:
-                            self.main_window.main_content_panel._do_download_mods_with_steamcmd(
-                                mods_to_download
-                            )
-                            # Don't sort yet - let the download completion handler do it
-                            return
-                        else:
-                            # Sort what we have so far
-                            self.main_window.main_content_panel._do_sort(
-                                check_deps=False
-                            )
+                    if workshop_id:
+                        mods_to_download.append(workshop_id)
                     else:
-                        # SteamCMD is already set up, proceed with download
+                        # If not in Steam metadata, try to find it in the mod's About.xml
+                        # search through all active mods' About.xml files
+                        for active_uuid in active_mods:
+                            active_mod_data = (
+                                self.metadata_manager.internal_local_metadata[
+                                    active_uuid
+                                ]
+                            )
+                            mod_path = active_mod_data.get("path")
+                            if not mod_path:
+                                continue
+
+                            about_path = os.path.join(mod_path, "About", "About.xml")
+                            if os.path.exists(about_path):
+                                try:
+                                    import xml.etree.ElementTree as ET
+
+                                    tree = ET.parse(about_path)
+                                    root = tree.getroot()
+
+                                    prefer_versioned = False
+                                    try:
+                                        prefer_versioned = self.metadata_manager.settings_controller.settings.prefer_versioned_about_tags
+                                    except Exception:
+                                        prefer_versioned = False
+
+                                    # First check versioned deps if preference enabled
+                                    # ByVersion precedence here mirrors MetadataManager.compile_metadata:
+                                    # - If ON and matching version key exists:
+                                    #   * empty -> suppress base (no fallback)
+                                    #   * non-empty -> use versioned only (no additive merge)
+                                    # - If ON and no matching key -> fall back to base
+                                    # - If OFF -> skip ByVersion entirely and use base only
+                                    used_versioned = False
+                                    if prefer_versioned:
+                                        try:
+                                            major, minor = (
+                                                self.metadata_manager.game_version.split(
+                                                    "."
+                                                )[:2]
+                                            )
+                                            target_keys = [
+                                                f"v{major}.{minor}",
+                                                f"{major}.{minor}",
+                                            ]
+                                        except Exception:
+                                            target_keys = []
+
+                                        deps_by_version = root.find(
+                                            "modDependenciesByVersion"
+                                        )
+                                        if deps_by_version is not None and target_keys:
+                                            # Try exact matches, then prefix matches
+                                            candidate = None
+                                            for child in list(deps_by_version):
+                                                if child.tag in target_keys:
+                                                    candidate = child
+                                                    break
+                                            if candidate is None:
+                                                for child in list(deps_by_version):
+                                                    if any(
+                                                        child.tag.startswith(k)
+                                                        for k in target_keys
+                                                        if k
+                                                    ):
+                                                        candidate = child
+                                                        break
+
+                                            if candidate is not None:
+                                                used_versioned = True
+                                                lis = candidate.findall("li")
+                                                if not lis:
+                                                    logger.debug(
+                                                        f"Prefer versioned tags: {candidate.tag} is present but empty; suppressing base modDependencies for {about_path}"
+                                                    )
+                                                else:
+                                                    logger.debug(
+                                                        f"Prefer versioned tags: using dependencies from {candidate.tag} in {about_path}"
+                                                    )
+                                                    workshop_id = (
+                                                        self._find_workshop_id_in_deps(
+                                                            candidate, dep_id
+                                                        )
+                                                    )
+                                                    if workshop_id:
+                                                        mods_to_download.append(
+                                                            workshop_id
+                                                        )
+                                                        break
+
+                                    if used_versioned:
+                                        # If versioned key existed (even if empty), don't fall back to base
+                                        pass
+                                    else:
+                                        # Fall back to base modDependencies
+                                        deps = root.find("modDependencies")
+                                        if deps is None:
+                                            continue
+
+                                        workshop_id = self._find_workshop_id_in_deps(
+                                            deps, dep_id
+                                        )
+                                        if workshop_id:
+                                            mods_to_download.append(workshop_id)
+                                            break
+                                    if workshop_id:
+                                        break  # Found the workshop ID, no need to check other mods
+                                except Exception:
+                                    continue
+
+            # First add any local mods to the active list
+            if local_mods:
+                for mod_id in local_mods:
+                    # Find the UUID for this package ID
+                    for (
+                        uuid,
+                        mod_data,
+                    ) in self.metadata_manager.internal_local_metadata.items():
+                        if mod_data.get("packageid") == mod_id:
+                            active_mods.add(uuid)
+                            break
+
+                # Update the active mods list with local mods
+                self.main_window.main_content_panel.mods_panel.active_mods_list.uuids = list(
+                    active_mods
+                )
+
+            # If there are mods to download, check SteamCMD setup first
+            if mods_to_download:
+                # Check if SteamCMD is set up
+                steamcmd_wrapper = self.main_window.main_content_panel.steamcmd_wrapper
+
+                if not steamcmd_wrapper.setup:
+                    # Set up SteamCMD first
+                    self.main_window.main_content_panel._do_setup_steamcmd()
+                    # After setup, try downloading again if setup was successful
+                    if steamcmd_wrapper.setup:
                         self.main_window.main_content_panel._do_download_mods_with_steamcmd(
                             mods_to_download
                         )
                         # Don't sort yet - let the download completion handler do it
                         return
+                    else:
+                        # Sort what we have so far
+                        self.main_window.main_content_panel._do_sort(check_deps=False)
                 else:
-                    # Only local mods were selected, sort them now
-                    self.main_window.main_content_panel._do_sort(check_deps=False)
+                    # SteamCMD is already set up, proceed with download
+                    self.main_window.main_content_panel._do_download_mods_with_steamcmd(
+                        mods_to_download
+                    )
+                    # Don't sort yet - let the download completion handler do it
+                    return
             else:
-                # User clicked "Sort Without Adding", sort without checking dependencies again
+                # Only local mods were selected, sort them now
                 self.main_window.main_content_panel._do_sort(check_deps=False)
         else:
-            # No missing dependencies, sort without checking dependencies again
+            # User clicked "Sort Without Adding", sort without checking dependencies again
             self.main_window.main_content_panel._do_sort(check_deps=False)
 
     # @Slot() # TODO: fix @slot() related MYPY errors once bug is fixed in https://bugreports.qt.io/browse/PYSIDE-2942

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -1008,7 +1008,15 @@ class MainContent(QObject):
             missing_deps = self.metadata_manager.get_missing_dependencies(active_mods)
             if missing_deps:
                 dialog = MissingDependenciesDialog()
-                selected_deps = dialog.show_dialog(missing_deps)
+                # Build a deps_summary from the missing deps for the dialog display
+                deps_summary: dict[str, dict[str, set[str]]] = {}
+                for mod_id, deps in missing_deps.items():
+                    deps_summary[mod_id] = {
+                        "satisfied": set(),
+                        "local": set(),
+                        "download": deps,
+                    }
+                selected_deps = dialog.show_dialog(deps_summary, missing_deps)
 
                 if selected_deps:
                     # Add selected mods to active mods

--- a/app/windows/missing_dependencies_dialog.py
+++ b/app/windows/missing_dependencies_dialog.py
@@ -17,7 +17,13 @@ from app.utils.metadata import MetadataManager
 
 class MissingDependenciesDialog(QDialog):
     """
-    Dialog to display missing mod dependencies and allow user to select which to add.
+    Dialog to display all mod dependencies and allow user to select
+    which missing ones (local/download) to add.
+
+    Shows three groups per mod:
+        - Satisfied dependencies (already active)
+        - Local dependencies (available but not active)
+        - Dependencies that need to be downloaded
     """
 
     def __init__(self, parent: QWidget | None = None) -> None:
@@ -41,7 +47,7 @@ class MissingDependenciesDialog(QDialog):
 
         description = QLabel(
             self.tr(
-                "Some mods in your active list require other mods to work properly.\n"
+                "Showing dependencies of your active mods.\n"
                 "Select which missing dependencies to add to your active mods list."
             )
         )
@@ -79,20 +85,27 @@ class MissingDependenciesDialog(QDialog):
         # Set the window size
         self.resize(900, 600)
 
-    def show_dialog(self, missing_deps: dict[str, set[str]]) -> set[str]:
+    def show_dialog(
+        self,
+        deps_summary: dict[str, dict[str, set[str]]],
+        missing_deps: dict[str, set[str]],
+    ) -> set[str]:
         """
-        Show the dialog with missing dependencies and return selected mods.
+        Show the dialog with all dependencies (satisfied + missing) for each mod.
 
         Args:
-            missing_deps: dict mapping mod package IDs to sets of missing dependency package IDs
+            deps_summary: dict mapping each mod package ID to a dict with keys:
+                - "satisfied": set of dep package IDs already active
+                - "local": set of dep package IDs available locally but not active
+                - "download": set of dep package IDs that need to be downloaded
+            missing_deps: dict mapping mod package IDs to sets of missing
+                          dependency package IDs (same as before, used to
+                          determine if there are any missing deps at all)
 
         Returns:
             Set of selected mod package IDs if user accepted, empty set otherwise.
         """
-        if not missing_deps:
-            return set()
-
-        self._populate_dependencies(missing_deps)
+        self._populate_dependencies(deps_summary)
 
         result = self.exec()
         if result == QDialog.DialogCode.Accepted:
@@ -100,67 +113,195 @@ class MissingDependenciesDialog(QDialog):
         else:
             return set()
 
-    def _populate_dependencies(self, missing_deps: dict[str, set[str]]) -> None:
+    def _populate_dependencies(
+        self, deps_summary: dict[str, dict[str, set[str]]]
+    ) -> None:
         """
-        Populate the dialog with missing dependencies grouped by local and download.
+        Populate the dialog with all dependencies grouped by mod.
+        Each mod shows: satisfied, local, and download dependencies.
 
         Args:
-            missing_deps: dict mapping mod package IDs to sets of missing dependency package IDs
+            deps_summary: dict mapping each mod package ID to a dict with keys:
+                - "satisfied": set of dep package IDs already active
+                - "local": set of dep package IDs available locally but not active
+                - "download": set of dep package IDs that need to be downloaded
         """
         self.clear_dependencies()
 
-        local_deps, download_deps = self._classify_dependencies(missing_deps)
+        if not deps_summary:
+            label = QLabel(self.tr("No dependencies found for any active mod."))
+            label.setWordWrap(True)
+            self.scroll_layout.addWidget(label)
+            return
 
-        if local_deps:
-            local_label = QLabel(self.tr("Local mods (available but not active):"))
-            local_label.setObjectName("localDepsLabel")
-            self.scroll_layout.addWidget(local_label)
+        # --- Compute summary stats ---
+        total_satisfied = 0
+        total_local = 0
+        total_download = 0
+        total_missing_per_mod = 0  # number of mods that have at least one missing dep
+        mods_with_deps = 0
 
-            for dep_id, requiring_mods in local_deps.items():
-                self._add_dependency_group(dep_id, requiring_mods)
+        for mod_id, deps in deps_summary.items():
+            satisfied = deps.get("satisfied", set())
+            local = deps.get("local", set())
+            download = deps.get("download", set())
 
-            self.scroll_layout.addSpacing(20)
+            total_satisfied += len(satisfied)
+            total_local += len(local)
+            total_download += len(download)
 
-        if download_deps:
-            download_label = QLabel(self.tr("Mods that need to be downloaded:"))
-            download_label.setObjectName("downloadDepsLabel")
-            self.scroll_layout.addWidget(download_label)
+            if satisfied or local or download:
+                mods_with_deps += 1
 
-            for dep_id, requiring_mods in download_deps.items():
-                self._add_dependency_group(dep_id, requiring_mods)
+            if local or download:
+                total_missing_per_mod += 1
+
+        total_deps = total_satisfied + total_local + total_download
+        total_missing = total_local + total_download
+        has_missing = total_missing > 0
+
+        # --- Summary header ---
+        if has_missing:
+            summary_text = self.tr(
+                "<b>Summary:</b> {total_deps} total dependencies across {mods_with_deps} mods — "
+                "✅ {total_satisfied} fulfilled, "
+                "⚠️ {total_missing} missing ({total_local} local, {total_download} download) across {total_missing_per_mod} mod(s)"
+            ).format(
+                total_deps=total_deps,
+                mods_with_deps=mods_with_deps,
+                total_satisfied=total_satisfied,
+                total_missing=total_missing,
+                total_local=total_local,
+                total_download=total_download,
+                total_missing_per_mod=total_missing_per_mod,
+            )
+            summary_color = "#cc8800"  # amber/warning
+        else:
+            summary_text = self.tr(
+                "<b>Summary:</b> {total_deps} total dependencies across {mods_with_deps} mods — "
+                "✅ All {total_satisfied} dependencies fulfilled"
+            ).format(
+                total_deps=total_deps,
+                mods_with_deps=mods_with_deps,
+                total_satisfied=total_satisfied,
+            )
+            summary_color = "green"
+
+        summary_label = QLabel(summary_text)
+        summary_label.setWordWrap(True)
+        summary_label.setTextFormat(Qt.TextFormat.RichText)
+        summary_label.setStyleSheet(
+            f"color: {summary_color}; font-size: 13px; padding: 8px; "
+            f"background-color: #f5f5f5; border: 1px solid {summary_color}; "
+            f"border-radius: 4px; margin-bottom: 10px;"
+        )
+        self.scroll_layout.addWidget(summary_label)
+        self.scroll_layout.addSpacing(5)
+
+        # Sort mods alphabetically for consistent display
+        for mod_id in sorted(deps_summary.keys()):
+            deps = deps_summary[mod_id]
+            satisfied = deps.get("satisfied", set())
+            local = deps.get("local", set())
+            download = deps.get("download", set())
+
+            mod_name = self.metadata_manager.get_mod_name_from_package_id(mod_id)
+
+            # --- Mod header with per-mod badge ---
+            mod_header_parts = [f"<b>{mod_name}</b>  ({mod_id})"]
+            if local or download:
+                dep_count = len(satisfied)
+                missing_count = len(local) + len(download)
+                mod_header_parts.append(
+                    f"<span style='color:#cc8800;'>  [{dep_count} fulfilled, {missing_count} missing]</span>"
+                )
+            else:
+                dep_count = len(satisfied)
+                mod_header_parts.append(
+                    f"<span style='color:green;'>  [{dep_count} fulfilled]</span>"
+                )
+
+            header_label = QLabel("".join(mod_header_parts))
+            header_label.setWordWrap(True)
+            header_label.setTextFormat(Qt.TextFormat.RichText)
+            self.scroll_layout.addWidget(header_label)
+
+            # --- Satisfied deps (read-only) ---
+            if satisfied:
+                satisfied_label = QLabel(
+                    self.tr("  ✅ Satisfied: ") + ", ".join(sorted(satisfied))
+                )
+                satisfied_label.setStyleSheet("color: green; margin-left: 20px;")
+                satisfied_label.setWordWrap(True)
+                self.scroll_layout.addWidget(satisfied_label)
+
+            # --- Local deps (checkable) ---
+            if local:
+                for dep_id in sorted(local):
+                    dep_name = self.metadata_manager.get_mod_name_from_package_id(
+                        dep_id
+                    )
+                    checkbox = QCheckBox(f"  📦 {dep_name}  ({dep_id})")
+                    checkbox.setToolTip(
+                        self.tr("Available locally - add to active list")
+                    )
+                    checkbox.stateChanged.connect(
+                        partial(self._toggle_mod_selection, mod_id=dep_id)
+                    )
+                    self.scroll_layout.addWidget(checkbox)
+                    self.checkboxes[dep_id] = checkbox
+
+            # --- Download deps (checkable) ---
+            if download:
+                for dep_id in sorted(download):
+                    dep_name = self.metadata_manager.get_mod_name_from_package_id(
+                        dep_id
+                    )
+                    checkbox = QCheckBox(f"  🌐 {dep_name}  ({dep_id})")
+                    checkbox.setToolTip(
+                        self.tr("Needs to be downloaded - requires SteamCMD")
+                    )
+                    checkbox.stateChanged.connect(
+                        partial(self._toggle_mod_selection, mod_id=dep_id)
+                    )
+                    self.scroll_layout.addWidget(checkbox)
+                    self.checkboxes[dep_id] = checkbox
+
+            # Add a separator between mods
+            self.scroll_layout.addSpacing(10)
+
+        if not has_missing:
+            no_missing_label = QLabel(
+                self.tr(
+                    "\nAll dependencies are satisfied. No missing dependencies found."
+                )
+            )
+            no_missing_label.setStyleSheet("font-weight: bold; margin-top: 10px;")
+            no_missing_label.setWordWrap(True)
+            self.scroll_layout.addWidget(no_missing_label)
+            # Hide the add/sort buttons since there's nothing to add
+            self._set_action_buttons_visible(False)
 
         self.scroll_layout.addStretch()
 
-    def _classify_dependencies(
-        self, missing_deps: dict[str, set[str]]
-    ) -> tuple[dict[str, list[str]], dict[str, list[str]]]:
-        """
-        Classify missing dependencies into local and download groups.
-
-        Args:
-            missing_deps: dict mapping mod package IDs to sets of missing dependency package IDs
-
-        Returns:
-            Tuple of two dicts:
-            - local_deps: dependencies that exist locally but aren't active
-            - download_deps: dependencies that need to be downloaded
-        """
-        local_deps: dict[str, list[str]] = {}
-        download_deps: dict[str, list[str]] = {}
-
-        for mod_id, deps in missing_deps.items():
-            mod_name = self.metadata_manager.get_mod_name_from_package_id(mod_id)
-            for dep_id in deps:
-                exists_locally = any(
-                    mod_data.get("packageid") == dep_id
-                    for mod_data in self.metadata_manager.internal_local_metadata.values()
-                )
-                target_dict = local_deps if exists_locally else download_deps
-                if dep_id not in target_dict:
-                    target_dict[dep_id] = []
-                target_dict[dep_id].append(mod_name)
-
-        return local_deps, download_deps
+    def _set_action_buttons_visible(self, visible: bool) -> None:
+        """Show or hide the action buttons in the button layout."""
+        # The button layout is the last item in the main layout
+        layout = self.layout()
+        if layout is None:
+            return
+        item = layout.itemAt(layout.count() - 1)
+        if item is None:
+            return
+        btn_layout = item.layout()
+        if btn_layout is None:
+            return
+        for i in range(btn_layout.count()):
+            item = btn_layout.itemAt(i)
+            if item is not None:
+                w = item.widget()
+                if w is not None:
+                    w.setVisible(visible)
 
     def clear_dependencies(self) -> None:
         """
@@ -175,38 +316,6 @@ class MissingDependenciesDialog(QDialog):
                 widget.deleteLater()
         self.checkboxes.clear()
         self.selected_mods.clear()
-
-    def _add_dependency_group(self, dep_id: str, requiring_mods: list[str]) -> None:
-        """
-        Add a dependency group widget to the dialog.
-
-        Args:
-            dep_id: The package ID of the dependency.
-            requiring_mods: List of mod names that require this dependency.
-        """
-        group_widget = QWidget()
-        group_widget.setObjectName("dependencyGroupWidget")
-        group_layout = QVBoxLayout(group_widget)
-
-        dep_name = self.metadata_manager.get_mod_name_from_package_id(dep_id)
-        checkbox = QCheckBox(dep_name)
-        checkbox.setToolTip(self.tr("Package ID: {dep_id}").format(dep_id=dep_id))
-        checkbox.stateChanged.connect(
-            partial(self._toggle_mod_selection, mod_id=dep_id)
-        )
-        group_layout.addWidget(checkbox)
-        self.checkboxes[dep_id] = checkbox
-
-        requiring_label = QLabel(
-            self.tr("Required by:\n  • ") + "\n  • ".join(requiring_mods)
-        )
-        requiring_label.setStyleSheet("color: gray; margin-left: 20px;")
-        requiring_label.setWordWrap(True)
-        group_layout.addWidget(requiring_label)
-
-        group_layout.addSpacing(10)
-
-        self.scroll_layout.addWidget(group_widget)
 
     def select_all(self) -> None:
         """


### PR DESCRIPTION
- check_dependencies() now classifies deps as satisfied/local/download per mod and always shows the MissingDependenciesDialog on signal
- No sort triggered when no missing dependencies exist
- MissingDependenciesDialog shows grouped view per mod with:
  - Summary header bar (fulfilled vs missing counts, color-coded)
  - Per-mod status badges [N fulfilled] / [N fulfilled, M missing]
  - Satisfied (read-only), Local (checkable), Download (checkable) deps
  - Action buttons hidden when all deps are satisfied
- Removed obsolete _classify_dependencies/_add_dependency_group methods
- Fixed _do_sort() call to match new show_dialog() signature

NOTE: Themes need to be updated

<img width="902" height="632" alt="image" src="https://github.com/user-attachments/assets/43608b9b-8a12-44a1-839d-097917343ec9" />
<img width="902" height="632" alt="image" src="https://github.com/user-attachments/assets/25289c97-d7bb-4ead-9847-75864a9ef15c" />

