### PR TITLE
refactor: clean up PlayerLogTab watchdog observer lifecycle

### DIFF
--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -282,6 +282,9 @@ class MainWindow(QMainWindow):
         # Stop filesystem watchdog if running
         self.stop_watchdog_if_running()
 
+        # Stop player log monitoring if running
+        self.player_log_widget._stop_monitoring()
+
         # Close all child windows
         self.main_content_panel.close_child_windows()
 

--- a/app/views/player_log_tab.py
+++ b/app/views/player_log_tab.py
@@ -4,7 +4,10 @@ import re
 from collections import deque
 from datetime import datetime
 from pathlib import Path
-from typing import Callable, Deque, List, Optional, Tuple
+from typing import TYPE_CHECKING, Callable, Deque, List, Optional, Tuple
+
+if TYPE_CHECKING:
+    from watchdog.observers.api import BaseObserver
 
 from loguru import logger
 from PySide6.QtCore import (
@@ -371,6 +374,9 @@ class PlayerLogTab(QWidget):
             1000
         )  # 1000ms debounce interval less than 1000ms breaks log updates
         self._file_change_debounce_timer.timeout.connect(self._process_file_change)
+
+        self._observer: Optional["BaseObserver"] = None
+        self.file_changed_signal.connect(self.on_file_changed)
 
         self.init_ui()
         # Delay loading the log by 5 seconds after initialization
@@ -949,7 +955,6 @@ class PlayerLogTab(QWidget):
                     self._observer.stop()
                     self._observer.join()
             event_handler = PlayerLogEventHandler(self.file_changed_signal)
-            self.file_changed_signal.connect(self.on_file_changed)
             try:
                 self._observer.schedule(
                     event_handler, str(self.player_log_path.parent), recursive=False

--- a/app/views/player_log_tab.py
+++ b/app/views/player_log_tab.py
@@ -936,46 +936,43 @@ class PlayerLogTab(QWidget):
     def toggle_real_time_monitoring(self, enabled: bool) -> None:
         """Start or stop real-time monitoring of the player log file."""
         if enabled:
-            self._observer = Observer()
-            if (
-                hasattr(self, "_observer")
-                and self._observer is not None
-                and self._observer.is_alive()
-            ):
-                logger.debug("Real-time monitoring already running.")
-                return
-            if self.player_log_path is None:
-                show_warning("Player log path is not set.")
-                self.real_time_monitor_checkbox.setChecked(False)
-                return
-            # Stop existing observer if any before creating a new one
-            if hasattr(self, "_observer") and self._observer is not None:
-                if self._observer.is_alive():
-                    logger.debug("Stopping existing observer before starting new one.")
-                    self._observer.stop()
-                    self._observer.join()
-            event_handler = PlayerLogEventHandler(self.file_changed_signal)
-            try:
-                self._observer.schedule(
-                    event_handler, str(self.player_log_path.parent), recursive=False
-                )
-                self._observer.start()
-                logger.info(
-                    f"Started real-time monitoring of Player.log at {self.player_log_path}"
-                )
-            except Exception as e:
-                logger.error(f"Failed to start observer: {e}")
-                show_warning(f"Failed to start real-time monitoring: {e}")
-                self.real_time_monitor_checkbox.setChecked(False)
+            self._start_monitoring()
         else:
-            if (
-                hasattr(self, "_observer")
-                and self._observer is not None
-                and self._observer.is_alive()
-            ):
-                self._observer.stop()
-                self._observer.join()
-                logger.info("Stopped real-time monitoring of Player.log.")
+            self._stop_monitoring()
+
+    def _start_monitoring(self) -> None:
+        """Start the watchdog observer for real-time log monitoring."""
+        if self._observer is not None and self._observer.is_alive():
+            logger.debug("Real-time monitoring already running.")
+            return
+        if self.player_log_path is None:
+            show_warning("Player log path is not set.")
+            self.real_time_monitor_checkbox.setChecked(False)
+            return
+        self._stop_monitoring()
+        self._observer = Observer()
+        event_handler = PlayerLogEventHandler(self.file_changed_signal)
+        try:
+            self._observer.schedule(
+                event_handler, str(self.player_log_path.parent), recursive=False
+            )
+            self._observer.start()
+            logger.info(
+                f"Started real-time monitoring of Player.log at {self.player_log_path}"
+            )
+        except Exception as e:
+            logger.error(f"Failed to start observer: {e}")
+            show_warning(f"Failed to start real-time monitoring: {e}")
+            self._observer = None
+            self.real_time_monitor_checkbox.setChecked(False)
+
+    def _stop_monitoring(self) -> None:
+        """Stop the watchdog observer if running."""
+        if self._observer is not None and self._observer.is_alive():
+            self._observer.stop()
+            self._observer.join()
+            logger.info("Stopped real-time monitoring of Player.log.")
+        self._observer = None
 
     def disable_options(self, skip_mod_filter_input: bool = False) -> None:
         """Disable options that require a loaded log."""

--- a/app/views/player_log_tab.py
+++ b/app/views/player_log_tab.py
@@ -7,7 +7,15 @@ from pathlib import Path
 from typing import Callable, Deque, List, Optional, Tuple
 
 from loguru import logger
-from PySide6.QtCore import QObject, QPoint, QRegularExpression, Qt, QTimer, Signal
+from PySide6.QtCore import (
+    QObject,
+    QPoint,
+    QRegularExpression,
+    Qt,
+    QTimer,
+    Signal,
+    SignalInstance,
+)
 from PySide6.QtGui import (
     QColor,
     QFont,
@@ -43,6 +51,17 @@ from app.utils import http
 from app.utils.app_info import AppInfo
 from app.utils.generic import launch_process
 from app.views.dialogue import show_information, show_warning
+
+
+class PlayerLogEventHandler(FileSystemEventHandler):
+    """Watchdog event handler that emits a Qt signal when the monitored file is modified."""
+
+    def __init__(self, signal: SignalInstance) -> None:
+        super().__init__()
+        self._signal = signal
+
+    def on_modified(self, event: object) -> None:
+        self._signal.emit()
 
 
 class LogPatternManager:
@@ -910,17 +929,6 @@ class PlayerLogTab(QWidget):
 
     def toggle_real_time_monitoring(self, enabled: bool) -> None:
         """Start or stop real-time monitoring of the player log file."""
-
-        class PlayerLogEventHandler(FileSystemEventHandler, QObject):
-            def __init__(self, parent: "PlayerLogTab") -> None:
-                FileSystemEventHandler.__init__(self)
-                QObject.__init__(self)
-                self._parent = parent
-
-            def on_modified(self, event: object) -> None:
-                logger.debug(f"File modified event received: {event}")
-                self._parent.file_changed_signal.emit()
-
         if enabled:
             self._observer = Observer()
             if (
@@ -940,7 +948,7 @@ class PlayerLogTab(QWidget):
                     logger.debug("Stopping existing observer before starting new one.")
                     self._observer.stop()
                     self._observer.join()
-            event_handler = PlayerLogEventHandler(self)
+            event_handler = PlayerLogEventHandler(self.file_changed_signal)
             self.file_changed_signal.connect(self.on_file_changed)
             try:
                 self._observer.schedule(

--- a/app/views/player_log_tab.py
+++ b/app/views/player_log_tab.py
@@ -4,10 +4,7 @@ import re
 from collections import deque
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Deque, List, Optional, Tuple
-
-if TYPE_CHECKING:
-    from watchdog.observers.api import BaseObserver
+from typing import Callable, Deque, List, Optional, Tuple
 
 from loguru import logger
 from PySide6.QtCore import (
@@ -46,8 +43,9 @@ from PySide6.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-from watchdog.events import FileSystemEventHandler
+from watchdog.events import FileSystemEvent, FileSystemEventHandler
 from watchdog.observers import Observer
+from watchdog.observers.api import BaseObserver
 
 from app.controllers.settings_controller import SettingsController
 from app.utils import http
@@ -63,7 +61,8 @@ class PlayerLogEventHandler(FileSystemEventHandler):
         super().__init__()
         self._signal = signal
 
-    def on_modified(self, event: object) -> None:
+    def on_modified(self, event: FileSystemEvent) -> None:
+        logger.debug("Player log file modified event: {}", event.src_path)
         self._signal.emit()
 
 
@@ -375,7 +374,7 @@ class PlayerLogTab(QWidget):
         )  # 1000ms debounce interval less than 1000ms breaks log updates
         self._file_change_debounce_timer.timeout.connect(self._process_file_change)
 
-        self._observer: Optional["BaseObserver"] = None
+        self._observer: BaseObserver | None = None
         self.file_changed_signal.connect(self.on_file_changed)
 
         self.init_ui()
@@ -949,6 +948,7 @@ class PlayerLogTab(QWidget):
             show_warning("Player log path is not set.")
             self.real_time_monitor_checkbox.setChecked(False)
             return
+        # Clean up any dead observer before creating a new one
         self._stop_monitoring()
         self._observer = Observer()
         event_handler = PlayerLogEventHandler(self.file_changed_signal)
@@ -973,11 +973,6 @@ class PlayerLogTab(QWidget):
             self._observer.join()
             logger.info("Stopped real-time monitoring of Player.log.")
         self._observer = None
-
-    def closeEvent(self, event: object) -> None:
-        """Stop monitoring and clean up before the widget is destroyed."""
-        self._stop_monitoring()
-        super().closeEvent(event)  # type: ignore[arg-type]
 
     def disable_options(self, skip_mod_filter_input: bool = False) -> None:
         """Disable options that require a loaded log."""

--- a/app/views/player_log_tab.py
+++ b/app/views/player_log_tab.py
@@ -974,6 +974,11 @@ class PlayerLogTab(QWidget):
             logger.info("Stopped real-time monitoring of Player.log.")
         self._observer = None
 
+    def closeEvent(self, event: object) -> None:
+        """Stop monitoring and clean up before the widget is destroyed."""
+        self._stop_monitoring()
+        super().closeEvent(event)  # type: ignore[arg-type]
+
     def disable_options(self, skip_mod_filter_input: bool = False) -> None:
         """Disable options that require a loaded log."""
         self.load_default_button.setEnabled(False)

--- a/tests/views/test_main_window_close.py
+++ b/tests/views/test_main_window_close.py
@@ -34,6 +34,7 @@ def _make_stub_main_window() -> MainWindow:
     instance.main_content_panel = MagicMock()
     instance.watchdog_event_handler = None
     instance.stop_watchdog_if_running = MagicMock()  # type: ignore[method-assign]
+    instance.player_log_widget = MagicMock()
 
     return instance
 
@@ -59,6 +60,15 @@ class TestMainWindowCloseEvent:
         window.closeEvent(event)
 
         window.stop_watchdog_if_running.assert_called_once()  # type: ignore[attr-defined]
+
+    def test_close_event_stops_player_log_monitoring(self, qapp: object) -> None:
+        """Verify closeEvent stops player log monitoring if running."""
+        window = _make_stub_main_window()
+
+        event = QCloseEvent()
+        window.closeEvent(event)
+
+        window.player_log_widget._stop_monitoring.assert_called_once()  # type: ignore[attr-defined]
 
     def test_close_event_accepts(self, qapp: object) -> None:
         """Verify closeEvent accepts the event to allow window closure."""


### PR DESCRIPTION
## Summary

Fixes the broken watchdog observer lifecycle in `PlayerLogTab` — four bugs squashed, proper lifecycle methods added.

- **Fix dead-code bug**: `is_alive()` check was happening *after* creating a new `Observer()`, so the "already running" guard never triggered. Now checks before creating.
- **Fix signal accumulation**: `file_changed_signal.connect()` was called on every enable toggle, accumulating duplicate connections. Now connected once in `__init__`.
- **Extract `PlayerLogEventHandler`** to module level — was defined as a nested class inside `toggle_real_time_monitoring()`, recreated on every call. Now accepts a `Signal` directly instead of the parent widget.
- **Add proper lifecycle**: `_start_monitoring()` / `_stop_monitoring()` methods with idempotent cleanup. `toggle_real_time_monitoring()` is now a thin dispatcher.
- **Fix observer thread leak**: Cleanup on app shutdown via `MainWindow.closeEvent`, consistent with existing `WatchdogHandler` teardown pattern.

## Test plan

- [ ] Enable/disable real-time monitoring toggle — verify log updates appear and stop correctly
- [ ] Toggle monitoring rapidly (on/off/on) — verify no crashes or duplicate events
- [ ] Close the application while monitoring is active — verify clean shutdown (no hung threads)
- [x] Verify `just check` passes (ruff, mypy, pyright, jscpd)
- [x] Verify `just test` passes (699/699)

Fixes #2079