### PR TITLE
ci: auto-create Edge releases on push to main

### DIFF
--- a/.github/workflows/auto_build.yml
+++ b/.github/workflows/auto_build.yml
@@ -1,5 +1,5 @@
 # Auto build on push to main and PR.
-# Not recommended to release these builds due to versioning.
+# Pushes to main also create an Edge release on GitHub.
 
 name: Auto Build
 on:
@@ -78,7 +78,8 @@ jobs:
   pre-build:
     uses: ./.github/workflows/get_version_info.yml
     with:
-      format_only: true
+      type: ${{ github.event_name == 'push' && 'Edge' || 'Auto-Build' }}
+      format_only: ${{ github.event_name != 'push' }}
 
   attested-build:
     needs: [detect-changes, pre-build]
@@ -110,6 +111,94 @@ jobs:
       version_format: ${{ needs.pre-build.outputs.version_format }}
       attest: false
 
+  edge-release:
+    needs: [attested-build, pre-build, pre-pyright, pre-test]
+    if: >-
+      github.event_name == 'push'
+      && needs.attested-build.result == 'success'
+      && needs.pre-pyright.result == 'success'
+      && needs.pre-test.result == 'success'
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-tags: true
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v8.0.1
+        with:
+          path: artifacts
+
+      - name: Package artifacts
+        run: |
+          mv artifacts/Windows_x86_64_msi artifacts/msi
+          mv artifacts/Ubuntu-22.04_x86_64_appimage artifacts/appimage-u2204 || true
+          cd artifacts
+          for artifact in ./*; do
+            file=${artifact##*/}
+            if [[ "$file" == "msi" ]]; then
+              cd "$artifact"
+              name="RimSort-$VERSION-Windows_x86_64.msi"
+              mv ./*.msi "../$name"
+              cd ..
+            elif [[ "$file" == "appimage-u2204" ]]; then
+              cd "$artifact"
+              name="RimSort-$VERSION-x86_64.AppImage"
+              mv ./*.AppImage "../$name"
+              cd ..
+            else
+              base=${file%%.tar}
+              cd "$artifact"
+              if [[ $base == *"Windows"* ]]; then
+                rootname=RimSort
+                name="RimSort-$VERSION-$base.zip"
+                tar -xf "${file}.tar"
+                zip -rmqq "../$name" "$rootname" &
+              else
+                name="RimSort-$VERSION-$base.tar.gz"
+                gzip -c "${file}.tar" > "../$name" &
+              fi
+              cd ..
+            fi
+          done
+          wait
+          shopt -s extglob
+          rm -rf -- ./!(*.zip|*.tar.gz|*.msi|*.AppImage)
+        shell: bash
+        env:
+          VERSION: ${{ needs.pre-build.outputs.version }}
+
+      - name: Delete Previous Edge Release
+        run: |
+          gh release delete Edge -y --cleanup-tag || echo "No previous Edge release found"
+          git tag -d Edge || echo "Edge tag doesn't exist locally"
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create Edge Release
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
+        with:
+          artifacts: "artifacts/*.zip,artifacts/*.tar.gz,artifacts/*.msi,artifacts/*.AppImage"
+          tag: Edge
+          name: "Edge Build (Unstable)"
+          generateReleaseNotes: true
+          prerelease: true
+          draft: false
+          body: |
+            > **⚠️ This is an unstable edge build from the latest main branch. It may contain bugs and breaking changes. Use [stable releases](https://github.com/${{ github.repository }}/releases/latest) for production.**
+
+            Edge release ${{ needs.pre-build.outputs.version }}.
+            The latest commit is ${{ needs.pre-build.outputs.current_commit }}.
+
+            Refer to the [action run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) that created this release.
+          allowUpdates: true
+          removeArtifacts: true
+          commit: ${{ needs.pre-build.outputs.current_commit }}
+
   status-check:
     name: Status Check
     runs-on: ubuntu-latest
@@ -120,6 +209,7 @@ jobs:
       - pre-build
       - attested-build
       - non-attested-build
+      - edge-release
     if: always()
     steps:
       - name: Verify all required jobs succeeded
@@ -133,6 +223,7 @@ jobs:
             "${{ needs.pre-build.result }}"
             "${{ needs.attested-build.result }}"
             "${{ needs.non-attested-build.result }}"
+            "${{ needs.edge-release.result }}"
           )
           for r in "${results[@]}"; do
             if [[ "$r" == "failure" || "$r" == "cancelled" ]]; then

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,25 +65,6 @@ jobs:
             env:
               BUILD_OUTPUT: "app.dist"
               Executable: RimSort
-          # TODO(debt): Fedora/RPM builds disabled — the container: key was never
-          # applied at the job level so these always ran on Ubuntu. Revisit once
-          # AppImage support lands (see PR for appimage-distribution branch).
-          # - os: ubuntu-latest
-          #   container: fedora:42
-          #   platform: "Fedora-42"
-          #   arch: "x86_64"
-          #   env:
-          #     BUILD_OUTPUT: "app.dist"
-          #     Executable: RimSort
-          #     BUILD_RPM: "true"
-          # - os: ubuntu-latest
-          #   container: fedora:43
-          #   platform: "Fedora-43"
-          #   arch: "x86_64"
-          #   env:
-          #     BUILD_OUTPUT: "app.dist"
-          #     Executable: RimSort
-          #     BUILD_RPM: "true"
           - os: windows-latest
             platform: "Windows"
             arch: "x86_64"
@@ -318,56 +299,6 @@ jobs:
           tar -cvf "${{ steps.filename.outputs.FILENAME }}.tar" "$rootname"
           rm -rf "$rootname"
         shell: bash
-
-      # TODO(debt): RPM build steps disabled along with Fedora matrix entries.
-      # See comment in matrix.include above for details.
-      # - name: Install RPM build dependencies
-      #   if: matrix.env.BUILD_RPM == 'true'
-      #   run: |
-      #     dnf install -y rpm-build rpmdevtools git gcc gcc-c++ python3.12 python3.12-devel desktop-file-utils libappstream-glib
-      #   shell: bash
-      #
-      # - name: Setup RPM build environment
-      #   if: matrix.env.BUILD_RPM == 'true'
-      #   run: |
-      #     mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
-      #   shell: bash
-      #
-      # - name: Create source tarball for RPM
-      #   if: matrix.env.BUILD_RPM == 'true'
-      #   run: |
-      #     bash packaging/rpm/make-tarball.sh "${{ steps.sem_version.outputs.version }}"
-      #   shell: bash
-      #
-      # - name: Build RPM package
-      #   if: matrix.env.BUILD_RPM == 'true'
-      #   run: |
-      #     rpmbuild -bb packaging/rpm/rimsort.spec \
-      #       --define "version ${{ steps.sem_version.outputs.version }}"
-      #   shell: bash
-      #
-      # - name: Find RPM file
-      #   if: matrix.env.BUILD_RPM == 'true'
-      #   id: find_rpm
-      #   run: |
-      #     RPM_FILE=$(find ~/rpmbuild/RPMS/x86_64/ -name "rimsort-*.rpm" | head -n 1)
-      #     echo "RPM_FILE=$RPM_FILE" >> "$GITHUB_OUTPUT"
-      #     echo "Found RPM: $RPM_FILE"
-      #   shell: bash
-      #
-      # - name: Generate RPM attestation
-      #   uses: actions/attest-build-provenance@v4.1.0
-      #   if: ${{ inputs.attest && matrix.env.BUILD_RPM == 'true' }}
-      #   with:
-      #     subject-path: ${{ steps.find_rpm.outputs.RPM_FILE }}
-      #
-      # - name: Upload RPM Package
-      #   if: matrix.env.BUILD_RPM == 'true'
-      #   uses: actions/upload-artifact@main
-      #   with:
-      #     name: ${{ matrix.platform }}_${{ matrix.arch }}_rpm
-      #     path: ${{ steps.find_rpm.outputs.RPM_FILE }}
-      #     if-no-files-found: error
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v4.1.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,8 +117,6 @@ jobs:
         id: artifacts
         run: |
           mv artifacts/Windows_x86_64_msi artifacts/msi
-          mv artifacts/Fedora-42_x86_64_rpm artifacts/rpm-f42 || true
-          mv artifacts/Fedora-43_x86_64_rpm artifacts/rpm-f43 || true
           mv artifacts/Ubuntu-22.04_x86_64_appimage artifacts/appimage-u2204 || true
           cd artifacts
           for artifact in ./*; do
@@ -127,16 +125,6 @@ jobs:
               cd "$artifact"
               name="RimSort-${{ needs.pre-build.outputs.version }}-Windows_x86_64.msi"
               mv ./*.msi "../$name"
-              cd ..
-            elif [[ "$file" == "rpm-f42" ]]; then
-              cd "$artifact"
-              name="RimSort-${{ needs.pre-build.outputs.version }}-Fedora-42_x86_64.rpm"
-              mv ./*.rpm "../$name"
-              cd ..
-            elif [[ "$file" == "rpm-f43" ]]; then
-              cd "$artifact"
-              name="RimSort-${{ needs.pre-build.outputs.version }}-Fedora-43_x86_64.rpm"
-              mv ./*.rpm "../$name"
               cd ..
             elif [[ "$file" == "appimage-u2204" ]]; then
               cd "$artifact"
@@ -175,7 +163,7 @@ jobs:
           wait
           echo "Cleaning up - Removing non-archive files"
           shopt -s extglob
-          rm -rf -- ./!(*.zip|*.tar.gz|*.msi|*.rpm|*.AppImage)
+          rm -rf -- ./!(*.zip|*.tar.gz|*.msi|*.AppImage)
         shell: bash
 
       - name: Create body
@@ -199,10 +187,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Release
-        uses: ncipollo/release-action@v1.21.0
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         id: release
         with:
-          artifacts: "artifacts/*.zip,artifacts/*.tar.gz,artifacts/*.msi,artifacts/*.rpm,artifacts/*.AppImage"
+          artifacts: "artifacts/*.zip,artifacts/*.tar.gz,artifacts/*.msi,artifacts/*.AppImage"
           tag: ${{ steps.tag.outputs.tag }}
           generateReleaseNotes: true
           prerelease: ${{ needs.pre-build.outputs.prerelease }}


### PR DESCRIPTION
## Summary
- Pushes to main now automatically create a GitHub Edge release (non-draft, prerelease) when the build, pyright, and tests all pass
- Edge releases are named "Edge Build (Unstable)" with a warning banner linking to stable releases
- Only one Edge release exists at a time — the previous one is deleted before creating the new one
- Changelog is auto-generated by GitHub, showing all changes since the last stable release
- Removed dead Fedora/RPM CI code from `build.yml` and `release.yml`
- Pinned `ncipollo/release-action` to commit SHA in both workflows

## How it works
- `pre-build` now passes `type: Edge` and `format_only: false` for pushes to main (full version computation), and `type: Auto-Build` / `format_only: true` for PRs (unchanged)
- New `edge-release` job gates on `attested-build`, `pre-pyright`, and `pre-test` all succeeding
- Artifact packaging mirrors the existing `release.yml` logic (tar→tar.gz/zip, MSI, AppImage)
- Manual Edge releases via `release.yml` still work as a fallback

## Test plan
- [ ] Merge a PR that touches `app/` and verify the Edge release is created automatically
- [ ] Verify the release is marked as prerelease with the "Edge Build (Unstable)" title
- [ ] Verify the warning banner and changelog appear in the release body
- [ ] Verify PR builds are unaffected (no release created, Auto-Build version format)
- [ ] Verify manual `release.yml` Edge and Stable releases still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)