### PR TITLE
feat: consolidate filter controls into Filter popover panel

### DIFF
--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -924,10 +924,6 @@ class SettingsController(QObject):
         self.settings_dialog.show_duplicate_mods_warning_checkbox.setChecked(
             self.settings.duplicate_mods_warning
         )
-        # Mod type filter checkbox
-        self.settings_dialog.mod_type_filter_checkbox.setChecked(
-            self.settings.mod_type_filter
-        )
         # Hide invalid mod filtering checkbox
         self.settings_dialog.hide_invalid_mods_when_filtering_checkbox.setChecked(
             self.settings.hide_invalid_mods_when_filtering
@@ -1308,10 +1304,6 @@ class SettingsController(QObject):
         # Duplicate mod notification checkbox
         self.settings.duplicate_mods_warning = (
             self.settings_dialog.show_duplicate_mods_warning_checkbox.isChecked()
-        )
-        # Mod type filter checkbox
-        self.settings.mod_type_filter = (
-            self.settings_dialog.mod_type_filter_checkbox.isChecked()
         )
         # Hide invalid mod filtering checkbox
         self.settings.hide_invalid_mods_when_filtering = (

--- a/app/models/filter_state.py
+++ b/app/models/filter_state.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import ClassVar
+
+
+@dataclass
+class FilterState:
+    """
+    Immutable snapshot of all active filters in a mod list's filter panel.
+
+    :param sources: Set of enabled mod sources (workshop, local, expansion, steamcmd, git_repo)
+    :param mod_type: Mod type filter ("all", "csharp", or "xml")
+    :param tags: Set of selected tags to filter by
+    :param include_no_tags: Whether to include mods with no tags assigned
+    """
+
+    sources: set[str] = field(default_factory=lambda: set(FilterState.ALL_SOURCES))
+    mod_type: str = "all"
+    tags: set[str] = field(default_factory=set)
+    include_no_tags: bool = False
+
+    ALL_SOURCES: ClassVar[frozenset[str]] = frozenset(
+        {"workshop", "local", "expansion", "steamcmd", "git_repo"}
+    )
+
+    @classmethod
+    def default(cls) -> FilterState:
+        """
+        Create a FilterState with no active filters.
+
+        :return: FilterState with all sources enabled and no type/tag filters
+        """
+        return cls()
+
+    def has_active_filters(self) -> bool:
+        """
+        Check if any filters are currently active.
+
+        :return: True if any category is filtered (not default state)
+        """
+        if self.sources != self.ALL_SOURCES:
+            return True
+        if self.mod_type != "all":
+            return True
+        if self.tags or self.include_no_tags:
+            return True
+        return False
+
+    def active_category_count(self) -> int:
+        """
+        Count how many filter categories have active (non-default) filters.
+
+        :return: Number of active filter categories (0-3)
+        """
+        count = 0
+        if self.sources != self.ALL_SOURCES:
+            count += 1
+        if self.mod_type != "all":
+            count += 1
+        if self.tags or self.include_no_tags:
+            count += 1
+        return count

--- a/app/utils/constants.py
+++ b/app/utils/constants.py
@@ -75,16 +75,6 @@ RIMWORLD_DLC_METADATA = {
     },
 }
 RIMWORLD_PACKAGE_IDS = [v["packageid"] for v in RIMWORLD_DLC_METADATA.values()]
-SEARCH_DATA_SOURCE_FILTER_INDEXES = [
-    "all",
-    "expansion",
-    "local",
-    "git_repo",
-    "steamcmd",
-    "workshop",
-    "csharp",
-    "xml",
-]
 KNOWN_MOD_REPLACEMENTS = {
     "brrainz.harmony": {"zetrith.prepatcher", "jikulopo.prepatcher"},
     "aoba.motorization.engine": {"rimthunder.core"},

--- a/app/views/filter_panel.py
+++ b/app/views/filter_panel.py
@@ -1,0 +1,572 @@
+from __future__ import annotations
+
+from PySide6.QtCore import QPoint, QRect, QSize, Qt, Signal
+from PySide6.QtGui import QIcon, QMouseEvent
+from PySide6.QtWidgets import (
+    QButtonGroup,
+    QCheckBox,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QLayout,
+    QLayoutItem,
+    QRadioButton,
+    QToolButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from app.models.filter_state import FilterState
+from app.utils.app_info import AppInfo
+
+
+class FlowLayout(QLayout):
+    """Layout that arranges widgets in a flow, wrapping to the next line."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._items: list[QLayoutItem] = []
+        self._spacing = 6
+
+    def addItem(self, item: QLayoutItem) -> None:
+        """
+        Add an item to the layout.
+
+        :param item: Layout item to add
+        """
+        self._items.append(item)
+
+    def count(self) -> int:
+        """
+        Return the number of items in the layout.
+
+        :return: Item count
+        """
+        return len(self._items)
+
+    def itemAt(self, index: int) -> QLayoutItem | None:
+        """
+        Return the item at the given index.
+
+        :param index: Index of the item
+        :return: Layout item or None if out of range
+        """
+        if 0 <= index < len(self._items):
+            return self._items[index]
+        return None
+
+    def takeAt(self, index: int) -> QLayoutItem | None:
+        """
+        Remove and return the item at the given index.
+
+        :param index: Index of the item to remove
+        :return: Removed layout item or None if out of range
+        """
+        if 0 <= index < len(self._items):
+            return self._items.pop(index)
+        return None
+
+    def setSpacing(self, spacing: int) -> None:
+        """
+        Set the spacing between items.
+
+        :param spacing: Spacing in pixels
+        """
+        self._spacing = spacing
+
+    def spacing(self) -> int:
+        """
+        Return the spacing between items.
+
+        :return: Spacing in pixels
+        """
+        return self._spacing
+
+    def sizeHint(self) -> QSize:
+        """
+        Return the preferred size for this layout.
+
+        :return: Size hint
+        """
+        return self.minimumSize()
+
+    def minimumSize(self) -> QSize:
+        """
+        Return the minimum size for this layout.
+
+        :return: Minimum size
+        """
+        size = QSize()
+        for item in self._items:
+            size = size.expandedTo(item.minimumSize())
+        margins = self.contentsMargins()
+        size += QSize(
+            margins.left() + margins.right(), margins.top() + margins.bottom()
+        )
+        return size
+
+    def setGeometry(self, rect: QRect) -> None:
+        """
+        Set the geometry of all items in the layout.
+
+        :param rect: Rectangle to lay out within
+        """
+        super().setGeometry(rect)
+        self._do_layout(rect)
+
+    def _do_layout(self, rect: QRect) -> int:
+        """
+        Perform the actual layout of items within the given rectangle.
+
+        :param rect: Rectangle to lay out within
+        :return: The bottom Y coordinate of the last row
+        """
+        margins = self.contentsMargins()
+        effective = rect.adjusted(
+            margins.left(), margins.top(), -margins.right(), -margins.bottom()
+        )
+        x = effective.x()
+        y = effective.y()
+        line_height = 0
+        for item in self._items:
+            size = item.sizeHint()
+            next_x = x + size.width() + self._spacing
+            if next_x - self._spacing > effective.right() and line_height > 0:
+                x = effective.x()
+                y = y + line_height + self._spacing
+                next_x = x + size.width() + self._spacing
+                line_height = 0
+            item.setGeometry(QRect(QPoint(x, y), size))
+            x = next_x
+            line_height = max(line_height, size.height())
+        return y + line_height
+
+    def hasHeightForWidth(self) -> bool:
+        """
+        Return whether this layout supports height-for-width.
+
+        :return: Always True
+        """
+        return True
+
+    def heightForWidth(self, width: int) -> int:
+        """
+        Return the preferred height for the given width.
+
+        :param width: Available width
+        :return: Required height
+        """
+        return self._do_layout(QRect(0, 0, width, 0))
+
+
+class TagChip(QFrame):
+    """
+    A small clickable chip widget representing a single tag filter.
+
+    Displays a tag name with an active/inactive toggle state. When active,
+    shows a dismiss indicator (cross mark). The "no tags" variant uses
+    italic text to visually distinguish it.
+
+    :param tag_name: Display name for the tag
+    :param is_no_tags: Whether this chip represents the "no tags" filter
+    :param parent: Parent widget
+    """
+
+    toggled = Signal()
+
+    def __init__(
+        self,
+        tag_name: str,
+        is_no_tags: bool = False,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._tag_name = tag_name
+        self._is_no_tags = is_no_tags
+        self._active = False
+
+        self.setObjectName("TagChip")
+        self.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.setProperty("active", False)
+
+        layout = QHBoxLayout()
+        layout.setContentsMargins(6, 2, 6, 2)
+        layout.setSpacing(0)
+        self.setLayout(layout)
+
+        self._label = QLabel(tag_name)
+        if is_no_tags:
+            font = self._label.font()
+            font.setItalic(True)
+            self._label.setFont(font)
+        layout.addWidget(self._label)
+
+    @property
+    def tag_name(self) -> str:
+        """
+        Return the tag name for this chip.
+
+        :return: Tag name string
+        """
+        return self._tag_name
+
+    @property
+    def is_no_tags(self) -> bool:
+        """
+        Return whether this chip represents the "no tags" filter.
+
+        :return: True if this is the "no tags" chip
+        """
+        return self._is_no_tags
+
+    @property
+    def active(self) -> bool:
+        """
+        Return whether this chip is currently active (selected).
+
+        :return: True if active
+        """
+        return self._active
+
+    def set_active(self, active: bool) -> None:
+        """
+        Programmatically set the active state of this chip.
+
+        Updates the label text and the ``active`` dynamic property
+        for QSS styling.
+
+        :param active: New active state
+        """
+        self._active = active
+        self.setProperty("active", active)
+        self.style().unpolish(self)
+        self.style().polish(self)
+        if active:
+            self._label.setText(f"{self._tag_name} ✕")
+        else:
+            self._label.setText(self._tag_name)
+
+    def mousePressEvent(self, event: QMouseEvent) -> None:
+        """
+        Handle mouse press to toggle the chip state.
+
+        :param event: Mouse event
+        """
+        self.set_active(not self._active)
+        self.toggled.emit()
+
+
+class FilterPanel(QFrame):
+    """
+    Popup panel for filtering mods by source, type, and tags.
+
+    Displays checkboxes for mod sources, radio buttons for mod types,
+    and tag chips for tag-based filtering. Uses ``Qt.Popup`` window flag
+    so it auto-dismisses when the user clicks outside.
+
+    :param parent: Parent widget
+    """
+
+    filters_changed = Signal()
+
+    SOURCE_LABELS: dict[str, str] = {
+        "workshop": "Workshop",
+        "local": "Local",
+        "expansion": "Expansion",
+        "steamcmd": "SteamCMD",
+        "git_repo": "Git",
+    }
+
+    TYPE_LABELS: dict[str, str] = {
+        "all": "All",
+        "csharp": "C# Mods",
+        "xml": "XML-only",
+    }
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent, Qt.WindowType.Popup)
+        self.setObjectName("FilterPanel")
+        self.setMinimumWidth(320)
+
+        self._source_checkboxes: dict[str, QCheckBox] = {}
+        self._type_radios: dict[str, QRadioButton] = {}
+        self._tag_chips: dict[str, TagChip] = {}
+
+        main_layout = QVBoxLayout()
+        main_layout.setContentsMargins(12, 12, 12, 12)
+        main_layout.setSpacing(8)
+        self.setLayout(main_layout)
+
+        # --- Source and Type sections side by side ---
+        top_row = QHBoxLayout()
+        top_row.setSpacing(16)
+
+        # Source column
+        source_col = QVBoxLayout()
+        source_header = QLabel("Mod Source")
+        header_font = source_header.font()
+        header_font.setBold(True)
+        source_header.setFont(header_font)
+        source_col.addWidget(source_header)
+
+        for key, label in self.SOURCE_LABELS.items():
+            cb = QCheckBox(label)
+            cb.setChecked(True)
+            cb.toggled.connect(self._on_filter_changed)
+            self._source_checkboxes[key] = cb
+            source_col.addWidget(cb)
+
+        top_row.addLayout(source_col)
+
+        # Type column
+        type_col = QVBoxLayout()
+        type_header = QLabel("Mod Type")
+        type_header.setFont(header_font)
+        type_col.addWidget(type_header)
+
+        self._type_group = QButtonGroup(self)
+        for key, label in self.TYPE_LABELS.items():
+            rb = QRadioButton(label)
+            if key == "all":
+                rb.setChecked(True)
+            rb.toggled.connect(self._on_filter_changed)
+            self._type_radios[key] = rb
+            self._type_group.addButton(rb)
+            type_col.addWidget(rb)
+
+        top_row.addLayout(type_col)
+        top_row.addStretch()
+        main_layout.addLayout(top_row)
+
+        # --- Separator ---
+        sep1 = QFrame()
+        sep1.setFrameShape(QFrame.Shape.HLine)
+        sep1.setFrameShadow(QFrame.Shadow.Sunken)
+        main_layout.addWidget(sep1)
+
+        # --- Tags section ---
+        tags_header_row = QHBoxLayout()
+        tags_label = QLabel("Tags")
+        tags_label.setFont(header_font)
+        tags_header_row.addWidget(tags_label)
+        tags_header_row.addStretch()
+
+        self._select_all_label = QLabel("Select All")
+        self._select_all_label.setCursor(Qt.CursorShape.PointingHandCursor)
+        self._select_all_label.setStyleSheet("color: palette(link);")
+        self._select_all_label.mousePressEvent = self._on_select_all_tags  # type: ignore[method-assign]
+        tags_header_row.addWidget(self._select_all_label)
+
+        divider_label = QLabel("|")
+        tags_header_row.addWidget(divider_label)
+
+        self._select_none_label = QLabel("None")
+        self._select_none_label.setCursor(Qt.CursorShape.PointingHandCursor)
+        self._select_none_label.setStyleSheet("color: palette(link);")
+        self._select_none_label.mousePressEvent = self._on_select_none_tags  # type: ignore[method-assign]
+        tags_header_row.addWidget(self._select_none_label)
+
+        main_layout.addLayout(tags_header_row)
+
+        # Flow layout for tag chips
+        self._tags_flow = FlowLayout()
+        self._tags_flow.setSpacing(4)
+
+        # "No tags" chip is always present
+        self._no_tags_chip = TagChip("No tags", is_no_tags=True)
+        self._no_tags_chip.toggled.connect(self._on_filter_changed)
+        self._tag_chips["__no_tags__"] = self._no_tags_chip
+        self._tags_flow.addWidget(self._no_tags_chip)
+
+        main_layout.addLayout(self._tags_flow)
+
+        # --- Separator ---
+        sep2 = QFrame()
+        sep2.setFrameShape(QFrame.Shape.HLine)
+        sep2.setFrameShadow(QFrame.Shadow.Sunken)
+        main_layout.addWidget(sep2)
+
+        # --- Clear All button ---
+        clear_row = QHBoxLayout()
+        clear_row.addStretch()
+        self._clear_label = QLabel("Clear All")
+        self._clear_label.setCursor(Qt.CursorShape.PointingHandCursor)
+        self._clear_label.setStyleSheet("color: palette(link);")
+        self._clear_label.mousePressEvent = self._on_clear_all  # type: ignore[method-assign]
+        clear_row.addWidget(self._clear_label)
+        main_layout.addLayout(clear_row)
+
+    def set_available_tags(self, tags: list[str]) -> None:
+        """
+        Set the available user tags, creating tag chips for each.
+
+        Removes any previously created user tag chips and creates new ones.
+        The "no tags" chip is always preserved.
+
+        :param tags: List of tag names to display
+        """
+        # Remove existing user tag chips (not the no_tags chip)
+        keys_to_remove = [k for k in self._tag_chips if k != "__no_tags__"]
+        for key in keys_to_remove:
+            chip = self._tag_chips.pop(key)
+            self._tags_flow.removeWidget(chip)
+            chip.deleteLater()
+
+        # Remove the no_tags chip from layout temporarily so we can
+        # add user chips first, then re-add no_tags at the end
+        self._tags_flow.removeWidget(self._no_tags_chip)
+
+        for tag in tags:
+            chip = TagChip(tag)
+            chip.toggled.connect(self._on_filter_changed)
+            self._tag_chips[tag] = chip
+            self._tags_flow.addWidget(chip)
+
+        # Re-add no_tags chip at end
+        self._tags_flow.addWidget(self._no_tags_chip)
+
+    @property
+    def filter_state(self) -> FilterState:
+        """
+        Build a FilterState from the current widget state.
+
+        :return: FilterState reflecting current selections
+        """
+        sources: set[str] = set()
+        for key, cb in self._source_checkboxes.items():
+            if cb.isChecked():
+                sources.add(key)
+
+        mod_type = "all"
+        for key, rb in self._type_radios.items():
+            if rb.isChecked():
+                mod_type = key
+                break
+
+        tags: set[str] = set()
+        for key, chip in self._tag_chips.items():
+            if key != "__no_tags__" and chip.active:
+                tags.add(key)
+
+        include_no_tags = self._no_tags_chip.active
+
+        return FilterState(
+            sources=sources,
+            mod_type=mod_type,
+            tags=tags,
+            include_no_tags=include_no_tags,
+        )
+
+    def clear(self) -> None:
+        """
+        Reset all filters to their default state and emit ``filters_changed``.
+
+        Uses ``blockSignals`` to avoid cascading signal emissions during
+        the reset process.
+        """
+        # Block signals while resetting
+        for cb in self._source_checkboxes.values():
+            cb.blockSignals(True)
+            cb.setChecked(True)
+            cb.blockSignals(False)
+
+        for key, rb in self._type_radios.items():
+            rb.blockSignals(True)
+            if key == "all":
+                rb.setChecked(True)
+            rb.blockSignals(False)
+
+        for chip in self._tag_chips.values():
+            chip.set_active(False)
+
+        self.filters_changed.emit()
+
+    def _on_filter_changed(self) -> None:
+        """Emit ``filters_changed`` when any filter widget changes."""
+        self.filters_changed.emit()
+
+    def _on_select_all_tags(self, event: QMouseEvent) -> None:
+        """
+        Activate all tag chips (including "no tags").
+
+        :param event: Mouse event (unused)
+        """
+        for chip in self._tag_chips.values():
+            chip.set_active(True)
+        self.filters_changed.emit()
+
+    def _on_select_none_tags(self, event: QMouseEvent) -> None:
+        """
+        Deactivate all tag chips (including "no tags").
+
+        :param event: Mouse event (unused)
+        """
+        for chip in self._tag_chips.values():
+            chip.set_active(False)
+        self.filters_changed.emit()
+
+    def _on_clear_all(self, event: QMouseEvent) -> None:
+        """
+        Clear all filters via the "Clear All" label click.
+
+        :param event: Mouse event (unused)
+        """
+        self.clear()
+
+
+class FilterButton(QToolButton):
+    """
+    Toolbar button that owns a FilterPanel popup and displays a badge.
+
+    Clicking the button positions the FilterPanel below it and shows it.
+    A small badge overlay in the top-right corner shows the number of
+    active filter categories when any filters are engaged.
+
+    :param parent: Parent widget
+    """
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setObjectName("FilterButton")
+
+        icon_path = str(AppInfo().theme_data_folder / "default-icons" / "AppIcon_b.png")
+        self.setIcon(QIcon(icon_path))
+        self.setToolTip("Filter mods")
+
+        # Badge label positioned as a child widget (top-right corner)
+        self._badge_label = QLabel(self)
+        self._badge_label.setObjectName("FilterBadge")
+        self._badge_label.setFixedSize(16, 16)
+        self._badge_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self._badge_label.hide()
+
+        # Create the filter panel
+        self.filter_panel = FilterPanel()
+        self.filter_panel.filters_changed.connect(self._update_badge)
+
+        self.clicked.connect(self._show_panel)
+
+    def _show_panel(self) -> None:
+        """Position the filter panel below this button and show it."""
+        pos = self.mapToGlobal(QPoint(0, self.height()))
+        self.filter_panel.move(pos)
+        self.filter_panel.show()
+
+    def _update_badge(self) -> None:
+        """Update the badge label to reflect the active filter category count."""
+        count = self.filter_panel.filter_state.active_category_count()
+        if count > 0:
+            self._badge_label.setText(str(count))
+            self._badge_label.show()
+        else:
+            self._badge_label.hide()
+
+    def resizeEvent(self, event: object) -> None:
+        """
+        Reposition the badge when the button is resized.
+
+        :param event: Resize event
+        """
+        super().resizeEvent(event)  # type: ignore[arg-type]
+        # Position badge at top-right corner
+        self._badge_label.move(self.width() - 16, 0)

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -778,21 +778,8 @@ class MainContent(QObject):
             # Reset the data source filters to default and clear searches
             # Avoid recalculating warnings/errors when clearing search
             # Recalculation for each list will be triggered by mods being reinserted into inactive and active lists automatically
-            self.mods_panel.active_mods_filter_data_source_index = len(
-                self.mods_panel.data_source_filter_icons
-            )
-            self.mods_panel.signal_clear_search(
-                list_type="Active",
-            )
-            self.mods_panel.inactive_mods_filter_data_source_index = len(
-                self.mods_panel.data_source_filter_icons
-            )
-            self.mods_panel.signal_clear_search(
-                list_type="Inactive",
-            )
-            self.mods_panel.active_mods_filter_data_source_index = len(
-                self.mods_panel.data_source_filter_icons
-            )
+            self.mods_panel.reset_all_filters_and_search("Active")
+            self.mods_panel.reset_all_filters_and_search("Inactive")
         # Check if paths are set
         if self.check_if_essential_paths_are_set(prompt=is_initial):
             # Run expensive calculations to set cache data
@@ -849,14 +836,8 @@ class MainContent(QObject):
         Method to clear all the non-base, non-DLC mods from the active
         list widget and put them all into the inactive list widget.
         """
-        self.mods_panel.active_mods_filter_data_source_index = len(
-            self.mods_panel.data_source_filter_icons
-        )
-        self.mods_panel.signal_clear_search(list_type="Active")
-        self.mods_panel.inactive_mods_filter_data_source_index = len(
-            self.mods_panel.data_source_filter_icons
-        )
-        self.mods_panel.signal_clear_search(list_type="Inactive")
+        self.mods_panel.reset_all_filters_and_search("Active")
+        self.mods_panel.reset_all_filters_and_search("Inactive")
         # Metadata to insert
         active_mods_uuids: list[str] = []
         inactive_mods_uuids: list[str] = []
@@ -914,16 +895,8 @@ class MainContent(QObject):
         # Get the live list of active and inactive mods. This is because the user
         # will likely sort before saving.
         logger.debug("Starting sorting mods")
-        self.mods_panel.signal_clear_search(list_type="Active")
-        self.mods_panel.active_mods_filter_data_source_index = len(
-            self.mods_panel.data_source_filter_icons
-        )
-        self.mods_panel.on_active_mods_search_data_source_filter()
-        self.mods_panel.signal_clear_search(list_type="Inactive")
-        self.mods_panel.inactive_mods_filter_data_source_index = len(
-            self.mods_panel.data_source_filter_icons
-        )
-        self.mods_panel.on_inactive_mods_search_data_source_filter()
+        self.mods_panel.reset_all_filters_and_search("Active")
+        self.mods_panel.reset_all_filters_and_search("Inactive")
 
         # Get active mods (exclude dividers)
         active_mods = {
@@ -1077,16 +1050,8 @@ class MainContent(QObject):
         )
         logger.info(f"Selected path: {file_path}")
         if file_path:
-            self.mods_panel.signal_clear_search(list_type="Active")
-            self.mods_panel.active_mods_filter_data_source_index = len(
-                self.mods_panel.data_source_filter_icons
-            )
-            self.mods_panel.signal_search_source_filter(list_type="Active")
-            self.mods_panel.signal_clear_search(list_type="Inactive")
-            self.mods_panel.inactive_mods_filter_data_source_index = len(
-                self.mods_panel.data_source_filter_icons
-            )
-            self.mods_panel.signal_search_source_filter(list_type="Inactive")
+            self.mods_panel.reset_all_filters_and_search("Active")
+            self.mods_panel.reset_all_filters_and_search("Inactive")
             logger.info(f"Trying to import mods list from XML: {file_path}")
             (
                 active_mods_uuids,
@@ -1156,16 +1121,8 @@ class MainContent(QObject):
             logger.debug("USER ACTION: pressed cancel or no package IDs, passing")
             return
         # Clear Active and Inactive search and data source filter
-        self.mods_panel.signal_clear_search(list_type="Active")
-        self.mods_panel.active_mods_filter_data_source_index = len(
-            self.mods_panel.data_source_filter_icons
-        )
-        self.mods_panel.signal_search_source_filter(list_type="Active")
-        self.mods_panel.signal_clear_search(list_type="Inactive")
-        self.mods_panel.inactive_mods_filter_data_source_index = len(
-            self.mods_panel.data_source_filter_icons
-        )
-        self.mods_panel.signal_search_source_filter(list_type="Inactive")
+        self.mods_panel.reset_all_filters_and_search("Active")
+        self.mods_panel.reset_all_filters_and_search("Inactive")
 
         if rentry_import.publishedfileids:
             # Get set of publishedfileids already present locally
@@ -1307,16 +1264,8 @@ class MainContent(QObject):
             logger.debug("USER ACTION: pressed cancel or no package IDs, passing")
             return
         # Clear Active and Inactive search and data source filter
-        self.mods_panel.signal_clear_search(list_type="Active")
-        self.mods_panel.active_mods_filter_data_source_index = len(
-            self.mods_panel.data_source_filter_icons
-        )
-        self.mods_panel.signal_search_source_filter(list_type="Active")
-        self.mods_panel.signal_clear_search(list_type="Inactive")
-        self.mods_panel.inactive_mods_filter_data_source_index = len(
-            self.mods_panel.data_source_filter_icons
-        )
-        self.mods_panel.signal_search_source_filter(list_type="Inactive")
+        self.mods_panel.reset_all_filters_and_search("Active")
+        self.mods_panel.reset_all_filters_and_search("Inactive")
 
         # Log the attempt to import mods list from Workshop collection
         logger.info(
@@ -1468,16 +1417,8 @@ class MainContent(QObject):
             return
 
         # Clear searches and data source filters just like XML import
-        self.mods_panel.signal_clear_search(list_type="Active")
-        self.mods_panel.active_mods_filter_data_source_index = len(
-            self.mods_panel.data_source_filter_icons
-        )
-        self.mods_panel.signal_search_source_filter(list_type="Active")
-        self.mods_panel.signal_clear_search(list_type="Inactive")
-        self.mods_panel.inactive_mods_filter_data_source_index = len(
-            self.mods_panel.data_source_filter_icons
-        )
-        self.mods_panel.signal_search_source_filter(list_type="Inactive")
+        self.mods_panel.reset_all_filters_and_search("Active")
+        self.mods_panel.reset_all_filters_and_search("Inactive")
 
         logger.info(f"Trying to import mods list from save file: {file_path}")
         (
@@ -1669,16 +1610,8 @@ class MainContent(QObject):
             self.active_mods_uuids_restore_state
             and self.inactive_mods_uuids_restore_state
         ):
-            self.mods_panel.signal_clear_search("Active")
-            self.mods_panel.active_mods_filter_data_source_index = len(
-                self.mods_panel.data_source_filter_icons
-            )
-            self.mods_panel.on_active_mods_search_data_source_filter()
-            self.mods_panel.signal_clear_search("Inactive")
-            self.mods_panel.inactive_mods_filter_data_source_index = len(
-                self.mods_panel.data_source_filter_icons
-            )
-            self.mods_panel.on_inactive_mods_search_data_source_filter()
+            self.mods_panel.reset_all_filters_and_search("Active")
+            self.mods_panel.reset_all_filters_and_search("Inactive")
             logger.info(
                 f"Restoring cached mod lists with active list [{len(self.active_mods_uuids_restore_state)}] and inactive list [{len(self.inactive_mods_uuids_restore_state)}]"
             )

--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -84,7 +84,6 @@ from app.utils.aux_db_utils import (
 )
 from app.utils.constants import (
     KNOWN_MOD_REPLACEMENTS,
-    SEARCH_DATA_SOURCE_FILTER_INDEXES,
 )
 from app.utils.custom_list_widget_item import CustomListWidgetItem
 from app.utils.custom_list_widget_item_metadata import CustomListWidgetItemMetadata
@@ -108,6 +107,7 @@ from app.views.dialogue import (
     show_warning,
 )
 from app.views.divider_widget import DividerItemInner
+from app.views.filter_panel import FilterButton
 
 
 class ModListItemInner(QWidget):
@@ -773,140 +773,6 @@ class ModListItemInner(QWidget):
         self.show_tags = visible
         self.update_tags_label(tags)
         self._resize_text_after_icon_toggle()
-
-
-NO_TAGS_FILTER_VALUE = "__rimsort_no_tags__"
-
-
-class TagFilterButton(QToolButton):
-    tags_changed = Signal()
-
-    def __init__(
-        self, settings_controller: SettingsController, parent: QWidget | None = None
-    ) -> None:
-        super().__init__(parent)
-        self.settings_controller = settings_controller
-        self._tag_actions: dict[str, QAction] = {}
-        self._menu = QMenu(self)
-
-        self.setText(self.tr("Tags: All"))
-        self.setToolTip(self.tr("Filter by one or more user tags"))
-        self.setMinimumWidth(100)
-        self.setMaximumWidth(135)
-        self.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
-        self.setMenu(self._menu)
-
-        self.refresh_tags()
-
-    def refresh_tags(self) -> None:
-        previous_selected_tags = self.selected_tags()
-        previous_total_count = len(self._tag_actions)
-        previous_all_selected = (
-            previous_total_count == 0
-            or len(previous_selected_tags) == previous_total_count
-        )
-
-        self._menu.clear()
-        self._tag_actions.clear()
-
-        select_all_action = QAction(self.tr("Select all"), self)
-        select_none_action = QAction(self.tr("Select none"), self)
-
-        select_all_action.triggered.connect(self.select_all)
-        select_none_action.triggered.connect(self.select_none)
-
-        self._menu.addAction(select_all_action)
-        self._menu.addAction(select_none_action)
-        self._menu.addSeparator()
-
-        no_tags_action = QAction(self.tr("No tags"), self)
-        no_tags_action.setCheckable(True)
-        no_tags_action.setChecked(
-            previous_all_selected or NO_TAGS_FILTER_VALUE in previous_selected_tags
-        )
-        no_tags_action.toggled.connect(self._on_tag_toggled)
-        self._menu.addAction(no_tags_action)
-        self._tag_actions[NO_TAGS_FILTER_VALUE] = no_tags_action
-
-        try:
-            tags = auxdb_get_all_tags(self.settings_controller)
-        except Exception as e:
-            logger.debug(f"Unable to load tag filter list: {e}")
-            tags = []
-        if tags:
-            self._menu.addSeparator()
-
-        for tag in tags:
-            action = QAction(tag, self)
-            action.setCheckable(True)
-            action.setChecked(previous_all_selected or tag in previous_selected_tags)
-            action.toggled.connect(self._on_tag_toggled)
-            self._menu.addAction(action)
-            self._tag_actions[tag] = action
-
-        self._update_text()
-
-    def selected_tags(self) -> set[str]:
-        return {tag for tag, action in self._tag_actions.items() if action.isChecked()}
-
-    def selected_real_tags(self) -> set[str]:
-        return {tag for tag in self.selected_tags() if tag != NO_TAGS_FILTER_VALUE}
-
-    def no_tags_selected(self) -> bool:
-        return NO_TAGS_FILTER_VALUE in self.selected_tags()
-
-    def has_active_filter(self) -> bool:
-        selected_count = len(self.selected_tags())
-        total_count = len(self._tag_actions)
-        return total_count > 0 and selected_count != total_count
-
-    def select_all(self) -> None:
-        for action in self._tag_actions.values():
-            action.blockSignals(True)
-            action.setChecked(True)
-            action.blockSignals(False)
-        self._update_text()
-        self.tags_changed.emit()
-
-    def select_none(self) -> None:
-        for action in self._tag_actions.values():
-            action.blockSignals(True)
-            action.setChecked(False)
-            action.blockSignals(False)
-        self._update_text()
-        self.tags_changed.emit()
-
-    def _on_tag_toggled(self) -> None:
-        self._update_text()
-        self.tags_changed.emit()
-
-    def _update_text(self) -> None:
-        selected = self.selected_tags()
-        selected_count = len(selected)
-        total_count = len(self._tag_actions)
-
-        if total_count == 0:
-            self.setText(self.tr("Tags: None"))
-            self.setToolTip(self.tr("No user tags have been created yet"))
-        elif selected_count == total_count:
-            self.setText(self.tr("Tags: All"))
-            self.setToolTip(self.tr("Showing all tags and untagged mods"))
-        elif selected_count == 0:
-            self.setText(self.tr("Tags: 0"))
-            self.setToolTip(self.tr("No tags selected"))
-        elif selected == {NO_TAGS_FILTER_VALUE}:
-            self.setText(self.tr("Tags: No tags"))
-            self.setToolTip(self.tr("Showing mods without tags"))
-        else:
-            tooltip_parts = []
-            if NO_TAGS_FILTER_VALUE in selected:
-                tooltip_parts.append(self.tr("No tags"))
-            tooltip_parts.extend(
-                sorted(tag for tag in selected if tag != NO_TAGS_FILTER_VALUE)
-            )
-
-            self.setText(self.tr("Tags: {count}").format(count=selected_count))
-            self.setToolTip(", ".join(tooltip_parts))
 
 
 class TagEditDialog(QDialog):
@@ -4092,34 +3958,6 @@ class ModsPanel(QWidget):
         # Add the buttons frame below the lists panel
         self.panel.addWidget(self.button_panel_frame, 0)
 
-        # Filter icons and tooltips
-        self.data_source_filter_icons = [
-            QIcon(str(AppInfo().theme_data_folder / "default-icons" / "AppIcon_b.png")),
-            ModListIcons.ludeon_icon(),
-            ModListIcons.local_icon(),
-            ModListIcons.git_icon(),
-            ModListIcons.steamcmd_icon(),
-            ModListIcons.steam_icon(),
-        ]
-        self.data_source_filter_tooltips = [
-            self.tr("Showing All Mods"),
-            self.tr("Showing Core and DLC"),
-            self.tr("Showing Local Mods"),
-            self.tr("Showing Git Mods"),
-            self.tr("Showing SteamCMD Mods"),
-            self.tr("Showing Steam Mods"),
-        ]
-        self.data_source_filter_type_icons = [
-            QIcon(str(AppInfo().theme_data_folder / "default-icons" / "AppIcon_b.png")),
-            ModListIcons.csharp_icon(),
-            ModListIcons.xml_icon(),
-        ]
-        self.data_source_filter_type_tooltips = [
-            self.tr("Showing All Mod Types"),
-            self.tr("Showing C# Mods"),
-            self.tr("Showing XML Mods"),
-        ]
-
         self.mode_filter_icon = QIcon(
             str(AppInfo().theme_data_folder / "default-icons" / "filter.png")
         )
@@ -4180,38 +4018,6 @@ class ModsPanel(QWidget):
 
     def initialize_active_mods_search_widgets(self) -> None:
         """Initialize widgets for active mods search layout."""
-        self.active_mods_filter_data_source_index = 0
-        self.active_mods_data_source_filter = SEARCH_DATA_SOURCE_FILTER_INDEXES[
-            self.active_mods_filter_data_source_index
-        ]
-        self.active_mods_filter_data_source_button = QToolButton()
-        self.active_mods_filter_data_source_button.setIcon(
-            self.data_source_filter_icons[self.active_mods_filter_data_source_index]
-        )
-        self.active_mods_filter_data_source_button.setToolTip(
-            self.data_source_filter_tooltips[self.active_mods_filter_data_source_index]
-        )
-        self.active_mods_filter_data_source_button.clicked.connect(
-            self.on_active_mods_search_data_source_filter
-        )
-        self.active_data_source_filter_type_index = 0
-        self.active_mods_data_source_filter_type = SEARCH_DATA_SOURCE_FILTER_INDEXES[
-            self.active_data_source_filter_type_index
-        ]
-        self.active_data_source_filter_type_button = QToolButton()
-        self.active_data_source_filter_type_button.setIcon(
-            self.data_source_filter_type_icons[
-                self.active_data_source_filter_type_index
-            ]
-        )
-        self.active_data_source_filter_type_button.setToolTip(
-            self.data_source_filter_type_tooltips[
-                self.active_data_source_filter_type_index
-            ]
-        )
-        self.active_data_source_filter_type_button.clicked.connect(
-            self.on_active_mods_search_data_source_filter_type
-        )
         self.active_mods_search_filter_state = True
         self.active_mods_search_mode_filter_button = QToolButton()
         self.active_mods_search_mode_filter_button.setIcon(self.mode_filter_icon)
@@ -4248,41 +4054,22 @@ class ModsPanel(QWidget):
                 self.tr("Version"),
             ]
         )
-        self.active_mods_tag_filter_enabled = False
-        self.active_mods_tag_filter_button = QToolButton()
-        self.active_mods_tag_filter_button.setText(self.tr("Tags"))
-        self.active_mods_tag_filter_button.setIcon(self.mode_filter_icon)
-        self.active_mods_tag_filter_button.setToolButtonStyle(
-            Qt.ToolButtonStyle.ToolButtonTextBesideIcon
-        )
-        self.active_mods_tag_filter_button.setCheckable(True)
-        self.active_mods_tag_filter_button.setToolTip(self.tr("Tag filter disabled"))
-        self.active_mods_tag_filter_button.clicked.connect(
-            self.on_active_mods_tag_filter_toggle
-        )
 
-        self.active_mods_tag_filter_selector = TagFilterButton(
-            self.settings_controller, self
-        )
-        self.active_mods_tag_filter_selector.tags_changed.connect(
-            self.on_active_mods_tag_filter_changed
+        # FilterButton replaces old source/type/tag filter widgets
+        self.active_filter_button = FilterButton(self)
+        self.active_filter_button.filter_panel.filters_changed.connect(
+            lambda: self.signal_search_and_filters(
+                list_type="Active", pattern=self.active_mods_search.text()
+            )
         )
 
         # Active mods search layouts
-        self.active_mods_search_layout.addWidget(
-            self.active_mods_filter_data_source_button
-        )
-        if self.settings_controller.settings.mod_type_filter:
-            self.active_mods_search_layout.addWidget(
-                self.active_data_source_filter_type_button
-            )
+        self.active_mods_search_layout.addWidget(self.active_mods_search, 45)
+        self.active_mods_search_layout.addWidget(self.active_mods_search_filter, 70)
+        self.active_mods_search_layout.addWidget(self.active_filter_button)
         self.active_mods_search_layout.addWidget(
             self.active_mods_search_mode_filter_button
         )
-        self.active_mods_search_layout.addWidget(self.active_mods_search, 45)
-        self.active_mods_search_layout.addWidget(self.active_mods_search_filter, 70)
-        self.active_mods_search_layout.addWidget(self.active_mods_tag_filter_button)
-        self.active_mods_search_layout.addWidget(self.active_mods_tag_filter_selector)
         # Active mods list Errors/warnings widgets
         self.errors_summary_frame: QFrame = QFrame()
         self.errors_summary_frame.setObjectName("errorFrame")
@@ -4340,40 +4127,6 @@ class ModsPanel(QWidget):
 
     def initialize_inactive_mods_search_widgets(self) -> None:
         """Initialize widgets for inactive mods search layout."""
-        self.inactive_mods_filter_data_source_index = 0
-        self.inactive_mods_data_source_filter = SEARCH_DATA_SOURCE_FILTER_INDEXES[
-            self.inactive_mods_filter_data_source_index
-        ]
-        self.inactive_mods_filter_data_source_button = QToolButton()
-        self.inactive_mods_filter_data_source_button.setIcon(
-            self.data_source_filter_icons[self.inactive_mods_filter_data_source_index]
-        )
-        self.inactive_mods_filter_data_source_button.setToolTip(
-            self.data_source_filter_tooltips[
-                self.inactive_mods_filter_data_source_index
-            ]
-        )
-        self.inactive_mods_filter_data_source_button.clicked.connect(
-            self.on_inactive_mods_search_data_source_filter
-        )
-        self.inactive_data_source_filter_type_index = 0
-        self.inactive_mods_data_source_filter_type = SEARCH_DATA_SOURCE_FILTER_INDEXES[
-            self.inactive_data_source_filter_type_index
-        ]
-        self.inactive_data_source_filter_type_button = QToolButton()
-        self.inactive_data_source_filter_type_button.setIcon(
-            self.data_source_filter_type_icons[
-                self.inactive_data_source_filter_type_index
-            ]
-        )
-        self.inactive_data_source_filter_type_button.setToolTip(
-            self.data_source_filter_type_tooltips[
-                self.inactive_data_source_filter_type_index
-            ]
-        )
-        self.inactive_data_source_filter_type_button.clicked.connect(
-            self.on_inactive_mods_search_data_source_filter_type
-        )
         self.inactive_mods_search_filter_state = True
         self.inactive_mods_search_mode_filter_button = QToolButton()
         self.inactive_mods_search_mode_filter_button.setIcon(self.mode_filter_icon)
@@ -4416,26 +4169,12 @@ class ModsPanel(QWidget):
             ]
         )
 
-        self.inactive_mods_tag_filter_enabled = False
-        self.inactive_mods_tag_filter_button = QToolButton()
-        self.inactive_mods_tag_filter_button.setText(self.tr("Tags"))
-        self.inactive_mods_tag_filter_button.setIcon(self.mode_filter_icon)
-        self.inactive_mods_tag_filter_button.setToolButtonStyle(
-            Qt.ToolButtonStyle.ToolButtonTextBesideIcon
-        )
-        self.inactive_mods_tag_filter_button.setCheckable(True)
-        self.inactive_mods_tag_filter_button.setToolTip(
-            self.tr("Enable/disable tag filter")
-        )
-        self.inactive_mods_tag_filter_button.clicked.connect(
-            self.on_inactive_mods_tag_filter_toggle
-        )
-
-        self.inactive_mods_tag_filter_selector = TagFilterButton(
-            self.settings_controller, self
-        )
-        self.inactive_mods_tag_filter_selector.tags_changed.connect(
-            self.on_inactive_mods_tag_filter_changed
+        # FilterButton replaces old source/type/tag filter widgets
+        self.inactive_filter_button = FilterButton(self)
+        self.inactive_filter_button.filter_panel.filters_changed.connect(
+            lambda: self.signal_search_and_filters(
+                list_type="Inactive", pattern=self.inactive_mods_search.text()
+            )
         )
 
         self.inactive_mods_sort_combobox: QComboBox = QComboBox()
@@ -4497,21 +4236,11 @@ class ModsPanel(QWidget):
         self.inactive_mods_sort_order_button.setText(
             self.tr("Desc") if self.inactive_mods_sort_descending else self.tr("Asc")
         )
-        self.inactive_mods_search_layout.addWidget(
-            self.inactive_mods_filter_data_source_button
-        )
-        if self.settings_controller.settings.mod_type_filter:
-            self.inactive_mods_search_layout.addWidget(
-                self.inactive_data_source_filter_type_button
-            )
-        self.inactive_mods_search_layout.addWidget(
-            self.inactive_mods_search_mode_filter_button
-        )
         self.inactive_mods_search_layout.addWidget(self.inactive_mods_search, 45)
         self.inactive_mods_search_layout.addWidget(self.inactive_mods_search_filter, 70)
-        self.inactive_mods_search_layout.addWidget(self.inactive_mods_tag_filter_button)
+        self.inactive_mods_search_layout.addWidget(self.inactive_filter_button)
         self.inactive_mods_search_layout.addWidget(
-            self.inactive_mods_tag_filter_selector
+            self.inactive_mods_search_mode_filter_button
         )
         self.inactive_mods_search_layout.addWidget(
             self.inactive_mods_sort_combobox, 120
@@ -4522,14 +4251,6 @@ class ModsPanel(QWidget):
         if self.settings_controller.settings.inactive_mods_sorting:
             self.inactive_mods_sort_combobox.setVisible(True)
             self.inactive_mods_sort_order_button.setVisible(True)
-
-        # Adding Completer.
-        # self.completer = QCompleter(self.active_mods_list.get_list_items())
-        # self.completer.setCaseSensitivity(Qt.CaseInsensitive)
-        # self.active_mods_search.setCompleter(self.completer)
-        # self.inactive_mods_search.setCompleter(self.completer)
-
-        # Connect signals and slots
 
     def connect_signals(self) -> None:
         self.active_mods_list.list_update_signal.connect(
@@ -4846,12 +4567,6 @@ class ModsPanel(QWidget):
             list_type="Active",
         )
 
-    def on_active_mods_search_data_source_filter(self) -> None:
-        self.signal_search_source_filter(list_type="Active")
-
-    def on_active_mods_search_data_source_filter_type(self) -> None:
-        self.apply_mods_filter_type(list_type="Active")
-
     def on_active_mods_mode_filter_toggle(self) -> None:
         self.signal_search_mode_filter(list_type="Active")
 
@@ -4869,173 +4584,37 @@ class ModsPanel(QWidget):
             list_type="Inactive",
         )
 
-    def on_inactive_mods_search_data_source_filter(self) -> None:
-        self.signal_search_source_filter(list_type="Inactive")
-
-    def on_inactive_mods_search_data_source_filter_type(self) -> None:
-        self.apply_mods_filter_type(list_type="Inactive")
-
     def on_inactive_mods_mode_filter_toggle(self) -> None:
         self.signal_search_mode_filter(list_type="Inactive")
 
-    def refresh_tag_filter_combobox(self, combobox: QComboBox) -> None:
-        current_text = combobox.currentText()
-        combobox.blockSignals(True)
-        combobox.clear()
-        combobox.addItem(self.tr("All tags"))
-        for tag in auxdb_get_all_tags(self.settings_controller):
-            combobox.addItem(tag)
-        index = combobox.findText(current_text)
-        if index >= 0:
-            combobox.setCurrentIndex(index)
-        combobox.blockSignals(False)
-
     def refresh_all_tag_filter_selectors(self) -> None:
-        self.active_mods_tag_filter_selector.refresh_tags()
-        self.inactive_mods_tag_filter_selector.refresh_tags()
-
+        """Refresh the available tags in both filter panels from the aux DB."""
+        try:
+            tags = auxdb_get_all_tags(self.settings_controller)
+        except Exception as e:
+            logger.debug(f"Unable to load tag filter list: {e}")
+            tags = []
+        self.active_filter_button.filter_panel.set_available_tags(tags)
+        self.inactive_filter_button.filter_panel.set_available_tags(tags)
         self.signal_search_and_filters(
             list_type="Active",
             pattern=self.active_mods_search.text(),
-            filters_active=self.active_mods_tag_filter_enabled,
         )
         self.signal_search_and_filters(
             list_type="Inactive",
             pattern=self.inactive_mods_search.text(),
-            filters_active=self.inactive_mods_tag_filter_enabled,
         )
 
-    def on_active_mods_tag_filter_toggle(self) -> None:
-        self.active_mods_tag_filter_enabled = (
-            self.active_mods_tag_filter_button.isChecked()
-        )
-        self.active_mods_tag_filter_button.setIcon(
-            self.mode_nofilter_icon
-            if self.active_mods_tag_filter_enabled
-            else self.mode_filter_icon
-        )
-        self.active_mods_tag_filter_button.setToolTip(
-            self.tr("Tag filter enabled")
-            if self.active_mods_tag_filter_enabled
-            else self.tr("Tag filter disabled")
-        )
-        self.active_mods_list.set_tags_visible(self.active_mods_tag_filter_enabled)
-        self.signal_search_and_filters(
-            list_type="Active",
-            pattern=self.active_mods_search.text(),
-            filters_active=self.active_mods_tag_filter_enabled,
-        )
-
-    def on_inactive_mods_tag_filter_toggle(self) -> None:
-        self.inactive_mods_tag_filter_enabled = (
-            self.inactive_mods_tag_filter_button.isChecked()
-        )
-        self.inactive_mods_tag_filter_button.setIcon(
-            self.mode_nofilter_icon
-            if self.inactive_mods_tag_filter_enabled
-            else self.mode_filter_icon
-        )
-        self.inactive_mods_tag_filter_button.setToolTip(
-            self.tr("Tag filter enabled")
-            if self.inactive_mods_tag_filter_enabled
-            else self.tr("Tag filter disabled")
-        )
-        self.inactive_mods_list.set_tags_visible(self.inactive_mods_tag_filter_enabled)
-        self.signal_search_and_filters(
-            list_type="Inactive",
-            pattern=self.inactive_mods_search.text(),
-            filters_active=self.inactive_mods_tag_filter_enabled,
-        )
-
-    def on_active_mods_tag_filter_changed(self) -> None:
-        self.signal_search_and_filters(
-            list_type="Active",
-            pattern=self.active_mods_search.text(),
-            filters_active=self.active_mods_tag_filter_enabled,
-        )
-
-    def on_inactive_mods_tag_filter_changed(self) -> None:
-        self.signal_search_and_filters(
-            list_type="Inactive",
-            pattern=self.inactive_mods_search.text(),
-            filters_active=self.inactive_mods_tag_filter_enabled,
-        )
+    def reset_all_filters_and_search(self, list_type: str) -> None:
+        """Clear all filters and search text for the given list type."""
+        if list_type == "Active":
+            self.active_filter_button.filter_panel.clear()
+        elif list_type == "Inactive":
+            self.inactive_filter_button.filter_panel.clear()
+        self.signal_clear_search(list_type=list_type)
 
     def on_mod_created(self, uuid: str) -> None:
         self.inactive_mods_list.append_new_item(uuid)
-
-    def apply_mods_filter_type(self, list_type: str) -> None:
-        # Define the mod types
-        mod_types = ["csharp", "xml"]
-        source_filter_index: int = (
-            self.active_data_source_filter_type_index
-            or self.inactive_data_source_filter_type_index
-        )
-
-        if list_type == "Active":
-            button = self.active_data_source_filter_type_button
-            search = self.active_mods_search
-            source_index = source_filter_index
-        elif list_type == "Inactive":
-            button = self.inactive_data_source_filter_type_button
-            search = self.inactive_mods_search
-            source_index = source_filter_index
-        else:
-            raise NotImplementedError(f"Unknown list type: {list_type}")
-
-        # Update the filter index
-        if source_index < (len(self.data_source_filter_type_icons) - 1):
-            source_index += 1
-        else:
-            source_index = 0
-
-        button.setIcon(self.data_source_filter_type_icons[source_index])
-        button.setToolTip(self.data_source_filter_type_tooltips[source_index])
-
-        # Update the relevant index for the list type
-        if list_type == "Active":
-            self.active_data_source_filter_type_index = source_index
-            self.active_mods_data_source_filter_type = (
-                SEARCH_DATA_SOURCE_FILTER_INDEXES[source_index]
-            )
-        elif list_type == "Inactive":
-            self.inactive_data_source_filter_type_index = source_index
-            self.inactive_mods_data_source_filter_type = (
-                SEARCH_DATA_SOURCE_FILTER_INDEXES[source_index]
-            )
-
-        mod_list = (
-            self.active_mods_list if list_type == "Active" else self.inactive_mods_list
-        )
-
-        # Apply filtering based on the selected type
-        for idx, uuid in enumerate(mod_list.uuids):
-            if is_divider_uuid(uuid):
-                continue
-            item = mod_list.item(idx)
-            item_data = item.data(Qt.ItemDataRole.UserRole)
-
-            # Determine the mod type
-            mod_type = (
-                "csharp"
-                if self.metadata_manager.internal_local_metadata.get(uuid, {}).get(
-                    "csharp"
-                )
-                else "xml"
-            )
-            if mod_type and mod_types:
-                item.setData(Qt.ItemDataRole.UserRole, item_data)
-
-        if source_index == 0:
-            filters_active = False
-        else:
-            filters_active = True
-        # Trigger search and filters
-        self.signal_search_and_filters(
-            list_type=list_type,
-            pattern=search.text(),
-            filters_active=filters_active,
-        )
 
     def on_mod_deleted(self, uuid: str) -> None:
         if uuid in self.active_mods_list.uuids:
@@ -5186,22 +4765,22 @@ class ModsPanel(QWidget):
         self,
         list_type: str,
         pattern: str,
-        filters_active: bool = False,
     ) -> None:
         """
         Performs a search and/or applies filters based on the given parameters.
 
         Called anytime the search bar text changes or the filters change.
+        Filter state (source, type, tags) is read directly from the FilterPanel.
 
-        Args:
-            list_type (str): The type of list to search within (Active or Inactive).
-            pattern (str): The pattern to search for.
-            filters_active (bool): If any filter is active (inc. pattern search).
+        :param list_type: The type of list to search within (Active or Inactive).
+        :param pattern: The pattern to search for.
         """
-        _filter = None
-        filter_state = None  # The 'Hide Filter' state
-        source_filter = None
-        uuids = None
+        from app.models.filter_state import FilterState
+
+        _filter: QComboBox
+        filter_state: bool  # The 'Hide Filter' state
+        uuids: list[str]
+        fs: FilterState
         # Notify controller when search bar text or any filters change
         if list_type == "Active":
             EventBus().filters_changed_in_active_modlist.emit()
@@ -5211,27 +4790,20 @@ class ModsPanel(QWidget):
         if list_type == "Active":
             _filter = self.active_mods_search_filter
             filter_state = self.active_mods_search_filter_state
-            source_filter = self.active_mods_data_source_filter
             uuids = self.active_mods_list.uuids
-            tag_filter_enabled = self.active_mods_tag_filter_enabled
-            selected_tags = self.active_mods_tag_filter_selector.selected_real_tags()
-            no_tags_selected = self.active_mods_tag_filter_selector.no_tags_selected()
-            tag_filter_active = self.active_mods_tag_filter_selector.has_active_filter()
+            fs = self.active_filter_button.filter_panel.filter_state
         elif list_type == "Inactive":
             _filter = self.inactive_mods_search_filter
             filter_state = self.inactive_mods_search_filter_state
-            source_filter = self.inactive_mods_data_source_filter
             uuids = self.inactive_mods_list.uuids
-            tag_filter_enabled = self.inactive_mods_tag_filter_enabled
-            selected_tags = self.inactive_mods_tag_filter_selector.selected_real_tags()
-            no_tags_selected = self.inactive_mods_tag_filter_selector.no_tags_selected()
-            tag_filter_active = (
-                self.inactive_mods_tag_filter_selector.has_active_filter()
-            )
+            fs = self.inactive_filter_button.filter_panel.filter_state
         else:
             raise NotImplementedError(f"Unknown list type: {list_type}")
+
+        # Compute whether any filters are active
+        filters_active = bool(fs.has_active_filters() or pattern)
+
         # Evaluate the search filter state for the list
-        # consider using currentData() instead of currentText()
         search_filter = None
         if _filter.currentText() == self.tr("Name"):
             search_filter = "name"
@@ -5277,8 +4849,6 @@ class ModsPanel(QWidget):
             if uuid not in self.metadata_manager.internal_local_metadata:
                 continue
             metadata = self.metadata_manager.internal_local_metadata[uuid]
-            if pattern != "":
-                filters_active = True
             # Hide invalid items if enabled in settings
             if self.settings_controller.settings.hide_invalid_mods_when_filtering:
                 invalid = item_data["invalid"]
@@ -5308,12 +4878,12 @@ class ModsPanel(QWidget):
                     mod_path = metadata.get("path", "")
                     item_filtered = mod_path not in matches
             elif search_filter == "tags":
-                tags = item_data["mod_tags"]
+                tags_list = item_data["mod_tags"]
                 if not pattern.strip():
                     item_filtered = False
                 else:
                     item_filtered = not any(
-                        pattern.lower() in tag.lower() for tag in tags
+                        pattern.lower() in tag.lower() for tag in tags_list
                     )
             # Filter by name and mod notes
             elif (
@@ -5339,37 +4909,34 @@ class ModsPanel(QWidget):
             ):
                 item_filtered = True
 
-            # Source filtering
-            if not item_filtered:
-                if source_filter == "all":
-                    pass
-                elif source_filter == "git_repo":
-                    item_filtered = not metadata.get("git_repo")
-                elif source_filter == "steamcmd":
-                    item_filtered = not metadata.get("steamcmd")
-                elif source_filter != metadata.get("data_source"):
+            # Source filtering (set-based from FilterState)
+            if not item_filtered and fs.sources != FilterState.ALL_SOURCES:
+                data_source = metadata.get("data_source", "")
+                is_git = bool(metadata.get("git_repo"))
+                is_steamcmd = bool(metadata.get("steamcmd"))
+                source_match = False
+                if data_source in fs.sources:
+                    source_match = True
+                if "git_repo" in fs.sources and is_git:
+                    source_match = True
+                if "steamcmd" in fs.sources and is_steamcmd:
+                    source_match = True
+                if not source_match:
                     item_filtered = True
 
-            # Type filtering
-            type_filter_index = (
-                self.active_data_source_filter_type_index
-                if list_type == "Active"
-                else self.inactive_data_source_filter_type_index
-            )
+            # Type filtering (string-based from FilterState)
+            if not item_filtered and fs.mod_type != "all":
+                is_csharp = bool(metadata.get("csharp"))
+                if fs.mod_type == "csharp" and not is_csharp:
+                    item_filtered = True
+                elif fs.mod_type == "xml" and is_csharp:
+                    item_filtered = True
 
-            if type_filter_index == 1 and not metadata.get("csharp"):
-                item_filtered = True
-            elif type_filter_index == 2 and metadata.get("csharp"):
-                item_filtered = True
-
-            # User tag filtering
-            if tag_filter_enabled and tag_filter_active:
-                filters_active = True
-                tags = set(item_data["mod_tags"])
-
-                matches_selected_tags = bool(tags.intersection(selected_tags))
-                matches_no_tags = no_tags_selected and len(tags) == 0
-
+            # User tag filtering (from FilterState)
+            if not item_filtered and (fs.tags or fs.include_no_tags):
+                tags_set = set(item_data["mod_tags"])
+                matches_selected_tags = bool(tags_set.intersection(fs.tags))
+                matches_no_tags = fs.include_no_tags and len(tags_set) == 0
                 if not matches_selected_tags and not matches_no_tags:
                     item_filtered = True
 
@@ -5447,43 +5014,6 @@ class ModsPanel(QWidget):
             raise NotImplementedError(f"Unknown list type: {list_type}")
 
         self.signal_search_and_filters(list_type=list_type, pattern=pattern)
-
-    def signal_search_source_filter(self, list_type: str) -> None:
-        if list_type == "Active":
-            button = self.active_mods_filter_data_source_button
-            search = self.active_mods_search
-            source_index: int = self.active_mods_filter_data_source_index
-        elif list_type == "Inactive":
-            button = self.inactive_mods_filter_data_source_button
-            search = self.inactive_mods_search
-            source_index = self.inactive_mods_filter_data_source_index
-        else:
-            raise NotImplementedError(f"Unknown list type: {list_type}")
-        # Indexes by the icon
-        if source_index < (len(self.data_source_filter_icons) - 1):
-            source_index += 1
-        else:
-            source_index = 0
-        button.setIcon(self.data_source_filter_icons[source_index])
-        button.setToolTip(self.data_source_filter_tooltips[source_index])
-        if list_type == "Active":
-            self.active_mods_filter_data_source_index = source_index
-            self.active_mods_data_source_filter = SEARCH_DATA_SOURCE_FILTER_INDEXES[
-                source_index
-            ]
-        elif list_type == "Inactive":
-            self.inactive_mods_filter_data_source_index = source_index
-            self.inactive_mods_data_source_filter = SEARCH_DATA_SOURCE_FILTER_INDEXES[
-                source_index
-            ]
-        if source_index == 0:
-            filters_active = False
-        else:
-            filters_active = True
-        # Filter widgets by data source, while preserving any active search pattern
-        self.signal_search_and_filters(
-            list_type=list_type, pattern=search.text(), filters_active=filters_active
-        )
 
     def direct_update_count(
         self, list_type: str, filtered: int, unfiltered: int

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -892,15 +892,6 @@ This basically preserves your mod coloring, user notes etc. for this many second
             self.show_duplicate_mods_warning_checkbox
         )
 
-        # Mod type filter checkbox
-        self.mod_type_filter_checkbox = QCheckBox(self.tr("Enable mod type filter"))
-        self.mod_type_filter_checkbox.setToolTip(
-            self.tr(
-                "Add icons and filtering options for easy mods identification and grouping"
-            )
-        )
-        modlist_option_group_box_layout.addWidget(self.mod_type_filter_checkbox)
-
         # Hide invalid mod filtering checkbox
         self.hide_invalid_mods_when_filtering_checkbox = QCheckBox(
             self.tr("Hide invalid mods when filtering")

--- a/tests/models/test_filter_state.py
+++ b/tests/models/test_filter_state.py
@@ -1,0 +1,73 @@
+from app.models.filter_state import FilterState
+
+
+class TestFilterState:
+    def test_default_has_no_active_filters(self) -> None:
+        state = FilterState.default()
+        assert not state.has_active_filters()
+        assert state.active_category_count() == 0
+
+    def test_source_filter_active_when_subset(self) -> None:
+        state = FilterState(
+            sources={"workshop", "local"},
+            mod_type="all",
+            tags=set(),
+            include_no_tags=False,
+        )
+        assert state.has_active_filters()
+        assert state.active_category_count() == 1
+
+    def test_source_filter_inactive_when_all(self) -> None:
+        state = FilterState(
+            sources=set(FilterState.ALL_SOURCES),
+            mod_type="all",
+            tags=set(),
+            include_no_tags=False,
+        )
+        assert not state.has_active_filters()
+
+    def test_type_filter_active_when_not_all(self) -> None:
+        state = FilterState(
+            sources=set(FilterState.ALL_SOURCES),
+            mod_type="csharp",
+            tags=set(),
+            include_no_tags=False,
+        )
+        assert state.has_active_filters()
+        assert state.active_category_count() == 1
+
+    def test_tag_filter_active_when_tags_selected(self) -> None:
+        state = FilterState(
+            sources=set(FilterState.ALL_SOURCES),
+            mod_type="all",
+            tags={"Favorites"},
+            include_no_tags=False,
+        )
+        assert state.has_active_filters()
+        assert state.active_category_count() == 1
+
+    def test_tag_filter_active_when_no_tags_selected(self) -> None:
+        state = FilterState(
+            sources=set(FilterState.ALL_SOURCES),
+            mod_type="all",
+            tags=set(),
+            include_no_tags=True,
+        )
+        assert state.has_active_filters()
+        assert state.active_category_count() == 1
+
+    def test_multiple_categories_active(self) -> None:
+        state = FilterState(
+            sources={"workshop"},
+            mod_type="xml",
+            tags={"Cosmetic"},
+            include_no_tags=False,
+        )
+        assert state.active_category_count() == 3
+
+    def test_default_factory(self) -> None:
+        state = FilterState.default()
+        assert state.sources == FilterState.ALL_SOURCES
+        assert state.mod_type == "all"
+        assert state.tags == set()
+        assert state.include_no_tags is False

--- a/tests/utils/test_constants.py
+++ b/tests/utils/test_constants.py
@@ -5,7 +5,6 @@ from app.utils.constants import (
     KNOWN_TIER_ZERO_MODS,
     RIMWORLD_DLC_METADATA,
     RIMWORLD_PACKAGE_IDS,
-    SEARCH_DATA_SOURCE_FILTER_INDEXES,
     SortMethod,
 )
 
@@ -65,7 +64,3 @@ class TestMiscConstants:
 
     def test_default_missing_packageid(self) -> None:
         assert DEFAULT_MISSING_PACKAGEID == "missing.packageid"
-
-    def test_search_filter_indexes(self) -> None:
-        assert "all" in SEARCH_DATA_SOURCE_FILTER_INDEXES
-        assert "workshop" in SEARCH_DATA_SOURCE_FILTER_INDEXES

--- a/tests/views/test_filter_panel.py
+++ b/tests/views/test_filter_panel.py
@@ -1,0 +1,280 @@
+"""Tests for the filter panel components: TagChip, FilterPanel, FilterButton."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.models.filter_state import FilterState
+from app.views.filter_panel import FilterButton, FilterPanel, TagChip
+
+# ---------------------------------------------------------------------------
+# TagChip Tests
+# ---------------------------------------------------------------------------
+
+
+class TestTagChip:
+    """Tests for the TagChip clickable tag widget."""
+
+    @pytest.fixture
+    def chip(self, qtbot: Any) -> TagChip:
+        """Create a basic TagChip for testing."""
+        c = TagChip("Favorites")
+        qtbot.addWidget(c)
+        return c
+
+    @pytest.fixture
+    def no_tags_chip(self, qtbot: Any) -> TagChip:
+        """Create a 'no tags' TagChip for testing."""
+        c = TagChip("No tags", is_no_tags=True)
+        qtbot.addWidget(c)
+        return c
+
+    def test_initial_state_inactive(self, chip: TagChip) -> None:
+        """TagChip starts inactive by default."""
+        assert chip.active is False
+        assert chip.tag_name == "Favorites"
+        assert chip.is_no_tags is False
+
+    def test_click_toggles_active(self, chip: TagChip) -> None:
+        """Clicking a chip toggles it to active."""
+        chip.mousePressEvent(None)  # type: ignore[arg-type]
+        assert chip.active is True
+
+    def test_click_again_deactivates(self, chip: TagChip) -> None:
+        """Clicking an active chip deactivates it."""
+        chip.mousePressEvent(None)  # type: ignore[arg-type]
+        assert chip.active is True
+        chip.mousePressEvent(None)  # type: ignore[arg-type]
+        assert chip.active is False
+
+    def test_set_active_programmatic(self, chip: TagChip) -> None:
+        """set_active() changes state without requiring a click."""
+        chip.set_active(True)
+        assert chip.active is True
+        chip.set_active(False)
+        assert chip.active is False
+
+    def test_no_tags_chip_is_italic(self, no_tags_chip: TagChip) -> None:
+        """The 'no tags' chip uses italic text."""
+        assert no_tags_chip.is_no_tags is True
+        assert no_tags_chip._label.font().italic() is True
+
+    def test_label_shows_cross_when_active(self, chip: TagChip) -> None:
+        """Active chip label includes a dismiss cross mark."""
+        chip.set_active(True)
+        assert "✕" in chip._label.text()  # ✕
+
+    def test_label_no_cross_when_inactive(self, chip: TagChip) -> None:
+        """Inactive chip label has no cross mark."""
+        chip.set_active(False)
+        assert "✕" not in chip._label.text()
+        assert chip._label.text() == "Favorites"
+
+    def test_toggled_signal_emitted(self, chip: TagChip, qtbot: Any) -> None:
+        """The toggled signal is emitted when the chip is clicked."""
+        with qtbot.waitSignal(chip.toggled, timeout=1000):
+            chip.mousePressEvent(None)  # type: ignore[arg-type]
+
+    def test_dynamic_property_active(self, chip: TagChip) -> None:
+        """The 'active' dynamic property is updated on state change."""
+        assert chip.property("active") is False
+        chip.set_active(True)
+        assert chip.property("active") is True
+        chip.set_active(False)
+        assert chip.property("active") is False
+
+
+# ---------------------------------------------------------------------------
+# FilterPanel Tests
+# ---------------------------------------------------------------------------
+
+
+class TestFilterPanel:
+    """Tests for the FilterPanel popup widget."""
+
+    @pytest.fixture
+    def panel(self, qtbot: Any) -> FilterPanel:
+        """Create a FilterPanel for testing."""
+        p = FilterPanel()
+        qtbot.addWidget(p)
+        return p
+
+    def test_initial_state_no_filters(self, panel: FilterPanel) -> None:
+        """Panel starts with default filter state (no active filters)."""
+        state = panel.filter_state
+        assert state.sources == FilterState.ALL_SOURCES
+        assert state.mod_type == "all"
+        assert state.tags == set()
+        assert state.include_no_tags is False
+        assert state.has_active_filters() is False
+
+    def test_source_checkbox_unchecked_updates_state(self, panel: FilterPanel) -> None:
+        """Unchecking a source checkbox excludes it from the filter state."""
+        panel._source_checkboxes["workshop"].setChecked(False)
+        state = panel.filter_state
+        assert "workshop" not in state.sources
+        assert state.has_active_filters() is True
+
+    def test_type_radio_updates_state(self, panel: FilterPanel) -> None:
+        """Selecting a non-default type radio updates the filter state."""
+        panel._type_radios["csharp"].setChecked(True)
+        state = panel.filter_state
+        assert state.mod_type == "csharp"
+
+    def test_tag_chip_updates_state(self, panel: FilterPanel) -> None:
+        """Activating a tag chip adds it to the filter state tags."""
+        panel.set_available_tags(["Favorites", "QoL"])
+        panel._tag_chips["Favorites"].set_active(True)
+        state = panel.filter_state
+        assert "Favorites" in state.tags
+
+    def test_no_tags_chip(self, panel: FilterPanel) -> None:
+        """Activating the 'no tags' chip sets include_no_tags."""
+        panel._no_tags_chip.set_active(True)
+        state = panel.filter_state
+        assert state.include_no_tags is True
+
+    def test_clear_resets_all(self, panel: FilterPanel) -> None:
+        """clear() resets all filters to default state."""
+        # Engage some filters first
+        panel._source_checkboxes["local"].setChecked(False)
+        panel._type_radios["xml"].setChecked(True)
+        panel.set_available_tags(["QoL"])
+        panel._tag_chips["QoL"].set_active(True)
+        panel._no_tags_chip.set_active(True)
+
+        # Reset
+        panel.clear()
+
+        state = panel.filter_state
+        assert state.sources == FilterState.ALL_SOURCES
+        assert state.mod_type == "all"
+        assert state.tags == set()
+        assert state.include_no_tags is False
+
+    def test_filters_changed_signal_emitted(
+        self, panel: FilterPanel, qtbot: Any
+    ) -> None:
+        """filters_changed signal is emitted when a source checkbox changes."""
+        with qtbot.waitSignal(panel.filters_changed, timeout=1000):
+            panel._source_checkboxes["workshop"].setChecked(False)
+
+    def test_set_available_tags_creates_chips(self, panel: FilterPanel) -> None:
+        """set_available_tags creates tag chips for each provided tag."""
+        panel.set_available_tags(["Favorites", "Cosmetic", "QoL"])
+        assert "Favorites" in panel._tag_chips
+        assert "Cosmetic" in panel._tag_chips
+        assert "QoL" in panel._tag_chips
+        # "no tags" chip is always present
+        assert "__no_tags__" in panel._tag_chips
+
+    def test_set_available_tags_replaces_old_chips(self, panel: FilterPanel) -> None:
+        """Calling set_available_tags again replaces previous user tag chips."""
+        panel.set_available_tags(["Alpha", "Beta"])
+        assert "Alpha" in panel._tag_chips
+        assert "Beta" in panel._tag_chips
+
+        panel.set_available_tags(["Gamma"])
+        assert "Gamma" in panel._tag_chips
+        assert "Alpha" not in panel._tag_chips
+        assert "Beta" not in panel._tag_chips
+        # "no tags" chip survives
+        assert "__no_tags__" in panel._tag_chips
+
+    def test_select_all_tags(self, panel: FilterPanel) -> None:
+        """'Select All' activates all tag chips including 'no tags'."""
+        panel.set_available_tags(["Favorites", "QoL"])
+        panel._on_select_all_tags(None)  # type: ignore[arg-type]
+
+        for chip in panel._tag_chips.values():
+            assert chip.active is True
+
+    def test_select_none_tags(self, panel: FilterPanel) -> None:
+        """'None' deactivates all tag chips."""
+        panel.set_available_tags(["Favorites", "QoL"])
+        # Activate all first
+        for chip in panel._tag_chips.values():
+            chip.set_active(True)
+
+        panel._on_select_none_tags(None)  # type: ignore[arg-type]
+
+        for chip in panel._tag_chips.values():
+            assert chip.active is False
+
+    def test_clear_emits_filters_changed(self, panel: FilterPanel, qtbot: Any) -> None:
+        """clear() emits the filters_changed signal."""
+        with qtbot.waitSignal(panel.filters_changed, timeout=1000):
+            panel.clear()
+
+    def test_type_radio_mutual_exclusion(self, panel: FilterPanel) -> None:
+        """Only one type radio can be selected at a time."""
+        panel._type_radios["csharp"].setChecked(True)
+        assert panel._type_radios["all"].isChecked() is False
+        assert panel._type_radios["xml"].isChecked() is False
+
+        panel._type_radios["xml"].setChecked(True)
+        assert panel._type_radios["csharp"].isChecked() is False
+
+
+# ---------------------------------------------------------------------------
+# FilterButton Tests
+# ---------------------------------------------------------------------------
+
+
+class TestFilterButton:
+    """Tests for the FilterButton toolbar button with badge."""
+
+    @pytest.fixture
+    def button(self, qtbot: Any) -> FilterButton:
+        """Create a FilterButton for testing."""
+        btn = FilterButton()
+        qtbot.addWidget(btn)
+        return btn
+
+    def test_initial_badge_hidden(self, button: FilterButton) -> None:
+        """Badge is hidden when no filters are active."""
+        assert button._badge_label.isHidden() is True
+
+    def test_badge_shows_count(self, button: FilterButton) -> None:
+        """Badge shows the number of active filter categories."""
+        # Uncheck a source to activate the sources category
+        button.filter_panel._source_checkboxes["workshop"].setChecked(False)
+        assert button._badge_label.isHidden() is False
+        assert button._badge_label.text() == "1"
+
+    def test_badge_hides_when_cleared(self, button: FilterButton) -> None:
+        """Badge hides when all filters are cleared."""
+        button.filter_panel._source_checkboxes["workshop"].setChecked(False)
+        assert button._badge_label.isHidden() is False
+
+        button.filter_panel.clear()
+        assert button._badge_label.isHidden() is True
+
+    def test_badge_counts_categories_not_items(self, button: FilterButton) -> None:
+        """Badge counts active categories, not individual filter items."""
+        # Activate two sources category changes
+        button.filter_panel._source_checkboxes["workshop"].setChecked(False)
+        button.filter_panel._source_checkboxes["local"].setChecked(False)
+        # Both are source changes, so still only 1 category
+        assert button._badge_label.text() == "1"
+
+        # Now also change the type — adds a second category
+        button.filter_panel._type_radios["csharp"].setChecked(True)
+        assert button._badge_label.text() == "2"
+
+    def test_clicking_shows_panel(self, button: FilterButton, qtbot: Any) -> None:
+        """Clicking the button shows the filter panel."""
+        button.show()
+        button.resize(32, 32)
+        qtbot.addWidget(button.filter_panel)
+
+        # Use _show_panel directly to avoid popup grab issues in tests
+        button._show_panel()
+        assert button.filter_panel.isVisible() is True
+        button.filter_panel.hide()
+
+    def test_filter_panel_attribute(self, button: FilterButton) -> None:
+        """FilterButton exposes its filter panel as an attribute."""
+        assert isinstance(button.filter_panel, FilterPanel)


### PR DESCRIPTION
## Summary

Relates to #1738 — this PR provides the infrastructure to support additional filter types in the mods panel.

- Consolidates the scattered source cycling button, type cycling button, tag filter toggle, and tag filter selector into a single **Filter button** that opens a **popover panel**
- Source filter upgraded from single-select cycling to **multi-select checkboxes** (can now show Workshop + Local but not Expansion, etc.)
- Type filter changed from cycling button to **radio buttons** (All / C# / XML-only)
- Tag filter toggle removed — selecting tags = filtering active, no tags selected = no filtering
- Adds `FilterState` data model, `TagChip` widget, `FilterPanel` popup, and `FilterButton` with active filter count badge
- Refactors `signal_search_and_filters()` to read from `FilterState` instead of individual widget properties
- Replaces ~8 scattered filter reset sites in `MainContentPanel` with single `reset_all_filters_and_search()` method
- Removes `SEARCH_DATA_SOURCE_FILTER_INDEXES` constant and deprecates `settings.mod_type_filter`
- Net: **+1,079 / -660 lines** across 10 files

## Test plan

- [x] 793 tests passing (35 new for FilterState, TagChip, FilterPanel, FilterButton)
- [x] All quality gates pass (ruff, mypy, pyright, jscpd, shfmt, markdownlint)
- [x] Manual UI testing — app launches, filter panel opens, filters apply correctly
- [x] Verify filter panel behavior with large tag sets

🤖 Generated with help from [Claude Code](https://claude.com/claude-code)