### PR TITLE
fix(justfile): exclude .venv and submodules from shfmt checks

### DIFF
--- a/justfile
+++ b/justfile
@@ -77,11 +77,11 @@ jscpd:
 
 # Check shell script (.sh) formatting (shfmt) — diff-only, no changes made
 shfmt:
-    shfmt -d .
+    fd -e sh --exclude .venv --exclude submodules -x shfmt -d {}
 
 # Automatically fix shell script formatting issues (shfmt)
 shfmt-fix:
-    shfmt -w .
+    fd -e sh --exclude .venv --exclude submodules -x shfmt -w {}
 
 # Run all code quality checks: ruff + ruff-format + typecheck + pyright + jscpd + shfmt + markdown lint
 check: ruff ruff-format typecheck pyright jscpd shfmt markdownlint


### PR DESCRIPTION
## Summary
- `shfmt -d .` / `shfmt -w .` walked into `.venv/` and diffed vendored scripts (e.g. Nuitka's `compile-python-for-nuitka-mac.sh`), causing `just check` to fail
- CI avoided this via super-linter's `IGNORE_GITIGNORED_FILES: true`, but the local justfile recipes did not — creating a local/CI desync
- Use `fd` to scope shfmt to project-owned `.sh` files, excluding `.venv` and `submodules`

## Test plan
- [x] `just check` passes locally
- [x] `just shfmt` passes locally
- [ ] CI lint job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)