### PR TITLE
fix(ci): Nuitka version mismatch and broken status-check

### DIFF
--- a/.github/workflows/auto_build.yml
+++ b/.github/workflows/auto_build.yml
@@ -70,5 +70,19 @@ jobs:
       - non-attested-build
     if: always()
     steps:
-      - name: Set status check
-        run: echo "All required jobs have completed."
+      - name: Verify all required jobs succeeded
+        run: |
+          results=(
+            "${{ needs.pre-pyright.result }}"
+            "${{ needs.pre-test.result }}"
+            "${{ needs.pre-build.result }}"
+            "${{ needs.attested-build.result }}"
+            "${{ needs.non-attested-build.result }}"
+          )
+          for r in "${results[@]}"; do
+            if [[ "$r" == "failure" || "$r" == "cancelled" ]]; then
+              echo "::error::A required job finished with result: $r"
+              exit 1
+            fi
+          done
+          echo "All required jobs succeeded or were skipped."

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,7 +179,7 @@ jobs:
       - name: Build
         uses: Nuitka/Nuitka-Action@main
         with:
-          nuitka-version: 4.0.8
+          nuitka-version: 4.1.1
           script-name: app/
           python-flag: -m
           mode: ${{ runner.os == 'macos' && 'app' || 'standalone' }}


### PR DESCRIPTION
## Summary

- **Nuitka version alignment**: `build.yml` pinned Nuitka `4.0.8` while `pyproject.toml` specified `4.1.1`. Updated the workflow to match, preventing local/CI build divergence.
- **status-check actually checks results**: The `status-check` job in `auto_build.yml` used `if: always()` but never inspected `needs.*.result`, so it unconditionally reported success — even when upstream jobs failed. Now iterates over all upstream results and fails on `failure`/`cancelled`, while allowing `skipped` (since `attested-build` and `non-attested-build` are mutually exclusive).

## Test plan

- [x] Verify CI passes on this PR (non-attested build path exercises the status-check logic)
- [x] Confirm Nuitka version in build logs shows 4.1.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)