### PR TITLE
refactor(watchdog): self-contained lifecycle, fix elif shutdown bug

### DIFF
--- a/app/utils/update_utils.py
+++ b/app/utils/update_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import platform
 import re

--- a/app/utils/watchdog.py
+++ b/app/utils/watchdog.py
@@ -22,9 +22,7 @@ class WatchdogHandler(FileSystemEventHandler, QObject):
     mod_deleted = Signal(str, str, str)
     mod_updated = Signal(bool, bool, str, str, str)
 
-    def __init__(
-        self, settings_controller: SettingsController, targets: list[str]
-    ) -> None:
+    def __init__(self, settings_controller: SettingsController) -> None:
         """Initialize the WatchdogHandler.
 
         The WatchdogHandler is a subclass of :class:`watchdog.events.FileSystemEventHandler`
@@ -35,8 +33,6 @@ class WatchdogHandler(FileSystemEventHandler, QObject):
         instances. It also sets up the signals that are emitted when a change is detected.
 
         :param settings_controller: The settings controller for the application
-        :param targets: The list of target paths to monitor
-        :type targets: list[str]
 
         :return: None
         """
@@ -58,6 +54,48 @@ class WatchdogHandler(FileSystemEventHandler, QObject):
         self.cooldown_timers: dict[str, Any] = {}
         self.__add_acf_observers()
         self.__add_mod_observers(self.settings_controller.get_mod_paths())
+
+    def start(self) -> None:
+        """Start all configured observers.
+
+        Each observer is only started if it exists and is not already alive.
+        Logs a warning if an observer is None or already running.
+        """
+        try:
+            if self.watchdog_acf_observer is not None:
+                if self.watchdog_acf_observer.is_alive():
+                    logger.warning("Watchdog Steam .acf Observer is already running.")
+                else:
+                    self.watchdog_acf_observer.start()
+            else:
+                logger.warning("Watchdog Steam .acf Observer is None. Unable to start.")
+            if self.watchdog_mods_observer is not None:
+                if self.watchdog_mods_observer.is_alive():
+                    logger.warning("Watchdog Mods Observer is already running.")
+                else:
+                    self.watchdog_mods_observer.start()
+            else:
+                logger.warning("Watchdog Mods Observer is None. Unable to start.")
+        except Exception as e:
+            logger.warning(
+                f"Unable to start Watchdog Observer(s) due to exception: {str(e)}"
+            )
+
+    def stop(self) -> None:
+        """Stop all observers and cancel pending cooldown timers."""
+        if self.watchdog_acf_observer is not None:
+            if self.watchdog_acf_observer.is_alive():
+                self.watchdog_acf_observer.stop()
+                self.watchdog_acf_observer.join()
+            self.watchdog_acf_observer = None
+        if self.watchdog_mods_observer is not None:
+            if self.watchdog_mods_observer.is_alive():
+                self.watchdog_mods_observer.stop()
+                self.watchdog_mods_observer.join()
+            self.watchdog_mods_observer = None
+        for timer in self.cooldown_timers.values():
+            timer.cancel()
+        self.cooldown_timers.clear()
 
     def __add_acf_observers(self) -> None:
         """Add observers to the watchdog observer for applicable Steam .acf files.
@@ -304,33 +342,3 @@ class WatchdogHandler(FileSystemEventHandler, QObject):
             #     f"[event_scr_path_str: {event_scr_path_str}, uuid: {uuid}"
             # )
             return
-
-    def on_moved(self, event: FileSystemEvent) -> None:
-        """A function called when a file or directory is moved or renamed.
-
-        :param event: The event object representing the file or directory move event.
-        :type event: FileSystemEvent
-
-        :return: None
-        """
-        # logger.debug(f"File moved: {event.src_path} to {event.dest_path}")
-
-    def on_closed(self, event: FileSystemEvent) -> None:
-        """A function called when a file or directory is closed.
-
-        :param event: The event object representing the file or directory close event.
-        :type event: FileSystemEvent
-
-        :return: None
-        """
-        # logger.debug(f"File closed: {event.src_path}")
-
-    def on_opened(self, event: FileSystemEvent) -> None:
-        """A function called when a file or directory is opened.
-
-        :param event: The event object representing the file or directory open event.
-        :type event: FileSystemEvent
-
-        :return: None
-        """
-        # logger.debug(f"File opened: {event.src_path}")

--- a/app/utils/watchdog.py
+++ b/app/utils/watchdog.py
@@ -93,9 +93,10 @@ class WatchdogHandler(FileSystemEventHandler, QObject):
                 self.watchdog_mods_observer.stop()
                 self.watchdog_mods_observer.join()
             self.watchdog_mods_observer = None
-        for timer in self.cooldown_timers.values():
-            timer.cancel()
+        timers = list(self.cooldown_timers.values())
         self.cooldown_timers.clear()
+        for timer in timers:
+            timer.cancel()
 
     def __add_acf_observers(self) -> None:
         """Add observers to the watchdog observer for applicable Steam .acf files.

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -1145,25 +1145,8 @@ class MainWindow(QMainWindow):
         # INITIALIZE WATCHDOG - WE WAIT TO START UNTIL DONE PARSING MOD LIST
         # Instantiate event handler
         # Pass a mapper of metadata-containing About.xml or Scenario.rsc files to their mod uuids
-        current_instance = self.settings_controller.settings.current_instance
         self.watchdog_event_handler = WatchdogHandler(
             settings_controller=self.settings_controller,
-            targets=[
-                str(
-                    Path(
-                        self.settings_controller.settings.instances[
-                            current_instance
-                        ].game_folder
-                    )
-                    / "Data"
-                ),
-                self.settings_controller.settings.instances[
-                    current_instance
-                ].local_folder,
-                self.settings_controller.settings.instances[
-                    current_instance
-                ].workshop_folder,
-            ],
         )
         # Connect watchdog to MetadataManager for ACF changes
         self.watchdog_event_handler.acf_changed.connect(

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -281,7 +281,7 @@ class MainWindow(QMainWindow):
         :param event: The close event to handle.
         """
         # Stop filesystem watchdog if running
-        self.stop_watchdog_if_running()
+        self.shutdown_watchdog()
 
         # Close all child windows
         self.main_content_panel.close_child_windows()
@@ -1119,7 +1119,7 @@ class MainWindow(QMainWindow):
 
     def __switch_to_instance(self, instance: str) -> None:
         """Switch to a different instance."""
-        self.stop_watchdog_if_running()
+        self.shutdown_watchdog()
         # Set current instance
         self.settings_controller.settings.current_instance = instance
         instance_path = str(InstanceController.get_instance_folder_path(instance))
@@ -1159,10 +1159,6 @@ class MainWindow(QMainWindow):
             self.main_content_panel.metadata_manager.process_update
         )
         self.watchdog_event_handler.start()
-
-    def stop_watchdog_if_running(self) -> None:
-        if self.watchdog_event_handler is not None:
-            self.shutdown_watchdog()
 
     def shutdown_watchdog(self) -> None:
         if self.watchdog_event_handler is not None:

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -111,6 +111,7 @@ class MainWindow(QMainWindow):
         self.main_content_panel.disable_enable_widgets_signal.connect(
             self.__disable_enable_widgets
         )
+        self.main_content_panel.stop_watchdog_signal.connect(self.shutdown_watchdog)
         self.bottom_panel = Status()
 
         # Create and add the Main Content panel tab
@@ -1142,13 +1143,9 @@ class MainWindow(QMainWindow):
 
     def initialize_watchdog(self) -> None:
         logger.info("Initializing watchdog FS Observer")
-        # INITIALIZE WATCHDOG - WE WAIT TO START UNTIL DONE PARSING MOD LIST
-        # Instantiate event handler
-        # Pass a mapper of metadata-containing About.xml or Scenario.rsc files to their mod uuids
         self.watchdog_event_handler = WatchdogHandler(
             settings_controller=self.settings_controller,
         )
-        # Connect watchdog to MetadataManager for ACF changes
         self.watchdog_event_handler.acf_changed.connect(
             partial(refresh_acf_metadata, self.main_content_panel.metadata_manager)
         )
@@ -1161,47 +1158,13 @@ class MainWindow(QMainWindow):
         self.watchdog_event_handler.mod_updated.connect(
             self.main_content_panel.metadata_manager.process_update
         )
-        # Connect main content signal so it can stop watchdog
-        self.main_content_panel.stop_watchdog_signal.connect(self.shutdown_watchdog)
-        # Start watchdog
-        try:
-            if self.watchdog_event_handler.watchdog_acf_observer is not None:
-                self.watchdog_event_handler.watchdog_acf_observer.start()
-            else:
-                logger.warning("Watchdog Steam .acf Observer is None. Unable to start.")
-            if self.watchdog_event_handler.watchdog_mods_observer is not None:
-                self.watchdog_event_handler.watchdog_mods_observer.start()
-            else:
-                logger.warning("Watchdog Mods Observer is None. Unable to start.")
-        except Exception as e:
-            logger.warning(
-                f"Unable to initialize Watchdog Observer(s) due to exception: {str(e)}"
-            )
+        self.watchdog_event_handler.start()
 
     def stop_watchdog_if_running(self) -> None:
-        # STOP WATCHDOG IF IT IS ALREADY RUNNING
         if self.watchdog_event_handler is not None:
-            if self.watchdog_event_handler.watchdog_acf_observer is not None or (
-                self.watchdog_event_handler.watchdog_mods_observer is not None
-            ):
-                self.shutdown_watchdog()
+            self.shutdown_watchdog()
 
     def shutdown_watchdog(self) -> None:
-        if (
-            self.watchdog_event_handler is not None
-            and self.watchdog_event_handler.watchdog_acf_observer is not None
-            and self.watchdog_event_handler.watchdog_mods_observer is not None
-        ):
-            # Handle Steam .acf Observer shutdown
-            if self.watchdog_event_handler.watchdog_acf_observer.is_alive():
-                self.watchdog_event_handler.watchdog_acf_observer.stop()
-                self.watchdog_event_handler.watchdog_acf_observer.join()
-                self.watchdog_event_handler.watchdog_acf_observer = None
-            # Handle Mod Directory Observer shutdown
-            elif self.watchdog_event_handler.watchdog_mods_observer.is_alive():
-                self.watchdog_event_handler.watchdog_mods_observer.stop()
-                self.watchdog_event_handler.watchdog_mods_observer.join()
-                self.watchdog_event_handler.watchdog_mods_observer = None
-                for timer in self.watchdog_event_handler.cooldown_timers.values():
-                    timer.cancel()
+        if self.watchdog_event_handler is not None:
+            self.watchdog_event_handler.stop()
             self.watchdog_event_handler = None

--- a/tests/utils/test_watchdog.py
+++ b/tests/utils/test_watchdog.py
@@ -1,0 +1,146 @@
+"""Tests for WatchdogHandler lifecycle methods."""
+
+from __future__ import annotations
+
+from threading import Timer
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from PySide6.QtCore import QObject
+
+
+def _make_handler(acf_alive: bool = True, mods_alive: bool = True) -> Any:
+    """Create a WatchdogHandler without real observers."""
+    from app.utils.watchdog import WatchdogHandler
+
+    with patch.object(WatchdogHandler, "__init__", lambda self: QObject.__init__(self)):
+        handler = WatchdogHandler()  # type: ignore[call-arg]
+
+    handler.watchdog_acf_observer = MagicMock()
+    handler.watchdog_acf_observer.is_alive.return_value = acf_alive
+    handler.watchdog_mods_observer = MagicMock()
+    handler.watchdog_mods_observer.is_alive.return_value = mods_alive
+    handler.cooldown_timers = {
+        "t1": MagicMock(spec=Timer),
+        "t2": MagicMock(spec=Timer),
+    }
+    return handler
+
+
+class TestWatchdogHandlerStop:
+    """Tests for WatchdogHandler.stop() method."""
+
+    def test_stop_both_observers_alive(self, qapp: object) -> None:
+        """Both observers alive: both must be stopped and joined."""
+        handler = _make_handler(acf_alive=True, mods_alive=True)
+        acf_obs = handler.watchdog_acf_observer
+        mods_obs = handler.watchdog_mods_observer
+
+        handler.stop()
+
+        acf_obs.stop.assert_called_once()
+        acf_obs.join.assert_called_once()
+        mods_obs.stop.assert_called_once()
+        mods_obs.join.assert_called_once()
+
+    def test_stop_only_acf_alive(self, qapp: object) -> None:
+        """Only ACF alive: ACF stopped, mods skipped."""
+        handler = _make_handler(acf_alive=True, mods_alive=False)
+        acf_obs = handler.watchdog_acf_observer
+        mods_obs = handler.watchdog_mods_observer
+
+        handler.stop()
+
+        acf_obs.stop.assert_called_once()
+        mods_obs.stop.assert_not_called()
+
+    def test_stop_only_mods_alive(self, qapp: object) -> None:
+        """Only mods alive: mods stopped, ACF skipped."""
+        handler = _make_handler(acf_alive=False, mods_alive=True)
+        acf_obs = handler.watchdog_acf_observer
+        mods_obs = handler.watchdog_mods_observer
+
+        handler.stop()
+
+        acf_obs.stop.assert_not_called()
+        mods_obs.stop.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "acf_alive,mods_alive",
+        [(True, True), (True, False), (False, True), (False, False)],
+    )
+    def test_stop_always_cancels_timers(
+        self, qapp: object, acf_alive: bool, mods_alive: bool
+    ) -> None:
+        """Timers must always be cancelled regardless of which observers were alive."""
+        handler = _make_handler(acf_alive=acf_alive, mods_alive=mods_alive)
+        timers = list(handler.cooldown_timers.values())
+
+        handler.stop()
+
+        for timer in timers:
+            timer.cancel.assert_called_once()
+
+    def test_stop_clears_timers_dict(self, qapp: object) -> None:
+        """Timers dict must be empty after stop."""
+        handler = _make_handler()
+
+        handler.stop()
+
+        assert handler.cooldown_timers == {}
+
+    def test_stop_nulls_observers(self, qapp: object) -> None:
+        """Observers must be None after stop."""
+        handler = _make_handler()
+
+        handler.stop()
+
+        assert handler.watchdog_acf_observer is None
+        assert handler.watchdog_mods_observer is None
+
+    def test_stop_none_observers_is_noop(self, qapp: object) -> None:
+        """Calling stop when observers are already None should not raise."""
+        handler = _make_handler()
+        handler.watchdog_acf_observer = None
+        handler.watchdog_mods_observer = None
+        handler.cooldown_timers = {}
+
+        handler.stop()  # should not raise
+
+    def test_stop_idempotent(self, qapp: object) -> None:
+        """Calling stop twice should not raise."""
+        handler = _make_handler()
+
+        handler.stop()
+        handler.stop()  # second call is a noop
+
+
+class TestWatchdogHandlerStart:
+    """Tests for WatchdogHandler.start() method."""
+
+    def test_start_both_observers(self, qapp: object) -> None:
+        """Both observers present: both must be started."""
+        handler = _make_handler(acf_alive=False, mods_alive=False)
+
+        handler.start()
+
+        handler.watchdog_acf_observer.start.assert_called_once()
+        handler.watchdog_mods_observer.start.assert_called_once()
+
+    def test_start_skips_already_alive_with_warning(self, qapp: object) -> None:
+        """If an observer is already alive, skip it and log a warning."""
+        handler = _make_handler(acf_alive=True, mods_alive=True)
+
+        handler.start()  # should not raise
+
+        handler.watchdog_acf_observer.start.assert_not_called()
+        handler.watchdog_mods_observer.start.assert_not_called()
+
+    def test_start_none_observers_logs_warning(self, qapp: object) -> None:
+        """None observers should log warnings, not crash."""
+        handler = _make_handler()
+        handler.watchdog_acf_observer = None
+        handler.watchdog_mods_observer = None
+
+        handler.start()  # should not raise

--- a/tests/utils/test_watchdog.py
+++ b/tests/utils/test_watchdog.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from threading import Timer
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from PySide6.QtCore import QObject
@@ -14,8 +14,8 @@ def _make_handler(acf_alive: bool = True, mods_alive: bool = True) -> Any:
     """Create a WatchdogHandler without real observers."""
     from app.utils.watchdog import WatchdogHandler
 
-    with patch.object(WatchdogHandler, "__init__", lambda self: QObject.__init__(self)):
-        handler = WatchdogHandler()  # type: ignore[call-arg]
+    handler = WatchdogHandler.__new__(WatchdogHandler)
+    QObject.__init__(handler)
 
     handler.watchdog_acf_observer = MagicMock()
     handler.watchdog_acf_observer.is_alive.return_value = acf_alive

--- a/tests/views/conftest.py
+++ b/tests/views/conftest.py
@@ -1,17 +1,45 @@
 """Shared fixtures for view and widget tests."""
 
+from __future__ import annotations
+
+import sys
 import uuid as uuid_module
-from typing import Any, Union
+from types import ModuleType
+from typing import TYPE_CHECKING, Any, Union
 from unittest.mock import MagicMock
 
 import pytest
 from PySide6.QtCore import QCoreApplication, QObject
 from PySide6.QtGui import QColor
-from PySide6.QtWidgets import QApplication
+from PySide6.QtWidgets import QApplication, QMainWindow
 
 from app.controllers.settings_controller import SettingsController
 from app.models.instance import Instance
 from app.models.settings import Settings
+
+# Ensure the steamworks module is mockable for the MainWindow import chain.
+# This must run at import time, before any test imports MainWindow.
+if "steamworks" not in sys.modules:
+    sys.modules["steamworks"] = ModuleType("steamworks")
+    sys.modules["steamworks"].STEAMWORKS = MagicMock()  # type: ignore[attr-defined]
+
+if TYPE_CHECKING:
+    from app.views.main_window import MainWindow
+
+
+def make_stub_main_window() -> MainWindow:
+    """Create a MainWindow instance without running MainWindow.__init__.
+
+    Calls QMainWindow.__init__ to satisfy the C++ side (Shiboken),
+    then attaches the minimal attributes that downstream methods expect.
+    """
+    from app.views.main_window import MainWindow
+
+    instance = MainWindow.__new__(MainWindow)
+    QMainWindow.__init__(instance)
+    instance.main_content_panel = MagicMock()
+    instance.watchdog_event_handler = None
+    return instance
 
 
 @pytest.fixture

--- a/tests/views/test_main_window_close.py
+++ b/tests/views/test_main_window_close.py
@@ -24,13 +24,14 @@ class TestMainWindowCloseEvent:
     def test_close_event_stops_watchdog(self, qapp: object) -> None:
         """Verify closeEvent stops the watchdog if running."""
         window = make_stub_main_window()
-        window.watchdog_event_handler = MagicMock()
-        window.stop_watchdog_if_running = MagicMock()  # type: ignore[method-assign]
+        handler = MagicMock()
+        window.watchdog_event_handler = handler
 
         event = QCloseEvent()
         window.closeEvent(event)
 
-        window.stop_watchdog_if_running.assert_called_once()
+        handler.stop.assert_called_once()
+        assert window.watchdog_event_handler is None
 
     def test_close_event_accepts(self, qapp: object) -> None:
         """Verify closeEvent accepts the event to allow window closure."""

--- a/tests/views/test_main_window_close.py
+++ b/tests/views/test_main_window_close.py
@@ -2,40 +2,11 @@
 
 from __future__ import annotations
 
-import sys
-from types import ModuleType
-from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
 from PySide6.QtGui import QCloseEvent
-from PySide6.QtWidgets import QMainWindow
 
-# Ensure steamworks module is mockable for import chain
-if "steamworks" not in sys.modules:
-    sys.modules["steamworks"] = ModuleType("steamworks")
-    sys.modules["steamworks"].STEAMWORKS = MagicMock()  # type: ignore[attr-defined]
-
-if TYPE_CHECKING:
-    from app.views.main_window import MainWindow
-
-
-def _make_stub_main_window() -> MainWindow:
-    """Create a MainWindow instance without running MainWindow.__init__.
-
-    We call QMainWindow.__init__ to satisfy the C++ side (Shiboken),
-    then attach the minimal attributes that closeEvent expects.
-    """
-    from app.views.main_window import MainWindow
-
-    instance = MainWindow.__new__(MainWindow)
-    QMainWindow.__init__(instance)
-
-    # Attach attributes closeEvent relies on
-    instance.main_content_panel = MagicMock()
-    instance.watchdog_event_handler = None
-    instance.stop_watchdog_if_running = MagicMock()  # type: ignore[method-assign]
-
-    return instance
+from tests.views.conftest import make_stub_main_window
 
 
 class TestMainWindowCloseEvent:
@@ -43,7 +14,7 @@ class TestMainWindowCloseEvent:
 
     def test_close_event_calls_close_child_windows(self, qapp: object) -> None:
         """Verify closeEvent delegates to MainContent.close_child_windows."""
-        window = _make_stub_main_window()
+        window = make_stub_main_window()
 
         event = QCloseEvent()
         window.closeEvent(event)
@@ -52,17 +23,18 @@ class TestMainWindowCloseEvent:
 
     def test_close_event_stops_watchdog(self, qapp: object) -> None:
         """Verify closeEvent stops the watchdog if running."""
-        window = _make_stub_main_window()
+        window = make_stub_main_window()
         window.watchdog_event_handler = MagicMock()
+        window.stop_watchdog_if_running = MagicMock()  # type: ignore[method-assign]
 
         event = QCloseEvent()
         window.closeEvent(event)
 
-        window.stop_watchdog_if_running.assert_called_once()  # type: ignore[attr-defined]
+        window.stop_watchdog_if_running.assert_called_once()
 
     def test_close_event_accepts(self, qapp: object) -> None:
         """Verify closeEvent accepts the event to allow window closure."""
-        window = _make_stub_main_window()
+        window = make_stub_main_window()
 
         event = QCloseEvent()
         window.closeEvent(event)

--- a/tests/views/test_main_window_watchdog.py
+++ b/tests/views/test_main_window_watchdog.py
@@ -1,0 +1,47 @@
+"""Tests for MainWindow watchdog delegation."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from tests.views.conftest import make_stub_main_window
+
+
+class TestShutdownWatchdog:
+    def test_delegates_to_handler_stop(self, qapp: object) -> None:
+        """shutdown_watchdog must call handler.stop() and clear the reference."""
+        window = make_stub_main_window()
+        handler = MagicMock()
+        window.watchdog_event_handler = handler
+
+        window.shutdown_watchdog()
+
+        handler.stop.assert_called_once()
+        assert window.watchdog_event_handler is None
+
+    def test_no_handler_is_noop(self, qapp: object) -> None:
+        """Calling shutdown with no handler should not raise."""
+        window = make_stub_main_window()
+        window.watchdog_event_handler = None
+
+        window.shutdown_watchdog()
+
+        assert window.watchdog_event_handler is None
+
+    def test_stop_if_running_delegates(self, qapp: object) -> None:
+        """stop_watchdog_if_running calls shutdown when handler exists."""
+        window = make_stub_main_window()
+        handler = MagicMock()
+        window.watchdog_event_handler = handler
+
+        window.stop_watchdog_if_running()
+
+        handler.stop.assert_called_once()
+        assert window.watchdog_event_handler is None
+
+    def test_stop_if_running_noop_when_none(self, qapp: object) -> None:
+        """stop_watchdog_if_running is a noop when handler is None."""
+        window = make_stub_main_window()
+        window.watchdog_event_handler = None
+
+        window.stop_watchdog_if_running()  # should not raise

--- a/tests/views/test_main_window_watchdog.py
+++ b/tests/views/test_main_window_watchdog.py
@@ -27,21 +27,3 @@ class TestShutdownWatchdog:
         window.shutdown_watchdog()
 
         assert window.watchdog_event_handler is None
-
-    def test_stop_if_running_delegates(self, qapp: object) -> None:
-        """stop_watchdog_if_running calls shutdown when handler exists."""
-        window = make_stub_main_window()
-        handler = MagicMock()
-        window.watchdog_event_handler = handler
-
-        window.stop_watchdog_if_running()
-
-        handler.stop.assert_called_once()
-        assert window.watchdog_event_handler is None
-
-    def test_stop_if_running_noop_when_none(self, qapp: object) -> None:
-        """stop_watchdog_if_running is a noop when handler is None."""
-        window = make_stub_main_window()
-        window.watchdog_event_handler = None
-
-        window.stop_watchdog_if_running()  # should not raise


### PR DESCRIPTION
## Summary

- **Fix elif shutdown bug**: `MainWindow.shutdown_watchdog()` used `elif` between ACF and mods observer shutdown — only one observer was ever stopped per call. Both observers now independently checked via `if`/`if`.
- **Move lifecycle into WatchdogHandler**: Added `start()` and `stop()` methods so the handler owns its own lifecycle. `MainWindow` is now a thin consumer that calls `start()`/`stop()`.
- **Fix signal accumulation bug**: `stop_watchdog_signal.connect()` was called inside `initialize_watchdog()`, adding a new connection on every instance switch. Moved to `MainWindow.__init__()` so it connects exactly once.
- **Fix timer dict iteration race**: `stop()` now snapshots `cooldown_timers` before clearing/cancelling to prevent `RuntimeError` if a pending `Timer` callback modifies the dict during iteration.
- **Cleanup**: Removed unused `targets` parameter from `WatchdogHandler.__init__()`, removed empty `on_moved`/`on_closed`/`on_opened` stubs, removed redundant `stop_watchdog_if_running()` wrapper, fixed pre-existing `update_utils.py` import issue.

## Test plan

- [x] 14 new unit tests for `WatchdogHandler.start()`/`stop()` lifecycle (`tests/utils/test_watchdog.py`)
- [x] 2 delegation tests for `MainWindow.shutdown_watchdog()` (`tests/views/test_main_window_watchdog.py`)
- [x] 3 existing `closeEvent` tests updated and passing (`tests/views/test_main_window_close.py`)
- [x] All quality gates pass (ruff, ruff-format, mypy, pyright, jscpd, shfmt, markdownlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)