### PR TITLE
fix: stop both watchdog observers and cancel timers on shutdown

### DIFF
--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -1215,10 +1215,11 @@ class MainWindow(QMainWindow):
                 self.watchdog_event_handler.watchdog_acf_observer.join()
                 self.watchdog_event_handler.watchdog_acf_observer = None
             # Handle Mod Directory Observer shutdown
-            elif self.watchdog_event_handler.watchdog_mods_observer.is_alive():
+            if self.watchdog_event_handler.watchdog_mods_observer.is_alive():
                 self.watchdog_event_handler.watchdog_mods_observer.stop()
                 self.watchdog_event_handler.watchdog_mods_observer.join()
                 self.watchdog_event_handler.watchdog_mods_observer = None
-                for timer in self.watchdog_event_handler.cooldown_timers.values():
-                    timer.cancel()
+            # Cancel all pending cooldown timers to prevent callbacks on stale handler
+            for timer in self.watchdog_event_handler.cooldown_timers.values():
+                timer.cancel()
             self.watchdog_event_handler = None


### PR DESCRIPTION
## Summary

- **`elif` → `if`**: The ACF observer and mods observer shutdowns were mutually exclusive — if the ACF observer was alive, the mods observer was never stopped, leaving a filesystem monitor running after instance switch
- **Timer cancellation moved outside conditionals**: Cooldown timers were only cancelled inside the `elif` branch, so they'd keep firing on a dereferenced `WatchdogHandler` when the ACF observer was the one that was alive

## Test plan

- [ ] Switch RimWorld instances — verify no stale filesystem events after switch
- [ ] Close application with both observers running — verify clean shutdown (no warnings in log)
- [ ] All 699 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)