### PR TITLE
feat(metadata): port authority into MetadataController (PR 1 of #2051)

### DIFF
--- a/app/controllers/app_controller.py
+++ b/app/controllers/app_controller.py
@@ -42,6 +42,8 @@ class AppController(QObject):
         self.do_dds_cleanup()
         # Initialize the metadata manager
         self.initialize_metadata_manager()
+        # Initialize the new MetadataController (runs alongside MetadataManager)
+        self.initialize_metadata_controller()
         # Initialize the main window controller
         self.initialize_main_window()
 
@@ -118,6 +120,19 @@ class AppController(QObject):
         """Initializes the MetadataManager."""
         self.metadata_manager = MetadataManager.instance(
             settings_controller=self.settings_controller
+        )
+
+    def initialize_metadata_controller(self) -> None:
+        """Initializes the new MetadataController alongside MetadataManager."""
+        from app.controllers.metadata_controller import MetadataController
+        from app.controllers.metadata_db_controller import AuxMetadataController
+
+        aux_db_controller = AuxMetadataController.get_or_create_cached_instance(
+            self.settings_controller.settings.aux_db_path
+        )
+        self.metadata_controller = MetadataController.instance(
+            settings_controller=self.settings_controller,
+            metadata_db_controller=aux_db_controller,
         )
 
     def initialize_main_window(self) -> None:

--- a/app/controllers/metadata_controller.py
+++ b/app/controllers/metadata_controller.py
@@ -1,6 +1,9 @@
-from pathlib import Path
+from __future__ import annotations
 
-from PySide6.QtCore import QObject, Slot
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from PySide6.QtCore import QObject, Signal, Slot
 
 from app.controllers.metadata_db_controller import AuxMetadataController
 from app.controllers.settings_controller import SettingsController
@@ -16,9 +19,22 @@ from app.utils.app_info import AppInfo
 from app.utils.constants import KNOWN_TIER_ONE_MODS, KNOWN_TIER_ZERO_MODS
 from app.utils.steam.steamcmd.wrapper import SteamcmdInterface
 
+if TYPE_CHECKING:
+    from app.models.metadata.metadata_structure import (
+        ExternalRulesSchema,
+        SteamDbSchema,
+    )
+
 
 class MetadataController(QObject):
     """Controller class for metadata."""
+
+    _instance: MetadataController | None = None
+
+    mod_created_signal = Signal(str)
+    mod_deleted_signal = Signal(str)
+    mod_metadata_updated_signal = Signal(str)
+    show_warning_signal = Signal(str, str, str, str)
 
     def __init__(
         self,
@@ -42,10 +58,32 @@ class MetadataController(QObject):
         self.metadata_db_controller = metadata_db_controller
         self.steamcmd_wrapper = SteamcmdInterface.instance()
 
+    @classmethod
+    def instance(
+        cls,
+        settings_controller: SettingsController | None = None,
+        metadata_db_controller: AuxMetadataController | None = None,
+    ) -> MetadataController:
+        """Get or create the singleton instance.
+
+        :param settings_controller: Required on first call
+        :param metadata_db_controller: Required on first call
+        :return: The singleton instance
+        :raises RuntimeError: If called before initialization
+        """
+        if cls._instance is None:
+            if settings_controller is None or metadata_db_controller is None:
+                raise RuntimeError(
+                    "MetadataController.instance() called before initialization"
+                )
+            cls._instance = cls(settings_controller, metadata_db_controller)
+        return cls._instance
+
     @Slot()
     def refresh_metadata(self) -> None:
         """Refresh the metadata."""
-        self.metadata_mediator.refresh_metadata()
+        prefer_versioned = self.settings_controller.settings.prefer_versioned_about_tags
+        self.metadata_mediator.refresh_metadata(prefer_versioned=prefer_versioned)
         self._refresh_metadata_db()
 
         with self.metadata_db_controller.Session() as session:
@@ -125,6 +163,119 @@ class MetadataController(QObject):
 
         for p in path:
             self.metadata_mediator.mods_metadata.pop(str(p), None)
+
+    def compile(
+        self,
+        use_moddependencies_as_loadTheseBefore: bool = False,
+        use_alternative_package_ids_as_satisfying_dependencies: bool = True,
+    ) -> CompiledDependencyData:
+        """Compile dependency data from current metadata state.
+
+        :param use_moddependencies_as_loadTheseBefore: Treat modDependencies as loadAfter
+        :param use_alternative_package_ids_as_satisfying_dependencies: Use alt package IDs
+        :return: Compiled dependency data
+        """
+        return self._build_compiled_data(
+            self.metadata_mediator.mods_metadata,
+            use_moddependencies_as_loadTheseBefore,
+            use_alternative_package_ids_as_satisfying_dependencies,
+        )
+
+    @property
+    def mods_metadata(self) -> dict[str, ListedMod]:
+        """Get the current mods metadata dictionary."""
+        return self.metadata_mediator.mods_metadata
+
+    @property
+    def packageid_to_paths(self) -> dict[str, set[str]]:
+        """Build a mapping from package IDs to sets of mod paths."""
+        result: dict[str, set[str]] = {}
+        for path, mod in self.mods_metadata.items():
+            if isinstance(mod, AboutXmlMod):
+                pid = str(mod.package_id)
+                result.setdefault(pid, set()).add(path)
+        return result
+
+    @property
+    def game_version(self) -> str:
+        """Get the current game version."""
+        return self.metadata_mediator.game_version
+
+    @property
+    def steam_db(self) -> SteamDbSchema | None:
+        """Get the loaded Steam database, if any."""
+        return self.metadata_mediator.steam_db
+
+    @property
+    def community_rules(self) -> ExternalRulesSchema | None:
+        """Get the loaded community rules, if any."""
+        return self.metadata_mediator.community_rules
+
+    @property
+    def steamdb_packageid_to_name(self) -> dict[str, str]:
+        """Build a mapping from package IDs to Steam names from the Steam DB."""
+        if self.metadata_mediator.steam_db is None:
+            return {}
+        return {
+            pid: entry.steamName or entry.name
+            for pid, entry in self.metadata_mediator.steam_db.database.items()
+            if entry.steamName or entry.name
+        }
+
+    def get_missing_dependencies(
+        self, active_mod_paths: set[str]
+    ) -> dict[str, set[str]]:
+        """Compute missing dependencies for the given active mod paths.
+
+        :param active_mod_paths: Set of active mod paths
+        :return: Mapping from package ID to set of missing dependency package IDs
+        """
+        active_package_ids: set[str] = set()
+        for path in active_mod_paths:
+            mod = self.mods_metadata.get(path)
+            if isinstance(mod, AboutXmlMod):
+                active_package_ids.add(str(mod.package_id))
+
+        missing: dict[str, set[str]] = {}
+        for path in active_mod_paths:
+            mod = self.mods_metadata.get(path)
+            if not isinstance(mod, AboutXmlMod):
+                continue
+            pid = str(mod.package_id)
+            for dep_id in mod.overall_rules.dependencies:
+                dep_str = str(dep_id)
+                if dep_str not in active_package_ids:
+                    missing.setdefault(pid, set()).add(dep_str)
+        return missing
+
+    def is_version_mismatch(self, path: str) -> bool:
+        """Check if a mod has version mismatch with the current game version.
+
+        :param path: Mod path
+        :return: True if version mismatch, False otherwise
+        """
+        mod = self.mods_metadata.get(path)
+        if not isinstance(mod, AboutXmlMod):
+            return False
+        if not mod.supported_versions:
+            return False
+        game_major_minor = ".".join(self.game_version.split(".")[:2])
+        return game_major_minor not in mod.supported_versions
+
+    def has_alternative_mod(self, path: str) -> dict[str, str] | None:
+        """Check if a mod has a recommended replacement from Use This Instead DB.
+
+        :param path: Mod path
+        :return: Replacement info dict or None
+        """
+        mod = self.mods_metadata.get(path)
+        if not isinstance(mod, AboutXmlMod):
+            return None
+        use_this_instead = self.metadata_mediator.use_this_instead
+        if use_this_instead is None:
+            return None
+        pid = str(mod.package_id)
+        return use_this_instead.get(pid)
 
     @staticmethod
     def _build_compiled_data(

--- a/app/controllers/metadata_controller.py
+++ b/app/controllers/metadata_controller.py
@@ -6,8 +6,14 @@ from app.controllers.metadata_db_controller import AuxMetadataController
 from app.controllers.settings_controller import SettingsController
 from app.models.metadata.metadata_db import AuxMetadataEntry
 from app.models.metadata.metadata_mediator import MetadataMediator
-from app.models.metadata.metadata_structure import ListedMod, ModType
+from app.models.metadata.metadata_structure import (
+    AboutXmlMod,
+    CompiledDependencyData,
+    ListedMod,
+    ModType,
+)
 from app.utils.app_info import AppInfo
+from app.utils.constants import KNOWN_TIER_ONE_MODS, KNOWN_TIER_ZERO_MODS
 from app.utils.steam.steamcmd.wrapper import SteamcmdInterface
 
 
@@ -119,3 +125,87 @@ class MetadataController(QObject):
 
         for p in path:
             self.metadata_mediator.mods_metadata.pop(str(p), None)
+
+    @staticmethod
+    def _build_compiled_data(
+        mods_metadata: dict[str, ListedMod],
+        use_moddependencies_as_loadTheseBefore: bool = False,
+        use_alternative_package_ids_as_satisfying_dependencies: bool = True,
+    ) -> CompiledDependencyData:
+        """Build compiled dependency data from parsed mods.
+
+        This is the core compilation step that replaces the old
+        ``MetadataManager.compile_metadata()`` method.  It is a pure
+        function (static method) so that it can be tested without
+        instantiating any Qt objects or singletons.
+
+        :param mods_metadata: Mapping of mod-path strings to ``ListedMod``
+            objects, as produced by ``MetadataMediator``.
+        :param use_moddependencies_as_loadTheseBefore: When *True*, treat
+            declared ``modDependencies`` as implicit ``loadAfter`` edges.
+        :param use_alternative_package_ids_as_satisfying_dependencies: When
+            *True*, alternative package IDs on ``DependencyMod`` objects are
+            considered valid satisfiers when building the dependency graph.
+        :return: A fully-populated ``CompiledDependencyData`` instance.
+        """
+        compiled = CompiledDependencyData()
+
+        # CRITICAL: copy the known-tier sets so we never mutate the module-level constants.
+        compiled.tier_zero_mods = KNOWN_TIER_ZERO_MODS.copy()
+        compiled.tier_one_mods = KNOWN_TIER_ONE_MODS.copy()
+
+        # --- Step 1: Build packageid -> set[path] index and collect all known pids ---
+        packageid_to_paths: dict[str, set[str]] = {}
+        all_package_ids: set[str] = set()
+
+        for path_str, mod in mods_metadata.items():
+            if not isinstance(mod, AboutXmlMod):
+                continue
+            pid = str(mod.package_id)
+            all_package_ids.add(pid)
+            packageid_to_paths.setdefault(pid, set()).add(path_str)
+
+        # --- Step 2 & 3: Build forward and reverse dependency graphs ---
+        for mod in mods_metadata.values():
+            if not isinstance(mod, AboutXmlMod):
+                continue
+
+            pid = str(mod.package_id)
+
+            # Choose rules variant based on the deps-as-load-order flag
+            if use_moddependencies_as_loadTheseBefore:
+                rules = mod.overall_rules_with_deps
+            else:
+                rules = mod.overall_rules
+
+            # load_after: "I (pid) load after dep" -> pid depends on dep
+            for dep_ci in rules.load_after:
+                dep = str(dep_ci)
+                if dep not in all_package_ids:
+                    continue
+                compiled.deps_graph.setdefault(pid, set()).add(dep)
+                compiled.rev_deps_graph.setdefault(dep, set()).add(pid)
+
+            # load_before: "I (pid) load before target" -> target depends on pid
+            for target_ci in rules.load_before:
+                target = str(target_ci)
+                if target not in all_package_ids:
+                    continue
+                compiled.deps_graph.setdefault(target, set()).add(pid)
+                compiled.rev_deps_graph.setdefault(pid, set()).add(target)
+
+            # --- Step 4: Record incompatibilities (only between existing mods) ---
+            for incompat_ci in rules.incompatible_with:
+                incompat = str(incompat_ci)
+                if incompat not in all_package_ids:
+                    continue
+                compiled.incompatibilities.setdefault(pid, set()).add(incompat)
+
+            # --- Step 5: Tier classification ---
+            if rules.load_first and pid not in compiled.tier_zero_mods:
+                compiled.tier_one_mods.add(pid)
+
+            if rules.load_last:
+                compiled.tier_three_mods.add(pid)
+
+        return compiled

--- a/app/controllers/metadata_controller.py
+++ b/app/controllers/metadata_controller.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from PySide6.QtCore import QObject, Signal, Slot
 
@@ -137,6 +137,12 @@ class MetadataController(QObject):
         self.metadata_mediator.workshop_mods_path = workshop_mods_path
         self.metadata_mediator.local_mods_path = local_mods_path
         self.metadata_mediator.game_path = game_path
+        self.metadata_mediator.no_version_warning_path = _get_path(
+            active_settings.external_no_version_warning_file_path
+        )
+        self.metadata_mediator.use_this_instead_path = _get_path(
+            active_settings.external_use_this_instead_file_path
+        )
 
     def get_metadata_with_path(
         self, path: str | Path
@@ -167,18 +173,15 @@ class MetadataController(QObject):
     def compile(
         self,
         use_moddependencies_as_loadTheseBefore: bool = False,
-        use_alternative_package_ids_as_satisfying_dependencies: bool = True,
     ) -> CompiledDependencyData:
         """Compile dependency data from current metadata state.
 
         :param use_moddependencies_as_loadTheseBefore: Treat modDependencies as loadAfter
-        :param use_alternative_package_ids_as_satisfying_dependencies: Use alt package IDs
         :return: Compiled dependency data
         """
         return self._build_compiled_data(
             self.metadata_mediator.mods_metadata,
             use_moddependencies_as_loadTheseBefore,
-            use_alternative_package_ids_as_satisfying_dependencies,
         )
 
     @property
@@ -262,7 +265,7 @@ class MetadataController(QObject):
         game_major_minor = ".".join(self.game_version.split(".")[:2])
         return game_major_minor not in mod.supported_versions
 
-    def has_alternative_mod(self, path: str) -> dict[str, str] | None:
+    def has_alternative_mod(self, path: str) -> dict[str, Any] | None:
         """Check if a mod has a recommended replacement from Use This Instead DB.
 
         :param path: Mod path
@@ -281,7 +284,6 @@ class MetadataController(QObject):
     def _build_compiled_data(
         mods_metadata: dict[str, ListedMod],
         use_moddependencies_as_loadTheseBefore: bool = False,
-        use_alternative_package_ids_as_satisfying_dependencies: bool = True,
     ) -> CompiledDependencyData:
         """Build compiled dependency data from parsed mods.
 
@@ -294,9 +296,6 @@ class MetadataController(QObject):
             objects, as produced by ``MetadataMediator``.
         :param use_moddependencies_as_loadTheseBefore: When *True*, treat
             declared ``modDependencies`` as implicit ``loadAfter`` edges.
-        :param use_alternative_package_ids_as_satisfying_dependencies: When
-            *True*, alternative package IDs on ``DependencyMod`` objects are
-            considered valid satisfiers when building the dependency graph.
         :return: A fully-populated ``CompiledDependencyData`` instance.
         """
         compiled = CompiledDependencyData()

--- a/app/controllers/metadata_db_controller.py
+++ b/app/controllers/metadata_db_controller.py
@@ -35,6 +35,22 @@ class AuxMetadataController(MetadataDbController):
     def __init__(self, db_path: Path) -> None:
         super().__init__(db_path)
         Base.metadata.create_all(self.engine)
+        self._migrate_schema()
+
+    def _migrate_schema(self) -> None:
+        """Add columns that may be missing from older database versions."""
+        with self.engine.connect() as conn:
+            rows = conn.execute(text("PRAGMA table_info(auxiliary_metadata)"))
+            existing_columns = {row[1] for row in rows}
+            for col in ("external_time_created", "external_time_updated"):
+                if col not in existing_columns:
+                    conn.execute(
+                        text(
+                            f"ALTER TABLE auxiliary_metadata ADD COLUMN {col} INTEGER DEFAULT -1"
+                        )
+                    )
+                    logger.info(f"Migrated auxiliary_metadata: added column '{col}'")
+            conn.commit()
 
     @classmethod
     def get_or_create_cached_instance(cls, db_path: Path) -> "AuxMetadataController":

--- a/app/models/metadata/metadata_db.py
+++ b/app/models/metadata/metadata_db.py
@@ -32,6 +32,8 @@ class AuxMetadataEntry(Base):
     published_file_id: Mapped[int] = mapped_column(Integer, default=-1)
     acf_time_touched: Mapped[int] = mapped_column(Integer, default=-1)
     acf_time_updated: Mapped[int] = mapped_column(Integer, default=-1)
+    external_time_created: Mapped[int] = mapped_column(Integer, default=-1)
+    external_time_updated: Mapped[int] = mapped_column(Integer, default=-1)
 
     user_notes: Mapped[str] = mapped_column(String, default="")
     color_hex: Mapped[str] = mapped_column(

--- a/app/models/metadata/metadata_factory.py
+++ b/app/models/metadata/metadata_factory.py
@@ -223,12 +223,16 @@ def create_scenario_mod(scenario_data: dict[str, Any]) -> tuple[bool, ScenarioMo
 
 
 def create_about_mod(
-    mod_data: dict[str, Any], target_version: str
+    mod_data: dict[str, Any],
+    target_version: str,
+    prefer_versioned: bool = True,
 ) -> tuple[bool, AboutXmlMod]:
     """Factory method for creating a ListedMod object.
 
     :param mod_data: The dictionary containing the mod data.
     :param target_version: The version of RimWorld to target.
+    :param prefer_versioned: When True, ByVersion keys override base values
+        (non-additive). When False, ByVersion keys are ignored.
     :return: A tuple containing a boolean indicating if the mod is valid and the mod object."""
     mod = _parse_basic(mod_data, AboutXmlMod())
 
@@ -237,7 +241,7 @@ def create_about_mod(
         ruled_mod.__dict__ = mod.__dict__
         mod = ruled_mod
 
-    mod = _parse_optional(mod_data, mod, target_version)
+    mod = _parse_optional(mod_data, mod, target_version, prefer_versioned)
 
     return mod.valid, mod
 
@@ -323,7 +327,10 @@ def _parse_basic(mod_data: dict[str, Any], mod: AboutXmlMod) -> AboutXmlMod:
 
 
 def _parse_optional(
-    mod_data: dict[str, Any], mod: AboutXmlMod, target_version: str
+    mod_data: dict[str, Any],
+    mod: AboutXmlMod,
+    target_version: str,
+    prefer_versioned: bool = True,
 ) -> AboutXmlMod:
     """
     Parse the optional fields from the mod_data and set them on the mod object.
@@ -341,7 +348,7 @@ def _parse_optional(
     if url and isinstance(url, str):
         mod.url = url
 
-    mod.about_rules = create_base_rules(mod_data, target_version)
+    mod.about_rules = create_base_rules(mod_data, target_version, prefer_versioned)
 
     descriptions_by_version: bool | dict[str, str] = mod_data.get(
         "descriptionsByVersion", False
@@ -401,24 +408,84 @@ def _set_mod_type(
     return mod
 
 
+def _match_byversion_raw(
+    byversion_data: dict[str, Any],
+    target_version: str,
+) -> tuple[bool, Any]:
+    """Match a ByVersion dict against a target version, returning the raw value.
+
+    Unlike ``match_version``, this does **not** apply truthiness filtering on
+    the matched value.  An empty dict/list value is a valid match (meaning
+    "no entries for this version"), so we distinguish "key found" from
+    "key not found" via the boolean.
+
+    :param byversion_data: The raw ByVersion dict straight from mod_data
+        (e.g. ``{"v1.5": {"li": ["mod.a"]}}``)
+    :param target_version: RimWorld version string like ``"1.5.1234"``.
+    :return: ``(True, raw_value)`` when a version key matches, ``(False, None)``
+        otherwise.
+    """
+    try:
+        major, minor = target_version.split(".")[:2]
+    except ValueError:
+        return False, None
+
+    version_regex = f"v{major}.{minor}"
+
+    # Direct key lookup first (most common case)
+    if version_regex in byversion_data:
+        return True, byversion_data[version_regex]
+    if f"{major}.{minor}" in byversion_data:
+        return True, byversion_data[f"{major}.{minor}"]
+
+    # Regex fallback for keys like "v1.5.1234"
+    for key, value in byversion_data.items():
+        if re.match(version_regex, key):
+            return True, value
+
+    return False, None
+
+
 def create_base_rules(
-    mod_data: dict[str, Any], target_version: str
+    mod_data: dict[str, Any],
+    target_version: str,
+    prefer_versioned: bool = True,
 ) -> BaseRules | Rules:
+    """Create base load-order rules from mod About.xml data.
+
+    :param mod_data: Parsed mod metadata dict.
+    :param target_version: RimWorld version string (e.g. ``"1.5.1234"``).
+    :param prefer_versioned: When ``True`` (default) and a ``*ByVersion`` key
+        matches *target_version*, the versioned values **replace** the
+        corresponding base values (non-additive override).  When ``False``,
+        all ``*ByVersion`` keys are ignored and only base values are used.
+    """
     rules = BaseRules()
 
-    # Dependencies
+    # ── Dependencies ──────────────────────────────────────────────────
     mod_dependencies = value_extractor(mod_data.get("modDependencies", []))
     mod_dependencies = (
         mod_dependencies if isinstance(mod_dependencies, list) else [mod_dependencies]
     )
-    versioned_mod_dependencies = value_extractor(
-        mod_data.get("modDependenciesByVersion", {})
-    )
 
-    if isinstance(versioned_mod_dependencies, dict):
-        _, dependencies = match_version(versioned_mod_dependencies, target_version)
-        if dependencies:
-            mod_dependencies.extend(dependencies)
+    if prefer_versioned:
+        byversion_deps = mod_data.get("modDependenciesByVersion", {})
+        if isinstance(byversion_deps, dict) and byversion_deps:
+            matched, versioned_deps_raw = _match_byversion_raw(
+                byversion_deps, target_version
+            )
+            if matched:
+                # Non-additive override: replace base deps entirely
+                versioned_deps = (
+                    value_extractor(versioned_deps_raw) if versioned_deps_raw else []
+                )
+                mod_dependencies = (
+                    versioned_deps
+                    if isinstance(versioned_deps, list)
+                    else [versioned_deps]
+                    if versioned_deps
+                    else []
+                )
 
     for dependency in mod_dependencies:
         if isinstance(dependency, dict):
@@ -463,18 +530,33 @@ def create_base_rules(
                 f"Skipping invalid dependency: {dependency}. This mod may be invalid."
             )
 
+    # ── Load Before / Load After ──────────────────────────────────────
     def load_operations(
-        mod_data: dict[str, Any], key: str, force_key: str, target_version: str
+        mod_data: dict[str, Any],
+        key: str,
+        force_key: str,
+        target_version: str,
+        prefer_versioned: bool,
     ) -> CaseInsensitiveSet:
         load = value_extractor(mod_data.get(key, []))
         load = load if isinstance(load, list) else [load]
 
-        loadByVersion = value_extractor(mod_data.get(f"{key}ByVersion", {}))
-        if isinstance(loadByVersion, dict):
-            _, load_versioned = match_version(loadByVersion, target_version)
-            if load_versioned:
-                load.extend(load_versioned)
+        if prefer_versioned:
+            byversion = mod_data.get(f"{key}ByVersion", {})
+            if isinstance(byversion, dict) and byversion:
+                matched, versioned_raw = _match_byversion_raw(byversion, target_version)
+                if matched:
+                    # Non-additive override: replace base with versioned values
+                    versioned = value_extractor(versioned_raw) if versioned_raw else []
+                    load = (
+                        versioned
+                        if isinstance(versioned, list)
+                        else [versioned]
+                        if versioned
+                        else []
+                    )
 
+        # forceLoad* is ALWAYS applied regardless of prefer_versioned
         forceLoad = value_extractor(mod_data.get(force_key, []))
         forceLoad = forceLoad if isinstance(forceLoad, list) else [forceLoad]
         load.extend(forceLoad)
@@ -485,15 +567,15 @@ def create_base_rules(
 
     # Load Before
     rules.load_before = load_operations(
-        mod_data, "loadBefore", "forceLoadBefore", target_version
+        mod_data, "loadBefore", "forceLoadBefore", target_version, prefer_versioned
     )
 
     # Load After
     rules.load_after = load_operations(
-        mod_data, "loadAfter", "forceLoadAfter", target_version
+        mod_data, "loadAfter", "forceLoadAfter", target_version, prefer_versioned
     )
 
-    # incompatibleWith
+    # ── incompatibleWith ──────────────────────────────────────────────
     incompatible_with = value_extractor(mod_data.get("incompatibleWith", []))
     incompatible_with = (
         incompatible_with
@@ -501,13 +583,24 @@ def create_base_rules(
         else [incompatible_with]
     )
 
-    incompatible_withByVersion = value_extractor(
-        mod_data.get("incompatibleWithByVersion", {})
-    )
-    if isinstance(incompatible_withByVersion, dict):
-        _, incompatibles = match_version(incompatible_withByVersion, target_version)
-        if incompatibles:
-            incompatible_with.extend(incompatibles)
+    if prefer_versioned:
+        byversion_incompat = mod_data.get("incompatibleWithByVersion", {})
+        if isinstance(byversion_incompat, dict) and byversion_incompat:
+            matched, incompat_raw = _match_byversion_raw(
+                byversion_incompat, target_version
+            )
+            if matched:
+                # Non-additive override: replace base incompatibles
+                versioned_incompat = (
+                    value_extractor(incompat_raw) if incompat_raw else []
+                )
+                incompatible_with = (
+                    versioned_incompat
+                    if isinstance(versioned_incompat, list)
+                    else [versioned_incompat]
+                    if versioned_incompat
+                    else []
+                )
 
     incompatible_with = [
         item
@@ -550,7 +643,10 @@ def create_mod_dependency(input_dict: dict[str, str]) -> DependencyMod:
 
 
 def _create_about_mod_from_xml(
-    base_path: Path, mod_xml_path: Path, target_version: str
+    base_path: Path,
+    mod_xml_path: Path,
+    target_version: str,
+    prefer_versioned: bool = True,
 ) -> tuple[bool, AboutXmlMod]:
     try:
         mod_data = xml_path_to_json(str(mod_xml_path))
@@ -567,7 +663,7 @@ def _create_about_mod_from_xml(
         logger.error(f"Could not parse {mod_xml_path}.")
         return False, AboutXmlMod(valid=False)
 
-    valid, mod = create_about_mod(mod_data, target_version)
+    valid, mod = create_about_mod(mod_data, target_version, prefer_versioned)
 
     mod.mod_path = base_path
     return valid, mod
@@ -616,6 +712,7 @@ def create_listed_mod_from_path(
     local_path: Path,
     rimworld_path: Path,
     workshop_path: Path | None,
+    prefer_versioned: bool = True,
 ) -> tuple[bool, ListedMod]:
     """
     Create a ListedMod object from the given path.
@@ -625,6 +722,8 @@ def create_listed_mod_from_path(
     :param local_path: The path to the local mod.
     :param rimworld_path: The path to the RimWorld mods folder.
     :param workshop_path: The path to the workshop folder.
+    :param prefer_versioned: When True, ByVersion keys override base values
+        (non-additive). When False, ByVersion keys are ignored.
     :return: A tuple containing a boolean indicating if the mod is valid and the mod object.
     """
 
@@ -634,7 +733,7 @@ def create_listed_mod_from_path(
         about_xml_path = path / Path("About/About.xml")
         if about_xml_path.exists():
             success, about_mod = _create_about_mod_from_xml(
-                path, about_xml_path, target_version
+                path, about_xml_path, target_version, prefer_versioned
             )
             return success, _set_mod_type(
                 about_mod, local_path, rimworld_path, workshop_path

--- a/app/models/metadata/metadata_factory.py
+++ b/app/models/metadata/metadata_factory.py
@@ -25,7 +25,7 @@ from app.models.metadata.metadata_structure import (
     ScenarioMod,
     SteamDbSchema,
 )
-from app.utils.constants import RIMWORLD_DLC_METADATA
+from app.utils.constants import DEFAULT_MISSING_PACKAGEID, RIMWORLD_DLC_METADATA
 from app.utils.xml import json_to_xml_write, xml_path_to_json
 
 
@@ -262,19 +262,19 @@ def _set_mod_invalid(mod: ListedMod, message: str) -> ListedMod:
 def _parse_basic(mod_data: dict[str, Any], mod: AboutXmlMod) -> AboutXmlMod:
     """
     Parse the basic fields from the mod_data and set them on the mod object.
-    If package_id cannot be parsed correctly, the mod is considered invalid.
+    If package_id is missing or invalid, the sentinel value is assigned instead.
 
     :param mod_data: Dictionary with string keys to be used as the data source.
     :param mod: ListedMod the Listed mod that is the target of data being filled.
     :return: The filled out ListedMod
     """
     package_id = value_extractor(mod_data.get("packageId", False))
-    if isinstance(package_id, str):
+    if isinstance(package_id, str) and package_id.strip():
         mod.package_id = CaseInsensitiveStr(package_id)
     else:
-        _set_mod_invalid(
-            mod,
-            f"packageId was not a string: {package_id}. This mod will be considered invalid by RimWorld.",
+        mod.package_id = CaseInsensitiveStr(DEFAULT_MISSING_PACKAGEID)
+        logger.warning(
+            f"packageId missing or invalid: {package_id}. Assigned sentinel '{DEFAULT_MISSING_PACKAGEID}'."
         )
 
     # Prioritize app id from about.xml over hardcoded DLC app id

--- a/app/models/metadata/metadata_mediator.py
+++ b/app/models/metadata/metadata_mediator.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+from typing import Any
 
 from loguru import logger
 from PySide6.QtCore import QMutex, QRunnable, QThread, QThreadPool
@@ -26,6 +27,8 @@ class MetadataMediator:
     _steam_db: SteamDbSchema | None
     _mods_metadata: dict[str, ListedMod]
     _game_version: str = "Unknown"
+    _no_version_warning: list[str] | None
+    _use_this_instead: dict[str, Any] | None
 
     def __init__(
         self,
@@ -35,6 +38,8 @@ class MetadataMediator:
         workshop_mods_path: Path | None,
         local_mods_path: Path | None,
         game_path: Path | None,
+        no_version_warning_path: Path | None = None,
+        use_this_instead_path: Path | None = None,
     ):
         self.user_rules_path = user_rules_path
         self.community_rules_path = community_rules_path
@@ -42,6 +47,8 @@ class MetadataMediator:
         self.workshop_mods_path = workshop_mods_path
         self.local_mods_path = local_mods_path
         self.game_path = game_path
+        self.no_version_warning_path = no_version_warning_path
+        self.use_this_instead_path = use_this_instead_path
 
         self.parser_threadpool = QThreadPool.globalInstance()
 
@@ -88,6 +95,68 @@ class MetadataMediator:
     def game_version(self) -> str:
         return self._game_version
 
+    @property
+    def no_version_warning(self) -> list[str] | None:
+        if not hasattr(self, "_no_version_warning"):
+            return None
+        return self._no_version_warning
+
+    @property
+    def use_this_instead(self) -> dict[str, Any] | None:
+        if not hasattr(self, "_use_this_instead"):
+            return None
+        return self._use_this_instead
+
+    def _load_no_version_warning(self) -> None:
+        """Load No Version Warning DB (ModIdsToFix.xml)."""
+        if (
+            self.no_version_warning_path is None
+            or not self.no_version_warning_path.exists()
+        ):
+            self._no_version_warning = None
+            return
+        try:
+            from app.utils.xml import xml_path_to_json
+
+            data = xml_path_to_json(str(self.no_version_warning_path))
+            mod_ids = data.get("ModIdsToFix", {}).get("li", [])
+            if isinstance(mod_ids, str):
+                mod_ids = [mod_ids]
+            self._no_version_warning = [str(mid).lower() for mid in mod_ids]
+            logger.info(
+                f"Loaded {len(self._no_version_warning)} No Version Warning entries"
+            )
+        except Exception as e:
+            logger.error(f"Failed to load No Version Warning DB: {e}")
+            self._no_version_warning = None
+
+    def _load_use_this_instead(self) -> None:
+        """Load Use This Instead replacements DB (JSON, possibly gzip)."""
+        if (
+            self.use_this_instead_path is None
+            or not self.use_this_instead_path.exists()
+        ):
+            self._use_this_instead = None
+            return
+        try:
+            import gzip
+            import json
+
+            path = self.use_this_instead_path
+            if str(path).endswith(".gz"):
+                with gzip.open(path, "rt", encoding="utf-8") as f:
+                    self._use_this_instead = json.load(f)
+            else:
+                with open(path, encoding="utf-8") as f:
+                    self._use_this_instead = json.load(f)
+            if self._use_this_instead is not None:
+                logger.info(
+                    f"Loaded {len(self._use_this_instead)} Use This Instead entries"
+                )
+        except Exception as e:
+            logger.error(f"Failed to load Use This Instead DB: {e}")
+            self._use_this_instead = None
+
     def refresh_metadata(self, prefer_versioned: bool = True) -> None:
         """Force refreshes the internal metadata.
 
@@ -116,6 +185,10 @@ class MetadataMediator:
             if self.steam_db_path is not None
             else None
         )
+
+        # Load additional external metadata
+        self._load_no_version_warning()
+        self._load_use_this_instead()
 
         # Get all folders in the workshop and local mods paths
         mod_paths = list()

--- a/app/models/metadata/metadata_mediator.py
+++ b/app/models/metadata/metadata_mediator.py
@@ -1,3 +1,5 @@
+import gzip
+import json
 import os
 from pathlib import Path
 from typing import Any
@@ -22,14 +24,6 @@ from app.models.metadata.metadata_structure import (
 class MetadataMediator:
     "Mediator class for metadata."
 
-    _user_rules: ExternalRulesSchema | None
-    _community_rules: ExternalRulesSchema | None
-    _steam_db: SteamDbSchema | None
-    _mods_metadata: dict[str, ListedMod]
-    _game_version: str = "Unknown"
-    _no_version_warning: list[str] | None
-    _use_this_instead: dict[str, Any] | None
-
     def __init__(
         self,
         user_rules_path: Path,
@@ -50,24 +44,26 @@ class MetadataMediator:
         self.no_version_warning_path = no_version_warning_path
         self.use_this_instead_path = use_this_instead_path
 
+        self._user_rules: ExternalRulesSchema | None = None
+        self._community_rules: ExternalRulesSchema | None = None
+        self._steam_db: SteamDbSchema | None = None
+        self._mods_metadata: dict[str, ListedMod] | None = None
+        self._game_version: str = "Unknown"
+        self._no_version_warning: list[str] | None = None
+        self._use_this_instead: dict[str, Any] | None = None
+
         self.parser_threadpool = QThreadPool.globalInstance()
 
     @property
     def user_rules(self) -> ExternalRulesSchema | None:
-        if hasattr(self, "_user_rules") is False:
-            return None
         return self._user_rules
 
     @property
     def community_rules(self) -> ExternalRulesSchema | None:
-        if hasattr(self, "_community_rules") is False:
-            return None
         return self._community_rules
 
     @property
     def steam_db(self) -> SteamDbSchema | None:
-        if hasattr(self, "_steam_db") is False:
-            return None
         return self._steam_db
 
     @property
@@ -75,20 +71,18 @@ class MetadataMediator:
         """Mods_metadata is a dict representation of all the listedmods, where the key is
         the path to the mod.
 
-        :raises ValueError: Raised when mods_metadata has not been initated
-        :return: A dict represented of ListedMods, where the key is the path to the mod.
+        :raises ValueError: Raised when mods_metadata has not been initiated
+        :return: A dict of ListedMods keyed by mod path.
         :rtype: dict[str, ListedMod]
         """
-        if hasattr(self, "_mods_metadata") is False or self._mods_metadata is None:
+        if self._mods_metadata is None:
             raise ValueError("Mods metadata have not been initiated")
-
         return self._mods_metadata
 
     @property
     def game_modules_path(self) -> Path:
         if self.game_path is not None:
             return self.game_path / "Data"
-
         raise ValueError("Game path is not set")
 
     @property
@@ -97,14 +91,10 @@ class MetadataMediator:
 
     @property
     def no_version_warning(self) -> list[str] | None:
-        if not hasattr(self, "_no_version_warning"):
-            return None
         return self._no_version_warning
 
     @property
     def use_this_instead(self) -> dict[str, Any] | None:
-        if not hasattr(self, "_use_this_instead"):
-            return None
         return self._use_this_instead
 
     def _load_no_version_warning(self) -> None:
@@ -126,7 +116,7 @@ class MetadataMediator:
             logger.info(
                 f"Loaded {len(self._no_version_warning)} No Version Warning entries"
             )
-        except Exception as e:
+        except (OSError, ValueError, KeyError) as e:
             logger.error(f"Failed to load No Version Warning DB: {e}")
             self._no_version_warning = None
 
@@ -139,9 +129,6 @@ class MetadataMediator:
             self._use_this_instead = None
             return
         try:
-            import gzip
-            import json
-
             path = self.use_this_instead_path
             if str(path).endswith(".gz"):
                 with gzip.open(path, "rt", encoding="utf-8") as f:
@@ -153,7 +140,7 @@ class MetadataMediator:
                 logger.info(
                     f"Loaded {len(self._use_this_instead)} Use This Instead entries"
                 )
-        except Exception as e:
+        except (OSError, ValueError, json.JSONDecodeError) as e:
             logger.error(f"Failed to load Use This Instead DB: {e}")
             self._use_this_instead = None
 

--- a/app/models/metadata/metadata_mediator.py
+++ b/app/models/metadata/metadata_mediator.py
@@ -88,8 +88,13 @@ class MetadataMediator:
     def game_version(self) -> str:
         return self._game_version
 
-    def refresh_metadata(self) -> None:
-        """Force refreshes the internal metadata."""
+    def refresh_metadata(self, prefer_versioned: bool = True) -> None:
+        """Force refreshes the internal metadata.
+
+        :param prefer_versioned: When True (default), ByVersion keys in mod
+            About.xml override base values non-additively. When False, all
+            ByVersion keys are ignored and only base values are used.
+        """
 
         for path in {self.local_mods_path, self.game_path}:
             if path is None or not path.exists() or not path.is_dir():
@@ -166,6 +171,7 @@ class MetadataMediator:
                 self.steam_db,
                 metadata_mutex,
                 self._mods_metadata,
+                prefer_versioned,
             )
             for mod_path_batch in mod_paths_batches
         ]
@@ -219,6 +225,7 @@ class MetadataMediator:
             steam_db: SteamDbSchema | None,
             mutex: QMutex,
             mods_metadata: dict[str, ListedMod],
+            prefer_versioned: bool = True,
         ):
             """Creates a worker to parse mods in a separate thread. Mutates the mods_metadata dict.
 
@@ -242,6 +249,9 @@ class MetadataMediator:
             :type mutex: QMutex
             :param mods_metadata: Dict of mods metadata
             :type mods_metadata: dict[str, ListedMod]
+            :param prefer_versioned: When True, ByVersion keys override base
+                values non-additively. When False, ByVersion keys are ignored.
+            :type prefer_versioned: bool
             """
             super().__init__()
             self.mod_path = mod_path
@@ -256,6 +266,7 @@ class MetadataMediator:
 
             self.mutex = mutex
             self.mods_metadata = mods_metadata
+            self.prefer_versioned = prefer_versioned
 
         def run(self) -> None:
             paths = (
@@ -273,6 +284,7 @@ class MetadataMediator:
                         self.local_path,
                         self.rimworld_path,
                         self.workshop_path,
+                        self.prefer_versioned,
                     )
 
                     if not valid:

--- a/app/models/metadata/metadata_structure.py
+++ b/app/models/metadata/metadata_structure.py
@@ -261,6 +261,8 @@ class ListedMod(BaseMod):
 
     _mod_path: Path | None = None
     _mod_type: ModType = ModType.UNKNOWN
+    obsolete: bool = False
+    db_builder_no_name: bool = False
 
     @property
     def mod_path(self) -> Path | None:
@@ -506,6 +508,18 @@ class AboutXmlMod(ListedMod, PackageIdMod):
             del self.overall_rules_with_deps
         except AttributeError:
             pass
+
+
+@dataclass
+class CompiledDependencyData:
+    """Standalone compiled dependency data built by MetadataController."""
+
+    deps_graph: dict[str, set[str]] = field(default_factory=dict)
+    rev_deps_graph: dict[str, set[str]] = field(default_factory=dict)
+    tier_zero_mods: set[str] = field(default_factory=set)
+    tier_one_mods: set[str] = field(default_factory=set)
+    tier_three_mods: set[str] = field(default_factory=set)
+    incompatibilities: dict[str, set[str]] = field(default_factory=dict)
 
 
 class SubExternalRule(msgspec.Struct, omit_defaults=True):

--- a/tests/controllers/test_metadata_controller.py
+++ b/tests/controllers/test_metadata_controller.py
@@ -26,6 +26,8 @@ def mock_settings() -> Generator[MagicMock, None, None]:
 
         mock_settings.external_community_rules_file_path = ""
         mock_settings.external_steam_metadata_file_path = ""
+        mock_settings.external_no_version_warning_file_path = ""
+        mock_settings.external_use_this_instead_file_path = ""
         mock_settings.prefer_versioned_about_tags = True
 
         yield mock_settings

--- a/tests/controllers/test_metadata_controller.py
+++ b/tests/controllers/test_metadata_controller.py
@@ -26,6 +26,7 @@ def mock_settings() -> Generator[MagicMock, None, None]:
 
         mock_settings.external_community_rules_file_path = ""
         mock_settings.external_steam_metadata_file_path = ""
+        mock_settings.prefer_versioned_about_tags = True
 
         yield mock_settings
 

--- a/tests/controllers/test_metadata_controller_compile.py
+++ b/tests/controllers/test_metadata_controller_compile.py
@@ -14,6 +14,7 @@ from app.models.metadata.metadata_structure import (
     BaseRules,
     CaseInsensitiveSet,
     CaseInsensitiveStr,
+    CompiledDependencyData,
     DependencyMod,
     ListedMod,
     Rules,
@@ -43,7 +44,7 @@ def _make_mod(
     return mod
 
 
-def _compile(mods: dict[str, ListedMod], **kwargs: bool) -> "CompiledDependencyData":  # type: ignore[name-defined]  # noqa: F821
+def _compile(mods: dict[str, ListedMod], **kwargs: bool) -> CompiledDependencyData:
     """Shorthand for MetadataController._build_compiled_data."""
     return MetadataController._build_compiled_data(mods, **kwargs)
 

--- a/tests/controllers/test_metadata_controller_compile.py
+++ b/tests/controllers/test_metadata_controller_compile.py
@@ -1,0 +1,201 @@
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# Ensure steamworks can be imported even without the native binary
+if "steamworks" not in sys.modules:
+    sys.modules["steamworks"] = MagicMock()
+
+from app.controllers.metadata_controller import MetadataController
+from app.models.metadata.metadata_structure import (
+    AboutXmlMod,
+    BaseRules,
+    CaseInsensitiveSet,
+    CaseInsensitiveStr,
+    DependencyMod,
+    ListedMod,
+    Rules,
+)
+
+
+def _make_mod(
+    package_id: str,
+    path: str,
+    load_after: list[str] | None = None,
+    load_before: list[str] | None = None,
+    load_first: bool = False,
+    load_last: bool = False,
+    incompatible_with: list[str] | None = None,
+) -> AboutXmlMod:
+    """Helper to create a test mod with specified rules."""
+    mod = AboutXmlMod()
+    mod.package_id = CaseInsensitiveStr(package_id)
+    mod.mod_path = Path(path)
+    mod.about_rules = BaseRules(
+        load_after=CaseInsensitiveSet(load_after or []),
+        load_before=CaseInsensitiveSet(load_before or []),
+        incompatible_with=CaseInsensitiveSet(incompatible_with or []),
+    )
+    mod.community_rules = Rules(load_first=load_first, load_last=load_last)
+    mod.user_rules = Rules()
+    return mod
+
+
+def _compile(mods: dict[str, ListedMod], **kwargs: bool) -> "CompiledDependencyData":  # type: ignore[name-defined]  # noqa: F821
+    """Shorthand for MetadataController._build_compiled_data."""
+    return MetadataController._build_compiled_data(mods, **kwargs)
+
+
+@pytest.fixture
+def two_mods_load_after() -> dict[str, ListedMod]:
+    """mod.a loads after mod.b."""
+    return {
+        "/mods/a": _make_mod("mod.a", "/mods/a", load_after=["mod.b"]),
+        "/mods/b": _make_mod("mod.b", "/mods/b"),
+    }
+
+
+@pytest.fixture
+def two_mods_load_before() -> dict[str, ListedMod]:
+    """mod.a loads before mod.b."""
+    return {
+        "/mods/a": _make_mod("mod.a", "/mods/a", load_before=["mod.b"]),
+        "/mods/b": _make_mod("mod.b", "/mods/b"),
+    }
+
+
+def test_compile_forward_and_reverse_deps_from_load_after(
+    two_mods_load_after: dict[str, ListedMod],
+) -> None:
+    """load_after creates forward dep and reverse dep entries."""
+    compiled = _compile(two_mods_load_after)
+    assert "mod.b" in compiled.deps_graph.get("mod.a", set())
+    assert "mod.a" in compiled.rev_deps_graph.get("mod.b", set())
+
+
+def test_compile_forward_and_reverse_deps_from_load_before(
+    two_mods_load_before: dict[str, ListedMod],
+) -> None:
+    """load_before: A loads before B → B depends on A."""
+    compiled = _compile(two_mods_load_before)
+    assert "mod.a" in compiled.deps_graph.get("mod.b", set())
+    assert "mod.b" in compiled.rev_deps_graph.get("mod.a", set())
+
+
+def test_compile_tier_classification() -> None:
+    mods: dict[str, ListedMod] = {
+        "/mods/fw": _make_mod("my.framework", "/mods/fw", load_first=True),
+        "/mods/bot": _make_mod("my.bottom", "/mods/bot", load_last=True),
+        "/mods/reg": _make_mod("my.regular", "/mods/reg"),
+    }
+    compiled = _compile(mods)
+
+    assert "my.framework" in compiled.tier_one_mods
+    assert "my.bottom" in compiled.tier_three_mods
+    assert "my.regular" not in compiled.tier_one_mods
+    assert "my.regular" not in compiled.tier_three_mods
+
+
+def test_compile_does_not_mutate_known_tier_constants() -> None:
+    from app.utils.constants import KNOWN_TIER_ONE_MODS
+
+    original_size = len(KNOWN_TIER_ONE_MODS)
+    mods: dict[str, ListedMod] = {
+        "/mods/dyn": _make_mod("dynamic.framework", "/mods/dyn", load_first=True)
+    }
+    compiled = _compile(mods)
+
+    assert "dynamic.framework" in compiled.tier_one_mods
+    assert len(KNOWN_TIER_ONE_MODS) == original_size
+
+
+def test_compile_incompatibility_only_includes_existing_mods() -> None:
+    mods: dict[str, ListedMod] = {
+        "/mods/a": _make_mod(
+            "mod.a", "/mods/a", incompatible_with=["mod.b", "mod.nonexistent"]
+        ),
+        "/mods/b": _make_mod("mod.b", "/mods/b"),
+    }
+    compiled = _compile(mods)
+
+    assert "mod.b" in compiled.incompatibilities.get("mod.a", set())
+    assert "mod.nonexistent" not in compiled.incompatibilities.get("mod.a", set())
+
+
+def test_compile_empty_mods() -> None:
+    compiled = _compile({})
+    assert compiled.deps_graph == {}
+    assert compiled.rev_deps_graph == {}
+    assert compiled.tier_three_mods == set()
+    assert compiled.incompatibilities == {}
+
+
+def test_compile_nonexistent_deps_not_in_graph() -> None:
+    mods: dict[str, ListedMod] = {
+        "/mods/a": _make_mod("mod.a", "/mods/a", load_after=["nonexistent.mod"])
+    }
+    compiled = _compile(mods)
+    assert "nonexistent.mod" not in compiled.deps_graph.get("mod.a", set())
+
+
+def test_compile_skips_non_aboutxmlmod() -> None:
+    listed_mod = ListedMod()
+    listed_mod.mod_path = Path("/mods/invalid")
+    compiled = _compile({"/mods/invalid": listed_mod})
+    assert compiled.deps_graph == {}
+    assert compiled.rev_deps_graph == {}
+
+
+def test_compile_tier_zero_contains_known_mods() -> None:
+    from app.utils.constants import KNOWN_TIER_ZERO_MODS
+
+    compiled = _compile({})
+    assert compiled.tier_zero_mods == KNOWN_TIER_ZERO_MODS
+
+
+def test_compile_tier_zero_not_in_tier_one() -> None:
+    """A mod in KNOWN_TIER_ZERO_MODS with load_first=True stays in tier_zero only."""
+    mods: dict[str, ListedMod] = {
+        "/mods/harmony": _make_mod("brrainz.harmony", "/mods/harmony", load_first=True)
+    }
+    compiled = _compile(mods)
+    assert "brrainz.harmony" in compiled.tier_zero_mods
+    assert "brrainz.harmony" not in compiled.tier_one_mods
+
+
+def test_compile_bidirectional_chain() -> None:
+    """Multi-hop chain: a→b→c produces correct forward and reverse graphs."""
+    mods: dict[str, ListedMod] = {
+        "/mods/a": _make_mod("mod.a", "/mods/a", load_after=["mod.b"]),
+        "/mods/b": _make_mod("mod.b", "/mods/b", load_after=["mod.c"]),
+        "/mods/c": _make_mod("mod.c", "/mods/c"),
+    }
+    compiled = _compile(mods)
+
+    assert "mod.b" in compiled.deps_graph["mod.a"]
+    assert "mod.c" in compiled.deps_graph["mod.b"]
+    assert "mod.a" in compiled.rev_deps_graph["mod.b"]
+    assert "mod.b" in compiled.rev_deps_graph["mod.c"]
+
+
+def _make_dep_mods() -> dict[str, ListedMod]:
+    """Create a fresh pair of mods where mod.a depends on mod.b."""
+    mod_a = _make_mod("mod.a", "/mods/a")
+    mod_a.about_rules.dependencies[CaseInsensitiveStr("mod.b")] = DependencyMod(
+        package_id=CaseInsensitiveStr("mod.b")
+    )
+    return {"/mods/a": mod_a, "/mods/b": _make_mod("mod.b", "/mods/b")}
+
+
+def test_compile_deps_as_load_order_on() -> None:
+    """use_moddependencies_as_loadTheseBefore=True creates load edges from dependencies."""
+    compiled = _compile(_make_dep_mods(), use_moddependencies_as_loadTheseBefore=True)
+    assert "mod.b" in compiled.deps_graph.get("mod.a", set())
+
+
+def test_compile_deps_as_load_order_off() -> None:
+    """use_moddependencies_as_loadTheseBefore=False (default) does not create load edges."""
+    compiled = _compile(_make_dep_mods(), use_moddependencies_as_loadTheseBefore=False)
+    assert "mod.b" not in compiled.deps_graph.get("mod.a", set())

--- a/tests/controllers/test_metadata_db_controller.py
+++ b/tests/controllers/test_metadata_db_controller.py
@@ -118,3 +118,23 @@ def test_tags(temp_db: AuxMetadataController) -> None:
         entry = temp_db.get(session, item_path)
         assert entry is not None
         assert entry.tags == ["tag1", "tag3"]
+
+
+def test_aux_metadata_webapi_timestamp_fields(tmp_path: Path) -> None:
+    """WebAPI timestamp columns exist and default to -1."""
+    from app.controllers.metadata_db_controller import AuxMetadataController
+
+    controller = AuxMetadataController(tmp_path / "test.db")
+    with controller.Session() as session:
+        entry = controller.get_or_create(session, "/test/mod/path")
+        assert entry.external_time_created == -1
+        assert entry.external_time_updated == -1
+        entry.external_time_created = 1234567890
+        entry.external_time_updated = 1234567891
+        session.commit()
+
+    with controller.Session() as session:
+        fetched = controller.get(session, "/test/mod/path")
+        assert fetched is not None
+        assert fetched.external_time_created == 1234567890
+        assert fetched.external_time_updated == 1234567891

--- a/tests/controllers/test_metadata_parity.py
+++ b/tests/controllers/test_metadata_parity.py
@@ -1,0 +1,146 @@
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# Ensure steamworks can be imported even without the native binary
+if "steamworks" not in sys.modules:
+    sys.modules["steamworks"] = MagicMock()
+
+from app.controllers.metadata_controller import MetadataController
+from app.models.metadata.metadata_mediator import MetadataMediator
+from app.models.metadata.metadata_structure import (
+    AboutXmlMod,
+    CompiledDependencyData,
+    ListedMod,
+)
+from app.utils.constants import DEFAULT_USER_RULES
+
+MOD_EXAMPLES = Path(__file__).parent.parent / "data" / "mod_examples"
+
+
+@pytest.fixture
+def parity_mediator(tmp_path: Path) -> MetadataMediator:
+    """Create a MetadataMediator with test fixtures loaded."""
+    user_rules_path = tmp_path / "userRules.json"
+    user_rules_path.write_text(json.dumps(DEFAULT_USER_RULES))
+
+    mediator = MetadataMediator(
+        user_rules_path=user_rules_path,
+        community_rules_path=None,
+        steam_db_path=None,
+        workshop_mods_path=MOD_EXAMPLES / "Steam",
+        local_mods_path=MOD_EXAMPLES / "Local",
+        game_path=MOD_EXAMPLES / "RimWorld",
+    )
+    mediator.refresh_metadata()
+    return mediator
+
+
+@pytest.fixture
+def parity_mods(parity_mediator: MetadataMediator) -> dict[str, ListedMod]:
+    """Load mods from existing test fixtures using the new system."""
+    return parity_mediator.mods_metadata
+
+
+def test_mods_are_parsed(parity_mods: dict[str, ListedMod]) -> None:
+    """All expected mods are parsed from fixtures."""
+    assert len(parity_mods) > 0
+
+    # Extract package IDs from all parsed mods
+    package_ids = {
+        str(mod.package_id)
+        for mod in parity_mods.values()
+        if isinstance(mod, AboutXmlMod)
+    }
+
+    # Known mods that should be present
+    assert "ludeon.rimworld" in package_ids  # Core
+    assert "ludeon.rimworld.royalty" in package_ids  # Royalty DLC
+    assert "ludeon.rimworld.biotech" in package_ids  # Biotech DLC
+    assert "bs.fishery" in package_ids  # Fishery mod
+
+
+def test_compile_produces_valid_graph(parity_mods: dict[str, ListedMod]) -> None:
+    """compile() produces valid CompiledDependencyData."""
+    compiled = MetadataController._build_compiled_data(parity_mods)
+
+    assert isinstance(compiled, CompiledDependencyData)
+    assert isinstance(compiled.deps_graph, dict)
+    assert isinstance(compiled.rev_deps_graph, dict)
+    assert isinstance(compiled.tier_zero_mods, set)
+    assert isinstance(compiled.tier_one_mods, set)
+    assert isinstance(compiled.tier_three_mods, set)
+    assert isinstance(compiled.incompatibilities, dict)
+
+
+def test_compile_reverse_graph_is_inverse_of_forward_graph(
+    parity_mods: dict[str, ListedMod],
+) -> None:
+    """rev_deps_graph is the exact inverse of deps_graph."""
+    compiled = MetadataController._build_compiled_data(parity_mods)
+
+    # For every edge A -> B in deps_graph, there must be B -> A in rev_deps_graph
+    for pkg_id, deps in compiled.deps_graph.items():
+        for dep in deps:
+            assert pkg_id in compiled.rev_deps_graph.get(dep, set()), (
+                f"deps_graph has {pkg_id} -> {dep}, "
+                f"but rev_deps_graph missing {dep} -> {pkg_id}"
+            )
+
+    # And vice versa
+    for pkg_id, rev_deps in compiled.rev_deps_graph.items():
+        for rev_dep in rev_deps:
+            assert pkg_id in compiled.deps_graph.get(rev_dep, set()), (
+                f"rev_deps_graph has {pkg_id} -> {rev_dep}, "
+                f"but deps_graph missing {rev_dep} -> {pkg_id}"
+            )
+
+
+def test_compile_tier_zero_contains_core(
+    parity_mods: dict[str, ListedMod],
+) -> None:
+    """tier_zero_mods contains ludeon.rimworld (Core)."""
+    compiled = MetadataController._build_compiled_data(parity_mods)
+    assert "ludeon.rimworld" in compiled.tier_zero_mods
+
+
+def test_compile_cores_force_load_before_creates_dependency_edges(
+    parity_mods: dict[str, ListedMod],
+) -> None:
+    """Core's forceLoadBefore creates dependency edges for DLCs."""
+    # Core has forceLoadBefore: Ludeon.RimWorld.Ideology, Ludeon.RimWorld.Royalty
+    # This means those DLCs should depend on Core (Core must load before them)
+    compiled = MetadataController._build_compiled_data(parity_mods)
+
+    # Royalty should depend on Core (because Core has forceLoadBefore Royalty)
+    royalty_deps = compiled.deps_graph.get("ludeon.rimworld.royalty", set())
+    assert "ludeon.rimworld" in royalty_deps, (
+        "Royalty should depend on Core due to Core's forceLoadBefore"
+    )
+
+    # Core should be in the reverse dependency graph for Royalty
+    core_rev_deps = compiled.rev_deps_graph.get("ludeon.rimworld", set())
+    assert "ludeon.rimworld.royalty" in core_rev_deps, (
+        "Core should show Royalty in reverse deps"
+    )
+
+
+def test_game_version_is_parsed(parity_mediator: MetadataMediator) -> None:
+    """Game version is parsed from Version.txt."""
+    # Check that Version.txt exists in fixtures
+    version_file = MOD_EXAMPLES / "RimWorld" / "Version.txt"
+    assert version_file.exists(), "Version.txt must exist in fixtures"
+
+    # Game version should not be "Unknown"
+    assert parity_mediator.game_version != "Unknown", (
+        f"Game version should be parsed from {version_file}, "
+        f"got: {parity_mediator.game_version}"
+    )
+
+    # Should match the expected version from the fixture
+    assert "1.5" in parity_mediator.game_version, (
+        f"Expected version to contain '1.5', got: {parity_mediator.game_version}"
+    )

--- a/tests/models/metadata/test_byversion_precedence.py
+++ b/tests/models/metadata/test_byversion_precedence.py
@@ -1,0 +1,301 @@
+"""Tests for ByVersion non-additive override behavior in create_base_rules.
+
+When ``prefer_versioned=True`` (the default) and a ByVersion key matches the
+target RimWorld version, the versioned values REPLACE (not extend) the
+corresponding base values.  ``forceLoad*`` keys are always applied on top.
+"""
+
+from typing import Any
+
+import pytest
+
+from app.models.metadata.metadata_factory import create_base_rules
+
+
+@pytest.fixture
+def mod_data_with_both_base_and_versioned() -> dict[str, Any]:
+    """Mod with base loadAfter AND a matching loadAfterByVersion."""
+    return {
+        "loadAfter": {"li": ["base.mod.a", "base.mod.b"]},
+        "loadAfterByVersion": {
+            "v1.5": {"li": ["versioned.mod.c"]},
+        },
+        "loadBefore": {"li": ["base.before.a"]},
+        "loadBeforeByVersion": {
+            "v1.5": {"li": ["versioned.before.b"]},
+        },
+        "incompatibleWith": {"li": ["base.incompat.a"]},
+        "incompatibleWithByVersion": {
+            "v1.5": {"li": ["versioned.incompat.b"]},
+        },
+        "modDependencies": {
+            "li": [{"packageId": "base.dep.a", "displayName": "Base Dep A"}]
+        },
+        "modDependenciesByVersion": {
+            "v1.5": {
+                "li": [
+                    {"packageId": "versioned.dep.b", "displayName": "Versioned Dep B"}
+                ]
+            },
+        },
+    }
+
+
+# ── prefer_versioned=False ────────────────────────────────────────────
+
+
+def test_byversion_off_uses_only_base(
+    mod_data_with_both_base_and_versioned: dict[str, Any],
+) -> None:
+    """When prefer_versioned is False, ByVersion tags are ignored entirely."""
+    rules = create_base_rules(
+        mod_data_with_both_base_and_versioned,
+        target_version="1.5.1234",
+        prefer_versioned=False,
+    )
+    assert "base.mod.a" in rules.load_after
+    assert "base.mod.b" in rules.load_after
+    assert "versioned.mod.c" not in rules.load_after
+    assert "base.before.a" in rules.load_before
+    assert "versioned.before.b" not in rules.load_before
+
+
+def test_byversion_off_ignores_dependencies(
+    mod_data_with_both_base_and_versioned: dict[str, Any],
+) -> None:
+    """When prefer_versioned is False, modDependenciesByVersion is ignored."""
+    rules = create_base_rules(
+        mod_data_with_both_base_and_versioned,
+        target_version="1.5.1234",
+        prefer_versioned=False,
+    )
+    assert "base.dep.a" in rules.dependencies
+    assert "versioned.dep.b" not in rules.dependencies
+
+
+def test_byversion_off_ignores_incompatible(
+    mod_data_with_both_base_and_versioned: dict[str, Any],
+) -> None:
+    """When prefer_versioned is False, incompatibleWithByVersion is ignored."""
+    rules = create_base_rules(
+        mod_data_with_both_base_and_versioned,
+        target_version="1.5.1234",
+        prefer_versioned=False,
+    )
+    assert "base.incompat.a" in rules.incompatible_with
+    assert "versioned.incompat.b" not in rules.incompatible_with
+
+
+# ── prefer_versioned=True (default) — version matches ─────────────────
+
+
+def test_byversion_on_suppresses_base_when_version_matches(
+    mod_data_with_both_base_and_versioned: dict[str, Any],
+) -> None:
+    """When prefer_versioned is True and version matches, use ONLY versioned, suppress base."""
+    rules = create_base_rules(
+        mod_data_with_both_base_and_versioned,
+        target_version="1.5.1234",
+        prefer_versioned=True,
+    )
+    # Versioned should be present
+    assert "versioned.mod.c" in rules.load_after
+    # Base should be suppressed
+    assert "base.mod.a" not in rules.load_after
+    assert "base.mod.b" not in rules.load_after
+
+
+def test_byversion_on_suppresses_base_load_before(
+    mod_data_with_both_base_and_versioned: dict[str, Any],
+) -> None:
+    """loadBefore base is suppressed when loadBeforeByVersion matches."""
+    rules = create_base_rules(
+        mod_data_with_both_base_and_versioned,
+        target_version="1.5.1234",
+        prefer_versioned=True,
+    )
+    assert "versioned.before.b" in rules.load_before
+    assert "base.before.a" not in rules.load_before
+
+
+def test_byversion_on_suppresses_base_incompatible(
+    mod_data_with_both_base_and_versioned: dict[str, Any],
+) -> None:
+    """incompatibleWith base is suppressed when incompatibleWithByVersion matches."""
+    rules = create_base_rules(
+        mod_data_with_both_base_and_versioned,
+        target_version="1.5.1234",
+        prefer_versioned=True,
+    )
+    assert "versioned.incompat.b" in rules.incompatible_with
+    assert "base.incompat.a" not in rules.incompatible_with
+
+
+def test_byversion_on_suppresses_base_dependencies(
+    mod_data_with_both_base_and_versioned: dict[str, Any],
+) -> None:
+    """modDependencies base is suppressed when modDependenciesByVersion matches."""
+    rules = create_base_rules(
+        mod_data_with_both_base_and_versioned,
+        target_version="1.5.1234",
+        prefer_versioned=True,
+    )
+    assert "versioned.dep.b" in rules.dependencies
+    assert "base.dep.a" not in rules.dependencies
+
+
+# ── Empty versioned key ───────────────────────────────────────────────
+
+
+def test_byversion_on_empty_version_suppresses_base() -> None:
+    """When prefer_versioned is True and versioned key is empty, suppress base (no requirements)."""
+    mod_data = {
+        "loadAfter": {"li": ["base.mod.a"]},
+        "loadAfterByVersion": {
+            "v1.5": {},  # Empty — means "no loadAfter for v1.5"
+        },
+    }
+    rules = create_base_rules(
+        mod_data, target_version="1.5.1234", prefer_versioned=True
+    )
+    assert "base.mod.a" not in rules.load_after
+    assert len(rules.load_after) == 0
+
+
+def test_byversion_on_empty_dependencies_suppresses_base() -> None:
+    """Empty modDependenciesByVersion version means no deps for that version."""
+    mod_data = {
+        "modDependencies": {
+            "li": [{"packageId": "base.dep.a", "displayName": "Base Dep A"}]
+        },
+        "modDependenciesByVersion": {
+            "v1.5": {},  # Empty
+        },
+    }
+    rules = create_base_rules(
+        mod_data, target_version="1.5.1234", prefer_versioned=True
+    )
+    assert len(rules.dependencies) == 0
+
+
+def test_byversion_on_empty_incompatible_suppresses_base() -> None:
+    """Empty incompatibleWithByVersion version means no incompatibilities for that version."""
+    mod_data = {
+        "incompatibleWith": {"li": ["base.incompat.a"]},
+        "incompatibleWithByVersion": {
+            "v1.5": {},  # Empty
+        },
+    }
+    rules = create_base_rules(
+        mod_data, target_version="1.5.1234", prefer_versioned=True
+    )
+    assert len(rules.incompatible_with) == 0
+
+
+# ── No matching version — falls back to base ─────────────────────────
+
+
+def test_byversion_on_no_matching_version_falls_back_to_base() -> None:
+    """When prefer_versioned is True but no matching version key, fall back to base."""
+    mod_data = {
+        "loadAfter": {"li": ["base.mod.a"]},
+        "loadAfterByVersion": {
+            "v1.4": {"li": ["old.version.mod"]},
+        },
+    }
+    rules = create_base_rules(
+        mod_data, target_version="1.5.1234", prefer_versioned=True
+    )
+    assert "base.mod.a" in rules.load_after
+    assert "old.version.mod" not in rules.load_after
+
+
+def test_byversion_on_no_matching_dependencies_falls_back() -> None:
+    """modDependencies falls back to base when no version matches."""
+    mod_data = {
+        "modDependencies": {
+            "li": [{"packageId": "base.dep.a", "displayName": "Base Dep A"}]
+        },
+        "modDependenciesByVersion": {
+            "v1.4": {"li": [{"packageId": "old.dep", "displayName": "Old Dep"}]},
+        },
+    }
+    rules = create_base_rules(
+        mod_data, target_version="1.5.1234", prefer_versioned=True
+    )
+    assert "base.dep.a" in rules.dependencies
+    assert "old.dep" not in rules.dependencies
+
+
+# ── forceLoad always applied ──────────────────────────────────────────
+
+
+def test_byversion_force_load_always_applied() -> None:
+    """forceLoadAfter/forceLoadBefore are always applied regardless of prefer_versioned."""
+    mod_data = {
+        "loadAfter": {"li": ["base.mod.a"]},
+        "loadAfterByVersion": {
+            "v1.5": {"li": ["versioned.mod.c"]},
+        },
+        "forceLoadAfter": {"li": ["force.mod.x"]},
+    }
+    rules = create_base_rules(
+        mod_data, target_version="1.5.1234", prefer_versioned=True
+    )
+    assert "versioned.mod.c" in rules.load_after
+    assert "force.mod.x" in rules.load_after
+    assert "base.mod.a" not in rules.load_after
+
+
+def test_byversion_force_load_before_always_applied() -> None:
+    """forceLoadBefore is always applied even when loadBeforeByVersion overrides base."""
+    mod_data = {
+        "loadBefore": {"li": ["base.before.a"]},
+        "loadBeforeByVersion": {
+            "v1.5": {"li": ["versioned.before.b"]},
+        },
+        "forceLoadBefore": {"li": ["force.before.x"]},
+    }
+    rules = create_base_rules(
+        mod_data, target_version="1.5.1234", prefer_versioned=True
+    )
+    assert "versioned.before.b" in rules.load_before
+    assert "force.before.x" in rules.load_before
+    assert "base.before.a" not in rules.load_before
+
+
+# ── Default parameter — backward compatibility ───────────────────────
+
+
+def test_default_prefer_versioned_is_true() -> None:
+    """Calling create_base_rules without prefer_versioned should default to True (override)."""
+    mod_data = {
+        "loadAfter": {"li": ["base.mod.a"]},
+        "loadAfterByVersion": {
+            "v1.5": {"li": ["versioned.mod.c"]},
+        },
+    }
+    # Call WITHOUT prefer_versioned — should behave as prefer_versioned=True
+    rules = create_base_rules(mod_data, target_version="1.5.1234")
+    assert "versioned.mod.c" in rules.load_after
+    assert "base.mod.a" not in rules.load_after
+
+
+# ── Multi-version keys ───────────────────────────────────────────────
+
+
+def test_byversion_multi_version_keys_only_matching() -> None:
+    """When multiple version keys exist, only the matching one is used."""
+    mod_data = {
+        "loadAfter": {"li": ["base.mod.a"]},
+        "loadAfterByVersion": {
+            "v1.4": {"li": ["old.mod"]},
+            "v1.5": {"li": ["current.mod"]},
+        },
+    }
+    rules = create_base_rules(
+        mod_data, target_version="1.5.1234", prefer_versioned=True
+    )
+    assert "current.mod" in rules.load_after
+    assert "old.mod" not in rules.load_after
+    assert "base.mod.a" not in rules.load_after

--- a/tests/models/metadata/test_byversion_precedence.py
+++ b/tests/models/metadata/test_byversion_precedence.py
@@ -299,3 +299,47 @@ def test_byversion_multi_version_keys_only_matching() -> None:
     assert "current.mod" in rules.load_after
     assert "old.mod" not in rules.load_after
     assert "base.mod.a" not in rules.load_after
+
+
+# ── Missing packageId sentinel ───────────────────────────────────────
+
+
+def test_missing_packageid_gets_sentinel() -> None:
+    """Mods with missing packageId get the sentinel value, not marked invalid."""
+    from app.models.metadata.metadata_factory import create_about_mod
+    from app.utils.constants import DEFAULT_MISSING_PACKAGEID
+
+    mod_data = {
+        "name": "Test Mod Without PackageId",
+    }
+    valid, mod = create_about_mod(mod_data, target_version="1.5.1234")
+    assert mod.package_id == DEFAULT_MISSING_PACKAGEID
+    assert mod.valid is True
+
+
+def test_empty_packageid_gets_sentinel() -> None:
+    """Mods with empty packageId get the sentinel value, not marked invalid."""
+    from app.models.metadata.metadata_factory import create_about_mod
+    from app.utils.constants import DEFAULT_MISSING_PACKAGEID
+
+    mod_data = {
+        "name": "Test Mod With Empty PackageId",
+        "packageId": "   ",  # Only whitespace
+    }
+    valid, mod = create_about_mod(mod_data, target_version="1.5.1234")
+    assert mod.package_id == DEFAULT_MISSING_PACKAGEID
+    assert mod.valid is True
+
+
+def test_non_string_packageid_gets_sentinel() -> None:
+    """Mods with non-string packageId get the sentinel value, not marked invalid."""
+    from app.models.metadata.metadata_factory import create_about_mod
+    from app.utils.constants import DEFAULT_MISSING_PACKAGEID
+
+    mod_data = {
+        "name": "Test Mod With Non-String PackageId",
+        "packageId": 12345,  # Integer instead of string
+    }
+    valid, mod = create_about_mod(mod_data, target_version="1.5.1234")
+    assert mod.package_id == DEFAULT_MISSING_PACKAGEID
+    assert mod.valid is True

--- a/tests/models/metadata/test_metadata_mediator.py
+++ b/tests/models/metadata/test_metadata_mediator.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 import pytest
@@ -77,3 +78,70 @@ def test_user_rules_addition(mediator: MetadataMediator) -> None:
 
     assert mod.user_rules.load_last
     assert mod.overall_rules.load_last
+
+
+def test_mediator_no_version_warning_defaults_none(tmp_path: Path) -> None:
+    """no_version_warning is None when no path configured."""
+    mediator = MetadataMediator(
+        user_rules_path=tmp_path / "rules.json",
+        community_rules_path=None,
+        steam_db_path=None,
+        workshop_mods_path=None,
+        local_mods_path=None,
+        game_path=None,
+    )
+    assert mediator.no_version_warning is None
+
+
+def test_mediator_use_this_instead_defaults_none(tmp_path: Path) -> None:
+    """use_this_instead is None when no path configured."""
+    mediator = MetadataMediator(
+        user_rules_path=tmp_path / "rules.json",
+        community_rules_path=None,
+        steam_db_path=None,
+        workshop_mods_path=None,
+        local_mods_path=None,
+        game_path=None,
+    )
+    assert mediator.use_this_instead is None
+
+
+def test_mediator_loads_no_version_warning(tmp_path: Path) -> None:
+    """Mediator loads No Version Warning from XML file."""
+    xml_content = '<?xml version="1.0" encoding="utf-8"?>\n<ModIdsToFix><li>mod.a</li><li>mod.b</li></ModIdsToFix>'
+    nvw_path = tmp_path / "ModIdsToFix.xml"
+    nvw_path.write_text(xml_content)
+
+    mediator = MetadataMediator(
+        user_rules_path=tmp_path / "rules.json",
+        community_rules_path=None,
+        steam_db_path=None,
+        workshop_mods_path=None,
+        local_mods_path=None,
+        game_path=None,
+        no_version_warning_path=nvw_path,
+    )
+    mediator._load_no_version_warning()
+    assert mediator.no_version_warning is not None
+    assert "mod.a" in mediator.no_version_warning
+    assert "mod.b" in mediator.no_version_warning
+
+
+def test_mediator_loads_use_this_instead(tmp_path: Path) -> None:
+    """Mediator loads Use This Instead from JSON file."""
+    uti_data = {"old.mod.a": {"replacement": "new.mod.b"}}
+    uti_path = tmp_path / "use_this_instead.json"
+    uti_path.write_text(json.dumps(uti_data))
+
+    mediator = MetadataMediator(
+        user_rules_path=tmp_path / "rules.json",
+        community_rules_path=None,
+        steam_db_path=None,
+        workshop_mods_path=None,
+        local_mods_path=None,
+        game_path=None,
+        use_this_instead_path=uti_path,
+    )
+    mediator._load_use_this_instead()
+    assert mediator.use_this_instead is not None
+    assert "old.mod.a" in mediator.use_this_instead

--- a/tests/models/metadata/test_metadata_structure.py
+++ b/tests/models/metadata/test_metadata_structure.py
@@ -216,3 +216,25 @@ def test_about_xml_mod_overall_rules() -> None:
 def test_listed_mod_c_sharp_mod_default() -> None:
     mod = ListedMod()
     assert not mod.c_sharp_mod
+
+
+def test_compiled_dependency_data_defaults() -> None:
+    from app.models.metadata.metadata_structure import CompiledDependencyData
+
+    compiled = CompiledDependencyData()
+    assert compiled.deps_graph == {}
+    assert compiled.rev_deps_graph == {}
+    assert compiled.tier_zero_mods == set()
+    assert compiled.tier_one_mods == set()
+    assert compiled.tier_three_mods == set()
+    assert compiled.incompatibilities == {}
+
+
+def test_listed_mod_new_fields() -> None:
+    mod = ListedMod()
+    assert mod.obsolete is False
+    assert mod.db_builder_no_name is False
+    mod.obsolete = True
+    mod.db_builder_no_name = True
+    assert mod.obsolete is True
+    assert mod.db_builder_no_name is True


### PR DESCRIPTION
## Summary

First PR of the MetadataManager replacement (#2051). Ports the "authority" — core compilation logic — into the new `MetadataController` system, running alongside the old `MetadataManager` without replacing any consumers yet.

- Add `CompiledDependencyData` dataclass for standalone dependency graph state
- Fix ByVersion non-additive override in factory (versioned values replace base, not merge)
- Fix missing-packageId sentinel handling (assign sentinel instead of marking invalid)
- Add WebAPI timestamp columns to `AuxMetadataEntry` with DB migration
- Add No Version Warning and Use This Instead loading to `MetadataMediator`
- Implement `_build_compiled_data()` — dependency graphs, tier classification, incompatibilities
- Add Qt signals, singleton pattern, `compile()`, utility methods to `MetadataController`
- Wire `MetadataController` into app startup alongside `MetadataManager`
- Comprehensive test coverage (ByVersion precedence, compilation, parity)

## Key design decisions

- **PATH as identifier** — deterministic, debuggable, matches AuxMetadataController
- **Standalone `CompiledDependencyData`** — mods stay immutable after parsing, cross-mod state computed separately
- **ByVersion fixed in factory** — non-additive override at parse time, not in compile()
- **Tier constants copied** — prevents mutation bug #2041
- **Strangler fig** — both systems coexist, consumers migrate in PRs 2-4

## Deferred to later PRs

- DLC metadata normalization (needs design decision on where it belongs)
- `packageid_to_paths` / `steamdb_packageid_to_name` caching (no consumers yet)
- `use_alternative_package_ids_as_satisfying_dependencies` (PR 2 when sort migrates)
- Schema validation for external JSON DBs (#2055)

## Test plan

- [x] 16 ByVersion precedence tests (all override scenarios)
- [x] 13 compilation unit tests (graphs, tiers, incompatibilities, constants immutability)
- [x] 6 parity tests against real mod fixtures
- [x] 4 mediator external metadata tests
- [x] 3 packageId sentinel tests
- [x] 2 WebAPI timestamp tests
- [x] `just check` passes (ruff, mypy, pyright, jscpd, shfmt, markdownlint)
- [x] `just test` passes (416/416)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)