### PR TITLE
feat: dynamic path autodetection for all platforms (#64 & #2026)

### DIFF
--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -83,6 +83,8 @@ class SettingsController(QObject):
 
         self._http_download_worker: HttpDownloadWorker | None = None
 
+        self._detected_steam_root: Path | None = None
+
         # Initialize the settings dialog from the settings model
 
         self._update_view_from_model()
@@ -2068,7 +2070,7 @@ class SettingsController(QObject):
         ]
 
         steam_root = self._find_steam_root(candidates)
-        self._detected_steam_root: Path | None = steam_root
+        self._detected_steam_root = steam_root
 
         if steam_root:
             game_folder_str = find_steam_rimworld(steam_root)

--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -1874,6 +1874,32 @@ class SettingsController(QObject):
         self.settings_dialog.steam_mods_folder_location.setText("")
         self.settings_dialog.local_mods_folder_location.setText("")
 
+    @staticmethod
+    def _find_steam_root(candidates: list[Path]) -> Path | None:
+        """
+        Find the Steam installation root from a prioritized list of candidate paths.
+
+        A candidate is valid if it exists as a directory and contains either
+        a ``steamapps/`` directory or ``config/libraryfolders.vdf``.
+
+        :param candidates: Ordered list of candidate Steam root paths
+        :return: First valid Steam root, or None if no candidate matches
+        """
+        for candidate in candidates:
+            if not candidate.is_dir():
+                logger.debug(f"Steam root candidate does not exist: {candidate}")
+                continue
+            has_steamapps = (candidate / "steamapps").is_dir()
+            has_vdf = (candidate / "config" / "libraryfolders.vdf").is_file()
+            if has_steamapps or has_vdf:
+                logger.info(f"Found Steam root: {candidate}")
+                return candidate
+            logger.debug(
+                f"Steam root candidate exists but has no steamapps/ or config/libraryfolders.vdf: {candidate}"
+            )
+        logger.warning("No valid Steam root found from any candidate path")
+        return None
+
     @Slot()
     def _on_locations_autodetect_button_clicked(self) -> None:
         """

--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -1964,20 +1964,66 @@ class SettingsController(QObject):
 
     def __get_darwin_paths(self) -> tuple[Path, Path, Path]:
         """
-        Get the default paths for macOS.
+        Get paths for macOS. Uses VDF parsing to locate RimWorld in non-default
+        Steam library folders, with hardcoded fallback.
 
-        Returns:
-            tuple[Path, Path, Path]: game_folder, config_folder, steam_mods_folder
+        :return: (game_folder, config_folder, steam_mods_folder)
         """
         user_home = Path.home()
-        game_folder = Path(
-            f"/{user_home}/Library/Application Support/Steam/steamapps/common/Rimworld/RimworldMac.app"
-        )
-        config_folder = Path(
-            f"/{user_home}/Library/Application Support/Rimworld/Config"
-        )
-        steam_mods_folder = Path(
-            f"/{user_home}/Library/Application Support/Steam/steamapps/workshop/content/294100"
+        candidates = [
+            user_home / "Library" / "Application Support" / "Steam",
+        ]
+
+        steam_root = self._find_steam_root(candidates)
+
+        if steam_root:
+            game_folder_str = find_steam_rimworld(steam_root)
+            if game_folder_str:
+                game_folder = Path(game_folder_str) / "RimworldMac.app"
+                logger.debug(f"VDF parsing found RimWorld at: {game_folder}")
+            else:
+                game_folder = (
+                    steam_root / "steamapps" / "common" / "Rimworld" / "RimworldMac.app"
+                )
+                logger.debug(
+                    f"VDF parsing did not find RimWorld, using fallback: {game_folder}"
+                )
+
+            steam_mods_folder_str = get_path_up_to_string(
+                game_folder.parent, "common", exclude=True
+            )
+            if steam_mods_folder_str == "":
+                steam_mods_folder: Path = (
+                    steam_root / "steamapps" / "workshop" / "content" / "294100"
+                )
+            else:
+                steam_mods_folder = (
+                    Path(steam_mods_folder_str) / "workshop" / "content" / "294100"
+                )
+        else:
+            game_folder = (
+                user_home
+                / "Library"
+                / "Application Support"
+                / "Steam"
+                / "steamapps"
+                / "common"
+                / "Rimworld"
+                / "RimworldMac.app"
+            )
+            steam_mods_folder = (
+                user_home
+                / "Library"
+                / "Application Support"
+                / "Steam"
+                / "steamapps"
+                / "workshop"
+                / "content"
+                / "294100"
+            )
+
+        config_folder = (
+            user_home / "Library" / "Application Support" / "Rimworld" / "Config"
         )
 
         return game_folder, config_folder, steam_mods_folder

--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -1991,6 +1991,7 @@ class SettingsController(QObject):
         ]
 
         steam_root = self._find_steam_root(candidates)
+        self._detected_steam_root = steam_root
 
         if steam_root:
             game_folder_str = find_steam_rimworld(steam_root)

--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -1915,6 +1915,20 @@ class SettingsController(QObject):
         elif SystemInfo().operating_system == SystemInfo.OperatingSystem.LINUX:
             os_paths = self.__get_linux_paths()
             logger.info(f"Running on Linux with the following paths: {os_paths}")
+            if (
+                self._detected_steam_root is not None
+                and "snap" in self._detected_steam_root.parts
+            ):
+                show_warning(
+                    title="Unsupported Steam installation",
+                    text="Snap-based Steam installation detected.",
+                    information=(
+                        "Steam installed via Snap is not officially supported and may cause issues. "
+                        "We recommend installing Steam via your distribution's native package manager "
+                        "or Flatpak instead.\n\n"
+                        "Autodetection will continue, but some paths may not work correctly."
+                    ),
+                )
         elif sys.platform == "win32":
             os_paths = self.__get_windows_paths()
             logger.info(f"Running on Windows with the following paths: {os_paths}")

--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -1913,7 +1913,7 @@ class SettingsController(QObject):
             os_paths = self.__get_darwin_paths()
             logger.info(f"Running on MacOS with the following paths: {os_paths}")
         elif SystemInfo().operating_system == SystemInfo.OperatingSystem.LINUX:
-            os_paths = self.__get_debian_paths()
+            os_paths = self.__get_linux_paths()
             logger.info(f"Running on Linux with the following paths: {os_paths}")
         elif sys.platform == "win32":
             os_paths = self.__get_windows_paths()
@@ -1982,24 +1982,102 @@ class SettingsController(QObject):
 
         return game_folder, config_folder, steam_mods_folder
 
-    def __get_debian_paths(self) -> tuple[Path, Path, Path]:
+    def __get_linux_paths(self) -> tuple[Path, Path, Path]:
         """
-        Get the default paths for Debian-based Linux distributions.
+        Get paths for Linux by discovering the Steam root across distribution methods.
 
-        Returns:
-            tuple[Path, Path, Path]: game_folder, config_folder, steam_mods_folder
+        Checks Debian, native, Flatpak, and Snap Steam installations in priority
+        order. Uses VDF parsing to locate RimWorld in non-default library folders.
+        Detects Proton prefix for config folder.
+
+        :return: (game_folder, config_folder, steam_mods_folder)
         """
         user_home = Path.home()
-        debian_path = user_home / ".steam/debian-installation"
-        if not debian_path.exists():
-            steam_path = user_home / ".steam/steam"
-            debian_path = steam_path / "steamapps/common/RimWorld"
-        game_folder = debian_path / "steamapps/common/RimWorld"
-        config_folder = (
+        candidates = [
+            user_home / ".steam" / "debian-installation",
+            user_home / ".steam" / "steam",
+            user_home / ".local" / "share" / "Steam",
             user_home
-            / ".config/unity3d/Ludeon Studios/RimWorld by Ludeon Studios/Config"
+            / ".var"
+            / "app"
+            / "com.valvesoftware.Steam"
+            / ".local"
+            / "share"
+            / "Steam",
+            user_home / "snap" / "steam" / "common" / ".local" / "share" / "Steam",
+        ]
+
+        steam_root = self._find_steam_root(candidates)
+        self._detected_steam_root: Path | None = steam_root
+
+        if steam_root:
+            game_folder_str = find_steam_rimworld(steam_root)
+            if game_folder_str:
+                game_folder = Path(game_folder_str)
+                logger.debug(f"VDF parsing found RimWorld at: {game_folder}")
+            else:
+                game_folder = steam_root / "steamapps" / "common" / "RimWorld"
+                logger.debug(
+                    f"VDF parsing did not find RimWorld, using fallback: {game_folder}"
+                )
+
+            steam_mods_folder_str = get_path_up_to_string(
+                game_folder, "common", exclude=True
+            )
+            if steam_mods_folder_str == "":
+                steam_mods_folder = (
+                    steam_root / "steamapps" / "workshop" / "content" / "294100"
+                )
+            else:
+                steam_mods_folder = (
+                    Path(steam_mods_folder_str) / "workshop" / "content" / "294100"
+                )
+        else:
+            game_folder = (
+                user_home / ".steam" / "steam" / "steamapps" / "common" / "RimWorld"
+            )
+            steam_mods_folder = (
+                user_home
+                / ".steam"
+                / "steam"
+                / "steamapps"
+                / "workshop"
+                / "content"
+                / "294100"
+            )
+
+        # Config folder: check Proton prefix first, then native
+        native_config = (
+            user_home
+            / ".config"
+            / "unity3d"
+            / "Ludeon Studios"
+            / "RimWorld by Ludeon Studios"
+            / "Config"
         )
-        steam_mods_folder = debian_path / "steamapps/workshop/content/294100"
+        if steam_root:
+            proton_config = (
+                steam_root
+                / "steamapps"
+                / "compatdata"
+                / "294100"
+                / "pfx"
+                / "drive_c"
+                / "users"
+                / "steamuser"
+                / "AppData"
+                / "LocalLow"
+                / "Ludeon Studios"
+                / "RimWorld by Ludeon Studios"
+                / "Config"
+            )
+            if proton_config.exists():
+                logger.info(f"Proton prefix detected for config: {proton_config}")
+                config_folder = proton_config
+            else:
+                config_folder = native_config
+        else:
+            config_folder = native_config
 
         return game_folder, config_folder, steam_mods_folder
 

--- a/app/utils/generic.py
+++ b/app/utils/generic.py
@@ -699,12 +699,20 @@ def find_steam_rimworld(steam_folder: Path | str) -> str:
 
     if os.path.exists(steam_folder / primary_library):
         logger.debug(f"Attempting to get RimWorld path from {primary_library}")
-        with open(steam_folder / primary_library, "r") as f:
-            rimworld_path = __load_data(f)
+        try:
+            with open(steam_folder / primary_library, "r") as f:
+                rimworld_path = __load_data(f)
+        except Exception:
+            logger.warning(f"Failed to parse {primary_library}", exc_info=True)
+            return rimworld_path
     elif os.path.exists(steam_folder / backup_library):
         logger.debug(f"Attempting to get RimWorld path from {backup_library}")
-        with open(steam_folder / backup_library, "r") as f:
-            rimworld_path = __load_data(f)
+        try:
+            with open(steam_folder / backup_library, "r") as f:
+                rimworld_path = __load_data(f)
+        except Exception:
+            logger.warning(f"Failed to parse {backup_library}", exc_info=True)
+            return rimworld_path
     else:
         logger.warning("Failed retrieving RimWorld path from libraryfolders.vdf")
         return rimworld_path

--- a/tests/controllers/test_path_autodetection.py
+++ b/tests/controllers/test_path_autodetection.py
@@ -4,6 +4,11 @@ from unittest.mock import patch
 from app.controllers.settings_controller import SettingsController
 
 
+def _vdf_escape(path: Path) -> str:
+    """Escape backslashes for VDF format (matches real Steam VDF files on Windows)."""
+    return str(path).replace("\\", "\\\\")
+
+
 def _setup_steam_root(tmp_path: Path, subdir: str) -> Path:
     """Create a fake Steam root with steamapps dir at the given subdir under tmp_path."""
     steam_root = tmp_path / subdir
@@ -141,7 +146,7 @@ class TestGetLinuxPaths:
 
         vdf_dir = steam_root / "config"
         vdf_dir.mkdir(parents=True)
-        vdf_content = f'"libraryfolders"\n{{\n    "0"\n    {{\n        "path"    "{steam_root}"\n        "apps"\n        {{\n        }}\n    }}\n    "1"\n    {{\n        "path"    "{secondary_lib}"\n        "apps"\n        {{\n            "294100"    "1234567890"\n        }}\n    }}\n}}\n'
+        vdf_content = f'"libraryfolders"\n{{\n    "0"\n    {{\n        "path"    "{_vdf_escape(steam_root)}"\n        "apps"\n        {{\n        }}\n    }}\n    "1"\n    {{\n        "path"    "{_vdf_escape(secondary_lib)}"\n        "apps"\n        {{\n            "294100"    "1234567890"\n        }}\n    }}\n}}\n'
         (vdf_dir / "libraryfolders.vdf").write_text(vdf_content)
 
         with patch("pathlib.Path.home", return_value=tmp_path):
@@ -240,7 +245,7 @@ class TestGetDarwinPaths:
         )
         vdf_dir = steam_root / "config"
         vdf_dir.mkdir(parents=True)
-        vdf_content = f'"libraryfolders"\n{{\n    "0"\n    {{\n        "path"    "{steam_root}"\n        "apps"\n        {{\n            "294100"    "1234567890"\n        }}\n    }}\n}}\n'
+        vdf_content = f'"libraryfolders"\n{{\n    "0"\n    {{\n        "path"    "{_vdf_escape(steam_root)}"\n        "apps"\n        {{\n            "294100"    "1234567890"\n        }}\n    }}\n}}\n'
         (vdf_dir / "libraryfolders.vdf").write_text(vdf_content)
 
         with patch("pathlib.Path.home", return_value=tmp_path):
@@ -281,7 +286,7 @@ class TestGetDarwinPaths:
         with patch("pathlib.Path.home", return_value=tmp_path):
             result = self._call(_make_controller())
 
-        assert str(result[2]).endswith("workshop/content/294100")
+        assert result[2].parts[-3:] == ("workshop", "content", "294100")
 
     def test_no_steam_root_returns_hardcoded_paths(self, tmp_path: Path) -> None:
         with patch("pathlib.Path.home", return_value=tmp_path):
@@ -355,7 +360,7 @@ class TestVdfEdgeCases:
             "{\n"
             '    "0"\n'
             "    {\n"
-            f'        "path"    "{steam_root}"\n'
+            f'        "path"    "{_vdf_escape(steam_root)}"\n'
             '        "apps"\n'
             "        {\n"
             '            "730"    "12345"\n'

--- a/tests/controllers/test_path_autodetection.py
+++ b/tests/controllers/test_path_autodetection.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+
+from app.controllers.settings_controller import SettingsController
+
+
+class TestFindSteamRoot:
+    """Tests for SettingsController._find_steam_root()."""
+
+    def test_returns_first_valid_candidate_with_steamapps(self, tmp_path: Path) -> None:
+        candidate = tmp_path / ".steam" / "steam"
+        candidate.mkdir(parents=True)
+        (candidate / "steamapps").mkdir()
+
+        result = SettingsController._find_steam_root([candidate])
+        assert result == candidate
+
+    def test_returns_first_valid_candidate_with_vdf(self, tmp_path: Path) -> None:
+        candidate = tmp_path / ".steam" / "steam"
+        (candidate / "config").mkdir(parents=True)
+        (candidate / "config" / "libraryfolders.vdf").touch()
+
+        result = SettingsController._find_steam_root([candidate])
+        assert result == candidate
+
+    def test_skips_nonexistent_candidates(self, tmp_path: Path) -> None:
+        nonexistent = tmp_path / "does_not_exist"
+        valid = tmp_path / "valid_steam"
+        valid.mkdir()
+        (valid / "steamapps").mkdir()
+
+        result = SettingsController._find_steam_root([nonexistent, valid])
+        assert result == valid
+
+    def test_skips_candidates_without_steamapps_or_vdf(self, tmp_path: Path) -> None:
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+
+        result = SettingsController._find_steam_root([empty_dir])
+        assert result is None
+
+    def test_returns_none_when_no_candidates_match(self, tmp_path: Path) -> None:
+        result = SettingsController._find_steam_root([tmp_path / "a", tmp_path / "b"])
+        assert result is None
+
+    def test_respects_priority_order(self, tmp_path: Path) -> None:
+        first = tmp_path / "first"
+        first.mkdir()
+        (first / "steamapps").mkdir()
+
+        second = tmp_path / "second"
+        second.mkdir()
+        (second / "steamapps").mkdir()
+
+        result = SettingsController._find_steam_root([first, second])
+        assert result == first
+
+    def test_returns_none_for_empty_list(self) -> None:
+        result = SettingsController._find_steam_root([])
+        assert result is None

--- a/tests/controllers/test_path_autodetection.py
+++ b/tests/controllers/test_path_autodetection.py
@@ -1,6 +1,25 @@
 from pathlib import Path
+from unittest.mock import patch
 
 from app.controllers.settings_controller import SettingsController
+
+
+def _setup_steam_root(tmp_path: Path, subdir: str) -> Path:
+    """Create a fake Steam root with steamapps dir at the given subdir under tmp_path."""
+    steam_root = tmp_path / subdir
+    steam_root.mkdir(parents=True)
+    (steam_root / "steamapps" / "common" / "RimWorld").mkdir(parents=True)
+    (steam_root / "steamapps" / "workshop" / "content" / "294100").mkdir(parents=True)
+    return steam_root
+
+
+def _make_controller() -> SettingsController:
+    """Create a SettingsController without __init__ (which requires Qt widgets).
+
+    Safe because the path detection methods only use Path.home(), static
+    methods, and module-level utility functions — no instance attributes.
+    """
+    return SettingsController.__new__(SettingsController)
 
 
 class TestFindSteamRoot:
@@ -57,3 +76,135 @@ class TestFindSteamRoot:
     def test_returns_none_for_empty_list(self) -> None:
         result = SettingsController._find_steam_root([])
         assert result is None
+
+
+class TestGetLinuxPaths:
+    """Tests for SettingsController.__get_linux_paths() via the name-mangled accessor."""
+
+    def _call(self, controller: SettingsController) -> tuple[Path, Path, Path]:
+        return controller._SettingsController__get_linux_paths()  # type: ignore[attr-defined]
+
+    def test_debian_installation_path(self, tmp_path: Path) -> None:
+        steam_root = _setup_steam_root(tmp_path, ".steam/debian-installation")
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            result = self._call(_make_controller())
+
+        assert result[0] == steam_root / "steamapps" / "common" / "RimWorld"
+        assert result[2] == steam_root / "steamapps" / "workshop" / "content" / "294100"
+
+    def test_native_steam_path(self, tmp_path: Path) -> None:
+        steam_root = _setup_steam_root(tmp_path, ".steam/steam")
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            result = self._call(_make_controller())
+
+        assert result[0] == steam_root / "steamapps" / "common" / "RimWorld"
+
+    def test_local_share_path(self, tmp_path: Path) -> None:
+        steam_root = _setup_steam_root(tmp_path, ".local/share/Steam")
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            result = self._call(_make_controller())
+
+        assert result[0] == steam_root / "steamapps" / "common" / "RimWorld"
+
+    def test_flatpak_path(self, tmp_path: Path) -> None:
+        steam_root = _setup_steam_root(
+            tmp_path,
+            ".var/app/com.valvesoftware.Steam/.local/share/Steam",
+        )
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            result = self._call(_make_controller())
+
+        assert result[0] == steam_root / "steamapps" / "common" / "RimWorld"
+
+    def test_snap_path(self, tmp_path: Path) -> None:
+        steam_root = _setup_steam_root(tmp_path, "snap/steam/common/.local/share/Steam")
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            result = self._call(_make_controller())
+
+        assert result[0] == steam_root / "steamapps" / "common" / "RimWorld"
+
+    def test_vdf_finds_rimworld_in_secondary_library(self, tmp_path: Path) -> None:
+        steam_root = tmp_path / ".steam" / "steam"
+        steam_root.mkdir(parents=True)
+        (steam_root / "steamapps").mkdir()
+
+        secondary_lib = tmp_path / "games" / "SteamLibrary"
+        (secondary_lib / "steamapps" / "common" / "RimWorld").mkdir(parents=True)
+        (secondary_lib / "steamapps" / "workshop" / "content" / "294100").mkdir(
+            parents=True
+        )
+
+        vdf_dir = steam_root / "config"
+        vdf_dir.mkdir(parents=True)
+        vdf_content = f'"libraryfolders"\n{{\n    "0"\n    {{\n        "path"    "{steam_root}"\n        "apps"\n        {{\n        }}\n    }}\n    "1"\n    {{\n        "path"    "{secondary_lib}"\n        "apps"\n        {{\n            "294100"    "1234567890"\n        }}\n    }}\n}}\n'
+        (vdf_dir / "libraryfolders.vdf").write_text(vdf_content)
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            result = self._call(_make_controller())
+
+        assert result[0] == secondary_lib / "steamapps" / "common" / "RimWorld"
+        assert (
+            result[2] == secondary_lib / "steamapps" / "workshop" / "content" / "294100"
+        )
+
+    def test_proton_config_takes_priority(self, tmp_path: Path) -> None:
+        steam_root = _setup_steam_root(tmp_path, ".steam/steam")
+        proton_config = (
+            steam_root
+            / "steamapps"
+            / "compatdata"
+            / "294100"
+            / "pfx"
+            / "drive_c"
+            / "users"
+            / "steamuser"
+            / "AppData"
+            / "LocalLow"
+            / "Ludeon Studios"
+            / "RimWorld by Ludeon Studios"
+            / "Config"
+        )
+        proton_config.mkdir(parents=True)
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            result = self._call(_make_controller())
+
+        assert result[1] == proton_config
+
+    def test_native_config_when_no_proton(self, tmp_path: Path) -> None:
+        _setup_steam_root(tmp_path, ".steam/steam")
+        native_config = (
+            tmp_path
+            / ".config"
+            / "unity3d"
+            / "Ludeon Studios"
+            / "RimWorld by Ludeon Studios"
+            / "Config"
+        )
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            result = self._call(_make_controller())
+
+        assert result[1] == native_config
+
+    def test_no_steam_root_returns_fallback_paths(self, tmp_path: Path) -> None:
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            result = self._call(_make_controller())
+
+        assert "steamapps" in str(result[0])
+        assert "Config" in str(result[1])
+        assert "294100" in str(result[2])
+
+    def test_priority_debian_over_native(self, tmp_path: Path) -> None:
+        debian_root = _setup_steam_root(tmp_path, ".steam/debian-installation")
+        _setup_steam_root(tmp_path, ".steam/steam")
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            result = self._call(_make_controller())
+
+        assert result[0] == debian_root / "steamapps" / "common" / "RimWorld"

--- a/tests/controllers/test_path_autodetection.py
+++ b/tests/controllers/test_path_autodetection.py
@@ -322,3 +322,50 @@ class TestSnapWarning:
             controller._SettingsController__get_linux_paths()  # type: ignore[attr-defined]
 
         assert controller._detected_steam_root is None
+
+
+class TestVdfEdgeCases:
+    """Tests for VDF parsing edge cases in path autodetection."""
+
+    def _call_linux(self, controller: SettingsController) -> tuple[Path, Path, Path]:
+        return controller._SettingsController__get_linux_paths()  # type: ignore[attr-defined]
+
+    def test_malformed_vdf_falls_back_to_default(self, tmp_path: Path) -> None:
+        steam_root = tmp_path / ".steam" / "steam"
+        steam_root.mkdir(parents=True)
+        (steam_root / "steamapps").mkdir()
+        vdf_dir = steam_root / "config"
+        vdf_dir.mkdir()
+        (vdf_dir / "libraryfolders.vdf").write_text("this is not valid vdf {{{")
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            result = self._call_linux(_make_controller())
+
+        assert result[0] == steam_root / "steamapps" / "common" / "RimWorld"
+        assert result[2] == steam_root / "steamapps" / "workshop" / "content" / "294100"
+
+    def test_vdf_without_rimworld_falls_back(self, tmp_path: Path) -> None:
+        steam_root = tmp_path / ".steam" / "steam"
+        steam_root.mkdir(parents=True)
+        (steam_root / "steamapps").mkdir()
+        vdf_dir = steam_root / "config"
+        vdf_dir.mkdir()
+        vdf_content = (
+            '"libraryfolders"\n'
+            "{\n"
+            '    "0"\n'
+            "    {\n"
+            f'        "path"    "{steam_root}"\n'
+            '        "apps"\n'
+            "        {\n"
+            '            "730"    "12345"\n'
+            "        }\n"
+            "    }\n"
+            "}\n"
+        )
+        (vdf_dir / "libraryfolders.vdf").write_text(vdf_content)
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            result = self._call_linux(_make_controller())
+
+        assert result[0] == steam_root / "steamapps" / "common" / "RimWorld"

--- a/tests/controllers/test_path_autodetection.py
+++ b/tests/controllers/test_path_autodetection.py
@@ -208,3 +208,85 @@ class TestGetLinuxPaths:
             result = self._call(_make_controller())
 
         assert result[0] == debian_root / "steamapps" / "common" / "RimWorld"
+
+
+class TestGetDarwinPaths:
+    """Tests for SettingsController.__get_darwin_paths().
+
+    Note: macOS uses "Rimworld" (lowercase w) in hardcoded fallback paths,
+    while VDF parsing returns "RimWorld" (capital W). This is fine because
+    macOS has a case-insensitive filesystem by default. Tests assert the
+    exact casing each code path produces.
+    """
+
+    def _call(self, controller: SettingsController) -> tuple[Path, Path, Path]:
+        return controller._SettingsController__get_darwin_paths()  # type: ignore[attr-defined]
+
+    @staticmethod
+    def _make_darwin_steam_root(tmp_path: Path) -> Path:
+        """Create a minimal macOS Steam root directory tree."""
+        steam_root = tmp_path / "Library" / "Application Support" / "Steam"
+        steam_root.mkdir(parents=True)
+        (steam_root / "steamapps").mkdir()
+        return steam_root
+
+    def test_vdf_based_detection(self, tmp_path: Path) -> None:
+        steam_root = self._make_darwin_steam_root(tmp_path)
+        (steam_root / "steamapps" / "common" / "RimWorld" / "RimworldMac.app").mkdir(
+            parents=True
+        )
+        (steam_root / "steamapps" / "workshop" / "content" / "294100").mkdir(
+            parents=True
+        )
+        vdf_dir = steam_root / "config"
+        vdf_dir.mkdir(parents=True)
+        vdf_content = f'"libraryfolders"\n{{\n    "0"\n    {{\n        "path"    "{steam_root}"\n        "apps"\n        {{\n            "294100"    "1234567890"\n        }}\n    }}\n}}\n'
+        (vdf_dir / "libraryfolders.vdf").write_text(vdf_content)
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            result = self._call(_make_controller())
+
+        # VDF returns "RimWorld" (capital W)
+        assert (
+            result[0]
+            == steam_root / "steamapps" / "common" / "RimWorld" / "RimworldMac.app"
+        )
+
+    def test_fallback_when_no_vdf(self, tmp_path: Path) -> None:
+        steam_root = self._make_darwin_steam_root(tmp_path)
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            result = self._call(_make_controller())
+
+        # Fallback uses "Rimworld" (lowercase w) — matches existing behavior
+        expected_game = (
+            steam_root / "steamapps" / "common" / "Rimworld" / "RimworldMac.app"
+        )
+        assert result[0] == expected_game
+
+    def test_config_folder_unchanged(self, tmp_path: Path) -> None:
+        self._make_darwin_steam_root(tmp_path)
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            result = self._call(_make_controller())
+
+        expected_config = (
+            tmp_path / "Library" / "Application Support" / "Rimworld" / "Config"
+        )
+        assert result[1] == expected_config
+
+    def test_workshop_folder_derived_from_game(self, tmp_path: Path) -> None:
+        self._make_darwin_steam_root(tmp_path)
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            result = self._call(_make_controller())
+
+        assert str(result[2]).endswith("workshop/content/294100")
+
+    def test_no_steam_root_returns_hardcoded_paths(self, tmp_path: Path) -> None:
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            result = self._call(_make_controller())
+
+        assert "RimworldMac.app" in str(result[0])
+        assert "Config" in str(result[1])
+        assert "294100" in str(result[2])

--- a/tests/controllers/test_path_autodetection.py
+++ b/tests/controllers/test_path_autodetection.py
@@ -290,3 +290,35 @@ class TestGetDarwinPaths:
         assert "RimworldMac.app" in str(result[0])
         assert "Config" in str(result[1])
         assert "294100" in str(result[2])
+
+
+class TestSnapWarning:
+    """Tests for Snap detection via _detected_steam_root."""
+
+    def test_snap_steam_root_detected(self, tmp_path: Path) -> None:
+        _setup_steam_root(tmp_path, "snap/steam/common/.local/share/Steam")
+        controller = _make_controller()
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            controller._SettingsController__get_linux_paths()  # type: ignore[attr-defined]
+
+        assert controller._detected_steam_root is not None
+        assert "snap" in controller._detected_steam_root.parts
+
+    def test_native_steam_root_not_flagged(self, tmp_path: Path) -> None:
+        _setup_steam_root(tmp_path, ".steam/steam")
+        controller = _make_controller()
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            controller._SettingsController__get_linux_paths()  # type: ignore[attr-defined]
+
+        assert controller._detected_steam_root is not None
+        assert "snap" not in controller._detected_steam_root.parts
+
+    def test_no_steam_root_not_flagged(self, tmp_path: Path) -> None:
+        controller = _make_controller()
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            controller._SettingsController__get_linux_paths()  # type: ignore[attr-defined]
+
+        assert controller._detected_steam_root is None


### PR DESCRIPTION
## Summary

- **Fixes the double-path bug** in Linux autodetection where the fallback produced `~/.steam/steam/steamapps/common/RimWorld/steamapps/common/RimWorld`
- **Adds dynamic Steam root discovery** via `_find_steam_root()` that checks candidate paths for `steamapps/` or `config/libraryfolders.vdf` — supports Debian, native (`~/.steam/steam`, `~/.local/share/Steam`), Flatpak, and Snap Steam installations
- **Uses VDF parsing on Linux and macOS** (via existing `find_steam_rimworld()`) to find RimWorld in non-default Steam library folders, matching the approach Windows already uses
- **Detects Proton config prefix** on Linux — checks `compatdata/294100/pfx/...` before the native `~/.config/unity3d/...` path
- **Warns on Snap Steam** — advisory, non-blocking dialog recommending native or Flatpak installation
- **Hardens VDF parsing** — `find_steam_rimworld()` now catches malformed `libraryfolders.vdf` instead of crashing
- **Fixes Windows CI test failures** — VDF test content now properly escapes backslashes (matching real Steam VDF format), preventing the `vdf` library's `_unescape()` from corrupting paths containing `\r` or `\t` sequences

Closes #64 and #2026

## Changes

| File | What changed |
|------|-------------|
| `app/controllers/settings_controller.py` | New `_find_steam_root()` static method; `__get_debian_paths()` → `__get_linux_paths()` with 5 candidate paths + VDF + Proton; `__get_darwin_paths()` enhanced with VDF; Snap warning in caller |
| `app/utils/generic.py` | `find_steam_rimworld()` wrapped in try/except for malformed VDF |
| `tests/controllers/test_path_autodetection.py` | 27 new tests covering all platforms, VDF edge cases, Proton, Snap detection; VDF content uses proper backslash escaping for cross-platform correctness |

## Test plan

- [x] 27 new tests added (785 total, all passing)
- [x] All quality gates pass (ruff, ruff-format, mypy, pyright, jscpd, shfmt, markdownlint)
- [x] Windows CI — VDF backslash escaping fixed
- [ ] Manual testing on Linux with native Steam
- [ ] Manual testing on Linux with Flatpak Steam
- [x] Manual testing on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)