### PR TITLE
feat(ui): Combine Databases and Additional Databases settings tabs

### DIFF
--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -14,6 +14,7 @@ from PySide6.QtWidgets import (
     QLineEdit,
     QPushButton,
     QRadioButton,
+    QScrollArea,
     QSizePolicy,
     QSpinBox,
     QTabWidget,
@@ -73,7 +74,6 @@ class SettingsDialog(QDialog):
         self._do_locations_tab()
         self._do_game_launch_tab()
         self._do_databases_tab()
-        self._do_cross_version_databases_tab()
         self._do_sorting_tab()
         self._do_db_builder_tab()
         self._do_steamcmd_tab()
@@ -386,22 +386,21 @@ class SettingsDialog(QDialog):
         tab_layout.addStretch()
 
     def _do_databases_tab(self) -> None:
-        tab = QWidget()
-        self.tab_widget.addTab(tab, self.tr("Databases"))
+        scroll_area = QScrollArea()
+        scroll_area.setWidgetResizable(True)
+        scroll_area.setFrameShape(QScrollArea.Shape.NoFrame)
+        self.tab_widget.addTab(scroll_area, self.tr("Databases"))
+
+        content = QWidget()
+        scroll_area.setWidget(content)
+        content.setAutoFillBackground(False)
+        scroll_area.viewport().setAutoFillBackground(False)
 
         tab_layout = QVBoxLayout()
-        tab.setLayout(tab_layout)
+        content.setLayout(tab_layout)
 
         self._do_community_rules_db_group(tab_layout)
         self._do_steam_workshop_db_group(tab_layout)
-
-    def _do_cross_version_databases_tab(self) -> None:
-        tab = QWidget()
-        self.tab_widget.addTab(tab, self.tr("Additional Databases"))
-
-        tab_layout = QVBoxLayout()
-        tab.setLayout(tab_layout)
-
         self._do_no_version_warning_db_group(tab_layout)
         self._do_use_this_instead_db_group(tab_layout)
 

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -391,13 +391,13 @@ class SettingsDialog(QDialog):
         scroll_area.setFrameShape(QScrollArea.Shape.NoFrame)
         self.tab_widget.addTab(scroll_area, self.tr("Databases"))
 
-        content = QWidget()
-        scroll_area.setWidget(content)
-        content.setAutoFillBackground(False)
+        tab = QWidget()
+        scroll_area.setWidget(tab)
+        tab.setAutoFillBackground(False)
         scroll_area.viewport().setAutoFillBackground(False)
 
         tab_layout = QVBoxLayout()
-        content.setLayout(tab_layout)
+        tab.setLayout(tab_layout)
 
         self._do_community_rules_db_group(tab_layout)
         self._do_steam_workshop_db_group(tab_layout)


### PR DESCRIPTION
## Summary
- Merges the "Databases" and "Additional Databases" settings tabs into a single scrollable "Databases" tab
- All four database configuration groups (Community Rules, Steam Workshop, No Version Warning, Use This Instead) now live in one tab, reducing tab clutter
- Uses a QScrollArea so the settings dialog can be resized without losing access to any database group

## Test plan
- [x] Open Settings dialog → verify "Databases" tab contains all four database groups
- [x] Verify "Additional Databases" tab no longer exists
- [x] Scroll down in the Databases tab to see all groups
- [x] Resize the settings dialog smaller → verify scrollbar appears and all content is accessible
- [x] Verify background color matches other tabs (no color mismatch from scroll area)
- [x] Verify buttons (Upload, Download, Choose) are styled correctly and clickable
- [x] Test with different themes (Modern, RimPy, Nature, SunSet, Wood)
- [x] Verify radio button selection and text input still work for each database group

🤖 Generated with [Claude Code](https://claude.com/claude-code)