### PR TITLE
fix: recursively search Assemblies directory for DLLs

### DIFF
--- a/app/utils/files.py
+++ b/app/utils/files.py
@@ -46,9 +46,9 @@ def subfolder_contains_candidate_path(
         candidate_path = subfolder_path / candidate_directory
         if candidate_path.exists() and candidate_path.is_dir():
             if case_sensitive:
-                return any(candidate_path.glob(glob_pattern))
+                return any(candidate_path.rglob(glob_pattern))
             else:
-                for file_path in candidate_path.glob(glob_pattern):
+                for file_path in candidate_path.rglob(glob_pattern):
                     if fnmatch.fnmatch(file_path.name.lower(), glob_pattern.lower()):
                         return True
         return False

--- a/app/utils/metadata.py
+++ b/app/utils/metadata.py
@@ -31,6 +31,7 @@ from app.utils.constants import (
 from app.utils.external_metadata_loaders import (
     ExternalMetadataLoader,
 )
+from app.utils.files import subfolder_contains_candidate_path
 from app.utils.generic import directories, scanpath
 from app.utils.schema import generate_rimworld_mods_list, validate_rimworld_mods_list
 from app.utils.steam.steamcmd.wrapper import SteamcmdInterface
@@ -1710,43 +1711,10 @@ class ModParser(QRunnable):
                             f"https://steamcommunity.com/sharedfiles/filedetails/?id={pfid}"
                         )
                     # If a mod contains C# assemblies, we want to tag the mod
-                    assemblies_path = str(directory_path / "Assemblies")
-                    # Check if the 'Assemblies' directory exists and is a directory
-                    if os.path.exists(assemblies_path) and os.path.isdir(
-                        assemblies_path
+                    if subfolder_contains_candidate_path(
+                        directory_path, "Assemblies", "*.dll"
                     ):
-                        try:
-                            # Check if there are any .dll files in the 'Assemblies' directory
-                            if any(
-                                filename.endswith((".dll", ".DLL"))
-                                for filename in os.listdir(assemblies_path)
-                            ):
-                                mod_metadata["csharp"] = (
-                                    True  # Tag the mod as containing C# code
-                                )
-                        except Exception as e:
-                            logger.error(
-                                f"Failed to list directory {assemblies_path}: {e}"
-                            )
-                    else:
-                        # If no 'Assemblies' directory in the main folder, check in subfolders
-                        subfolder_paths = [
-                            str(directory_path / folder)
-                            for folder in os.listdir(mod_directory)
-                            if os.path.isdir(str(directory_path / folder))
-                        ]
-                        for subfolder_path in subfolder_paths:
-                            assemblies_path = str(Path(subfolder_path) / "Assemblies")
-                            # Check if the 'Assemblies' directory exists in the subfolder
-                            if os.path.exists(assemblies_path):
-                                # Check if there are any .dll files in this 'Assemblies' directory
-                                if any(
-                                    filename.endswith((".dll", ".DLL"))
-                                    for filename in os.listdir(assemblies_path)
-                                ):
-                                    mod_metadata["csharp"] = (
-                                        True  # Tag the mod as containing C# code
-                                    )
+                        mod_metadata["csharp"] = True
                     # data_source will be used with setIcon later
                     mod_metadata["data_source"] = data_source
                     mod_metadata["folder"] = directory_name

--- a/tests/utils/test_files.py
+++ b/tests/utils/test_files.py
@@ -47,6 +47,23 @@ class TestSubfolderContainsCandidatePath:
             subfolder_contains_candidate_path(tmp_path, "Assemblies", "*.dll") is True
         )
 
+    def test_finds_dll_nested_inside_assemblies(self, tmp_path: Path) -> None:
+        candidate = tmp_path / "Assemblies" / "net472"
+        candidate.mkdir(parents=True)
+        (candidate / "mod.dll").write_text("dll")
+        assert (
+            subfolder_contains_candidate_path(tmp_path, "Assemblies", "*.dll") is True
+        )
+
+    def test_empty_root_assemblies_finds_dll_in_subfolder(self, tmp_path: Path) -> None:
+        (tmp_path / "Assemblies").mkdir()
+        sub = tmp_path / "1.5" / "Assemblies"
+        sub.mkdir(parents=True)
+        (sub / "mod.dll").write_text("dll")
+        assert (
+            subfolder_contains_candidate_path(tmp_path, "Assemblies", "*.dll") is True
+        )
+
 
 class TestCleanupOldBackups:
     def _create_backups(self, backup_dir: Path, count: int) -> list[Path]:


### PR DESCRIPTION
## Summary
- Fixes mods with DLLs nested inside subdirectories of `Assemblies/` (e.g. `Assemblies/net472/Mod.dll`) or with an empty root `Assemblies/` folder being incorrectly classified as XML-only
- Changed `glob` → `rglob` in `subfolder_contains_candidate_path` for recursive search
- Replaced the ~30-line inline C# detection block in `metadata.py` with the shared `subfolder_contains_candidate_path` helper (which already handles subfolder iteration correctly)

## Test plan
- [x] Added test for DLLs nested inside subdirectories of Assemblies (`Assemblies/net472/mod.dll`)
- [x] Added test for empty root `Assemblies/` with DLLs in versioned subfolder (`1.5/Assemblies/mod.dll`)
- [x] All existing tests pass
- [x] Manual verification with a mod like SlaveBar that has an empty root Assemblies folder

Closes #1070