### PR TITLE
fix(ui): add confirmation before deleting optimized textures

### DIFF
--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -2234,6 +2234,22 @@ class MainContent(QObject):
 
         The operation runs asynchronously in a UI panel showing progress.
         """
+        answer = dialogue.show_dialogue_conditional(
+            title=self.tr("Confirm texture deletion"),
+            text=self.tr(
+                "This will delete all optimized .dds textures from your active mods"
+            ),
+            information=self.tr(
+                "Are you sure you want to delete all .dds textures? "
+                "You can re-optimize them later if needed."
+            ),
+            button_text_override=[
+                self.tr("Delete textures"),
+            ],
+        )
+        if self.tr("Delete textures") not in str(answer):
+            return
+
         logger.info("Deleting .dds textures with todds...")
 
         # Create todds interface with clean preset (removes .dds files)


### PR DESCRIPTION
## Summary
- Add a confirmation dialog to the global "Delete .dds Textures" menu action (`Tools > Textures > Delete .dds Textures`)
- Previously this action ran immediately without any user confirmation, unlike other destructive operations
- Uses the same `show_dialogue_conditional` pattern as ACF import and other destructive actions in the codebase

## Test plan
- [x] Open RimSort, go to Tools > Textures > Delete .dds Textures
- [x] Verify confirmation dialog appears with title, description, and "Delete textures" button
- [x] Click cancel/close — verify no deletion occurs
- [x] Click "Delete textures" — verify todds clean runs as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)