### PR TITLE
chore: add AppImage release type to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -18,6 +18,7 @@ body:
         - Compiled (Darwin ARM64)
         - Compiled (Ubuntu 22.04)
         - Compiled (Ubuntu 24.04)
+        - AppImage (x86-64)
         - Self-Compiled
         - Python Interpreter
     validations:


### PR DESCRIPTION
## Summary
- Adds "AppImage (x86-64)" as a release type option in the bug report issue template dropdown