### PR TITLE
fix: macOS self-update broken by nested .app bundle and wrong arch detection

### DIFF
--- a/app/utils/update_utils.py
+++ b/app/utils/update_utils.py
@@ -420,8 +420,8 @@ class UpdateManager(QObject):
         "Darwin": {
             "patterns": ["Darwin", "macOS", "Mac"],
             "arch_patterns": {
-                "64bit": ["x86_64", "intel"],
-                "ARM64": ["arm64", "apple"],
+                "arm64": ["arm64", "arm", "apple"],
+                "x86_64": ["x86_64", "i386", "intel"],
             },
         },
         "Linux": {
@@ -474,7 +474,12 @@ class UpdateManager(QObject):
         self._elevation_needed: Optional[bool] = None  # Cache elevation check result
         # Cache platform info to avoid repeated calls
         self._system = platform.system()
-        self._arch = platform.architecture()[0]
+        # On macOS, platform.architecture()[0] returns "64bit" for both Intel and
+        # ARM, so use platform.machine() which returns "arm64" or "x86_64".
+        if self._system == "Darwin":
+            self._arch = platform.machine()
+        else:
+            self._arch = platform.architecture()[0]
         # Cache platform patterns for performance
         self._cached_patterns = (
             self._platform_patterns[self._system]

--- a/update.sh
+++ b/update.sh
@@ -304,6 +304,13 @@ if [ -d "$UPDATE_SOURCE_FOLDER/RimSort" ]; then
 	log_info "Adjusted update source to subdirectory: $UPDATE_SOURCE_FOLDER"
 fi
 
+# On macOS, adjust source if it contains a RimSort.app bundle so rsync copies the
+# bundle contents rather than nesting RimSort.app inside the target .app directory.
+if [ "$OS" = "Darwin" ] && [ -d "$UPDATE_SOURCE_FOLDER/RimSort.app" ]; then
+	UPDATE_SOURCE_FOLDER="$UPDATE_SOURCE_FOLDER/RimSort.app"
+	log_info "Adjusted update source to .app bundle: $UPDATE_SOURCE_FOLDER"
+fi
+
 # Verify checksum if available
 checksum_file="$UPDATE_SOURCE_FOLDER/checksum.sha256"
 if [ -f "$checksum_file" ]; then


### PR DESCRIPTION
## Summary

- **Nested `.app` bundle**: After extraction, `update.sh` rsync'd the temp directory (containing `RimSort.app/`) into the target `RimSort.app/`, producing `RimSort.app/RimSort.app/Contents/...` — an invalid bundle that macOS won't recognize. Added a `.app` subdirectory check so rsync copies bundle *contents* instead.
- **Wrong architecture download**: `platform.architecture()[0]` returns `"64bit"` on both Intel and ARM Macs, so arch-specific asset matching always failed and fell back to whichever Darwin asset appeared first in the API response. Now uses `platform.machine()` on macOS and updated patterns to match the actual asset naming convention (`arm`/`i386` from `distribute.py`).

## Test plan

- [x] `just check` — all quality gates pass (ruff, mypy, pyright, jscpd, shfmt, markdownlint)
- [x] `just test` — 758 tests pass
- [x] Verify the updated app launches correctly after update (no nested `.app` structure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)