### PR TITLE
ci: skip builds for docs-only PRs

### DIFF
--- a/.github/workflows/auto_build.yml
+++ b/.github/workflows/auto_build.yml
@@ -18,6 +18,29 @@ on:
 permissions: {}
 
 jobs:
+  detect-changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      app_changed: ${{ steps.filter.outputs.app }}
+    steps:
+      - uses: actions/checkout@main
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            app:
+              - '**'
+              - '!docs/**'
+              - '!**/*.md'
+              - '!.github/ISSUE_TEMPLATE/**'
+              - '!.github/release.yml'
+              - '!.github/labeler.yml'
+              - '!LICENSE*'
+
   pre-pyright:
     permissions:
       contents: read
@@ -34,8 +57,10 @@ jobs:
       format_only: true
 
   attested-build:
-    needs: pre-build
-    if: github.event_name != 'pull_request'
+    needs: [detect-changes, pre-build]
+    if: >-
+      needs.detect-changes.outputs.app_changed == 'true'
+      && github.event_name != 'pull_request'
     permissions:
       id-token: write
       contents: read
@@ -47,8 +72,10 @@ jobs:
       attest: true
 
   non-attested-build:
-    needs: pre-build
-    if: github.event_name == 'pull_request'
+    needs: [detect-changes, pre-build]
+    if: >-
+      needs.detect-changes.outputs.app_changed == 'true'
+      && github.event_name == 'pull_request'
     permissions:
       id-token: write
       contents: read
@@ -63,6 +90,7 @@ jobs:
     name: Status Check
     runs-on: ubuntu-latest
     needs:
+      - detect-changes
       - pre-pyright
       - pre-test
       - pre-build
@@ -72,6 +100,9 @@ jobs:
     steps:
       - name: Verify all required jobs succeeded
         run: |
+          if [[ "${{ needs.detect-changes.outputs.app_changed }}" != "true" ]]; then
+            echo "No app-relevant changes detected — builds were skipped."
+          fi
           results=(
             "${{ needs.pre-pyright.result }}"
             "${{ needs.pre-test.result }}"

--- a/.github/workflows/auto_build.yml
+++ b/.github/workflows/auto_build.yml
@@ -23,23 +23,47 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
     outputs:
-      app_changed: ${{ steps.filter.outputs.app }}
+      app_changed: ${{ steps.check.outputs.app_changed }}
     steps:
       - uses: actions/checkout@main
-      - uses: dorny/paths-filter@v3
-        id: filter
         with:
-          filters: |
-            app:
-              - '**'
-              - '!docs/**'
-              - '!**/*.md'
-              - '!.github/ISSUE_TEMPLATE/**'
-              - '!.github/release.yml'
-              - '!.github/labeler.yml'
-              - '!LICENSE*'
+          fetch-depth: 0
+      - name: Check for app-relevant changes
+        id: check
+        env:
+          GH_EVENT: ${{ github.event_name }}
+          PR_BASE: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD: ${{ github.event.pull_request.head.sha }}
+          MG_BASE: ${{ github.event.merge_group.base_sha }}
+          MG_HEAD: ${{ github.event.merge_group.head_sha }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          PUSH_SHA: ${{ github.sha }}
+        run: |
+          if [[ "$GH_EVENT" == "pull_request" ]]; then
+            CHANGED=$(git diff --name-only "$PR_BASE"..."$PR_HEAD")
+          elif [[ "$GH_EVENT" == "merge_group" ]]; then
+            CHANGED=$(git diff --name-only "$MG_BASE"..."$MG_HEAD")
+          else
+            CHANGED=$(git diff --name-only "$PUSH_BEFORE" "$PUSH_SHA")
+          fi
+
+          APP_CHANGED=$(echo "$CHANGED" \
+            | grep -v -E '^docs/' \
+            | grep -v -E '\.md$' \
+            | grep -v -E '^\.github/ISSUE_TEMPLATE/' \
+            | grep -v -E '^\.github/(release|labeler)\.yml$' \
+            | grep -v -E '^LICENSE' \
+            || true)
+
+          if [[ -n "$APP_CHANGED" ]]; then
+            echo "app_changed=true" >> "$GITHUB_OUTPUT"
+            echo "App-relevant files changed:"
+            echo "$APP_CHANGED"
+          else
+            echo "app_changed=false" >> "$GITHUB_OUTPUT"
+            echo "Only documentation files changed — builds will be skipped"
+          fi
 
   pre-pyright:
     permissions:


### PR DESCRIPTION
## Summary
- Adds a `detect-changes` job that uses `git diff` + `grep -v` to check whether any app-relevant files changed
- Gates the expensive Nuitka build matrix (5 platforms) on the result — docs-only PRs skip builds entirely
- Pyright and pytest still run on every PR as a safety net
- `status-check` job still passes for docs-only PRs so they aren't blocked by missing required checks

**Excluded from triggering builds (docs-only paths):**
- `docs/**`
- `**/*.md`
- `.github/ISSUE_TEMPLATE/**`
- `.github/release.yml`, `.github/labeler.yml`
- `LICENSE*`

**Everything else triggers builds**, including all workflow files, `pyproject.toml`, `app/`, `libs/`, `submodules/`, `themes/`, etc.

## Test plan
- [x] Verify this PR itself triggers builds (it changes a workflow file)
- [x] Create a test PR that only changes a `.md` file and confirm builds are skipped — #2072
- [x] Confirm `Status Check` still passes for docs-only PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)