### PR TITLE
feat(ci): add Codecov coverage badge

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -60,6 +60,15 @@ jobs:
           QT_DEBUG_PLUGINS: "1"
           PYTHONIOENCODING: "utf-8"
 
+      - name: Upload coverage to Codecov
+        if: matrix.os == 'ubuntu-latest'
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
+        with:
+          files: coverage.xml
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
       - name: Upload pytest test results
         uses: actions/upload-artifact@v7
         with:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
     Built from the ground up to be reliable and community managed.<br>
     Includes support for Linux, Mac, and Windows.</p>
     <p align="center"><strong><a href="https://github.com/RimSort/RimSort/releases">Releases</a> | <a href="https://rimsort.github.io/RimSort/">Wiki</a> | <a href="https://discord.gg/aV7g69JmR2">Discord</a></strong> </p>
+    <p align="center">
+        <a href="https://codecov.io/gh/RimSort/RimSort"><img src="https://codecov.io/gh/RimSort/RimSort/graph/badge.svg" alt="codecov"></a>
+    </p>
     <br><br><br>
 </p>
 


### PR DESCRIPTION
## Summary

- Adds a Codecov upload step to the pytest CI workflow (Ubuntu runner only) so coverage data is tracked over time
- Adds a Codecov coverage badge to the README header
- Codecov action pinned to commit SHA for supply chain safety

## Setup required

Before the badge will display, two steps are needed:

1. **Enable Codecov** on the repo at [codecov.io](https://codecov.io) — sign in with GitHub and add `RimSort/RimSort`
2. **Add the `CODECOV_TOKEN` secret** — Codecov provides a token during setup; add it as a repository secret in **GitHub Settings → Secrets and variables → Actions**

Once both are done, the next CI run on `main` will populate the badge.

## Test plan

- [ ] Enable Codecov on the repo and add the `CODECOV_TOKEN` secret
- [ ] Merge this PR and verify the badge appears on the README
- [ ] Confirm coverage data shows up at https://codecov.io/gh/RimSort/RimSort

🤖 Generated with [Claude Code](https://claude.com/claude-code)