### PR TITLE
fix: terminate cleanly when closed during startup scanning

### DIFF
--- a/app/controllers/app_controller.py
+++ b/app/controllers/app_controller.py
@@ -144,6 +144,12 @@ class AppController(QObject):
         """Runs the main application loop after initializing the main window."""
         self.main_window.show()
         self.main_window.initialize_content(is_initial=True)
+        # If the window was closed during initialization (e.g. user closed during
+        # mod scanning), skip the main event loop — Qt resets the quit flag in exec()
+        # so a prior quit() from quitOnLastWindowClosed would have no effect and the
+        # event loop would block forever with no visible windows.
+        if not self.main_window.isVisible():
+            return 0
         return self.app.exec()
 
     def shutdown_watchdog(self) -> None:

--- a/app/utils/metadata.py
+++ b/app/utils/metadata.py
@@ -90,6 +90,9 @@ class MetadataManager(QObject):
             self.settings_controller = settings_controller
             self.steamcmd_wrapper = SteamcmdInterface.instance()
 
+            # Abort flag for cancelling long-running refresh operations (e.g. on app close)
+            self._abort_requested = False
+
             # Initialize our threadpool for multithreaded parsing
             self.parser_threadpool = QThreadPool.globalInstance()
 
@@ -143,6 +146,17 @@ class MetadataManager(QObject):
         elif args or kwargs:
             raise ValueError("MetadataManager instance has already been initialized.")
         return cls._instance
+
+    def request_abort(self) -> None:
+        """Request cancellation of any in-progress refresh_cache operation.
+
+        Sets the abort flag and clears queued (not yet started) runnables from the
+        thread pool. Already-running ModParser tasks will finish their current mod
+        but no new work will be queued.
+        """
+        logger.info("Abort requested for metadata refresh")
+        self._abort_requested = True
+        self.parser_threadpool.clear()
 
     def __read_game_version(self) -> None:
         """Read game version from Version.txt file.
@@ -430,11 +444,23 @@ class MetadataManager(QObject):
         # Process official RimWorld content (Base game + DLC)
         process_data_source_folder("expansion", game_folder, "Data")
 
+        if self._abort_requested:
+            self.parser_threadpool.clear()
+            return
+
         # Process locally installed mods (SteamCMD, manual installs)
         process_data_source_folder("local", settings_instance.local_folder)
 
+        if self._abort_requested:
+            self.parser_threadpool.clear()
+            return
+
         # Process Steam Workshop mods
         process_data_source_folder("workshop", settings_instance.workshop_folder)
+
+        if self._abort_requested:
+            self.parser_threadpool.clear()
+            return
 
         # ===== THREAD SYNCHRONIZATION =====
         # Wait for all queued metadata parsing tasks to complete before rebuilding mappers
@@ -1380,6 +1406,7 @@ class MetadataManager(QObject):
             is_initial (bool): If True, indicates initial load and skips purging orphaned metadata.
         """
         logger.warning("Refreshing metadata cache...")
+        self._abort_requested = False
 
         # If we are refreshing cache from user action, update user paths as well in case of change
         if not is_initial:
@@ -1389,6 +1416,9 @@ class MetadataManager(QObject):
 
         # Refresh ACF metadata from Steam sources for workshop mod details
         refresh_acf_metadata(self, steamclient=True, steamcmd=True)
+        if self._abort_requested:
+            logger.info("Metadata refresh aborted after ACF metadata")
+            return
         # Read game version first since external metadata loading (e.g., No Version Warning) depends on it
         self.__read_game_version()
         # Load external metadata sources in parallel (user rules, Steam DB, community rules, etc.)
@@ -1396,8 +1426,14 @@ class MetadataManager(QObject):
         # which depend on SteamDB for generating missing mod info are assigned proper data correctly.
         # This is necessary for compatibility with old mods, such as https://steamcommunity.com/sharedfiles/filedetails/?id=1147799676
         self.__refresh_external_metadata()
+        if self._abort_requested:
+            logger.info("Metadata refresh aborted after external metadata")
+            return
         # Scan and refresh internal mod metadata from file system (expansion, local, workshop)
         self.__refresh_internal_metadata(is_initial=is_initial)
+        if self._abort_requested:
+            logger.info("Metadata refresh aborted after internal metadata")
+            return
         # Compile metadata to calculate dependencies, incompatibilities, and load rules
         self.compile_metadata(uuids=list(self.internal_local_metadata.keys()))
 

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -299,6 +299,7 @@ class MainContent(QObject):
         self.duplicate_mods: dict[str, Any] = {}
         self._extract_progress_widget: Optional[TaskProgressWindow] = None
         self.window_manager = WindowManager(self.metadata_manager)
+        self._active_loading_loop: QEventLoop | None = None
 
     @classmethod
     def instance(cls, *args: Any, **kwargs: Any) -> "MainContent":
@@ -307,6 +308,15 @@ class MainContent(QObject):
         elif args or kwargs:
             raise ValueError("MainContent instance has already been initialized.")
         return cls._instance
+
+    def abort_loading(self) -> None:
+        """Abort any in-progress loading animation by quitting its nested event loop.
+
+        Called from MainWindow.closeEvent to unblock the startup scanning so
+        the process can exit cleanly.
+        """
+        if self._active_loading_loop is not None:
+            self._active_loading_loop.quit()
 
     def close_child_windows(self) -> None:
         """Close all tracked child windows.
@@ -752,7 +762,13 @@ class MainContent(QObject):
             self.mod_info_panel.panel.addWidget(loading_animation_text_label)
         loop = QEventLoop()
         loading_animation.finished.connect(loop.quit)
+        # Store ref so closeEvent can break out of this loop
+        self._active_loading_loop = loop
         loop.exec_()
+        self._active_loading_loop = None
+        # If the loop was quit externally (e.g. window close), skip UI cleanup
+        if not loading_animation.animation_finished:
+            return None
         data = loading_animation.data
         # Remove text label if it was passed
         if text and loading_animation_text_label is not None:
@@ -796,7 +812,7 @@ class MainContent(QObject):
         # Check if paths are set
         if self.check_if_essential_paths_are_set(prompt=is_initial):
             # Run expensive calculations to set cache data
-            self.do_threaded_loading_animation(
+            result = self.do_threaded_loading_animation(
                 gif_path=str(
                     AppInfo().theme_data_folder / "default-icons" / "rimsort.gif"
                 ),
@@ -805,6 +821,10 @@ class MainContent(QObject):
                 ),
                 text=self.tr("Scanning mod sources and populating metadata..."),
             )
+
+            # If loading was aborted (e.g. window closed during scan), skip remaining work
+            if result is None and self.metadata_manager._abort_requested:
+                return
 
             # Refresh MetadataController alongside MetadataManager
             MetadataController.instance().refresh_metadata()

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -319,6 +319,9 @@ class MainWindow(QMainWindow):
         )
         # REFRESH CONFIGURED METADATA
         self.main_content_panel._do_refresh(is_initial=is_initial)
+        # If the window was closed during scanning, skip remaining initialization
+        if not self.isVisible():
+            return
         # CHECK FOR STEAMCMD SETUP
         if not os.path.exists(
             self.steamcmd_wrapper.steamcmd_prefix

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -45,6 +45,7 @@ from app.utils.constants import (
 from app.utils.event_bus import EventBus
 from app.utils.generic import handle_remove_read_only
 from app.utils.gui_info import GUIInfo
+from app.utils.metadata import MetadataManager
 from app.utils.steam.steamcmd.wrapper import SteamcmdInterface
 from app.utils.watchdog import WatchdogHandler
 from app.views.acf_log_reader import AcfLogReader
@@ -287,6 +288,13 @@ class MainWindow(QMainWindow):
 
         :param event: The close event to handle.
         """
+        # Abort any in-progress metadata scanning so background threads stop
+        MetadataManager.instance().request_abort()
+
+        # Break out of the nested QEventLoop in do_threaded_loading_animation
+        # so the startup sequence can unwind and the process can exit
+        self.main_content_panel.abort_loading()
+
         # Stop filesystem watchdog if running
         self.shutdown_watchdog()
 

--- a/tests/views/test_main_window_close.py
+++ b/tests/views/test_main_window_close.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from PySide6.QtGui import QCloseEvent
 
@@ -12,7 +12,10 @@ from tests.views.conftest import make_stub_main_window
 class TestMainWindowCloseEvent:
     """Test that closeEvent closes child windows."""
 
-    def test_close_event_calls_close_child_windows(self, qapp: object) -> None:
+    @patch("app.views.main_window.MetadataManager")
+    def test_close_event_calls_close_child_windows(
+        self, mock_mm_cls: MagicMock, qapp: object
+    ) -> None:
         """Verify closeEvent delegates to MainContent.close_child_windows."""
         window = make_stub_main_window()
 
@@ -21,7 +24,10 @@ class TestMainWindowCloseEvent:
 
         window.main_content_panel.close_child_windows.assert_called_once()  # type: ignore[attr-defined]
 
-    def test_close_event_stops_watchdog(self, qapp: object) -> None:
+    @patch("app.views.main_window.MetadataManager")
+    def test_close_event_stops_watchdog(
+        self, mock_mm_cls: MagicMock, qapp: object
+    ) -> None:
         """Verify closeEvent stops the watchdog if running."""
         window = make_stub_main_window()
         handler = MagicMock()
@@ -33,7 +39,8 @@ class TestMainWindowCloseEvent:
         handler.stop.assert_called_once()
         assert window.watchdog_event_handler is None
 
-    def test_close_event_accepts(self, qapp: object) -> None:
+    @patch("app.views.main_window.MetadataManager")
+    def test_close_event_accepts(self, mock_mm_cls: MagicMock, qapp: object) -> None:
         """Verify closeEvent accepts the event to allow window closure."""
         window = make_stub_main_window()
 
@@ -41,3 +48,29 @@ class TestMainWindowCloseEvent:
         window.closeEvent(event)
 
         assert event.isAccepted()
+
+    @patch("app.views.main_window.MetadataManager")
+    def test_close_event_aborts_metadata_refresh(
+        self, mock_mm_cls: MagicMock, qapp: object
+    ) -> None:
+        """Verify closeEvent requests abort on MetadataManager."""
+        mock_instance = MagicMock()
+        mock_mm_cls.instance.return_value = mock_instance
+        window = make_stub_main_window()
+
+        event = QCloseEvent()
+        window.closeEvent(event)
+
+        mock_instance.request_abort.assert_called_once()
+
+    @patch("app.views.main_window.MetadataManager")
+    def test_close_event_aborts_loading_animation(
+        self, mock_mm_cls: MagicMock, qapp: object
+    ) -> None:
+        """Verify closeEvent calls abort_loading on the content panel."""
+        window = make_stub_main_window()
+
+        event = QCloseEvent()
+        window.closeEvent(event)
+
+        window.main_content_panel.abort_loading.assert_called_once()  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

Fixes #1141 — closing RimSort while it scans mod sources during startup left the process running, preventing restart.

**Root cause (two layers):**

1. `do_threaded_loading_animation()` blocks in a nested `QEventLoop` waiting for the `WorkThread` to finish scanning. `closeEvent` had no way to break out of it.
2. Even after breaking the nested loop, `initialize_content()` continued executing (SteamCMD checks, DB updates, watchdog) and then `app.exec()` started a **new** main event loop. Qt 6 resets the quit flag in `exec()`, so the prior `quit()` from `quitOnLastWindowClosed` had no effect — the loop blocked forever with no visible windows.

**Fix:**

- Add `_abort_requested` flag and `request_abort()` to `MetadataManager` — clears queued threadpool runnables and short-circuits `refresh_cache()` between scanning phases
- Store the active `QEventLoop` ref on `MainContent` so `closeEvent` can quit it via `abort_loading()`
- `closeEvent` now calls `request_abort()` + `abort_loading()` before watchdog/child-window cleanup
- `initialize_content()` returns early if the window is no longer visible after `_do_refresh()`
- `AppController.run()` skips `app.exec()` if the window was closed during initialization

## Test plan

- [x] Existing close-event tests updated to mock `MetadataManager` and verify `request_abort()` and `abort_loading()` are called
- [x] New test verifying `closeEvent` aborts metadata refresh
- [x] New test verifying `closeEvent` aborts loading animation
- [x] All 760 tests pass
- [x] Full quality gate passes (`just check` — ruff, mypy, pyright, jscpd, shfmt, markdownlint)
- [x] Manual testing: close during startup scanning — process exits cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)