### PR TITLE
fix: sync mediator paths before metadata refresh

### DIFF
--- a/app/controllers/metadata_controller.py
+++ b/app/controllers/metadata_controller.py
@@ -84,6 +84,7 @@ class MetadataController(QObject):
     @Slot()
     def refresh_metadata(self) -> None:
         """Refresh the metadata."""
+        self.reset_paths()
         prefer_versioned = self.settings_controller.settings.prefer_versioned_about_tags
         self.metadata_mediator.refresh_metadata(prefer_versioned=prefer_versioned)
         self._refresh_metadata_db()


### PR DESCRIPTION
## Summary

- `MetadataMediator` paths (`local_mods_path`, `game_path`) were set once at `MetadataController.__init__` via `reset_paths()` but never updated afterward
- When the user autodetected and saved new paths, `_update_model_from_view()` updated the settings model, but the mediator retained stale `None` values
- The `check_if_essential_paths_are_set` guard passed (it reads from the updated settings model), then `refresh_metadata()` hit the mediator's stale paths and raised `ValueError: Essential paths are missing, invalid, or not directories`
- Fix: call `self.reset_paths()` at the top of `MetadataController.refresh_metadata()` so the mediator always has current paths before validation

## Test plan

- [ ] Launch app with no paths configured
- [ ] Use autodetect to set paths, save settings
- [ ] Verify mods load without `ValueError`
- [ ] Verify manual path changes also work on subsequent refreshes

🤖 Generated with [Claude Code](https://claude.com/claude-code)