### PR TITLE
feat: GitHub mod support — install, update, and manage mods from GitHub releases

### DIFF
--- a/app/controllers/main_content_controller.py
+++ b/app/controllers/main_content_controller.py
@@ -40,7 +40,11 @@ from app.utils.github.provider import (
     ReleaseInfo,
     parse_github_url,
 )
-from app.utils.github.worker import GitHubInstallWorker, GitHubVersionSwitchWorker
+from app.utils.github.worker import (
+    GitHubInstallWorker,
+    GitHubUpdateCheckWorker,
+    GitHubVersionSwitchWorker,
+)
 from app.utils.http_downloader import (
     DatabaseDownloadTask,
     DownloadResult,
@@ -56,6 +60,7 @@ from app.views.main_content_panel import MainContent
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
+    from app.utils.github.updater import UpdateAvailable
     from app.windows.github_mods_panel import GitHubModsPanel
 
 
@@ -74,6 +79,7 @@ class MainContentController(QObject):
         self._http_download_worker: Optional[HttpDownloadWorker] = None
         self._github_install_worker: Optional[GitHubInstallWorker] = None
         self._github_version_switch_worker: Optional[GitHubVersionSwitchWorker] = None
+        self._github_update_check_worker: Optional[GitHubUpdateCheckWorker] = None
         self._github_mods_panel: Optional[GitHubModsPanel] = None
 
         # Thread pool for concurrent tasks
@@ -126,6 +132,72 @@ class MainContentController(QObject):
         }
 
         self._connect_signals()
+        self._start_github_update_check()
+
+    def _start_github_update_check(self) -> None:
+        """Run a background GitHub update check if enabled in settings."""
+        from app.utils.github.worker import GitHubUpdateCheckWorker
+
+        settings = self.settings_controller.settings
+        if not settings.github_update_check_enabled:
+            return
+
+        try:
+            from app.controllers.metadata_db_controller import AuxMetadataController
+            from app.models.metadata.metadata_db import Base
+            from app.utils.github.models import GitHubModEntry
+
+            aux_controller = AuxMetadataController.get_or_create_cached_instance(
+                settings.aux_db_path
+            )
+            Base.metadata.create_all(aux_controller.engine)
+
+            with aux_controller.Session() as session:
+                count = session.query(GitHubModEntry).count()
+            if count == 0:
+                return
+        except Exception:
+            return
+
+        cache_session = self._get_github_cache_session()
+        provider = GitHubProvider(
+            github_token=settings.github_token or None,
+            cache_session=cache_session,
+        )
+
+        self._github_update_check_worker = GitHubUpdateCheckWorker(
+            provider=provider,
+            instance_session_factory=aux_controller.Session,
+            check_interval_hours=settings.github_update_check_interval_hours,
+        )
+        self._github_update_check_worker.finished.connect(
+            self._on_github_update_check_finished
+        )
+        self._github_update_check_worker.error.connect(
+            lambda msg: logger.warning(f"GitHub update check failed: {msg}")
+        )
+        self._github_update_check_worker.start()
+        logger.info(f"Started background GitHub update check for {count} mod(s)")
+
+    def _on_github_update_check_finished(self, updates: list[UpdateAvailable]) -> None:
+        """Handle results from background GitHub update check."""
+        if not updates:
+            logger.info("All GitHub mods are up to date")
+            return
+
+        mod_names = ", ".join(u.owner_repo for u in updates[:5])
+        suffix = f" and {len(updates) - 5} more" if len(updates) > 5 else ""
+        logger.info(f"GitHub updates available: {mod_names}{suffix}")
+
+        InformationBox(
+            title=self.tr("GitHub Mod Updates Available"),
+            text=self.tr("{count} GitHub mod(s) have updates available.").format(
+                count=len(updates)
+            ),
+            information=self.tr(
+                "Use Download → GitHub Mods to view and install updates."
+            ),
+        ).exec()
 
     def _connect_signals(self) -> None:
         # Bind install mod signal

--- a/app/controllers/main_content_controller.py
+++ b/app/controllers/main_content_controller.py
@@ -38,7 +38,7 @@ from app.utils.github.provider import (
     ReleaseInfo,
     parse_github_url,
 )
-from app.utils.github.worker import GitHubInstallWorker
+from app.utils.github.worker import GitHubInstallWorker, GitHubVersionSwitchWorker
 from app.utils.http_downloader import (
     DatabaseDownloadTask,
     DownloadResult,
@@ -69,6 +69,7 @@ class MainContentController(QObject):
         self._git_stage_commit_worker: Optional[GitStageCommitWorker] = None
         self._http_download_worker: Optional[HttpDownloadWorker] = None
         self._github_install_worker: Optional[GitHubInstallWorker] = None
+        self._github_version_switch_worker: Optional[GitHubVersionSwitchWorker] = None
         self._github_mods_panel: Optional[GitHubModsPanel] = None
 
         # Thread pool for concurrent tasks
@@ -160,6 +161,9 @@ class MainContentController(QObject):
         )
         EventBus().do_upload_community_rules_db_to_github.connect(
             self._on_do_upload_community_db_to_github
+        )
+        EventBus().github_version_switch_requested.connect(
+            self._on_github_version_switch
         )
 
     def _on_open_github_mods_panel(self) -> None:
@@ -1041,6 +1045,120 @@ class MainContentController(QObject):
         InformationBox(
             title=self.tr("GitHub Mod Installed"),
             text=self.tr("Successfully installed {owner_repo} ({version})").format(
+                owner_repo=owner_repo, version=version
+            ),
+        ).exec()
+
+        EventBus().do_refresh_mods_lists.emit()
+
+    @Slot(str, str)
+    def _on_github_version_switch(self, mod_path: str, selected_tag: str) -> None:
+        """Handle version switch request from the mod info panel combo box."""
+        from app.controllers.metadata_db_controller import AuxMetadataController
+        from app.models.metadata.metadata_db import Base
+        from app.utils.github.models import GitHubModEntry
+        from app.utils.github.worker import GitHubVersionSwitchWorker
+
+        settings = self.settings_controller.settings
+        aux_controller = AuxMetadataController.get_or_create_cached_instance(
+            settings.aux_db_path
+        )
+        Base.metadata.create_all(aux_controller.engine)
+
+        with aux_controller.Session() as session:
+            entry = session.query(GitHubModEntry).filter_by(mod_path=mod_path).first()
+            if entry is None:
+                logger.warning(f"No GitHub mod entry for {mod_path}")
+                return
+            owner_repo = entry.owner_repo
+
+        provider = GitHubProvider(github_token=settings.github_token or None)
+        releases = provider.get_releases(owner_repo)
+
+        target_release = None
+        target_asset = None
+
+        if selected_tag != "HEAD (latest commit)":
+            target_release = next((r for r in releases if r.tag == selected_tag), None)
+            if target_release is not None:
+                custom_zips = target_release.get_custom_zip_assets()
+                if len(custom_zips) == 1:
+                    target_asset = custom_zips[0]
+                elif len(custom_zips) > 1:
+                    asset_names = [a.name for a in custom_zips]
+                    chosen_asset, ok = QInputDialog().getItem(
+                        self.view.mods_panel,
+                        self.tr("Select Asset"),
+                        self.tr("Multiple release assets found. Choose one:"),
+                        asset_names,
+                        0,
+                        False,
+                    )
+                    if not ok:
+                        return
+                    target_asset = custom_zips[asset_names.index(chosen_asset)]
+                else:
+                    answer = show_dialogue_conditional(
+                        title=self.tr("No Release ZIP Found"),
+                        text=self.tr(
+                            "Release {tag} has no ZIP assets. Switch to HEAD instead?"
+                        ).format(tag=selected_tag),
+                    )
+                    if answer != QMessageBox.StandardButton.Yes:
+                        return
+                    target_release = None
+
+        repo_url = f"https://github.com/{owner_repo}.git"
+
+        self._github_version_switch_worker = GitHubVersionSwitchWorker(
+            mod_path=mod_path,
+            owner_repo=owner_repo,
+            repo_url=repo_url,
+            target_release=target_release,
+            target_asset=target_asset,
+        )
+        self._github_version_switch_worker.finished.connect(
+            lambda ok, ver, path: self._on_github_version_switch_finished(
+                ok, ver, path, owner_repo
+            )
+        )
+        self._github_version_switch_worker.start()
+
+    def _on_github_version_switch_finished(
+        self, success: bool, new_version: str, mod_path: str, owner_repo: str
+    ) -> None:
+        """Handle completed version switch."""
+        if not success:
+            InformationBox(
+                title=self.tr("Version Switch Failed"),
+                text=self.tr("Failed to switch version: {error}").format(
+                    error=new_version
+                ),
+            ).exec()
+            return
+
+        from app.controllers.metadata_db_controller import AuxMetadataController
+        from app.utils.github.models import GitHubModEntry
+
+        settings = self.settings_controller.settings
+        aux_controller = AuxMetadataController.get_or_create_cached_instance(
+            settings.aux_db_path
+        )
+
+        version = "HEAD" if new_version.startswith("HEAD") else new_version
+        with aux_controller.Session() as session:
+            entry = (
+                session.query(GitHubModEntry)
+                .filter_by(owner_repo=owner_repo, mod_path=mod_path)
+                .first()
+            )
+            if entry is not None:
+                entry.installed_version = version
+                session.commit()
+
+        InformationBox(
+            title=self.tr("Version Switched"),
+            text=self.tr("Switched {owner_repo} to {version}").format(
                 owner_repo=owner_repo, version=version
             ),
         ).exec()

--- a/app/controllers/main_content_controller.py
+++ b/app/controllers/main_content_controller.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 import json
 import time
@@ -52,6 +54,8 @@ from app.views.dialogue import (
 from app.views.main_content_panel import MainContent
 
 if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
     from app.windows.github_mods_panel import GitHubModsPanel
 
 
@@ -165,6 +169,18 @@ class MainContentController(QObject):
         EventBus().github_version_switch_requested.connect(
             self._on_github_version_switch
         )
+
+    def _get_github_cache_session(self) -> Session:
+        """Create a session for the global GitHub release cache DB."""
+        from sqlalchemy import create_engine
+        from sqlalchemy.orm import sessionmaker
+
+        from app.utils.github.models import CacheBase
+
+        cache_db = AppInfo().app_storage_folder / "github_release_cache.db"
+        engine = create_engine(f"sqlite+pysqlite:///{cache_db}")
+        CacheBase.metadata.create_all(engine)
+        return sessionmaker(bind=engine)()
 
     def _on_open_github_mods_panel(self) -> None:
         """Open the GitHub Mods panel, reusing the existing window if open."""
@@ -845,7 +861,11 @@ class MainContentController(QObject):
             return
 
         settings = self.settings_controller.settings
-        provider = GitHubProvider(github_token=settings.github_token or None)
+        cache_session = self._get_github_cache_session()
+        provider = GitHubProvider(
+            github_token=settings.github_token or None,
+            cache_session=cache_session,
+        )
 
         try:
             releases = provider.get_releases(owner_repo, force_refresh=True)
@@ -1072,7 +1092,11 @@ class MainContentController(QObject):
                 return
             owner_repo = entry.owner_repo
 
-        provider = GitHubProvider(github_token=settings.github_token or None)
+        cache_session = self._get_github_cache_session()
+        provider = GitHubProvider(
+            github_token=settings.github_token or None,
+            cache_session=cache_session,
+        )
         releases = provider.get_releases(owner_repo)
 
         target_release = None

--- a/app/controllers/main_content_controller.py
+++ b/app/controllers/main_content_controller.py
@@ -185,19 +185,125 @@ class MainContentController(QObject):
             logger.info("All GitHub mods are up to date")
             return
 
-        mod_names = ", ".join(u.owner_repo for u in updates[:5])
-        suffix = f" and {len(updates) - 5} more" if len(updates) > 5 else ""
-        logger.info(f"GitHub updates available: {mod_names}{suffix}")
+        auto = [u for u in updates if u.auto_update]
+        manual = [u for u in updates if not u.auto_update]
 
-        InformationBox(
-            title=self.tr("GitHub Mod Updates Available"),
-            text=self.tr("{count} GitHub mod(s) have updates available.").format(
-                count=len(updates)
-            ),
-            information=self.tr(
-                "Use Download → GitHub Mods to view and install updates."
-            ),
-        ).exec()
+        if manual:
+            names = ", ".join(u.owner_repo for u in manual[:5])
+            suffix = f" and {len(manual) - 5} more" if len(manual) > 5 else ""
+            logger.info(f"GitHub updates available (manual): {names}{suffix}")
+            InformationBox(
+                title=self.tr("GitHub Mod Updates Available"),
+                text=self.tr("{count} GitHub mod(s) have updates available.").format(
+                    count=len(manual)
+                ),
+                information=self.tr(
+                    "Use Download → GitHub Mods to view and install updates."
+                ),
+            ).exec()
+
+        if auto:
+            logger.info(
+                f"Auto-updating {len(auto)} GitHub mod(s): "
+                + ", ".join(u.owner_repo for u in auto)
+            )
+            self._github_auto_update_queue = list(auto)
+            self._github_auto_update_results: list[tuple[str, bool]] = []
+            self._process_next_auto_update()
+        elif not manual:
+            logger.info("All GitHub mods are up to date")
+
+    def _process_next_auto_update(self) -> None:
+        """Process the next mod in the auto-update queue."""
+        if not self._github_auto_update_queue:
+            self._on_auto_updates_complete()
+            return
+
+        update = self._github_auto_update_queue.pop(0)
+        release = update.latest_release
+        if release is None:
+            self._github_auto_update_results.append((update.owner_repo, False))
+            self._process_next_auto_update()
+            return
+
+        target_asset = None
+        custom_zips = release.get_custom_zip_assets()
+        if len(custom_zips) >= 1:
+            target_asset = custom_zips[0]
+
+        repo_url = f"https://github.com/{update.owner_repo}.git"
+        worker = GitHubVersionSwitchWorker(
+            mod_path=update.mod_path,
+            owner_repo=update.owner_repo,
+            repo_url=repo_url,
+            target_release=release if target_asset else None,
+            target_asset=target_asset,
+        )
+        owner_repo = update.owner_repo
+        worker.finished.connect(
+            lambda ok, ver, path: self._on_auto_update_one_finished(
+                ok, ver, path, owner_repo
+            )
+        )
+        self._github_version_switch_worker = worker
+        worker.start()
+
+    def _on_auto_update_one_finished(
+        self, success: bool, new_version: str, mod_path: str, owner_repo: str
+    ) -> None:
+        """Handle completion of a single auto-update, then process the next."""
+        self._github_auto_update_results.append((owner_repo, success))
+
+        if success:
+            from app.controllers.metadata_db_controller import AuxMetadataController
+            from app.utils.github.models import GitHubModEntry
+
+            settings = self.settings_controller.settings
+            aux_controller = AuxMetadataController.get_or_create_cached_instance(
+                settings.aux_db_path
+            )
+            version = "HEAD" if new_version.startswith("HEAD") else new_version
+            with aux_controller.Session() as session:
+                entry = (
+                    session.query(GitHubModEntry)
+                    .filter_by(owner_repo=owner_repo, mod_path=mod_path)
+                    .first()
+                )
+                if entry is not None:
+                    entry.installed_version = version
+                    session.commit()
+            logger.info(f"Auto-updated {owner_repo} to {version}")
+        else:
+            logger.warning(f"Auto-update failed for {owner_repo}: {new_version}")
+
+        self._process_next_auto_update()
+
+    def _on_auto_updates_complete(self) -> None:
+        """Show results after all auto-updates finish and offer to refresh."""
+        results = self._github_auto_update_results
+        succeeded = [r for r, ok in results if ok]
+        failed = [r for r, ok in results if not ok]
+
+        summary_parts = []
+        if succeeded:
+            summary_parts.append(
+                self.tr("Updated: {mods}").format(mods=", ".join(succeeded))
+            )
+        if failed:
+            summary_parts.append(
+                self.tr("Failed: {mods}").format(mods=", ".join(failed))
+            )
+
+        refresh_now = show_dialogue_conditional(
+            title=self.tr("GitHub Auto-Update Complete"),
+            text=self.tr(
+                "{count} mod(s) were auto-updated.\n\n{summary}\n\n"
+                "The updated versions won't appear until you refresh. "
+                "Refresh now?"
+            ).format(count=len(succeeded), summary="\n".join(summary_parts)),
+        )
+        if refresh_now:
+            EventBus().do_refresh_mods_lists.emit()
 
     def _connect_signals(self) -> None:
         # Bind install mod signal

--- a/app/controllers/main_content_controller.py
+++ b/app/controllers/main_content_controller.py
@@ -374,7 +374,7 @@ class MainContentController(QObject):
             self._github_mods_panel.deleteLater()
 
         self._github_mods_panel = GitHubModsPanel()
-        self.view._child_windows.append(self._github_mods_panel)
+        self.view.window_manager.register(self._github_mods_panel)
         self._github_mods_panel.show()
 
     @Slot(list)

--- a/app/controllers/main_content_controller.py
+++ b/app/controllers/main_content_controller.py
@@ -31,6 +31,14 @@ from app.utils.git_worker import (
     GitStageCommitWorker,
     PushConfig,
 )
+from app.utils.github.provider import (
+    GitHubProvider,
+    GitHubRateLimitError,
+    ReleaseAsset,
+    ReleaseInfo,
+    parse_github_url,
+)
+from app.utils.github.worker import GitHubInstallWorker
 from app.utils.http_downloader import (
     DatabaseDownloadTask,
     DownloadResult,
@@ -57,6 +65,7 @@ class MainContentController(QObject):
         self._git_push_worker: Optional[GitPushWorker] = None
         self._git_stage_commit_worker: Optional[GitStageCommitWorker] = None
         self._http_download_worker: Optional[HttpDownloadWorker] = None
+        self._github_install_worker: Optional[GitHubInstallWorker] = None
 
         # Thread pool for concurrent tasks
         self.thread_pool = QThreadPool.globalInstance()
@@ -221,13 +230,38 @@ class MainContentController(QObject):
         else:
             logger.debug("User declined batch update.")
 
+    def _filter_non_github_repos(self, repos_paths: List[Path]) -> List[Path]:
+        """Filter out paths tracked as GitHub mods in the current instance."""
+        from app.controllers.metadata_db_controller import AuxMetadataController
+        from app.utils.github.models import GitHubModEntry
+
+        settings = self.settings_controller.settings
+        try:
+            aux_controller = AuxMetadataController.get_or_create_cached_instance(
+                settings.aux_db_path
+            )
+            with aux_controller.Session() as session:
+                github_paths = {
+                    entry.mod_path for entry in session.query(GitHubModEntry).all()
+                }
+        except Exception as e:
+            logger.debug(f"Could not check GitHub mods table: {e}")
+            return list(repos_paths)
+
+        return [p for p in repos_paths if str(p) not in github_paths]
+
     def _on_update_repos(self, repos_paths: List[Path]) -> None:
         """Schedule concurrent batch pull for multiple repositories."""
+        filtered_paths = self._filter_non_github_repos(repos_paths)
+        if not filtered_paths:
+            logger.debug("All repos are GitHub mods, skipping batch update.")
+            return
         logger.debug(
-            f"Scheduling concurrent update for {len(repos_paths)} repositories."
+            f"Scheduling concurrent update for {len(filtered_paths)} repositories "
+            f"({len(repos_paths) - len(filtered_paths)} GitHub mods excluded)."
         )
         config = GitOperationConfig(notify_errors=True)
-        worker = GitBatchUpdateWorker(repos_paths, config=config)
+        worker = GitBatchUpdateWorker(filtered_paths, config=config)
         worker.signals.finished.connect(self._handle_batch_update_results)
         self.thread_pool.start(worker)
 
@@ -551,11 +585,14 @@ class MainContentController(QObject):
 
     def _on_update_repos_silent(self, repos_paths: List[Path]) -> None:
         """Schedule concurrent batch pull for multiple repositories silently."""
+        filtered_paths = self._filter_non_github_repos(repos_paths)
+        if not filtered_paths:
+            return
         logger.debug(
-            f"Scheduling silent concurrent update for {len(repos_paths)} repositories."
+            f"Scheduling silent concurrent update for {len(filtered_paths)} repositories."
         )
         config = GitOperationConfig(notify_errors=False)
-        worker = GitBatchUpdateWorker(repos_paths, config=config)
+        worker = GitBatchUpdateWorker(filtered_paths, config=config)
         worker.signals.finished.connect(self._handle_batch_update_results_silent)
         self.thread_pool.start(worker)
 
@@ -751,23 +788,233 @@ class MainContentController(QObject):
 
     @Slot()
     def _do_git_install_mod(self) -> None:
-        """Prompt user for repo URL and trigger clone."""
+        """Prompt user for repo URL and trigger clone or GitHub install."""
         args, ok = QInputDialog().getText(
             self.view.mods_panel,
             self.tr("Enter git repo"),
             self.tr("Enter a git repository url (http/https) to clone to local mods:"),
         )
-        if ok and args:
-            self._do_git_clone(
-                base_path=str(
-                    self.settings_controller.settings.instances[
-                        self.settings_controller.settings.current_instance
-                    ].local_folder
-                ),
-                repo_url=args,
+        if not ok or not args:
+            logger.debug("Cancelled git install mod.")
+            return
+
+        base_path = str(
+            self.settings_controller.settings.instances[
+                self.settings_controller.settings.current_instance
+            ].local_folder
+        )
+
+        parsed = parse_github_url(args)
+        if parsed is not None:
+            owner, repo = parsed
+            self._do_github_install_flow(f"{owner}/{repo}", args, base_path)
+        else:
+            self._do_git_clone(base_path=base_path, repo_url=args)
+
+    def _do_github_install_flow(
+        self, owner_repo: str, repo_url: str, base_path: str
+    ) -> None:
+        """Handle GitHub URL: query releases, offer choice dialog, install."""
+        if not check_internet_connection():
+            return
+
+        settings = self.settings_controller.settings
+        provider = GitHubProvider(github_token=settings.github_token or None)
+
+        try:
+            releases = provider.get_releases(owner_repo, force_refresh=True)
+        except GitHubRateLimitError as e:
+            InformationBox(
+                title=self.tr("GitHub Rate Limit"),
+                text=str(e),
+            ).exec()
+            releases = []
+        except Exception as e:
+            logger.error(f"Failed to query GitHub releases: {e}")
+            releases = []
+
+        if releases:
+            dialog_text = self.tr(
+                "This repository is hosted on GitHub. You can install it as a "
+                "GitHub Mod to track releases and manage versions, or clone it "
+                "directly as a standard git mod."
             )
         else:
-            logger.debug("Cancelled git install mod.")
+            dialog_text = self.tr(
+                "No releases found for this repository. You can install it as a "
+                "GitHub Mod tracking the latest commit (you'll be notified if "
+                "releases are published in the future), or clone it directly "
+                "as a standard git mod."
+            )
+
+        choice = BinaryChoiceDialog(
+            title=self.tr("GitHub Repository Detected"),
+            text=dialog_text,
+            information=self.tr("Repository: {owner_repo}").format(
+                owner_repo=owner_repo
+            ),
+            positive_text=self.tr("Install as GitHub Mod"),
+            negative_text=self.tr("Clone as Git Mod"),
+        )
+
+        if not choice.exec_is_positive():
+            self._do_git_clone(base_path=base_path, repo_url=repo_url)
+            return
+
+        version_labels: list[str] = []
+        releases_by_label: dict[str, ReleaseInfo | None] = {}
+
+        for r in releases:
+            label = f"{r.tag} (pre-release)" if r.prerelease else r.tag
+            version_labels.append(label)
+            releases_by_label[label] = r
+
+        version_labels.append("HEAD (latest commit)")
+        releases_by_label["HEAD (latest commit)"] = None
+
+        stable = [r for r in releases if not r.prerelease]
+        if stable:
+            default_label = stable[0].tag
+        elif releases:
+            default_label = version_labels[0]
+        else:
+            default_label = "HEAD (latest commit)"
+
+        chosen_label, ok = QInputDialog().getItem(
+            self.view.mods_panel,
+            self.tr("Select Version"),
+            self.tr("Choose a version to install:"),
+            version_labels,
+            version_labels.index(default_label),
+            False,
+        )
+        if not ok:
+            return
+
+        target_release = releases_by_label.get(chosen_label)
+        target_asset: ReleaseAsset | None = None
+
+        if target_release is not None:
+            custom_zips = target_release.get_custom_zip_assets()
+            if len(custom_zips) == 1:
+                target_asset = custom_zips[0]
+            elif len(custom_zips) > 1:
+                asset_names = [a.name for a in custom_zips]
+                chosen_asset, ok = QInputDialog().getItem(
+                    self.view.mods_panel,
+                    self.tr("Select Asset"),
+                    self.tr("Multiple release assets found. Choose one:"),
+                    asset_names,
+                    0,
+                    False,
+                )
+                if not ok:
+                    return
+                target_asset = custom_zips[asset_names.index(chosen_asset)]
+            else:
+                answer = show_dialogue_conditional(
+                    title=self.tr("No Release ZIP Found"),
+                    text=self.tr(
+                        "Release {tag} has no ZIP assets. "
+                        "Install from HEAD (latest commit) instead?"
+                    ).format(tag=target_release.tag),
+                    information=self.tr(
+                        "The release only contains source archives, which may "
+                        "not work as a RimWorld mod."
+                    ),
+                )
+                if answer != QMessageBox.StandardButton.Yes:
+                    return
+                target_release = None
+
+        repo_name = owner_repo.split("/")[1]
+        target_dir = str(Path(base_path) / repo_name)
+
+        if Path(target_dir).exists():
+            answer = show_dialogue_conditional(
+                title=self.tr("Existing mod found"),
+                text=self.tr(
+                    "A mod folder already exists at this location: {path}"
+                ).format(path=target_dir),
+                information=self.tr("Replace it with the GitHub mod?"),
+            )
+            if answer != QMessageBox.StandardButton.Yes:
+                return
+            import shutil
+
+            shutil.rmtree(target_dir, ignore_errors=True)
+
+        self._github_install_worker = GitHubInstallWorker(
+            owner_repo=owner_repo,
+            release=target_release,
+            asset=target_asset,
+            repo_url=repo_url,
+            target_dir=target_dir,
+        )
+        self._github_install_worker.finished.connect(
+            lambda ok, msg, path: self._on_github_install_finished(
+                ok, msg, path, owner_repo, target_release, target_asset
+            )
+        )
+        self._github_install_worker.start()
+
+    def _on_github_install_finished(
+        self,
+        success: bool,
+        message: str,
+        mod_path: str,
+        owner_repo: str,
+        release: ReleaseInfo | None,
+        asset: ReleaseAsset | None,
+    ) -> None:
+        """Handle completed GitHub mod install -- record metadata and refresh."""
+        if not success:
+            InformationBox(
+                title=self.tr("GitHub Install Failed"),
+                text=self.tr("Failed to install GitHub mod: {error}").format(
+                    error=message
+                ),
+            ).exec()
+            return
+
+        from app.controllers.metadata_db_controller import AuxMetadataController
+        from app.models.metadata.metadata_db import Base
+        from app.utils.github.models import GitHubModEntry
+
+        settings = self.settings_controller.settings
+        aux_controller = AuxMetadataController.get_or_create_cached_instance(
+            settings.aux_db_path
+        )
+
+        # Ensure the github_mods table exists (GitHubModEntry shares
+        # the same Base as AuxMetadataEntry, but the controller may
+        # have been created before this model was imported).
+        Base.metadata.create_all(aux_controller.engine)
+
+        with aux_controller.Session() as session:
+            AuxMetadataController.get_or_create(session, mod_path)
+            session.commit()
+
+            version = "HEAD" if release is None else release.tag
+            asset_name = asset.name if asset else None
+
+            entry = GitHubModEntry(
+                owner_repo=owner_repo,
+                mod_path=mod_path,
+                installed_version=version,
+                installed_asset_name=asset_name,
+            )
+            session.add(entry)
+            session.commit()
+
+        InformationBox(
+            title=self.tr("GitHub Mod Installed"),
+            text=self.tr("Successfully installed {owner_repo} ({version})").format(
+                owner_repo=owner_repo, version=version
+            ),
+        ).exec()
+
+        EventBus().do_refresh_mods_lists.emit()
 
     @Slot(str, str)
     def _do_upload_db_to_repo(self, repo_url: str, file_name: str) -> None:

--- a/app/controllers/main_content_controller.py
+++ b/app/controllers/main_content_controller.py
@@ -2,7 +2,7 @@ import datetime
 import json
 import time
 from pathlib import Path
-from typing import List, Optional, cast
+from typing import Any, List, Optional, cast
 
 from github import Github, Repository
 from loguru import logger
@@ -66,6 +66,7 @@ class MainContentController(QObject):
         self._git_stage_commit_worker: Optional[GitStageCommitWorker] = None
         self._http_download_worker: Optional[HttpDownloadWorker] = None
         self._github_install_worker: Optional[GitHubInstallWorker] = None
+        self._github_mods_panel: Any = None
 
         # Thread pool for concurrent tasks
         self.thread_pool = QThreadPool.globalInstance()
@@ -121,6 +122,7 @@ class MainContentController(QObject):
     def _connect_signals(self) -> None:
         # Bind install mod signal
         EventBus().do_add_git_mod.connect(self._do_git_install_mod)
+        EventBus().do_open_github_mods_panel.connect(self._on_open_github_mods_panel)
 
         # Bind update check signals
         update_targets = [
@@ -156,6 +158,13 @@ class MainContentController(QObject):
         EventBus().do_upload_community_rules_db_to_github.connect(
             self._on_do_upload_community_db_to_github
         )
+
+    def _on_open_github_mods_panel(self) -> None:
+        """Open the GitHub Mods panel."""
+        from app.windows.github_mods_panel import GitHubModsPanel
+
+        self._github_mods_panel = GitHubModsPanel()
+        self._github_mods_panel.show()
 
     @Slot(list)
     def _on_check_updates_requested(self, repos_paths: List[Path]) -> None:

--- a/app/controllers/main_content_controller.py
+++ b/app/controllers/main_content_controller.py
@@ -2,7 +2,7 @@ import datetime
 import json
 import time
 from pathlib import Path
-from typing import Any, List, Optional, cast
+from typing import TYPE_CHECKING, List, Optional, cast
 
 from github import Github, Repository
 from loguru import logger
@@ -51,6 +51,9 @@ from app.views.dialogue import (
 )
 from app.views.main_content_panel import MainContent
 
+if TYPE_CHECKING:
+    from app.windows.github_mods_panel import GitHubModsPanel
+
 
 class MainContentController(QObject):
     """Controller with concurrent checking/updating and improved structure."""
@@ -66,7 +69,7 @@ class MainContentController(QObject):
         self._git_stage_commit_worker: Optional[GitStageCommitWorker] = None
         self._http_download_worker: Optional[HttpDownloadWorker] = None
         self._github_install_worker: Optional[GitHubInstallWorker] = None
-        self._github_mods_panel: Any = None
+        self._github_mods_panel: Optional[GitHubModsPanel] = None
 
         # Thread pool for concurrent tasks
         self.thread_pool = QThreadPool.globalInstance()
@@ -160,10 +163,20 @@ class MainContentController(QObject):
         )
 
     def _on_open_github_mods_panel(self) -> None:
-        """Open the GitHub Mods panel."""
+        """Open the GitHub Mods panel, reusing the existing window if open."""
         from app.windows.github_mods_panel import GitHubModsPanel
 
+        if self._github_mods_panel is not None and self._github_mods_panel.isVisible():
+            self._github_mods_panel.raise_()
+            self._github_mods_panel.activateWindow()
+            return
+
+        if self._github_mods_panel is not None:
+            self._github_mods_panel.close()
+            self._github_mods_panel.deleteLater()
+
         self._github_mods_panel = GitHubModsPanel()
+        self.view._child_windows.append(self._github_mods_panel)
         self._github_mods_panel.show()
 
     @Slot(list)
@@ -1007,13 +1020,22 @@ class MainContentController(QObject):
             version = "HEAD" if release is None else release.tag
             asset_name = asset.name if asset else None
 
-            entry = GitHubModEntry(
-                owner_repo=owner_repo,
-                mod_path=mod_path,
-                installed_version=version,
-                installed_asset_name=asset_name,
+            existing = (
+                session.query(GitHubModEntry)
+                .filter_by(owner_repo=owner_repo, mod_path=mod_path)
+                .first()
             )
-            session.add(entry)
+            if existing is not None:
+                existing.installed_version = version
+                existing.installed_asset_name = asset_name
+            else:
+                entry = GitHubModEntry(
+                    owner_repo=owner_repo,
+                    mod_path=mod_path,
+                    installed_version=version,
+                    installed_asset_name=asset_name,
+                )
+                session.add(entry)
             session.commit()
 
         InformationBox(

--- a/app/controllers/menu_bar_controller.py
+++ b/app/controllers/menu_bar_controller.py
@@ -129,6 +129,9 @@ class MenuBarController(QObject):
         self.menu_bar.add_git_mod_action.triggered.connect(
             EventBus().do_add_git_mod.emit
         )
+        self.menu_bar.github_mods_action.triggered.connect(
+            lambda: EventBus().do_open_github_mods_panel.emit()
+        )
         self.menu_bar.add_zip_mod_action.triggered.connect(
             EventBus().do_add_zip_mod.emit
         )

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -209,6 +209,10 @@ class Settings(QObject):
         self.github_username: str = ""
         self.github_token: str = ""
 
+        # GitHub Mod Updates
+        self.github_update_check_enabled: bool = True
+        self.github_update_check_interval_hours: int = 24
+
         # Auxiliary Metadata DB
         self.enable_aux_db_behavior_editing: bool = False
 

--- a/app/utils/event_bus.py
+++ b/app/utils/event_bus.py
@@ -51,6 +51,8 @@ class EventBus(QObject):
 
     # Download Menu bar signals
     do_add_git_mod = Signal()
+    do_open_github_mods_panel = Signal()
+    github_version_switch_requested = Signal(str, str)  # mod_path, target_tag
     do_add_zip_mod = Signal()
     do_browse_workshop = Signal()
     do_check_for_workshop_updates = Signal()

--- a/app/utils/github/__init__.py
+++ b/app/utils/github/__init__.py
@@ -1,0 +1,37 @@
+from app.utils.github.installer import (
+    GitHubInstaller,
+    UnwrapResult,
+    unwrap_extracted_mod,
+)
+from app.utils.github.models import GitHubModEntry, GitHubReleaseCache
+from app.utils.github.provider import (
+    GitHubProvider,
+    GitHubRateLimitError,
+    ReleaseAsset,
+    ReleaseInfo,
+    parse_github_url,
+)
+from app.utils.github.updater import UpdateAvailable, check_for_updates
+from app.utils.github.worker import (
+    GitHubInstallWorker,
+    GitHubUpdateCheckWorker,
+    GitHubVersionSwitchWorker,
+)
+
+__all__ = [
+    "GitHubInstaller",
+    "GitHubInstallWorker",
+    "GitHubModEntry",
+    "GitHubProvider",
+    "GitHubRateLimitError",
+    "GitHubReleaseCache",
+    "GitHubUpdateCheckWorker",
+    "GitHubVersionSwitchWorker",
+    "ReleaseAsset",
+    "ReleaseInfo",
+    "UnwrapResult",
+    "UpdateAvailable",
+    "check_for_updates",
+    "parse_github_url",
+    "unwrap_extracted_mod",
+]

--- a/app/utils/github/installer.py
+++ b/app/utils/github/installer.py
@@ -1,0 +1,246 @@
+"""GitHub mod installer: zip extraction, unwrap heuristic, and backup/restore.
+
+Provides file-system operations for installing GitHub-hosted RimWorld mods:
+
+- :func:`unwrap_extracted_mod` — Detect and unwrap the single-directory wrapper
+  that most GitHub release ZIPs create (``ModName/About/About.xml`` →
+  ``About/About.xml``).
+- :class:`GitHubInstaller` — Static methods for zip extraction (with zip-slip
+  protection), HEAD cloning via ``git_utils``, and backup/restore for safe
+  version switching.
+"""
+
+import os
+import shutil
+import tempfile
+from enum import Enum
+from pathlib import Path
+from zipfile import ZipFile
+
+from loguru import logger
+
+
+class UnwrapResult(Enum):
+    """Outcome of attempting to unwrap an extracted mod directory."""
+
+    UNWRAPPED = "unwrapped"
+    ALREADY_CORRECT = "already_correct"
+    NO_ABOUT_XML = "no_about_xml"
+
+
+def _has_about_xml(directory: Path) -> bool:
+    """Check whether *directory* contains an ``About/About.xml`` (case-insensitive).
+
+    :param directory: Directory to inspect.
+    :return: ``True`` if an ``About.xml`` file is found inside an ``About``
+        sub-directory (matching is case-insensitive for both the folder and
+        the file name).
+    """
+    about_dir: Path | None = None
+
+    # Try exact-case first (common), then fall back to case-insensitive scan.
+    candidate = directory / "About"
+    if candidate.is_dir():
+        about_dir = candidate
+    else:
+        for item in directory.iterdir():
+            if item.is_dir() and item.name.lower() == "about":
+                about_dir = item
+                break
+
+    if about_dir is None:
+        return False
+
+    for item in about_dir.iterdir():
+        if item.name.lower() == "about.xml":
+            return True
+    return False
+
+
+def unwrap_extracted_mod(target_dir: Path) -> UnwrapResult:
+    """Unwrap a single-directory wrapper around a mod if necessary.
+
+    Many GitHub release ZIPs contain a single top-level directory that wraps
+    the actual mod content (e.g. ``ModName-1.2.3/About/About.xml``).  This
+    function detects that pattern and moves the contents up one level so that
+    the ``About/`` folder sits directly inside *target_dir*.
+
+    :param target_dir: The directory to inspect / unwrap.
+    :return: An :class:`UnwrapResult` describing what happened.
+    """
+    # If About/About.xml is already at the root level, nothing to do.
+    if _has_about_xml(target_dir):
+        return UnwrapResult.ALREADY_CORRECT
+
+    # Check for a single sub-directory that itself contains About/About.xml.
+    top_level = [item for item in target_dir.iterdir() if item.is_dir()]
+    if len(top_level) == 1 and _has_about_xml(top_level[0]):
+        wrapper = top_level[0]
+        temp_dir = target_dir.parent / f"{target_dir.name}._unwrap_temp"
+        shutil.move(str(wrapper), str(temp_dir))
+
+        for item in temp_dir.iterdir():
+            dest = target_dir / item.name
+            shutil.move(str(item), str(dest))
+
+        shutil.rmtree(str(temp_dir), ignore_errors=True)
+        return UnwrapResult.UNWRAPPED
+
+    return UnwrapResult.NO_ABOUT_XML
+
+
+class GitHubInstaller:
+    """Static helpers for installing, updating, and rolling back GitHub mods."""
+
+    # ------------------------------------------------------------------
+    # Zip extraction
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def extract_release_zip(zip_path: str, target_dir: str) -> UnwrapResult:
+        """Extract a release ZIP to *target_dir* with zip-slip protection.
+
+        After extraction the directory is passed through
+        :func:`unwrap_extracted_mod` so the caller always gets a flat mod
+        layout with ``About/About.xml`` at the root.
+
+        :param zip_path: Path to the ZIP file.
+        :param target_dir: Destination directory (created if absent).
+        :return: The :class:`UnwrapResult` from the unwrap step.
+        """
+        target = Path(target_dir)
+        target.mkdir(parents=True, exist_ok=True)
+
+        real_target = os.path.realpath(str(target))
+        with ZipFile(zip_path) as zf:
+            for info in zf.infolist():
+                dst = os.path.realpath(os.path.join(str(target), info.filename))
+                if not (dst.startswith(real_target + os.sep) or dst == real_target):
+                    logger.warning(f"Zip slip detected, skipping: {info.filename}")
+                    continue
+                if info.is_dir():
+                    os.makedirs(dst, exist_ok=True)
+                else:
+                    os.makedirs(os.path.dirname(dst), exist_ok=True)
+                    with zf.open(info) as src, open(dst, "wb") as out:
+                        shutil.copyfileobj(src, out)
+
+        return unwrap_extracted_mod(target)
+
+    @staticmethod
+    def download_and_extract_release(
+        asset_url: str, asset_name: str, target_dir: str
+    ) -> UnwrapResult:
+        """Download a release asset ZIP and extract it to *target_dir*.
+
+        :param asset_url: Direct download URL for the release asset.
+        :param asset_name: File name for the downloaded ZIP.
+        :param target_dir: Destination directory for extraction.
+        :return: The :class:`UnwrapResult` from the unwrap step.
+        """
+        from app.utils import http
+
+        with tempfile.TemporaryDirectory() as tmp:
+            zip_path = os.path.join(tmp, asset_name)
+            response = http.get(asset_url, stream=True, timeout=300)
+            response.raise_for_status()
+
+            with open(zip_path, "wb") as f:
+                for chunk in response.iter_content(chunk_size=8192):
+                    f.write(chunk)
+
+            return GitHubInstaller.extract_release_zip(zip_path, target_dir)
+
+    # ------------------------------------------------------------------
+    # HEAD clone (via existing git_utils)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def install_head(repo_url: str, target_dir: str) -> tuple[bool, str | None]:
+        """Shallow-clone a repository HEAD into *target_dir*.
+
+        Uses the project's existing :mod:`app.utils.git_utils` infrastructure.
+        Imports are deferred to avoid pulling in Qt/PySide6 at module load
+        time.
+
+        :param repo_url: HTTPS clone URL for the repository.
+        :param target_dir: Destination path for the clone.
+        :return: ``(success, short_sha)`` — the short SHA of HEAD on success,
+            or ``(False, None)`` on failure.
+        """
+        # Deferred imports: git_utils imports PySide6 through its dependency
+        # chain, and pygit2 is heavy.  Keep them out of module scope.
+        from app.utils import git_utils
+        from app.utils.git_utils import GitOperationConfig
+
+        config = GitOperationConfig.create_silent()
+        repo, result = git_utils.git_clone(
+            repo_url=repo_url,
+            repo_path=target_dir,
+            depth=1,
+            config=config,
+        )
+        if repo is not None:
+            git_utils.git_cleanup(repo)
+
+        if result.is_successful():
+            import pygit2
+
+            commit_info = git_utils.git_get_commit_info(pygit2.Repository(target_dir))
+            sha = commit_info["short_id"] if commit_info else None
+            return True, sha
+        return False, None
+
+    # ------------------------------------------------------------------
+    # Backup / restore for safe version switching
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def backup_mod(mod_path: Path) -> Path:
+        """Move a mod directory to a ``.rimsort_backup`` sibling.
+
+        If a previous backup already exists at the same location it is
+        removed first.
+
+        :param mod_path: Path to the mod directory.
+        :return: Path to the backup directory.
+        """
+        backup_path = mod_path.parent / f"{mod_path.name}.rimsort_backup"
+        if backup_path.exists():
+            shutil.rmtree(str(backup_path))
+        shutil.move(str(mod_path), str(backup_path))
+        return backup_path
+
+    @staticmethod
+    def restore_backup(backup_path: Path, mod_path: Path) -> None:
+        """Restore a backup, replacing any current mod directory.
+
+        :param backup_path: Path to the ``.rimsort_backup`` directory.
+        :param mod_path: Destination path (the original mod location).
+        """
+        if mod_path.exists():
+            shutil.rmtree(str(mod_path))
+        shutil.move(str(backup_path), str(mod_path))
+
+    @staticmethod
+    def delete_backup(backup_path: Path) -> None:
+        """Delete a backup directory if it exists.
+
+        :param backup_path: Path to the ``.rimsort_backup`` directory.
+        """
+        if backup_path.exists():
+            shutil.rmtree(str(backup_path))
+
+    @staticmethod
+    def check_stale_backup(mod_path: Path) -> Path | None:
+        """Check whether a stale backup exists for a mod.
+
+        A stale backup indicates a previous install/update was interrupted.
+
+        :param mod_path: Path to the mod directory.
+        :return: Path to the backup if it exists, otherwise ``None``.
+        """
+        backup_path = mod_path.parent / f"{mod_path.name}.rimsort_backup"
+        if backup_path.exists():
+            return backup_path
+        return None

--- a/app/utils/github/models.py
+++ b/app/utils/github/models.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    UniqueConstraint,
+    create_engine,
+    func,
+)
+from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column, sessionmaker
+
+from app.models.metadata.metadata_db import Base
+
+
+class GitHubModEntry(Base):
+    """Per-instance table -- lives in the same DB as auxiliary_metadata."""
+
+    __tablename__ = "github_mods"
+    __table_args__ = (UniqueConstraint("owner_repo", "mod_path", name="uq_github_mod"),)
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    owner_repo: Mapped[str] = mapped_column(String, index=True)
+    mod_path: Mapped[str] = mapped_column(String, ForeignKey("auxiliary_metadata.path"))
+    installed_version: Mapped[str] = mapped_column(String)
+    installed_asset_name: Mapped[str | None] = mapped_column(
+        String, nullable=True, default=None
+    )
+    installed_commit_sha: Mapped[str | None] = mapped_column(
+        String, nullable=True, default=None
+    )
+    auto_update: Mapped[bool] = mapped_column(Boolean, default=False)
+    created_at = Column(DateTime, default=func.now())
+    updated_at = Column(DateTime, default=func.now(), onupdate=func.now())
+
+
+class CacheBase(DeclarativeBase):
+    """Separate base for the global release cache DB."""
+
+    pass
+
+
+class GitHubReleaseCache(CacheBase):
+    """Global table -- lives in app-level storage, shared across instances."""
+
+    __tablename__ = "github_release_cache"
+
+    owner_repo: Mapped[str] = mapped_column(String, primary_key=True)
+    releases_json: Mapped[str] = mapped_column(String, default="[]")
+    etag: Mapped[str | None] = mapped_column(String, nullable=True, default=None)
+    last_checked = Column(DateTime, default=func.now())
+
+
+def get_cache_session(db_path: Path) -> Session:
+    """Create a session for the global release cache DB."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    engine = create_engine(f"sqlite+pysqlite:///{db_path}")
+    CacheBase.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()

--- a/app/utils/github/provider.py
+++ b/app/utils/github/provider.py
@@ -1,0 +1,309 @@
+"""
+GitHub API provider with caching and rate limit handling.
+
+Wraps PyGitHub to fetch release data from GitHub repositories,
+caching results in SQLAlchemy-backed SQLite to respect rate limits.
+"""
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from urllib.parse import urlparse
+
+from github import Github, GithubException
+from loguru import logger
+from sqlalchemy.orm import Session
+
+from app.utils.github.models import GitHubReleaseCache
+
+
+@dataclass
+class ReleaseAsset:
+    """A downloadable asset attached to a GitHub release."""
+
+    name: str
+    download_url: str
+    size: int
+
+
+@dataclass
+class ReleaseInfo:
+    """Parsed GitHub release with filtered asset access."""
+
+    tag: str
+    name: str
+    published_at: datetime
+    prerelease: bool
+    assets: list[ReleaseAsset]
+    body: str
+
+    def get_custom_zip_assets(self) -> list[ReleaseAsset]:
+        """Return .zip assets that are NOT auto-generated source archives.
+
+        GitHub auto-generates "Source code (zip)" and "Source code (tar.gz)"
+        for every release. Mod authors upload separate .zip files containing
+        the actual mod contents. This method filters to only those.
+        """
+        source_prefixes = ("source code",)
+        return [
+            a
+            for a in self.assets
+            if a.name.lower().endswith(".zip")
+            and not a.name.lower().startswith(source_prefixes)
+        ]
+
+
+class GitHubRateLimitError(Exception):
+    """Raised when the GitHub API rate limit is exceeded."""
+
+
+def parse_github_url(url: str) -> tuple[str, str] | None:
+    """Extract (owner, repo) from a GitHub URL.
+
+    :param url: URL to parse (e.g. ``https://github.com/owner/repo``)
+    :return: ``(owner, repo)`` tuple, or ``None`` if the URL is not
+        a valid GitHub repository URL.
+    """
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return None
+
+    if parsed.hostname not in ("github.com", "www.github.com"):
+        return None
+
+    path = parsed.path.strip("/")
+    if path.endswith(".git"):
+        path = path[:-4]
+
+    parts = path.split("/")
+    if len(parts) < 2:
+        return None
+
+    owner, repo = parts[0], parts[1]
+    if not owner or not repo:
+        return None
+    return owner, repo
+
+
+def _releases_from_json(data: str) -> list[ReleaseInfo]:
+    """Deserialize cached JSON into ``ReleaseInfo`` objects."""
+    raw: list[dict[str, object]] = json.loads(data)
+    releases: list[ReleaseInfo] = []
+    for r in raw:
+        assets_raw = r.get("assets", [])
+        assert isinstance(assets_raw, list)
+        assets = [
+            ReleaseAsset(
+                name=str(a["name"]),
+                download_url=str(a["download_url"]),
+                size=int(a.get("size", 0)),
+            )
+            for a in assets_raw
+        ]
+        published_at_raw = r.get("published_at")
+        assert isinstance(published_at_raw, str)
+        releases.append(
+            ReleaseInfo(
+                tag=str(r["tag"]),
+                name=str(r.get("name", r["tag"])),
+                published_at=datetime.fromisoformat(published_at_raw),
+                prerelease=bool(r.get("prerelease", False)),
+                assets=assets,
+                body=str(r.get("body", "")),
+            )
+        )
+    return releases
+
+
+def _releases_to_json(releases: list[ReleaseInfo]) -> str:
+    """Serialize ``ReleaseInfo`` objects to JSON for caching."""
+    data = []
+    for r in releases:
+        data.append(
+            {
+                "tag": r.tag,
+                "name": r.name,
+                "published_at": r.published_at.isoformat(),
+                "prerelease": r.prerelease,
+                "assets": [
+                    {
+                        "name": a.name,
+                        "download_url": a.download_url,
+                        "size": a.size,
+                    }
+                    for a in r.assets
+                ],
+                "body": r.body,
+            }
+        )
+    return json.dumps(data)
+
+
+class GitHubProvider:
+    """Fetches GitHub release data with SQLite-backed caching.
+
+    Wraps PyGitHub to query the GitHub Releases API. Results are cached
+    in ``GitHubReleaseCache`` rows so repeated lookups within
+    ``check_interval_hours`` avoid network calls entirely.
+
+    :param github_token: Optional personal access token. Without one,
+        the unauthenticated rate limit is 60 req/hour; with one it's 5,000.
+    :param cache_session: SQLAlchemy session bound to a DB containing
+        ``GitHubReleaseCache``. If ``None``, caching is disabled.
+    """
+
+    def __init__(
+        self,
+        github_token: str | None = None,
+        cache_session: Session | None = None,
+    ) -> None:
+        self._token = github_token
+        self._cache_session = cache_session
+
+    def _get_github_client(self) -> Github:
+        """Create a PyGitHub client, optionally authenticated."""
+        if self._token:
+            return Github(self._token)
+        return Github()
+
+    def get_releases(
+        self,
+        owner_repo: str,
+        check_interval_hours: int = 24,
+        force_refresh: bool = False,
+    ) -> list[ReleaseInfo]:
+        """Fetch releases for ``owner/repo``, using cache when fresh.
+
+        :param owner_repo: Repository slug, e.g. ``"owner/repo"``.
+        :param check_interval_hours: How many hours before cached data
+            is considered stale. Defaults to 24.
+        :param force_refresh: If ``True``, bypass cache entirely.
+        :return: List of releases, newest first.
+        :raises GitHubRateLimitError: If the API rate limit is exceeded.
+        """
+        if self._cache_session and not force_refresh:
+            cached = self._get_cached_releases(owner_repo, check_interval_hours)
+            if cached is not None:
+                return cached
+
+        return self._fetch_releases_from_api(owner_repo)
+
+    def _get_cached_releases(
+        self, owner_repo: str, check_interval_hours: int
+    ) -> list[ReleaseInfo] | None:
+        """Return cached releases if they exist and are fresh enough."""
+        if self._cache_session is None:
+            return None
+
+        entry = (
+            self._cache_session.query(GitHubReleaseCache)
+            .filter_by(owner_repo=owner_repo)
+            .first()
+        )
+        if entry is None:
+            return None
+
+        # last_checked is a legacy Column(DateTime); cast to datetime for
+        # type-safe comparisons (at runtime SQLAlchemy returns a datetime).
+        last_checked_raw: datetime | None = entry.last_checked  # type: ignore[assignment]
+        if last_checked_raw is None:
+            return None
+
+        last_checked: datetime = last_checked_raw
+        if last_checked.tzinfo is None:
+            last_checked = last_checked.replace(tzinfo=timezone.utc)
+
+        cutoff = datetime.now(tz=timezone.utc) - timedelta(hours=check_interval_hours)
+        if last_checked < cutoff:
+            return None
+
+        logger.debug(f"Using cached releases for {owner_repo}")
+        return _releases_from_json(entry.releases_json)
+
+    def _fetch_releases_from_api(self, owner_repo: str) -> list[ReleaseInfo]:
+        """Hit the GitHub Releases API and update the cache."""
+        try:
+            gh = self._get_github_client()
+            repo = gh.get_repo(owner_repo)
+            gh_releases = repo.get_releases()
+
+            releases: list[ReleaseInfo] = []
+            for rel in gh_releases:
+                assets = [
+                    ReleaseAsset(
+                        name=a.name,
+                        download_url=a.browser_download_url,
+                        size=a.size,
+                    )
+                    for a in rel.get_assets()
+                ]
+                published = rel.published_at
+                if published and published.tzinfo is None:
+                    published = published.replace(tzinfo=timezone.utc)
+                releases.append(
+                    ReleaseInfo(
+                        tag=rel.tag_name,
+                        name=rel.name or rel.tag_name,
+                        published_at=published or datetime.now(tz=timezone.utc),
+                        prerelease=rel.prerelease,
+                        assets=assets,
+                        body=rel.body or "",
+                    )
+                )
+
+            self._update_cache(owner_repo, releases)
+            return releases
+
+        except GithubException as e:
+            if e.status in (403, 429):
+                logger.warning(f"GitHub rate limit hit for {owner_repo}")
+                raise GitHubRateLimitError(
+                    "GitHub API rate limit reached. Configure a GitHub token "
+                    "in Settings for higher limits (5,000 requests/hour vs 60)."
+                ) from e
+            if e.status == 404:
+                logger.warning(f"Repository {owner_repo} not found or private")
+                return []
+            raise
+
+    def _update_cache(self, owner_repo: str, releases: list[ReleaseInfo]) -> None:
+        """Upsert the release cache row for ``owner_repo``."""
+        if self._cache_session is None:
+            return
+
+        entry = (
+            self._cache_session.query(GitHubReleaseCache)
+            .filter_by(owner_repo=owner_repo)
+            .first()
+        )
+        now = datetime.now(tz=timezone.utc)
+        if entry is None:
+            entry = GitHubReleaseCache(
+                owner_repo=owner_repo,
+                releases_json=_releases_to_json(releases),
+                last_checked=now,
+            )
+            self._cache_session.add(entry)
+        else:
+            entry.releases_json = _releases_to_json(releases)
+            entry.last_checked = now  # type: ignore[assignment]
+
+        self._cache_session.commit()
+
+    @staticmethod
+    def get_latest_stable_release(
+        releases: list[ReleaseInfo],
+    ) -> ReleaseInfo | None:
+        """Return the most recently published non-prerelease.
+
+        Falls back to the first release in the list (newest) if
+        no stable release exists.
+
+        :param releases: List of releases to search.
+        :return: The latest stable release, or ``None`` if empty.
+        """
+        stable = [r for r in releases if not r.prerelease]
+        if not stable:
+            return releases[0] if releases else None
+        return max(stable, key=lambda r: r.published_at)

--- a/app/utils/github/updater.py
+++ b/app/utils/github/updater.py
@@ -30,6 +30,7 @@ class UpdateAvailable:
     latest_version: str
     release_notes: str
     latest_release: ReleaseInfo | None = None
+    auto_update: bool = False
 
 
 def check_for_updates(
@@ -76,45 +77,32 @@ def check_for_updates(
 
         if mod.installed_version == "HEAD":
             updates.append(
-                UpdateAvailable(
-                    owner_repo=mod.owner_repo,
-                    mod_path=mod.mod_path,
-                    installed_version="HEAD",
-                    latest_version=latest_stable.tag,
-                    release_notes=_truncate(latest_stable.body, 200),
-                    latest_release=latest_stable,
-                )
+                _make_update(mod, latest_stable),
             )
             continue
 
         installed_release = _find_release_by_tag(releases, mod.installed_version)
         if installed_release is None:
-            # Installed tag not found in releases -- treat as outdated
-            updates.append(
-                UpdateAvailable(
-                    owner_repo=mod.owner_repo,
-                    mod_path=mod.mod_path,
-                    installed_version=mod.installed_version,
-                    latest_version=latest_stable.tag,
-                    release_notes=_truncate(latest_stable.body, 200),
-                    latest_release=latest_stable,
-                )
-            )
+            updates.append(_make_update(mod, latest_stable))
             continue
 
         if latest_stable.published_at > installed_release.published_at:
-            updates.append(
-                UpdateAvailable(
-                    owner_repo=mod.owner_repo,
-                    mod_path=mod.mod_path,
-                    installed_version=mod.installed_version,
-                    latest_version=latest_stable.tag,
-                    release_notes=_truncate(latest_stable.body, 200),
-                    latest_release=latest_stable,
-                )
-            )
+            updates.append(_make_update(mod, latest_stable))
 
     return updates
+
+
+def _make_update(mod: GitHubModEntry, latest: ReleaseInfo) -> UpdateAvailable:
+    """Build an ``UpdateAvailable`` from a DB entry and the latest release."""
+    return UpdateAvailable(
+        owner_repo=mod.owner_repo,
+        mod_path=mod.mod_path,
+        installed_version=mod.installed_version,
+        latest_version=latest.tag,
+        release_notes=_truncate(latest.body, 200),
+        latest_release=latest,
+        auto_update=mod.auto_update,
+    )
 
 
 def _find_release_by_tag(releases: list[ReleaseInfo], tag: str) -> ReleaseInfo | None:

--- a/app/utils/github/updater.py
+++ b/app/utils/github/updater.py
@@ -1,0 +1,132 @@
+"""
+Update checker for GitHub-installed mods.
+
+Compares installed version tags against cached release data to
+determine which mods have newer versions available. Uses publish-date
+comparison rather than semver parsing so it works with arbitrary tag
+formats (``v1.0.0``, ``2024.3``, ``release-5``, etc.).
+"""
+
+from dataclasses import dataclass
+
+from loguru import logger
+from sqlalchemy.orm import Session
+
+from app.utils.github.models import GitHubModEntry
+from app.utils.github.provider import (
+    GitHubProvider,
+    GitHubRateLimitError,
+    ReleaseInfo,
+)
+
+
+@dataclass
+class UpdateAvailable:
+    """Describes a pending update for a single GitHub-installed mod."""
+
+    owner_repo: str
+    mod_path: str
+    installed_version: str
+    latest_version: str
+    release_notes: str
+    latest_release: ReleaseInfo | None = None
+
+
+def check_for_updates(
+    instance_session: Session,
+    provider: GitHubProvider,
+    check_interval_hours: int = 24,
+) -> list[UpdateAvailable]:
+    """Check all tracked GitHub mods for available updates.
+
+    Iterates every ``GitHubModEntry`` in the instance DB, fetches
+    releases via ``provider`` (which consults the cache first), and
+    compares installed versions against the latest stable release.
+
+    :param instance_session: SQLAlchemy session for the instance DB
+        (contains ``GitHubModEntry`` rows).
+    :param provider: :class:`GitHubProvider` configured with a cache
+        session for the global release cache.
+    :param check_interval_hours: Cache freshness window passed through
+        to :meth:`GitHubProvider.get_releases`.
+    :return: List of mods that have a newer release available.
+    """
+    mods = instance_session.query(GitHubModEntry).all()
+    updates: list[UpdateAvailable] = []
+
+    for mod in mods:
+        try:
+            releases = provider.get_releases(
+                mod.owner_repo,
+                check_interval_hours=check_interval_hours,
+            )
+        except GitHubRateLimitError:
+            logger.warning(f"Rate limit hit while checking {mod.owner_repo}, skipping")
+            continue
+        except Exception as e:
+            logger.error(f"Error checking updates for {mod.owner_repo}: {e}")
+            continue
+
+        if not releases:
+            continue
+
+        latest_stable = provider.get_latest_stable_release(releases)
+        if latest_stable is None:
+            continue
+
+        if mod.installed_version == "HEAD":
+            updates.append(
+                UpdateAvailable(
+                    owner_repo=mod.owner_repo,
+                    mod_path=mod.mod_path,
+                    installed_version="HEAD",
+                    latest_version=latest_stable.tag,
+                    release_notes=_truncate(latest_stable.body, 200),
+                    latest_release=latest_stable,
+                )
+            )
+            continue
+
+        installed_release = _find_release_by_tag(releases, mod.installed_version)
+        if installed_release is None:
+            # Installed tag not found in releases -- treat as outdated
+            updates.append(
+                UpdateAvailable(
+                    owner_repo=mod.owner_repo,
+                    mod_path=mod.mod_path,
+                    installed_version=mod.installed_version,
+                    latest_version=latest_stable.tag,
+                    release_notes=_truncate(latest_stable.body, 200),
+                    latest_release=latest_stable,
+                )
+            )
+            continue
+
+        if latest_stable.published_at > installed_release.published_at:
+            updates.append(
+                UpdateAvailable(
+                    owner_repo=mod.owner_repo,
+                    mod_path=mod.mod_path,
+                    installed_version=mod.installed_version,
+                    latest_version=latest_stable.tag,
+                    release_notes=_truncate(latest_stable.body, 200),
+                    latest_release=latest_stable,
+                )
+            )
+
+    return updates
+
+
+def _find_release_by_tag(releases: list[ReleaseInfo], tag: str) -> ReleaseInfo | None:
+    """Find a release matching ``tag`` exactly."""
+    for r in releases:
+        if r.tag == tag:
+            return r
+    return None
+
+
+def _truncate(text: str, max_len: int) -> str:
+    """Truncate ``text`` to ``max_len`` chars, adding ellipsis if needed."""
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 3] + "..."

--- a/app/utils/github/worker.py
+++ b/app/utils/github/worker.py
@@ -1,0 +1,153 @@
+"""QThread workers for non-blocking GitHub mod operations.
+
+Follows the ``BaseGitWorker(QThread)`` pattern from ``app/utils/git_worker.py``.
+Each worker emits progress/finished/error signals so the UI stays responsive.
+"""
+
+from pathlib import Path
+
+from loguru import logger
+from PySide6.QtCore import QThread, Signal
+from sqlalchemy.orm import sessionmaker
+
+from app.utils.github.installer import GitHubInstaller, UnwrapResult
+from app.utils.github.provider import GitHubProvider, ReleaseAsset, ReleaseInfo
+
+
+class GitHubInstallWorker(QThread):
+    """Download and install a mod from GitHub (release asset or HEAD clone)."""
+
+    progress = Signal(str)
+    finished = Signal(bool, str, str)  # success, message, mod_path
+
+    def __init__(
+        self,
+        owner_repo: str,
+        release: ReleaseInfo | None,
+        asset: ReleaseAsset | None,
+        repo_url: str,
+        target_dir: str,
+    ) -> None:
+        super().__init__()
+        self._owner_repo = owner_repo
+        self._release = release
+        self._asset = asset
+        self._repo_url = repo_url
+        self._target_dir = target_dir
+
+    def run(self) -> None:
+        try:
+            if self._release and self._asset:
+                self.progress.emit(f"Downloading {self._asset.name}...")
+                result = GitHubInstaller.download_and_extract_release(
+                    self._asset.download_url, self._asset.name, self._target_dir
+                )
+                if result == UnwrapResult.NO_ABOUT_XML:
+                    logger.warning("Extracted mod has no About.xml")
+                self.finished.emit(True, self._release.tag, self._target_dir)
+            else:
+                self.progress.emit(f"Cloning {self._owner_repo}...")
+                success, sha = GitHubInstaller.install_head(
+                    self._repo_url, self._target_dir
+                )
+                if success:
+                    self.finished.emit(
+                        True, f"HEAD@{sha or 'unknown'}", self._target_dir
+                    )
+                else:
+                    self.finished.emit(False, "Clone failed", self._target_dir)
+        except Exception as e:
+            logger.error(f"GitHub install failed: {e}")
+            self.finished.emit(False, str(e), self._target_dir)
+
+
+class GitHubVersionSwitchWorker(QThread):
+    """Replace an installed mod with a different release or HEAD."""
+
+    progress = Signal(str)
+    finished = Signal(bool, str, str)  # success, new_version, mod_path
+
+    def __init__(
+        self,
+        mod_path: str,
+        owner_repo: str,
+        repo_url: str,
+        target_release: ReleaseInfo | None,
+        target_asset: ReleaseAsset | None,
+    ) -> None:
+        super().__init__()
+        self._mod_path = Path(mod_path)
+        self._owner_repo = owner_repo
+        self._repo_url = repo_url
+        self._target_release = target_release
+        self._target_asset = target_asset
+
+    def run(self) -> None:
+        backup_path: Path | None = None
+        try:
+            self.progress.emit("Backing up current version...")
+            backup_path = GitHubInstaller.backup_mod(self._mod_path)
+
+            self.progress.emit("Installing new version...")
+            if self._target_release and self._target_asset:
+                GitHubInstaller.download_and_extract_release(
+                    self._target_asset.download_url,
+                    self._target_asset.name,
+                    str(self._mod_path),
+                )
+                new_version = self._target_release.tag
+            else:
+                success, sha = GitHubInstaller.install_head(
+                    self._repo_url, str(self._mod_path)
+                )
+                if not success:
+                    raise RuntimeError("HEAD clone failed")
+                new_version = f"HEAD@{sha or 'unknown'}"
+
+            GitHubInstaller.delete_backup(backup_path)
+            self.finished.emit(True, new_version, str(self._mod_path))
+
+        except Exception as e:
+            logger.error(f"Version switch failed for {self._owner_repo}: {e}")
+            if backup_path and backup_path.exists():
+                self.progress.emit("Restoring backup...")
+                GitHubInstaller.restore_backup(backup_path, self._mod_path)
+            self.finished.emit(False, str(e), str(self._mod_path))
+
+
+class GitHubUpdateCheckWorker(QThread):
+    """Background check for available updates across all tracked GitHub mods."""
+
+    finished = Signal(list)  # list of UpdateAvailable
+    error = Signal(str)
+
+    def __init__(
+        self,
+        provider: GitHubProvider,
+        instance_session_factory: sessionmaker,  # type: ignore[type-arg]
+        check_interval_hours: int = 24,
+    ) -> None:
+        super().__init__()
+        self._provider = provider
+        self._session_factory = instance_session_factory
+        self._check_interval = check_interval_hours
+
+    def run(self) -> None:
+        # Deferred import to avoid circular dependency:
+        # updater -> models -> ... -> worker -> updater
+        from app.utils.github.updater import check_for_updates
+
+        try:
+            session = self._session_factory()
+            try:
+                updates = check_for_updates(
+                    instance_session=session,
+                    provider=self._provider,
+                    check_interval_hours=self._check_interval,
+                )
+                self.finished.emit(updates)
+            finally:
+                session.close()
+        except Exception as e:
+            logger.error(f"GitHub update check failed: {e}")
+            self.error.emit(str(e))

--- a/app/views/menu_bar.py
+++ b/app/views/menu_bar.py
@@ -62,6 +62,7 @@ class MenuBar(QObject):
         self.add_zip_mod_action: QAction
         self.browse_workshop_action: QAction
         self.update_workshop_mods_action: QAction
+        self.github_mods_action: QAction
         self.steam_verify_game_files_action: QAction
         self.backup_instance_action: QAction
         self.restore_instance_action: QAction
@@ -307,6 +308,10 @@ class MenuBar(QObject):
         )
         self.update_workshop_mods_action = self._add_action(
             download_menu, self.tr("Update Workshop Mods")
+        )
+        download_menu.addSeparator()
+        self.github_mods_action = self._add_action(
+            download_menu, self.tr("GitHub Mods")
         )
         download_menu.addSeparator()
         self.steam_verify_game_files_action = self._add_action(

--- a/app/views/mod_info_panel.py
+++ b/app/views/mod_info_panel.py
@@ -472,6 +472,39 @@ class ModInfoPanel:
         self.mod_info_github_version_combo.setVisible(visible)
         self.mod_info_github_update_label.setVisible(visible)
 
+    def _update_github_info(self, mod_path: str | None) -> None:
+        """Check if mod is GitHub-tracked and show/hide info accordingly."""
+        if not mod_path:
+            self.hide_github_info()
+            return
+
+        try:
+            from app.models.metadata.metadata_db import Base
+            from app.utils.github.models import GitHubModEntry
+
+            aux_controller = AuxMetadataController.get_or_create_cached_instance(
+                self.settings_controller.settings.aux_db_path
+            )
+            Base.metadata.create_all(aux_controller.engine)
+
+            with aux_controller.Session() as session:
+                entry = (
+                    session.query(GitHubModEntry).filter_by(mod_path=mod_path).first()
+                )
+                if entry is None:
+                    self.hide_github_info()
+                    return
+
+                self.show_github_info(
+                    owner_repo=entry.owner_repo,
+                    installed_version=entry.installed_version,
+                    available_versions=[entry.installed_version],
+                    update_available=False,
+                )
+        except Exception:
+            logger.debug("Could not check GitHub mod status for {}", mod_path)
+            self.hide_github_info()
+
     def update_user_mod_notes(self) -> None:
         if self.current_mod_item is None:
             return
@@ -882,6 +915,9 @@ class ModInfoPanel:
 
         # Set path
         self.mod_info_path_value.setPath(mod_metadata.get("path"))
+
+        # Show or hide GitHub info based on whether this mod is tracked
+        self._update_github_info(mod_metadata.get("path"))
 
         # Set description
         self._set_description(mod_metadata, render_unity_rt)

--- a/app/views/mod_info_panel.py
+++ b/app/views/mod_info_panel.py
@@ -490,6 +490,7 @@ class ModInfoPanel:
         try:
             from app.models.metadata.metadata_db import Base
             from app.utils.github.models import GitHubModEntry
+            from app.utils.github.provider import GitHubProvider
 
             aux_controller = AuxMetadataController.get_or_create_cached_instance(
                 self.settings_controller.settings.aux_db_path
@@ -504,12 +505,39 @@ class ModInfoPanel:
                     self.hide_github_info()
                     return
 
-                self.show_github_info(
-                    owner_repo=entry.owner_repo,
-                    installed_version=entry.installed_version,
-                    available_versions=[entry.installed_version],
-                    update_available=False,
-                )
+                owner_repo = entry.owner_repo
+                installed_version = entry.installed_version
+
+            versions = [installed_version]
+            update_available = False
+            try:
+                token = self.settings_controller.settings.github_token or None
+                provider = GitHubProvider(github_token=token)
+                releases = provider.get_releases(owner_repo)
+                if releases:
+                    versions = [r.tag for r in releases]
+                    versions.append("HEAD (latest commit)")
+                    latest = provider.get_latest_stable_release(releases)
+                    if latest and installed_version != "HEAD":
+                        installed_rel = next(
+                            (r for r in releases if r.tag == installed_version), None
+                        )
+                        if (
+                            installed_rel
+                            and latest.published_at > installed_rel.published_at
+                        ):
+                            update_available = True
+                    elif latest and installed_version == "HEAD":
+                        update_available = True
+            except Exception:
+                logger.debug("Could not fetch releases for {}", owner_repo)
+
+            self.show_github_info(
+                owner_repo=owner_repo,
+                installed_version=installed_version,
+                available_versions=versions,
+                update_available=update_available,
+            )
         except Exception:
             logger.debug("Could not check GitHub mod status for {}", mod_path)
             self.hide_github_info()

--- a/app/views/mod_info_panel.py
+++ b/app/views/mod_info_panel.py
@@ -445,6 +445,10 @@ class ModInfoPanel:
 
         self.hide_github_info()
 
+        from app.utils.event_bus import EventBus
+
+        EventBus().do_refresh_mods_lists.connect(self._refresh_github_info)
+
         logger.debug("Finished ModInfo initialization")
 
     def show_github_info(
@@ -505,6 +509,15 @@ class ModInfoPanel:
         self.mod_info_github_version_label.setVisible(visible)
         self.mod_info_github_version_combo.setVisible(visible)
         self.mod_info_github_update_label.setVisible(visible)
+
+    def _refresh_github_info(self) -> None:
+        """Re-check GitHub info for the currently displayed mod after a version switch."""
+        try:
+            mod_path = getattr(self, "_github_mod_path", None)
+            if mod_path:
+                self._update_github_info(mod_path)
+        except Exception:
+            logger.debug("Could not refresh GitHub info for current mod")
 
     def _update_github_info(self, mod_path: str | None) -> None:
         """Check if mod is GitHub-tracked and show/hide info accordingly."""

--- a/app/views/mod_info_panel.py
+++ b/app/views/mod_info_panel.py
@@ -259,7 +259,7 @@ class ModInfoPanel:
         )
         self.mod_info_github_source_value.setWordWrap(True)
 
-        self.mod_info_github_version_label = QLabel(self.tr("GitHub Version:"))
+        self.mod_info_github_version_label = QLabel(self.tr("Version:"))
         self.mod_info_github_version_label.setObjectName("summaryLabel")
         self.mod_info_github_version_combo = QComboBox()
         self.mod_info_github_version_combo.setObjectName("githubVersionCombo")
@@ -376,14 +376,23 @@ class ModInfoPanel:
         self.mod_info_steam_url_layout.addWidget(self.mod_info_steam_url_label, 20)
         self.mod_info_steam_url_layout.addWidget(self.mod_info_steam_url_value, 80)
         self.mod_info_layout.addLayout(self.mod_info_steam_url_layout)
-        self.mod_info_github_layout = QHBoxLayout()
-        self.mod_info_github_layout.addWidget(self.mod_info_github_source_label, 20)
-        self.mod_info_github_layout.addWidget(self.mod_info_github_source_value, 30)
-        self.mod_info_github_layout.addWidget(self.mod_info_github_version_label)
-        self.mod_info_github_layout.addWidget(self.mod_info_github_version_combo)
-        self.mod_info_github_layout.addWidget(self.mod_info_github_update_label)
-        self.mod_info_github_layout.addStretch()
-        self.mod_info_layout.addLayout(self.mod_info_github_layout)
+        self.mod_info_github_source_row = QHBoxLayout()
+        self.mod_info_github_source_row.addWidget(
+            self.mod_info_github_source_label, NAME_LABEL_RATIO
+        )
+        self.mod_info_github_source_row.addWidget(
+            self.mod_info_github_source_value, NAME_VALUE_RATIO
+        )
+        self.mod_info_layout.addLayout(self.mod_info_github_source_row)
+        self.mod_info_github_version_row = QHBoxLayout()
+        self.mod_info_github_version_row.addWidget(
+            self.mod_info_github_version_label, NAME_LABEL_RATIO
+        )
+        self.mod_info_github_version_row.addWidget(
+            self.mod_info_github_version_combo, NAME_VALUE_RATIO
+        )
+        self.mod_info_github_version_row.addWidget(self.mod_info_github_update_label)
+        self.mod_info_layout.addLayout(self.mod_info_github_version_row)
         self.notes_layout.addWidget(self.notes)
         self.mod_info_layout.addLayout(self.mod_info_last_touched)
         self.mod_info_layout.addLayout(self.mod_info_filesystem_time)

--- a/app/views/mod_info_panel.py
+++ b/app/views/mod_info_panel.py
@@ -515,7 +515,6 @@ class ModInfoPanel:
         try:
             from app.models.metadata.metadata_db import Base
             from app.utils.github.models import GitHubModEntry
-            from app.utils.github.provider import GitHubProvider
 
             aux_controller = AuxMetadataController.get_or_create_cached_instance(
                 self.settings_controller.settings.aux_db_path
@@ -535,42 +534,49 @@ class ModInfoPanel:
 
             versions = [installed_version]
             update_available = False
+
             try:
                 from sqlalchemy import create_engine
                 from sqlalchemy.orm import sessionmaker as sa_sessionmaker
 
-                from app.utils.github.models import CacheBase
+                from app.utils.github.models import CacheBase, GitHubReleaseCache
+                from app.utils.github.provider import (
+                    GitHubProvider,
+                    _releases_from_json,
+                )
 
                 cache_db = AppInfo().app_storage_folder / "github_release_cache.db"
                 cache_engine = create_engine(f"sqlite+pysqlite:///{cache_db}")
                 CacheBase.metadata.create_all(cache_engine)
                 cache_session = sa_sessionmaker(bind=cache_engine)()
                 try:
-                    token = self.settings_controller.settings.github_token or None
-                    provider = GitHubProvider(
-                        github_token=token, cache_session=cache_session
+                    cached = (
+                        cache_session.query(GitHubReleaseCache)
+                        .filter_by(owner_repo=owner_repo)
+                        .first()
                     )
-                    releases = provider.get_releases(owner_repo)
-                    if releases:
-                        versions = [r.tag for r in releases]
-                        versions.append("HEAD (latest commit)")
-                        latest = provider.get_latest_stable_release(releases)
-                        if latest and installed_version != "HEAD":
-                            installed_rel = next(
-                                (r for r in releases if r.tag == installed_version),
-                                None,
-                            )
-                            if (
-                                installed_rel
-                                and latest.published_at > installed_rel.published_at
-                            ):
+                    if cached is not None:
+                        releases = _releases_from_json(cached.releases_json)
+                        if releases:
+                            versions = [r.tag for r in releases]
+                            versions.append("HEAD (latest commit)")
+                            latest = GitHubProvider.get_latest_stable_release(releases)
+                            if latest and installed_version != "HEAD":
+                                installed_rel = next(
+                                    (r for r in releases if r.tag == installed_version),
+                                    None,
+                                )
+                                if (
+                                    installed_rel
+                                    and latest.published_at > installed_rel.published_at
+                                ):
+                                    update_available = True
+                            elif latest and installed_version == "HEAD":
                                 update_available = True
-                        elif latest and installed_version == "HEAD":
-                            update_available = True
                 finally:
                     cache_session.close()
             except Exception:
-                logger.debug("Could not fetch releases for {}", owner_repo)
+                logger.debug("Could not load cached releases for {}", owner_repo)
 
             self.show_github_info(
                 owner_repo=owner_repo,

--- a/app/views/mod_info_panel.py
+++ b/app/views/mod_info_panel.py
@@ -469,7 +469,7 @@ class ModInfoPanel:
         try:
             self.mod_info_github_version_combo.activated.disconnect()
         except RuntimeError:
-            pass
+            pass  # No prior connection exists; safe to ignore
 
         self.mod_info_github_version_combo.clear()
         self.mod_info_github_version_combo.addItems(available_versions)

--- a/app/views/mod_info_panel.py
+++ b/app/views/mod_info_panel.py
@@ -8,6 +8,7 @@ from loguru import logger
 from PySide6.QtCore import QCoreApplication, Qt
 from PySide6.QtGui import QMouseEvent, QPixmap
 from PySide6.QtWidgets import (
+    QComboBox,
     QFrame,
     QHBoxLayout,
     QLabel,
@@ -248,6 +249,27 @@ class ModInfoPanel:
             Qt.TextInteractionFlag.TextSelectableByMouse
         )
         self.mod_info_steam_url_value.setWordWrap(True)
+        # GitHub source and version
+        self.mod_info_github_source_label = QLabel(self.tr("GitHub:"))
+        self.mod_info_github_source_label.setObjectName("summaryLabel")
+        self.mod_info_github_source_value = QLabel()
+        self.mod_info_github_source_value.setObjectName("summaryValue")
+        self.mod_info_github_source_value.setTextInteractionFlags(
+            Qt.TextInteractionFlag.TextSelectableByMouse
+        )
+        self.mod_info_github_source_value.setWordWrap(True)
+
+        self.mod_info_github_version_label = QLabel(self.tr("GitHub Version:"))
+        self.mod_info_github_version_label.setObjectName("summaryLabel")
+        self.mod_info_github_version_combo = QComboBox()
+        self.mod_info_github_version_combo.setObjectName("githubVersionCombo")
+        self.mod_info_github_version_combo.setSizeAdjustPolicy(
+            QComboBox.SizeAdjustPolicy.AdjustToContents
+        )
+
+        self.mod_info_github_update_label = QLabel()
+        self.mod_info_github_update_label.setObjectName("githubUpdateBadge")
+        self.mod_info_github_update_label.hide()
         self.mod_info_last_touched_label = QLabel(self.tr("Last Touched:"))
         self.mod_info_last_touched_label.setObjectName("summaryLabel")
         self.mod_info_last_touched_value = QLabel()
@@ -354,6 +376,14 @@ class ModInfoPanel:
         self.mod_info_steam_url_layout.addWidget(self.mod_info_steam_url_label, 20)
         self.mod_info_steam_url_layout.addWidget(self.mod_info_steam_url_value, 80)
         self.mod_info_layout.addLayout(self.mod_info_steam_url_layout)
+        self.mod_info_github_layout = QHBoxLayout()
+        self.mod_info_github_layout.addWidget(self.mod_info_github_source_label, 20)
+        self.mod_info_github_layout.addWidget(self.mod_info_github_source_value, 30)
+        self.mod_info_github_layout.addWidget(self.mod_info_github_version_label)
+        self.mod_info_github_layout.addWidget(self.mod_info_github_version_combo)
+        self.mod_info_github_layout.addWidget(self.mod_info_github_update_label)
+        self.mod_info_github_layout.addStretch()
+        self.mod_info_layout.addLayout(self.mod_info_github_layout)
         self.notes_layout.addWidget(self.notes)
         self.mod_info_layout.addLayout(self.mod_info_last_touched)
         self.mod_info_layout.addLayout(self.mod_info_filesystem_time)
@@ -404,7 +434,43 @@ class ModInfoPanel:
         ):
             widget.hide()
 
+        self.hide_github_info()
+
         logger.debug("Finished ModInfo initialization")
+
+    def show_github_info(
+        self,
+        owner_repo: str,
+        installed_version: str,
+        available_versions: list[str],
+        update_available: bool,
+    ) -> None:
+        """Show GitHub source info for a GitHub-tracked mod."""
+        self.mod_info_github_source_value.setText(owner_repo)
+        self.mod_info_github_version_combo.clear()
+        self.mod_info_github_version_combo.addItems(available_versions)
+        idx = self.mod_info_github_version_combo.findText(installed_version)
+        if idx >= 0:
+            self.mod_info_github_version_combo.setCurrentIndex(idx)
+
+        if update_available:
+            self.mod_info_github_update_label.setText(self.tr("(Update available)"))
+            self.mod_info_github_update_label.show()
+        else:
+            self.mod_info_github_update_label.hide()
+
+        self._set_github_row_visible(True)
+
+    def hide_github_info(self) -> None:
+        """Hide GitHub info row for non-GitHub mods."""
+        self._set_github_row_visible(False)
+
+    def _set_github_row_visible(self, visible: bool) -> None:
+        self.mod_info_github_source_label.setVisible(visible)
+        self.mod_info_github_source_value.setVisible(visible)
+        self.mod_info_github_version_label.setVisible(visible)
+        self.mod_info_github_version_combo.setVisible(visible)
+        self.mod_info_github_update_label.setVisible(visible)
 
     def update_user_mod_notes(self) -> None:
         if self.current_mod_item is None:

--- a/app/views/mod_info_panel.py
+++ b/app/views/mod_info_panel.py
@@ -536,24 +536,39 @@ class ModInfoPanel:
             versions = [installed_version]
             update_available = False
             try:
-                token = self.settings_controller.settings.github_token or None
-                provider = GitHubProvider(github_token=token)
-                releases = provider.get_releases(owner_repo)
-                if releases:
-                    versions = [r.tag for r in releases]
-                    versions.append("HEAD (latest commit)")
-                    latest = provider.get_latest_stable_release(releases)
-                    if latest and installed_version != "HEAD":
-                        installed_rel = next(
-                            (r for r in releases if r.tag == installed_version), None
-                        )
-                        if (
-                            installed_rel
-                            and latest.published_at > installed_rel.published_at
-                        ):
+                from sqlalchemy import create_engine
+                from sqlalchemy.orm import sessionmaker as sa_sessionmaker
+
+                from app.utils.github.models import CacheBase
+
+                cache_db = AppInfo().app_storage_folder / "github_release_cache.db"
+                cache_engine = create_engine(f"sqlite+pysqlite:///{cache_db}")
+                CacheBase.metadata.create_all(cache_engine)
+                cache_session = sa_sessionmaker(bind=cache_engine)()
+                try:
+                    token = self.settings_controller.settings.github_token or None
+                    provider = GitHubProvider(
+                        github_token=token, cache_session=cache_session
+                    )
+                    releases = provider.get_releases(owner_repo)
+                    if releases:
+                        versions = [r.tag for r in releases]
+                        versions.append("HEAD (latest commit)")
+                        latest = provider.get_latest_stable_release(releases)
+                        if latest and installed_version != "HEAD":
+                            installed_rel = next(
+                                (r for r in releases if r.tag == installed_version),
+                                None,
+                            )
+                            if (
+                                installed_rel
+                                and latest.published_at > installed_rel.published_at
+                            ):
+                                update_available = True
+                        elif latest and installed_version == "HEAD":
                             update_available = True
-                    elif latest and installed_version == "HEAD":
-                        update_available = True
+                finally:
+                    cache_session.close()
             except Exception:
                 logger.debug("Could not fetch releases for {}", owner_repo)
 

--- a/app/views/mod_info_panel.py
+++ b/app/views/mod_info_panel.py
@@ -453,14 +453,29 @@ class ModInfoPanel:
         installed_version: str,
         available_versions: list[str],
         update_available: bool,
+        mod_path: str = "",
     ) -> None:
         """Show GitHub source info for a GitHub-tracked mod."""
+        self._github_owner_repo = owner_repo
+        self._github_installed_version = installed_version
+        self._github_mod_path = mod_path
+
         self.mod_info_github_source_value.setText(owner_repo)
+
+        try:
+            self.mod_info_github_version_combo.activated.disconnect()
+        except RuntimeError:
+            pass
+
         self.mod_info_github_version_combo.clear()
         self.mod_info_github_version_combo.addItems(available_versions)
         idx = self.mod_info_github_version_combo.findText(installed_version)
         if idx >= 0:
             self.mod_info_github_version_combo.setCurrentIndex(idx)
+
+        self.mod_info_github_version_combo.activated.connect(
+            self._on_github_version_selected
+        )
 
         if update_available:
             self.mod_info_github_update_label.setText(self.tr("(Update available)"))
@@ -469,6 +484,16 @@ class ModInfoPanel:
             self.mod_info_github_update_label.hide()
 
         self._set_github_row_visible(True)
+
+    def _on_github_version_selected(self, index: int) -> None:
+        """Handle user selecting a different version in the combo box."""
+        from app.utils.event_bus import EventBus
+
+        selected = self.mod_info_github_version_combo.itemText(index)
+        if selected == self._github_installed_version:
+            return
+
+        EventBus().github_version_switch_requested.emit(self._github_mod_path, selected)
 
     def hide_github_info(self) -> None:
         """Hide GitHub info row for non-GitHub mods."""
@@ -537,6 +562,7 @@ class ModInfoPanel:
                 installed_version=installed_version,
                 available_versions=versions,
                 update_available=update_available,
+                mod_path=mod_path,
             )
         except Exception:
             logger.debug("Could not check GitHub mod status for {}", mod_path)

--- a/app/windows/github_mods_panel.py
+++ b/app/windows/github_mods_panel.py
@@ -1,17 +1,34 @@
-from loguru import logger
+from __future__ import annotations
 
+from functools import partial
+from typing import Any
+
+from loguru import logger
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QBrush, QCloseEvent, QColor, QStandardItem
+from PySide6.QtWidgets import QCheckBox
+
+from app.utils.event_bus import EventBus
 from app.windows.base_mods_panel import (
     BaseModsPanel,
     ButtonConfig,
     ButtonType,
 )
 
+# Column indices (after the checkbox column 0 added by BaseModsPanel)
+_COL_NAME = 1
+_COL_REPO = 2
+_COL_INSTALLED = 3
+_COL_LATEST = 4
+_COL_AUTO_UPDATE = 5
+
 
 class GitHubModsPanel(BaseModsPanel):
     """Panel for managing GitHub mods -- view installed, check updates, switch versions."""
 
     def __init__(self) -> None:
-        logger.debug("Initializing GitHubModsPanel")
+        self._update_worker: Any = None
+        self._auto_update_signals_blocked = False
 
         super().__init__(
             object_name="githubModsPanel",
@@ -44,14 +61,252 @@ class GitHubModsPanel(BaseModsPanel):
         self._populate_from_mods()
         self._reconfigure_table_sorting(sorting_enabled=True)
 
+        EventBus().do_refresh_mods_lists.connect(self._populate_from_mods)
+
+    def closeEvent(self, event: QCloseEvent) -> None:
+        """Disconnect signals and wait for any running worker before closing."""
+        try:
+            EventBus().do_refresh_mods_lists.disconnect(self._populate_from_mods)
+        except RuntimeError:
+            pass
+        if self._update_worker is not None and self._update_worker.isRunning():
+            self._update_worker.quit()
+            self._update_worker.wait(5000)
+        super().closeEvent(event)
+
     def _populate_from_mods(self) -> None:
-        """Populate table from per-instance github_mods table."""
+        """Populate table from per-instance github_mods table and release cache."""
+        self._auto_update_signals_blocked = True
         self._clear_table_model()
+        self._auto_update_signals_blocked = False
+
+        try:
+            from sqlalchemy import create_engine
+            from sqlalchemy.orm import sessionmaker as sa_sessionmaker
+
+            from app.controllers.metadata_db_controller import AuxMetadataController
+            from app.models.metadata.metadata_db import Base
+            from app.utils.app_info import AppInfo
+            from app.utils.github.models import (
+                CacheBase,
+                GitHubModEntry,
+                GitHubReleaseCache,
+            )
+            from app.utils.github.provider import (
+                GitHubProvider,
+                ReleaseInfo,
+                _releases_from_json,
+            )
+
+            aux_controller = AuxMetadataController.get_or_create_cached_instance(
+                self.settings_controller.settings.aux_db_path
+            )
+            Base.metadata.create_all(aux_controller.engine)
+
+            with aux_controller.Session() as session:
+                entries = session.query(GitHubModEntry).all()
+                mod_data: list[dict[str, Any]] = [
+                    {
+                        "owner_repo": e.owner_repo,
+                        "mod_path": e.mod_path,
+                        "installed_version": e.installed_version,
+                        "auto_update": e.auto_update,
+                    }
+                    for e in entries
+                ]
+
+            if not mod_data:
+                return
+
+            cache_db = AppInfo().app_storage_folder / "github_release_cache.db"
+            cache_engine = create_engine(f"sqlite+pysqlite:///{cache_db}")
+            CacheBase.metadata.create_all(cache_engine)
+            cache_session = sa_sessionmaker(bind=cache_engine)()
+
+            try:
+                release_map: dict[str, list[ReleaseInfo]] = {}
+                for row in cache_session.query(GitHubReleaseCache).all():
+                    release_map[row.owner_repo] = _releases_from_json(row.releases_json)
+            finally:
+                cache_session.close()
+
+            path_to_uuid = self.metadata_manager.mod_metadata_dir_mapper
+            local_metadata = self.metadata_manager.internal_local_metadata
+            update_highlight = QBrush(QColor(255, 200, 50, 60))
+
+            for mod in mod_data:
+                mod_name: str = mod["owner_repo"]
+                uuid = path_to_uuid.get(mod["mod_path"])
+                if uuid and uuid in local_metadata:
+                    meta = local_metadata[uuid]
+                    mod_name = meta.get("name", mod_name)
+
+                latest_version = "—"
+                has_update = False
+                releases = release_map.get(mod["owner_repo"], [])
+                if releases:
+                    latest = GitHubProvider.get_latest_stable_release(releases)
+                    if latest:
+                        latest_version = latest.tag
+                        has_update = latest_version != mod["installed_version"]
+
+                name_item = QStandardItem(str(mod_name))
+                name_item.setData(mod["mod_path"], Qt.ItemDataRole.UserRole)
+
+                latest_item = QStandardItem(latest_version)
+                latest_item.setData(latest_version, Qt.ItemDataRole.UserRole)
+
+                row_items = [
+                    name_item,
+                    QStandardItem(str(mod["owner_repo"])),
+                    QStandardItem(str(mod["installed_version"])),
+                    latest_item,
+                    QStandardItem(""),
+                ]
+
+                if has_update:
+                    for item in row_items:
+                        item.setBackground(update_highlight)
+
+                self._add_row(row_items)
+
+                row_idx = self.editor_model.rowCount() - 1
+                auto_cb = QCheckBox()
+                auto_cb.setChecked(bool(mod["auto_update"]))
+                auto_cb.toggled.connect(
+                    partial(self._on_auto_update_toggled, str(mod["mod_path"]))
+                )
+                auto_item = self.editor_model.item(row_idx, _COL_AUTO_UPDATE)
+                self.editor_table_view.setIndexWidget(auto_item.index(), auto_cb)
+
+        except Exception:
+            logger.opt(exception=True).warning("Failed to populate GitHub mods table")
+
+    def _on_auto_update_toggled(self, mod_path: str, checked: bool) -> None:
+        """Persist auto-update toggle to the instance DB."""
+        if self._auto_update_signals_blocked:
+            return
+
+        try:
+            from app.controllers.metadata_db_controller import AuxMetadataController
+            from app.models.metadata.metadata_db import Base
+            from app.utils.github.models import GitHubModEntry
+
+            aux_controller = AuxMetadataController.get_or_create_cached_instance(
+                self.settings_controller.settings.aux_db_path
+            )
+            Base.metadata.create_all(aux_controller.engine)
+
+            with aux_controller.Session() as session:
+                entry = (
+                    session.query(GitHubModEntry).filter_by(mod_path=mod_path).first()
+                )
+                if entry is not None:
+                    entry.auto_update = checked
+                    session.commit()
+        except Exception:
+            logger.opt(exception=True).warning(
+                f"Failed to update auto_update for {mod_path}"
+            )
 
     def _on_check_updates(self) -> None:
-        """Trigger update check for all GitHub mods."""
-        logger.debug("Check for updates requested")
+        """Trigger update check for all GitHub mods, then refresh the table."""
+        if self._update_worker is not None and self._update_worker.isRunning():
+            return
+
+        try:
+            from sqlalchemy import create_engine
+            from sqlalchemy.orm import sessionmaker as sa_sessionmaker
+
+            from app.controllers.metadata_db_controller import AuxMetadataController
+            from app.models.metadata.metadata_db import Base
+            from app.utils.app_info import AppInfo
+            from app.utils.github.models import CacheBase, GitHubModEntry
+            from app.utils.github.provider import GitHubProvider
+            from app.utils.github.worker import GitHubUpdateCheckWorker
+
+            aux_controller = AuxMetadataController.get_or_create_cached_instance(
+                self.settings_controller.settings.aux_db_path
+            )
+            Base.metadata.create_all(aux_controller.engine)
+
+            with aux_controller.Session() as session:
+                if session.query(GitHubModEntry).count() == 0:
+                    return
+
+            cache_db = AppInfo().app_storage_folder / "github_release_cache.db"
+            cache_engine = create_engine(f"sqlite+pysqlite:///{cache_db}")
+            CacheBase.metadata.create_all(cache_engine)
+            cache_session = sa_sessionmaker(bind=cache_engine)()
+
+            settings = self.settings_controller.settings
+            provider = GitHubProvider(
+                github_token=settings.github_token or None,
+                cache_session=cache_session,
+            )
+
+            self._update_worker = GitHubUpdateCheckWorker(
+                provider=provider,
+                instance_session_factory=aux_controller.Session,
+                check_interval_hours=0,
+            )
+            self._update_worker.finished.connect(self._on_check_updates_finished)
+            self._update_worker.error.connect(self._on_check_updates_error)
+            self._update_worker.start()
+
+            self.ui_elements.details_label.setText(self.tr("Checking for updates..."))
+
+        except Exception:
+            logger.opt(exception=True).warning("Failed to start GitHub update check")
+
+    def _on_check_updates_finished(self, updates: list[Any]) -> None:
+        """Refresh the table after an update check completes."""
+        self._populate_from_mods()
+        self._update_worker = None
+
+        if updates:
+            names = ", ".join(u.owner_repo for u in updates[:5])
+            suffix = f" and {len(updates) - 5} more" if len(updates) > 5 else ""
+            self.ui_elements.details_label.setText(
+                self.tr("{count} update(s) available: {names}{suffix}").format(
+                    count=len(updates), names=names, suffix=suffix
+                )
+            )
+        else:
+            self.ui_elements.details_label.setText(self.tr("All mods are up to date."))
+
+    def _on_check_updates_error(self, msg: str) -> None:
+        """Handle update check error."""
+        logger.warning(f"GitHub update check failed: {msg}")
+        self._update_worker = None
+        self.ui_elements.details_label.setText(
+            self.tr("Update check failed: {error}").format(error=msg)
+        )
 
     def _on_update_selected(self) -> None:
-        """Update selected mods to their latest versions."""
-        logger.debug("Update selected requested")
+        """Emit version-switch signals for each selected mod that has an update."""
+        selected = self._get_selected_row_indices()
+        if not selected:
+            return
+
+        for row in selected:
+            name_item = self.editor_model.item(row, _COL_NAME)
+            installed_item = self.editor_model.item(row, _COL_INSTALLED)
+            latest_item = self.editor_model.item(row, _COL_LATEST)
+            if not name_item or not installed_item or not latest_item:
+                continue
+
+            mod_path = name_item.data(Qt.ItemDataRole.UserRole)
+            latest_tag = latest_item.data(Qt.ItemDataRole.UserRole)
+            installed_tag = installed_item.text()
+
+            if not mod_path or not latest_tag or latest_tag == "—":
+                continue
+            if latest_tag == installed_tag:
+                continue
+
+            EventBus().github_version_switch_requested.emit(mod_path, latest_tag)
+
+    def _populate_from_metadata(self) -> None:
+        """Required by BaseModsPanel but GitHub panel uses _populate_from_mods instead."""
+        self._populate_from_mods()

--- a/app/windows/github_mods_panel.py
+++ b/app/windows/github_mods_panel.py
@@ -1,0 +1,57 @@
+from loguru import logger
+
+from app.windows.base_mods_panel import (
+    BaseModsPanel,
+    ButtonConfig,
+    ButtonType,
+)
+
+
+class GitHubModsPanel(BaseModsPanel):
+    """Panel for managing GitHub mods -- view installed, check updates, switch versions."""
+
+    def __init__(self) -> None:
+        logger.debug("Initializing GitHubModsPanel")
+
+        super().__init__(
+            object_name="githubModsPanel",
+            window_title=self.tr("RimSort - GitHub Mods"),
+            title_text=self.tr("GitHub Mods"),
+            details_text=self.tr("\nManage mods installed from GitHub releases."),
+            additional_columns=[
+                "Mod Name",
+                "Repository",
+                "Installed Version",
+                "Latest Version",
+                "Auto-Update",
+            ],
+        )
+
+        button_configs = [
+            ButtonConfig(
+                button_type=ButtonType.CUSTOM,
+                text=self.tr("Check for Updates"),
+                custom_callback=self._on_check_updates,
+            ),
+            ButtonConfig(
+                button_type=ButtonType.CUSTOM,
+                text=self.tr("Update Selected"),
+                custom_callback=self._on_update_selected,
+            ),
+        ]
+
+        self._setup_buttons_from_config(button_configs)
+        self._populate_from_mods()
+        self._reconfigure_table_sorting(sorting_enabled=True)
+
+    def _populate_from_mods(self) -> None:
+        """Populate table from per-instance github_mods table."""
+        self._clear_table_model()
+
+    def _on_check_updates(self) -> None:
+        """Trigger update check for all GitHub mods."""
+        logger.debug("Check for updates requested")
+
+    def _on_update_selected(self) -> None:
+        """Update selected mods to their latest versions."""
+        logger.debug("Update selected requested")

--- a/app/windows/github_mods_panel.py
+++ b/app/windows/github_mods_panel.py
@@ -17,7 +17,6 @@ from app.windows.base_mods_panel import (
 
 # Column indices (after the checkbox column 0 added by BaseModsPanel)
 _COL_NAME = 1
-_COL_REPO = 2
 _COL_INSTALLED = 3
 _COL_LATEST = 4
 _COL_AUTO_UPDATE = 5
@@ -68,7 +67,7 @@ class GitHubModsPanel(BaseModsPanel):
         try:
             EventBus().do_refresh_mods_lists.disconnect(self._populate_from_mods)
         except RuntimeError:
-            pass
+            logger.debug("Signal already disconnected during close")
         if self._update_worker is not None and self._update_worker.isRunning():
             self._update_worker.quit()
             self._update_worker.wait(5000)

--- a/tests/utils/github/conftest.py
+++ b/tests/utils/github/conftest.py
@@ -1,0 +1,19 @@
+"""Shared fixtures for GitHub utility tests."""
+
+from typing import Generator
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from app.utils.github.models import CacheBase
+
+
+@pytest.fixture
+def cache_session() -> Generator[Session, None, None]:
+    """Session for the global cache DB (github_release_cache)."""
+    engine = create_engine("sqlite:///:memory:")
+    CacheBase.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    yield session
+    session.close()

--- a/tests/utils/github/test_installer.py
+++ b/tests/utils/github/test_installer.py
@@ -1,0 +1,214 @@
+"""Tests for GitHub mod installer: zip extraction, unwrap heuristic, backup/restore."""
+
+from pathlib import Path
+from zipfile import ZipFile
+
+import pytest
+
+from app.utils.github.installer import (
+    GitHubInstaller,
+    UnwrapResult,
+    unwrap_extracted_mod,
+)
+
+
+@pytest.fixture
+def tmp_mods_dir(tmp_path: Path) -> Path:
+    mods = tmp_path / "Mods"
+    mods.mkdir()
+    return mods
+
+
+class TestUnwrapExtractedMod:
+    def test_single_dir_with_about_xml(self, tmp_path: Path) -> None:
+        wrapper = tmp_path / "ModName"
+        wrapper.mkdir()
+        about_dir = wrapper / "About"
+        about_dir.mkdir()
+        (about_dir / "About.xml").write_text("<xml/>")
+
+        result = unwrap_extracted_mod(tmp_path)
+        assert result == UnwrapResult.UNWRAPPED
+        assert (tmp_path / "About" / "About.xml").exists()
+        assert not wrapper.exists()
+
+    def test_root_has_about_xml(self, tmp_path: Path) -> None:
+        about_dir = tmp_path / "About"
+        about_dir.mkdir()
+        (about_dir / "About.xml").write_text("<xml/>")
+
+        result = unwrap_extracted_mod(tmp_path)
+        assert result == UnwrapResult.ALREADY_CORRECT
+        assert (tmp_path / "About" / "About.xml").exists()
+
+    def test_no_about_xml(self, tmp_path: Path) -> None:
+        wrapper = tmp_path / "SomeDir"
+        wrapper.mkdir()
+        (wrapper / "readme.txt").write_text("hello")
+
+        result = unwrap_extracted_mod(tmp_path)
+        assert result == UnwrapResult.NO_ABOUT_XML
+
+    def test_multiple_top_level_dirs(self, tmp_path: Path) -> None:
+        (tmp_path / "DirA").mkdir()
+        (tmp_path / "DirB").mkdir()
+
+        result = unwrap_extracted_mod(tmp_path)
+        assert result == UnwrapResult.NO_ABOUT_XML
+
+    def test_case_insensitive_about_dir(self, tmp_path: Path) -> None:
+        """About directory matching should be case-insensitive."""
+        wrapper = tmp_path / "ModName"
+        wrapper.mkdir()
+        about_dir = wrapper / "about"
+        about_dir.mkdir()
+        (about_dir / "about.xml").write_text("<xml/>")
+
+        result = unwrap_extracted_mod(tmp_path)
+        assert result == UnwrapResult.UNWRAPPED
+
+    def test_preserves_extra_content_on_unwrap(self, tmp_path: Path) -> None:
+        """Unwrapping should move all contents, not just About/."""
+        wrapper = tmp_path / "ModName"
+        wrapper.mkdir()
+        about_dir = wrapper / "About"
+        about_dir.mkdir()
+        (about_dir / "About.xml").write_text("<xml/>")
+        defs_dir = wrapper / "Defs"
+        defs_dir.mkdir()
+        (defs_dir / "ThingDef.xml").write_text("<thing/>")
+
+        result = unwrap_extracted_mod(tmp_path)
+        assert result == UnwrapResult.UNWRAPPED
+        assert (tmp_path / "Defs" / "ThingDef.xml").exists()
+
+
+class TestGitHubInstallerExtract:
+    def test_extract_zip_to_target(self, tmp_mods_dir: Path, tmp_path: Path) -> None:
+        zip_path = tmp_path / "mod.zip"
+        with ZipFile(zip_path, "w") as zf:
+            zf.writestr("ModName/About/About.xml", "<xml/>")
+            zf.writestr("ModName/Defs/ThingDef.xml", "<thing/>")
+
+        target = tmp_mods_dir / "ModName"
+        GitHubInstaller.extract_release_zip(str(zip_path), str(target))
+
+        assert (target / "About" / "About.xml").exists()
+        assert (target / "Defs" / "ThingDef.xml").exists()
+
+    def test_extract_zip_already_correct_structure(
+        self, tmp_mods_dir: Path, tmp_path: Path
+    ) -> None:
+        """ZIP where About/ is at root level (no wrapper dir)."""
+        zip_path = tmp_path / "mod.zip"
+        with ZipFile(zip_path, "w") as zf:
+            zf.writestr("About/About.xml", "<xml/>")
+            zf.writestr("Defs/ThingDef.xml", "<thing/>")
+
+        target = tmp_mods_dir / "ModName"
+        result = GitHubInstaller.extract_release_zip(str(zip_path), str(target))
+
+        assert result == UnwrapResult.ALREADY_CORRECT
+        assert (target / "About" / "About.xml").exists()
+
+    def test_extract_zip_slip_protection(
+        self, tmp_mods_dir: Path, tmp_path: Path
+    ) -> None:
+        """ZIP entries with path traversal should be skipped."""
+        zip_path = tmp_path / "evil.zip"
+        with ZipFile(zip_path, "w") as zf:
+            zf.writestr("About/About.xml", "<xml/>")
+            zf.writestr("../../../etc/passwd", "evil")
+
+        target = tmp_mods_dir / "SafeMod"
+        GitHubInstaller.extract_release_zip(str(zip_path), str(target))
+
+        assert (target / "About" / "About.xml").exists()
+        # The traversal entry should NOT have been extracted outside target
+        assert not (tmp_mods_dir / ".." / ".." / "etc" / "passwd").exists()
+
+
+class TestBackupRestore:
+    def test_backup_creates_backup_dir(self, tmp_mods_dir: Path) -> None:
+        mod_dir = tmp_mods_dir / "TestMod"
+        mod_dir.mkdir()
+        (mod_dir / "About").mkdir()
+        (mod_dir / "About" / "About.xml").write_text("<xml/>")
+
+        backup = GitHubInstaller.backup_mod(mod_dir)
+
+        assert backup.exists()
+        assert backup.name == "TestMod.rimsort_backup"
+        assert not mod_dir.exists()
+        assert (backup / "About" / "About.xml").exists()
+
+    def test_restore_backup(self, tmp_mods_dir: Path) -> None:
+        mod_dir = tmp_mods_dir / "TestMod"
+        mod_dir.mkdir()
+        (mod_dir / "data.txt").write_text("original")
+
+        backup = GitHubInstaller.backup_mod(mod_dir)
+        assert not mod_dir.exists()
+
+        GitHubInstaller.restore_backup(backup, mod_dir)
+        assert mod_dir.exists()
+        assert (mod_dir / "data.txt").read_text() == "original"
+        assert not backup.exists()
+
+    def test_delete_backup(self, tmp_mods_dir: Path) -> None:
+        backup = tmp_mods_dir / "TestMod.rimsort_backup"
+        backup.mkdir()
+        (backup / "file.txt").write_text("backup data")
+
+        GitHubInstaller.delete_backup(backup)
+        assert not backup.exists()
+
+    def test_check_stale_backup_found(self, tmp_mods_dir: Path) -> None:
+        mod_dir = tmp_mods_dir / "TestMod"
+        mod_dir.mkdir()
+        backup = tmp_mods_dir / "TestMod.rimsort_backup"
+        backup.mkdir()
+
+        result = GitHubInstaller.check_stale_backup(mod_dir)
+        assert result == backup
+
+    def test_check_stale_backup_not_found(self, tmp_mods_dir: Path) -> None:
+        mod_dir = tmp_mods_dir / "TestMod"
+        mod_dir.mkdir()
+
+        result = GitHubInstaller.check_stale_backup(mod_dir)
+        assert result is None
+
+    def test_backup_removes_existing_backup(self, tmp_mods_dir: Path) -> None:
+        mod_dir = tmp_mods_dir / "TestMod"
+        mod_dir.mkdir()
+        (mod_dir / "new.txt").write_text("new")
+
+        old_backup = tmp_mods_dir / "TestMod.rimsort_backup"
+        old_backup.mkdir()
+        (old_backup / "old.txt").write_text("old")
+
+        backup = GitHubInstaller.backup_mod(mod_dir)
+        assert (backup / "new.txt").exists()
+        assert not (backup / "old.txt").exists()
+
+    def test_restore_overwrites_existing_mod_dir(self, tmp_mods_dir: Path) -> None:
+        """If mod_dir already exists when restoring, it should be replaced."""
+        mod_dir = tmp_mods_dir / "TestMod"
+        mod_dir.mkdir()
+        (mod_dir / "original.txt").write_text("original")
+
+        backup = GitHubInstaller.backup_mod(mod_dir)
+
+        # Create a new mod_dir with different content (simulating a failed install)
+        mod_dir.mkdir()
+        (mod_dir / "broken.txt").write_text("broken")
+
+        GitHubInstaller.restore_backup(backup, mod_dir)
+        assert (mod_dir / "original.txt").exists()
+        assert not (mod_dir / "broken.txt").exists()
+
+    def test_delete_backup_noop_if_missing(self, tmp_mods_dir: Path) -> None:
+        """delete_backup should not raise if the backup doesn't exist."""
+        nonexistent = tmp_mods_dir / "Ghost.rimsort_backup"
+        GitHubInstaller.delete_backup(nonexistent)  # Should not raise

--- a/tests/utils/github/test_models.py
+++ b/tests/utils/github/test_models.py
@@ -1,0 +1,139 @@
+from typing import Generator
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from app.models.metadata.metadata_db import AuxMetadataEntry, Base
+from app.utils.github.models import (
+    CacheBase,
+    GitHubModEntry,
+    GitHubReleaseCache,
+)
+
+
+@pytest.fixture
+def instance_session() -> Generator[Session, None, None]:
+    """Session for the per-instance DB (aux_metadata + github_mods)."""
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    yield session
+    session.close()
+
+
+@pytest.fixture
+def cache_session() -> Generator[Session, None, None]:
+    """Session for the global cache DB (github_release_cache)."""
+    engine = create_engine("sqlite:///:memory:")
+    CacheBase.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    yield session
+    session.close()
+
+
+class TestGitHubModEntry:
+    def test_create_entry(self, instance_session: Session) -> None:
+        aux = AuxMetadataEntry(path="/mods/CoolMod")
+        instance_session.add(aux)
+        instance_session.flush()
+
+        entry = GitHubModEntry(
+            owner_repo="author/CoolMod",
+            mod_path="/mods/CoolMod",
+            installed_version="v1.2.0",
+            installed_asset_name="CoolMod.zip",
+            installed_commit_sha="abc1234",
+        )
+        instance_session.add(entry)
+        instance_session.commit()
+
+        result = instance_session.query(GitHubModEntry).first()
+        assert result is not None
+        assert result.owner_repo == "author/CoolMod"
+        assert result.mod_path == "/mods/CoolMod"
+        assert result.installed_version == "v1.2.0"
+        assert result.auto_update is False
+        assert result.created_at is not None
+        assert result.updated_at is not None
+
+    def test_unique_constraint(self, instance_session: Session) -> None:
+        aux = AuxMetadataEntry(path="/mods/CoolMod")
+        instance_session.add(aux)
+        instance_session.flush()
+
+        entry1 = GitHubModEntry(
+            owner_repo="author/CoolMod",
+            mod_path="/mods/CoolMod",
+            installed_version="v1.0.0",
+        )
+        instance_session.add(entry1)
+        instance_session.commit()
+
+        entry2 = GitHubModEntry(
+            owner_repo="author/CoolMod",
+            mod_path="/mods/CoolMod",
+            installed_version="v2.0.0",
+        )
+        instance_session.add(entry2)
+        with pytest.raises(Exception):
+            instance_session.commit()
+
+    def test_head_install(self, instance_session: Session) -> None:
+        aux = AuxMetadataEntry(path="/mods/HeadMod")
+        instance_session.add(aux)
+        instance_session.flush()
+
+        entry = GitHubModEntry(
+            owner_repo="author/HeadMod",
+            mod_path="/mods/HeadMod",
+            installed_version="HEAD",
+            installed_commit_sha="def5678",
+        )
+        instance_session.add(entry)
+        instance_session.commit()
+
+        result = instance_session.query(GitHubModEntry).first()
+        assert result is not None
+        assert result.installed_version == "HEAD"
+        assert result.installed_asset_name is None
+
+
+class TestGitHubReleaseCache:
+    def test_create_cache_entry(self, cache_session: Session) -> None:
+        cache = GitHubReleaseCache(
+            owner_repo="author/CoolMod",
+            releases_json='[{"tag": "v1.0.0"}]',
+            etag='"abc123"',
+        )
+        cache_session.add(cache)
+        cache_session.commit()
+
+        result = cache_session.query(GitHubReleaseCache).first()
+        assert result is not None
+        assert result.owner_repo == "author/CoolMod"
+        assert result.releases_json == '[{"tag": "v1.0.0"}]'
+        assert result.etag == '"abc123"'
+        assert result.last_checked is not None
+
+    def test_upsert_cache(self, cache_session: Session) -> None:
+        cache = GitHubReleaseCache(
+            owner_repo="author/CoolMod",
+            releases_json='[{"tag": "v1.0.0"}]',
+        )
+        cache_session.add(cache)
+        cache_session.commit()
+
+        existing = (
+            cache_session.query(GitHubReleaseCache)
+            .filter_by(owner_repo="author/CoolMod")
+            .first()
+        )
+        assert existing is not None
+        existing.releases_json = '[{"tag": "v1.0.0"}, {"tag": "v1.1.0"}]'
+        existing.etag = '"new_etag"'
+        cache_session.commit()
+
+        result = cache_session.query(GitHubReleaseCache).first()
+        assert result is not None
+        assert "v1.1.0" in result.releases_json

--- a/tests/utils/github/test_models.py
+++ b/tests/utils/github/test_models.py
@@ -6,7 +6,6 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from app.models.metadata.metadata_db import AuxMetadataEntry, Base
 from app.utils.github.models import (
-    CacheBase,
     GitHubModEntry,
     GitHubReleaseCache,
 )
@@ -17,16 +16,6 @@ def instance_session() -> Generator[Session, None, None]:
     """Session for the per-instance DB (aux_metadata + github_mods)."""
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
-    session = sessionmaker(bind=engine)()
-    yield session
-    session.close()
-
-
-@pytest.fixture
-def cache_session() -> Generator[Session, None, None]:
-    """Session for the global cache DB (github_release_cache)."""
-    engine = create_engine("sqlite:///:memory:")
-    CacheBase.metadata.create_all(engine)
     session = sessionmaker(bind=engine)()
     yield session
     session.close()

--- a/tests/utils/github/test_provider.py
+++ b/tests/utils/github/test_provider.py
@@ -1,12 +1,12 @@
 import json
 from datetime import datetime, timedelta, timezone
-from typing import Generator
+from unittest.mock import MagicMock, patch
 
 import pytest
-from sqlalchemy import create_engine
-from sqlalchemy.orm import Session, sessionmaker
+from github import GithubException
+from sqlalchemy.orm import Session
 
-from app.utils.github.models import CacheBase, GitHubReleaseCache
+from app.utils.github.models import GitHubReleaseCache
 from app.utils.github.provider import (
     GitHubProvider,
     GitHubRateLimitError,
@@ -104,14 +104,6 @@ class TestGitHubRateLimitError:
 
 
 class TestGitHubProvider:
-    @pytest.fixture
-    def cache_session(self) -> Generator[Session, None, None]:
-        engine = create_engine("sqlite:///:memory:")
-        CacheBase.metadata.create_all(engine)
-        session = sessionmaker(bind=engine)()
-        yield session
-        session.close()
-
     def test_get_releases_uses_cache_when_fresh(self, cache_session: Session) -> None:
         now = datetime.now(tz=timezone.utc)
         cached = GitHubReleaseCache(
@@ -172,3 +164,186 @@ class TestGitHubProvider:
         latest = provider.get_latest_stable_release(releases)
         assert latest is not None
         assert latest.tag == "v1.0.0"
+
+    def test_get_latest_stable_release_empty_list(self) -> None:
+        result = GitHubProvider.get_latest_stable_release([])
+        assert result is None
+
+    def test_get_latest_stable_release_all_prereleases(self) -> None:
+        now = datetime.now(tz=timezone.utc)
+        releases = [
+            ReleaseInfo(
+                tag="v2.0.0-beta",
+                name="Beta",
+                published_at=now,
+                prerelease=True,
+                assets=[],
+                body="",
+            ),
+        ]
+        result = GitHubProvider.get_latest_stable_release(releases)
+        assert result is not None
+        assert result.tag == "v2.0.0-beta"
+
+
+def _make_mock_asset(name: str, url: str, size: int = 1000) -> MagicMock:
+    asset = MagicMock()
+    asset.name = name
+    asset.browser_download_url = url
+    asset.size = size
+    return asset
+
+
+def _make_mock_release(
+    tag: str,
+    name: str | None = None,
+    published_at: datetime | None = None,
+    prerelease: bool = False,
+    draft: bool = False,
+    body: str = "",
+    assets: list[MagicMock] | None = None,
+) -> MagicMock:
+    rel = MagicMock()
+    rel.tag_name = tag
+    rel.name = name or tag
+    rel.published_at = published_at or datetime.now(tz=timezone.utc)
+    rel.prerelease = prerelease
+    rel.draft = draft
+    rel.body = body
+    rel.get_assets.return_value = assets or []
+    return rel
+
+
+class TestFetchReleasesFromApi:
+    """Tests for GitHubProvider._fetch_releases_from_api with mocked PyGitHub."""
+
+    @patch("app.utils.github.provider.Github")
+    def test_successful_fetch_returns_releases(
+        self, mock_github_cls: MagicMock
+    ) -> None:
+        now = datetime.now(tz=timezone.utc)
+        mock_asset = _make_mock_asset("Mod.zip", "https://github.com/dl/Mod.zip")
+        mock_release = _make_mock_release(
+            tag="v1.0.0",
+            published_at=now,
+            assets=[mock_asset],
+            body="Release notes",
+        )
+
+        mock_repo = MagicMock()
+        mock_repo.get_releases.return_value = [mock_release]
+        mock_github_cls.return_value.get_repo.return_value = mock_repo
+
+        provider = GitHubProvider()
+        releases = provider.get_releases("author/Mod", force_refresh=True)
+
+        assert len(releases) == 1
+        assert releases[0].tag == "v1.0.0"
+        assert releases[0].body == "Release notes"
+        assert len(releases[0].assets) == 1
+        assert releases[0].assets[0].name == "Mod.zip"
+
+    @patch("app.utils.github.provider.Github")
+    def test_successful_fetch_updates_cache(
+        self, mock_github_cls: MagicMock, cache_session: Session
+    ) -> None:
+        now = datetime.now(tz=timezone.utc)
+        mock_release = _make_mock_release(tag="v1.0.0", published_at=now)
+        mock_repo = MagicMock()
+        mock_repo.get_releases.return_value = [mock_release]
+        mock_github_cls.return_value.get_repo.return_value = mock_repo
+
+        provider = GitHubProvider(cache_session=cache_session)
+        provider.get_releases("author/Mod", force_refresh=True)
+
+        cached = (
+            cache_session.query(GitHubReleaseCache)
+            .filter_by(owner_repo="author/Mod")
+            .first()
+        )
+        assert cached is not None
+        assert "v1.0.0" in cached.releases_json
+
+    @patch("app.utils.github.provider.Github")
+    def test_rate_limit_raises_error(self, mock_github_cls: MagicMock) -> None:
+        mock_github_cls.return_value.get_repo.side_effect = GithubException(
+            403, {"message": "rate limit"}, None
+        )
+
+        provider = GitHubProvider()
+        with pytest.raises(GitHubRateLimitError):
+            provider.get_releases("author/Mod", force_refresh=True)
+
+    @patch("app.utils.github.provider.Github")
+    def test_429_raises_rate_limit_error(self, mock_github_cls: MagicMock) -> None:
+        mock_github_cls.return_value.get_repo.side_effect = GithubException(
+            429, {"message": "too many requests"}, None
+        )
+
+        provider = GitHubProvider()
+        with pytest.raises(GitHubRateLimitError):
+            provider.get_releases("author/Mod", force_refresh=True)
+
+    @patch("app.utils.github.provider.Github")
+    def test_404_returns_empty_list(self, mock_github_cls: MagicMock) -> None:
+        mock_github_cls.return_value.get_repo.side_effect = GithubException(
+            404, {"message": "not found"}, None
+        )
+
+        provider = GitHubProvider()
+        releases = provider.get_releases("author/Mod", force_refresh=True)
+        assert releases == []
+
+    @patch("app.utils.github.provider.Github")
+    def test_other_github_exception_propagates(
+        self, mock_github_cls: MagicMock
+    ) -> None:
+        mock_github_cls.return_value.get_repo.side_effect = GithubException(
+            500, {"message": "server error"}, None
+        )
+
+        provider = GitHubProvider()
+        with pytest.raises(GithubException):
+            provider.get_releases("author/Mod", force_refresh=True)
+
+    @patch("app.utils.github.provider.Github")
+    def test_naive_datetime_gets_utc_timezone(self, mock_github_cls: MagicMock) -> None:
+        naive_dt = datetime(2024, 1, 1, 12, 0, 0)
+        mock_release = _make_mock_release(tag="v1.0.0", published_at=naive_dt)
+        mock_repo = MagicMock()
+        mock_repo.get_releases.return_value = [mock_release]
+        mock_github_cls.return_value.get_repo.return_value = mock_repo
+
+        provider = GitHubProvider()
+        releases = provider.get_releases("author/Mod", force_refresh=True)
+
+        assert releases[0].published_at.tzinfo is not None
+        assert releases[0].published_at.tzinfo == timezone.utc
+
+    @patch("app.utils.github.provider.Github")
+    def test_release_with_none_name_uses_tag(self, mock_github_cls: MagicMock) -> None:
+        mock_release = _make_mock_release(tag="v1.0.0")
+        mock_release.name = None
+        mock_repo = MagicMock()
+        mock_repo.get_releases.return_value = [mock_release]
+        mock_github_cls.return_value.get_repo.return_value = mock_repo
+
+        provider = GitHubProvider()
+        releases = provider.get_releases("author/Mod", force_refresh=True)
+
+        assert releases[0].name == "v1.0.0"
+
+    @patch("app.utils.github.provider.Github")
+    def test_release_with_none_body_uses_empty_string(
+        self, mock_github_cls: MagicMock
+    ) -> None:
+        mock_release = _make_mock_release(tag="v1.0.0")
+        mock_release.body = None
+        mock_repo = MagicMock()
+        mock_repo.get_releases.return_value = [mock_release]
+        mock_github_cls.return_value.get_repo.return_value = mock_repo
+
+        provider = GitHubProvider()
+        releases = provider.get_releases("author/Mod", force_refresh=True)
+
+        assert releases[0].body == ""

--- a/tests/utils/github/test_provider.py
+++ b/tests/utils/github/test_provider.py
@@ -1,0 +1,174 @@
+import json
+from datetime import datetime, timedelta, timezone
+from typing import Generator
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from app.utils.github.models import CacheBase, GitHubReleaseCache
+from app.utils.github.provider import (
+    GitHubProvider,
+    GitHubRateLimitError,
+    ReleaseAsset,
+    ReleaseInfo,
+    parse_github_url,
+)
+
+
+class TestParseGitHubUrl:
+    def test_standard_url(self) -> None:
+        assert parse_github_url("https://github.com/owner/repo") == ("owner", "repo")
+
+    def test_url_with_git_suffix(self) -> None:
+        assert parse_github_url("https://github.com/owner/repo.git") == (
+            "owner",
+            "repo",
+        )
+
+    def test_url_with_trailing_path(self) -> None:
+        assert parse_github_url("https://github.com/owner/repo/tree/main") == (
+            "owner",
+            "repo",
+        )
+
+    def test_url_with_trailing_slash(self) -> None:
+        assert parse_github_url("https://github.com/owner/repo/") == ("owner", "repo")
+
+    def test_non_github_url(self) -> None:
+        assert parse_github_url("https://gitlab.com/owner/repo") is None
+
+    def test_invalid_url(self) -> None:
+        assert parse_github_url("not-a-url") is None
+
+    def test_github_url_missing_repo(self) -> None:
+        assert parse_github_url("https://github.com/owner") is None
+
+
+class TestReleaseInfo:
+    def test_filter_zip_assets(self) -> None:
+        assets = [
+            ReleaseAsset(
+                name="Mod.zip", download_url="https://example.com/Mod.zip", size=1000
+            ),
+            ReleaseAsset(
+                name="Mod.7z", download_url="https://example.com/Mod.7z", size=900
+            ),
+            ReleaseAsset(
+                name="Source code (zip)",
+                download_url="https://example.com/src.zip",
+                size=500,
+            ),
+        ]
+        release = ReleaseInfo(
+            tag="v1.0.0",
+            name="Release 1.0",
+            published_at=datetime.now(tz=timezone.utc),
+            prerelease=False,
+            assets=assets,
+            body="Release notes here",
+        )
+        custom_zips = release.get_custom_zip_assets()
+        assert len(custom_zips) == 1
+        assert custom_zips[0].name == "Mod.zip"
+
+    def test_filter_source_archives(self) -> None:
+        assets = [
+            ReleaseAsset(
+                name="Source code (zip)",
+                download_url="https://example.com/src.zip",
+                size=500,
+            ),
+            ReleaseAsset(
+                name="Source code (tar.gz)",
+                download_url="https://example.com/src.tar.gz",
+                size=600,
+            ),
+        ]
+        release = ReleaseInfo(
+            tag="v1.0.0",
+            name="Release 1.0",
+            published_at=datetime.now(tz=timezone.utc),
+            prerelease=False,
+            assets=assets,
+            body="",
+        )
+        assert len(release.get_custom_zip_assets()) == 0
+
+
+class TestGitHubRateLimitError:
+    def test_is_exception(self) -> None:
+        err = GitHubRateLimitError("rate limit exceeded")
+        assert isinstance(err, Exception)
+        assert str(err) == "rate limit exceeded"
+
+
+class TestGitHubProvider:
+    @pytest.fixture
+    def cache_session(self) -> Generator[Session, None, None]:
+        engine = create_engine("sqlite:///:memory:")
+        CacheBase.metadata.create_all(engine)
+        session = sessionmaker(bind=engine)()
+        yield session
+        session.close()
+
+    def test_get_releases_uses_cache_when_fresh(self, cache_session: Session) -> None:
+        now = datetime.now(tz=timezone.utc)
+        cached = GitHubReleaseCache(
+            owner_repo="author/Mod",
+            releases_json=json.dumps(
+                [
+                    {
+                        "tag": "v1.0.0",
+                        "name": "Release 1.0",
+                        "published_at": now.isoformat(),
+                        "prerelease": False,
+                        "assets": [],
+                        "body": "",
+                    }
+                ]
+            ),
+            etag='"etag"',
+            last_checked=now,
+        )
+        cache_session.add(cached)
+        cache_session.commit()
+
+        provider = GitHubProvider(cache_session=cache_session)
+        releases = provider.get_releases("author/Mod", check_interval_hours=24)
+        assert len(releases) == 1
+        assert releases[0].tag == "v1.0.0"
+
+    def test_get_latest_stable_release(self, cache_session: Session) -> None:
+        now = datetime.now(tz=timezone.utc)
+        releases_data = [
+            {
+                "tag": "v2.0.0-beta",
+                "name": "Beta 2.0",
+                "published_at": (now + timedelta(days=1)).isoformat(),
+                "prerelease": True,
+                "assets": [],
+                "body": "",
+            },
+            {
+                "tag": "v1.0.0",
+                "name": "Release 1.0",
+                "published_at": now.isoformat(),
+                "prerelease": False,
+                "assets": [],
+                "body": "",
+            },
+        ]
+        cached = GitHubReleaseCache(
+            owner_repo="author/Mod",
+            releases_json=json.dumps(releases_data),
+            last_checked=now,
+        )
+        cache_session.add(cached)
+        cache_session.commit()
+
+        provider = GitHubProvider(cache_session=cache_session)
+        releases = provider.get_releases("author/Mod", check_interval_hours=24)
+        latest = provider.get_latest_stable_release(releases)
+        assert latest is not None
+        assert latest.tag == "v1.0.0"

--- a/tests/utils/github/test_updater.py
+++ b/tests/utils/github/test_updater.py
@@ -1,0 +1,120 @@
+import json
+from datetime import datetime, timedelta, timezone
+from typing import Generator
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from app.models.metadata.metadata_db import AuxMetadataEntry, Base
+from app.utils.github.models import CacheBase, GitHubModEntry, GitHubReleaseCache
+from app.utils.github.provider import GitHubProvider
+from app.utils.github.updater import UpdateAvailable, check_for_updates
+
+
+@pytest.fixture
+def db_session() -> Generator[Session, None, None]:
+    """Combined session: instance tables + cache tables in one in-memory DB for test convenience."""
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    CacheBase.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    yield session
+    session.close()
+
+
+def _release_dict(
+    tag: str,
+    published_at: datetime,
+    *,
+    body: str = "",
+    prerelease: bool = False,
+) -> dict[str, object]:
+    """Build a minimal release JSON dict for cache seeding."""
+    return {
+        "tag": tag,
+        "name": tag,
+        "published_at": published_at.isoformat(),
+        "prerelease": prerelease,
+        "assets": [],
+        "body": body,
+    }
+
+
+def _seed_and_check(
+    session: Session,
+    owner_repo: str,
+    mod_path: str,
+    installed_version: str,
+    releases: list[dict[str, object]],
+) -> list[UpdateAvailable]:
+    """Insert a mod entry + cached releases, then run the update checker."""
+    aux = AuxMetadataEntry(path=mod_path)
+    session.add(aux)
+    session.flush()
+
+    session.add(
+        GitHubModEntry(
+            owner_repo=owner_repo,
+            mod_path=mod_path,
+            installed_version=installed_version,
+        )
+    )
+    session.add(
+        GitHubReleaseCache(
+            owner_repo=owner_repo,
+            releases_json=json.dumps(releases),
+            last_checked=datetime.now(tz=timezone.utc),
+        )
+    )
+    session.commit()
+
+    provider = GitHubProvider(cache_session=session)
+    return check_for_updates(
+        instance_session=session,
+        provider=provider,
+        check_interval_hours=24,
+    )
+
+
+class TestCheckForUpdates:
+    def test_update_available(self, db_session: Session) -> None:
+        now = datetime.now(tz=timezone.utc)
+        updates = _seed_and_check(
+            db_session,
+            "author/Mod",
+            "/mods/Mod",
+            "v1.0.0",
+            [
+                _release_dict("v2.0.0", now, body="New stuff"),
+                _release_dict("v1.0.0", now - timedelta(days=30)),
+            ],
+        )
+        assert len(updates) == 1
+        assert updates[0].owner_repo == "author/Mod"
+        assert updates[0].installed_version == "v1.0.0"
+        assert updates[0].latest_version == "v2.0.0"
+
+    def test_no_update_when_current(self, db_session: Session) -> None:
+        now = datetime.now(tz=timezone.utc)
+        updates = _seed_and_check(
+            db_session,
+            "author/Mod",
+            "/mods/Mod",
+            "v1.0.0",
+            [_release_dict("v1.0.0", now)],
+        )
+        assert len(updates) == 0
+
+    def test_head_mod_detects_new_releases(self, db_session: Session) -> None:
+        now = datetime.now(tz=timezone.utc)
+        updates = _seed_and_check(
+            db_session,
+            "author/Mod",
+            "/mods/Mod",
+            "HEAD",
+            [_release_dict("v1.0.0", now, body="First release")],
+        )
+        assert len(updates) == 1
+        assert updates[0].installed_version == "HEAD"
+        assert updates[0].latest_version == "v1.0.0"

--- a/tests/windows/conftest.py
+++ b/tests/windows/conftest.py
@@ -1,0 +1,13 @@
+"""Conftest for windows tests - handles missing submodule dependencies in worktrees."""
+
+import importlib.util
+import sys
+from unittest.mock import MagicMock
+
+# Pre-populate steamworks in sys.modules if the submodule isn't available,
+# allowing test collection to succeed in worktrees where submodules
+# haven't been initialized.
+if "steamworks" not in sys.modules:
+    _spec = importlib.util.find_spec("steamworks")
+    if _spec is None:
+        sys.modules["steamworks"] = MagicMock()

--- a/tests/windows/test_github_mods_panel.py
+++ b/tests/windows/test_github_mods_panel.py
@@ -1,0 +1,12 @@
+from unittest.mock import patch
+
+from PySide6.QtWidgets import QApplication
+
+from app.windows.github_mods_panel import GitHubModsPanel
+
+
+class TestGitHubModsPanel:
+    def test_panel_creates_without_error(self, qapp: QApplication) -> None:
+        with patch("app.windows.github_mods_panel.GitHubModsPanel._populate_from_mods"):
+            panel = GitHubModsPanel.__new__(GitHubModsPanel)
+            assert panel is not None


### PR DESCRIPTION
## Summary

Adds end-to-end support for installing, updating, and managing RimWorld mods from GitHub releases. This is a new mod source alongside Steam Workshop and SteamCMD.

**Core infrastructure:**
- GitHub API provider with SQLite-backed release caching and rate limit handling
- Installer with zip extraction, unwrap heuristic (finds About.xml), and backup/restore
- Update checker comparing installed versions against cached releases (publish-date based)
- QThread workers for non-blocking install, version switch, and update checks
- SQLAlchemy models: `GitHubModEntry` (per-instance) and `GitHubReleaseCache` (global)

**UI integration:**
- **Download > GitHub Mods** menu action opens a management panel
- GitHub Mods panel shows all tracked mods with installed/latest versions, yellow highlight for updates, and auto-update checkbox
- "Check for Updates" button triggers background update check with status feedback
- "Update Selected" button triggers version switches for checked mods with updates
- Mod info panel shows GitHub source info, version dropdown, and "(Update available)" badge
- Version switching from both the mod info panel combo box and the GitHub Mods panel

**Auto-update on startup:**
- Background update check runs on app startup (configurable interval)
- Mods with auto-update enabled are updated automatically without user interaction
- After auto-updates complete, user is prompted to refresh now or later
- Mods without auto-update show an informational popup directing to the GitHub Mods panel

Closes #1123

## Test plan

- [x] Install a mod from a GitHub release URL via the install flow
- [x] Verify mod appears in the GitHub Mods panel with correct version info
- [x] Click "Check for Updates" and verify status feedback and table refresh
- [x] Toggle auto-update checkbox and verify it persists across panel reopens
- [x] Use "Update Selected" to update a mod and verify table + mod info panel refresh
- [x] Switch versions from the mod info panel dropdown
- [x] Enable auto-update on a mod, restart app, verify it updates automatically
- [x] Verify the refresh prompt appears after auto-updates complete
- [x] Test with no GitHub token (unauthenticated rate limit)
- [x] Test with a GitHub token configured in settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)