### PR TITLE
fix: use platform-native commands for "Open in browser" on Linux/macOS

### DIFF
--- a/app/controllers/main_content_controller.py
+++ b/app/controllers/main_content_controller.py
@@ -17,6 +17,7 @@ from app.utils.generic import (
     check_internet_connection,
     extract_git_dir_name,
     extract_git_user_or_org,
+    open_url_browser,
 )
 from app.utils.git_utils import GitOperationConfig, pygit2
 from app.utils.git_worker import (
@@ -1407,13 +1408,7 @@ class MainContentController(QObject):
             )
 
             if answer == QMessageBox.StandardButton.Yes:
-                # Open URL in browser
-                try:
-                    import webbrowser
-
-                    webbrowser.open(pull_request.html_url)
-                except Exception as e:
-                    logger.error(f"Failed to open browser: {e}")
+                open_url_browser(pull_request.html_url)
 
         except Exception as e:
             logger.error(f"Failed to create pull request: {e}")

--- a/app/utils/generic.py
+++ b/app/utils/generic.py
@@ -457,10 +457,26 @@ def launch_process(
 
 def open_url_browser(url: str) -> None:
     """
-    Open a url in a user's default web browser
+    Open a url in a user's default web browser.
+
+    Uses platform-native commands on Linux and macOS to avoid issues with
+    ``webbrowser.open`` failing silently in bundled environments (e.g. Nuitka)
+    where ``LD_LIBRARY_PATH`` or other env vars interfere with spawned processes.
     """
     logger.info(f"USER ACTION: Opening url {url}")
-    webbrowser.open(url)
+    try:
+        if sys.platform == "linux":
+            subprocess.Popen(
+                ["xdg-open", url],
+                env=dict(os.environ, LD_LIBRARY_PATH=""),
+            )
+        elif sys.platform == "darwin":
+            subprocess.Popen(["open", url])
+        else:
+            webbrowser.open(url)
+    except Exception as e:
+        logger.error(f"Failed to open URL {url}: {e}")
+        webbrowser.open(url)
 
 
 def platform_specific_open(path: str | Path) -> None:

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -5,7 +5,6 @@ import sys
 import tempfile
 import time
 import traceback
-import webbrowser
 from functools import partial
 from pathlib import Path
 from typing import Any, Callable, Literal, Optional, cast, overload
@@ -1599,7 +1598,7 @@ class MainContent(QObject):
                     "The URL has been copied to your clipboard:\n\n{ret}"
                 ).format(ret=ret),
             )
-            webbrowser.open(ret)
+            open_url_browser(ret)
         else:
             dialogue.show_warning(
                 title=self.tr("Failed to upload file."),

--- a/app/views/mod_info_panel.py
+++ b/app/views/mod_info_panel.py
@@ -24,7 +24,12 @@ from app.sort.mod_sorting import uuid_to_folder_size
 from app.utils.app_info import AppInfo
 from app.utils.aux_db_utils import auxdb_get_mod_tags
 from app.utils.custom_list_widget_item import CustomListWidgetItem
-from app.utils.generic import format_file_size, platform_specific_open, scanpath
+from app.utils.generic import (
+    format_file_size,
+    open_url_browser,
+    platform_specific_open,
+    scanpath,
+)
 from app.utils.metadata import MetadataManager
 from app.utils.mod_info import UNKNOWN, ModInfo
 from app.views.description_widget import DescriptionWidget
@@ -75,13 +80,7 @@ class ClickablePathLabel(QLabel):
         if event.button() == Qt.MouseButton.LeftButton and self.path and self.clickable:
             # If path looks like a URL, open in browser
             if self.path.startswith("http://") or self.path.startswith("https://"):
-                import webbrowser
-
-                try:
-                    webbrowser.open(self.path)
-                    logger.info(f"Opening URL: {self.path}")
-                except Exception as e:
-                    logger.error(f"Failed to open URL {self.path}: {e}")
+                open_url_browser(self.path)
             else:
                 try:
                     path_obj = Path(self.path)


### PR DESCRIPTION
## Summary

- Replace `webbrowser.open()` with `xdg-open` (Linux) and `open` (macOS) in `open_url_browser()`, clearing `LD_LIBRARY_PATH` on Linux to prevent bundled Nuitka environment variables from interfering with spawned browser processes
- Consolidate all scattered inline `webbrowser.open()` calls across `mod_info_panel.py`, `main_content_panel.py`, and `main_content_controller.py` to use the shared `open_url_browser()` function
- Keep `webbrowser.open()` as the Windows default and as a fallback on error for all platforms

Fixes #1911

## Test plan

- [ ] Verify "Open URL in browser" context menu action works on Linux (compiled build)
- [ ] Verify clicking URL labels in the mod info panel opens the browser on Linux
- [ ] Verify 0x0.st upload URL opens in browser after upload on Linux
- [ ] Verify PR URL opens in browser after creation on Linux
- [ ] Verify all above still work on macOS and Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)