### PR TITLE
feat(ui): add deprecation notice for alphabetical sort in settings

### DIFF
--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -775,6 +775,10 @@ This basically preserves your mod coloring, user notes etc. for this many second
         sorting_label.setFont(GUIInfo().emphasis_font)
         sort_group_box_layout.addWidget(sorting_label)
 
+        self.sorting_topological_radio = QRadioButton(self.tr("Topologically"))
+        sort_group_box_layout.addWidget(self.sorting_topological_radio)
+
+        alphabetical_layout = QHBoxLayout()
         self.sorting_alphabetical_radio = QRadioButton(self.tr("Alphabetically"))
         self.sorting_alphabetical_radio.setToolTip(
             self.tr(
@@ -782,10 +786,12 @@ This basically preserves your mod coloring, user notes etc. for this many second
                 "Topological sorting is recommended."
             )
         )
-        sort_group_box_layout.addWidget(self.sorting_alphabetical_radio)
-
-        self.sorting_topological_radio = QRadioButton(self.tr("Topologically"))
-        sort_group_box_layout.addWidget(self.sorting_topological_radio)
+        alphabetical_layout.addWidget(self.sorting_alphabetical_radio)
+        alphabetical_warning = QLabel(self.tr("(Deprecated — use Topological instead)"))
+        alphabetical_warning.setStyleSheet("color: #e8a838; font-style: italic;")
+        alphabetical_layout.addWidget(alphabetical_warning)
+        alphabetical_layout.addStretch()
+        sort_group_box_layout.addLayout(alphabetical_layout)
 
         # Dependencies group
         deps_group_box = QGroupBox()


### PR DESCRIPTION
## Summary
- Swap sort radio button order so **Topological** appears first (recommended default)
- Add inline amber deprecation warning next to **Alphabetical** sort option

## Test plan
- [x] Launched app with `just run`, verified Sorting tab shows Topological first with deprecation warning on Alphabetical
- [x] `just check` passes all quality gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)