### PR TITLE
Fix inactive mods sorting checkbox toggle

### DIFF
--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -135,11 +135,6 @@ class SettingsController(QObject):
         except Exception:
             pass
 
-        # Sorting: wiring for inactive mods sorting checkbox
-        self.settings_dialog.enable_inactive_mods_sorting_checkbox.toggled.connect(
-            self._on_enable_inactive_mods_sorting_checkbox_toggled
-        )
-
         # Locations tab
         self.settings_dialog.game_location.textChanged.connect(
             self._on_game_location_text_changed
@@ -482,13 +477,6 @@ class SettingsController(QObject):
         # Update model immediately for live UI response
         self.settings.show_save_comparison_indicators = checked
         self.settings.save()
-
-    @Slot(bool)
-    def _on_enable_inactive_mods_sorting_checkbox_toggled(self, checked: bool) -> None:
-        """
-        Enable or disable the inactive mods sorting group box based on the checkbox state.
-        """
-        self.settings_dialog.inactive_mods_sorting_group_box.setEnabled(checked)
 
     def create_instance(
         self,
@@ -945,11 +933,7 @@ class SettingsController(QObject):
             self.settings.hide_invalid_mods_when_filtering
         )
         # Inactive mods sorting options checkbox
-        self.settings_dialog.enable_inactive_mods_sorting_checkbox.setChecked(
-            self.settings.inactive_mods_sorting
-        )
-        # Enable/disable the inactive mods sorting group box based on the checkbox state
-        self.settings_dialog.inactive_mods_sorting_group_box.setEnabled(
+        self.settings_dialog.inactive_mods_sorting_checkbox.setChecked(
             self.settings.inactive_mods_sorting
         )
         # Save inactive mods sort state
@@ -1335,7 +1319,7 @@ class SettingsController(QObject):
         )
         # Inactive mods sorting options checkbox
         self.settings.inactive_mods_sorting = (
-            self.settings_dialog.enable_inactive_mods_sorting_checkbox.isChecked()
+            self.settings_dialog.inactive_mods_sorting_checkbox.isChecked()
         )
         # Save inactive mods sort state
         self.settings.save_inactive_mods_sort_state = (

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -926,17 +926,17 @@ This basically preserves your mod coloring, user notes etc. for this many second
         inactive_mods_sorting_group_box_layout.addWidget(inactive_mods_sorting_label)
 
         # Inactive mods sorting options checkbox
-        self.enable_inactive_mods_sorting_checkbox = QCheckBox(
+        self.inactive_mods_sorting_checkbox = QCheckBox(
             self.tr("Enable inactive mods sorting")
         )
-        self.enable_inactive_mods_sorting_checkbox.setToolTip(
+        self.inactive_mods_sorting_checkbox.setToolTip(
             self.tr(
                 "Additional options like name, author, folder size, modified date will be available in the mods panel for sorting inactive mods \n"
                 "Disabling this can improve performance by avoiding heavy calculations."
             )
         )
         inactive_mods_sorting_group_box_layout.addWidget(
-            self.enable_inactive_mods_sorting_checkbox
+            self.inactive_mods_sorting_checkbox
         )
 
         self.save_inactive_mods_sort_state_checkbox = QCheckBox(


### PR DESCRIPTION
- Rename enable_inactive_mods_sorting_checkbox to inactive_mods_sorting_checkbox for clarity
- Remove the toggle signal connection and handler method that dynamically enabled/disabled the inactive mods sorting group box
- Update all references from enable_inactive_mods_sorting_checkbox to inactive_mods_sorting_checkbox in settings_controller.py