### PR TITLE
refactor(metadata): add ModList domain model (#2051 PR 2.75)

### DIFF
--- a/app/models/mod_list.py
+++ b/app/models/mod_list.py
@@ -10,8 +10,11 @@ from __future__ import annotations
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 
+from loguru import logger
+
 from app.models.metadata.metadata_structure import (
     CaseInsensitiveStr,
+    ModsConfig,
     ModType,
 )
 
@@ -216,3 +219,41 @@ class ModList:
             reordered = self_order != other_order
 
         return ModListDiff(added=added, removed=removed, reordered=reordered)
+
+    def to_mods_config(
+        self,
+        version: str,
+        expansions: list[CaseInsensitiveStr],
+    ) -> ModsConfig:
+        """Serialize to RimWorld's ModsConfig format.
+
+        :param version: Game version string.
+        :param expansions: Known expansion package IDs.
+        :return: A ModsConfig ready for XML serialization.
+        """
+        active_mods = [CaseInsensitiveStr(e.config_id) for e in self._entries]
+        return ModsConfig(
+            version=version,
+            activeMods=active_mods,
+            knownExpansions=expansions,
+        )
+
+    @classmethod
+    def from_sorted_paths(cls, sorted_paths: list[str], source: ModList) -> ModList:
+        """Create a new ModList by reordering entries from source.
+
+        Copies existing ModEntry objects (preserving config_id). Paths not
+        found in source are logged and skipped.
+
+        :param sorted_paths: Desired order of paths.
+        :param source: ModList to pull entries from.
+        :return: A new ModList in the sorted order.
+        """
+        entries: list[ModEntry] = []
+        for path in sorted_paths:
+            idx = source.index_of(path)
+            if idx is not None:
+                entries.append(source[idx])
+            else:
+                logger.warning(f"from_sorted_paths: path not in source, skipping: {path}")
+        return cls(entries)

--- a/app/models/mod_list.py
+++ b/app/models/mod_list.py
@@ -7,6 +7,7 @@ No Qt dependency.
 
 from __future__ import annotations
 
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 
 from app.models.metadata.metadata_structure import (
@@ -66,3 +67,62 @@ def create_mod_entry(
     else:
         config_id = str(package_id)
     return ModEntry(path=path, package_id=package_id, config_id=config_id)
+
+
+class ModList:
+    """Ordered collection of mod entries with maintained indices.
+
+    Pure Python — no Qt dependency. Both ModsConfig serialization and
+    ModListWidget rendering project from this.
+    """
+
+    def __init__(self, entries: Iterable[ModEntry] = ()) -> None:
+        self._entries: list[ModEntry] = list(entries)
+        self._path_index: dict[str, int] = {}
+        self._pid_index: dict[CaseInsensitiveStr, list[int]] = {}
+        self._rebuild_indices()
+
+    def _rebuild_indices(self) -> None:
+        """Full index rebuild from _entries. O(n)."""
+        self._path_index = {}
+        self._pid_index = {}
+        for i, entry in enumerate(self._entries):
+            self._path_index[entry.path] = i
+            self._pid_index.setdefault(entry.package_id, []).append(i)
+
+    def __len__(self) -> int:
+        return len(self._entries)
+
+    def __iter__(self) -> Iterator[ModEntry]:
+        return iter(self._entries)
+
+    def __contains__(self, path: str) -> bool:
+        return path in self._path_index
+
+    def __getitem__(self, index: int) -> ModEntry:
+        return self._entries[index]
+
+    def index_of(self, path: str) -> int | None:
+        """Return the position of a mod by path, or None if not found."""
+        return self._path_index.get(path)
+
+    def entries_for_package_id(self, pid: CaseInsensitiveStr) -> list[ModEntry]:
+        """Return all entries matching a package ID, in list order."""
+        indices = self._pid_index.get(pid, [])
+        return [self._entries[i] for i in indices]
+
+    def paths(self) -> list[str]:
+        """Return ordered list of paths."""
+        return [e.path for e in self._entries]
+
+    def package_ids(self) -> list[CaseInsensitiveStr]:
+        """Return ordered list of package IDs."""
+        return [e.package_id for e in self._entries]
+
+    def find_duplicate_package_ids(self) -> dict[CaseInsensitiveStr, list[str]]:
+        """Return packageIds that appear more than once, with their paths."""
+        return {
+            pid: [self._entries[i].path for i in indices]
+            for pid, indices in self._pid_index.items()
+            if len(indices) > 1
+        }

--- a/app/models/mod_list.py
+++ b/app/models/mod_list.py
@@ -155,7 +155,9 @@ class ModList:
         if entry.path in self._path_index:
             raise ValueError(f"Path already exists: {entry.path}")
         if index < 0 or index > len(self._entries):
-            raise IndexError(f"Index {index} out of range for list of length {len(self._entries)}")
+            raise IndexError(
+                f"Index {index} out of range for list of length {len(self._entries)}"
+            )
         self._entries.insert(index, entry)
         self._rebuild_indices()
 
@@ -271,7 +273,9 @@ class ModList:
             if idx is not None:
                 entries.append(source[idx])
             else:
-                logger.warning(f"from_sorted_paths: path not in source, skipping: {path}")
+                logger.warning(
+                    f"from_sorted_paths: path not in source, skipping: {path}"
+                )
         return cls(entries)
 
     @classmethod
@@ -297,7 +301,9 @@ class ModList:
         for config_id_ci in config.activeMods:
             config_id_str = str(config_id_ci)
             is_steam = config_id_str.endswith(_STEAM_SUFFIX)
-            raw_pid = config_id_str[: -len(_STEAM_SUFFIX)] if is_steam else config_id_str
+            raw_pid = (
+                config_id_str[: -len(_STEAM_SUFFIX)] if is_steam else config_id_str
+            )
 
             candidate_paths = pid_to_paths.get(raw_pid, set())
             if not candidate_paths:
@@ -350,3 +356,50 @@ class ModList:
         if remaining:
             return natsorted(remaining)[0]
         return None
+
+    @classmethod
+    def from_remaining(
+        cls,
+        all_mod_paths: set[str],
+        active: ModList,
+        metadata_controller: MetadataController,
+    ) -> ModList:
+        """Build the inactive mod list from all known paths minus active paths.
+
+        Entries use config_id = str(package_id) (no _steam suffix) since
+        inactive mods don't serialize to ModsConfig.xml.
+
+        :param all_mod_paths: Set of all known mod paths.
+        :param active: The active ModList to subtract.
+        :param metadata_controller: For looking up packageId and ModType per path.
+        :return: A ModList of inactive mods.
+        """
+        active_paths = set(active.paths())
+        inactive_paths = all_mod_paths - active_paths
+
+        entries: list[ModEntry] = []
+        for path in sorted(inactive_paths):
+            mod = metadata_controller.mods_metadata.get(path)
+            if mod is None:
+                logger.warning(
+                    f"from_remaining: path not in metadata, skipping: {path}"
+                )
+                continue
+            if not isinstance(mod, AboutXmlMod):
+                entry = create_mod_entry(
+                    path=path,
+                    package_id=CaseInsensitiveStr(""),
+                    mod_type=mod.mod_type
+                    if hasattr(mod, "mod_type")
+                    else ModType.UNKNOWN,
+                    has_duplicate=False,
+                )
+            else:
+                entry = create_mod_entry(
+                    path=path,
+                    package_id=mod.package_id,
+                    mod_type=mod.mod_type,
+                    has_duplicate=False,
+                )
+            entries.append(entry)
+        return cls(entries)

--- a/app/models/mod_list.py
+++ b/app/models/mod_list.py
@@ -199,3 +199,20 @@ class ModList:
         self._entries.clear()
         self._path_index.clear()
         self._pid_index.clear()
+
+    def diff(self, other: ModList) -> ModListDiff:
+        """Compare this list against another, returning added/removed/reordered."""
+        self_paths = set(self._path_index.keys())
+        other_paths = set(other._path_index.keys())
+
+        added = [other[other._path_index[p]] for p in other_paths - self_paths]
+        removed = [self[self._path_index[p]] for p in self_paths - other_paths]
+
+        common = self_paths & other_paths
+        reordered = False
+        if not added and not removed and common:
+            self_order = [e.path for e in self._entries if e.path in common]
+            other_order = [e.path for e in other._entries if e.path in common]
+            reordered = self_order != other_order
+
+        return ModListDiff(added=added, removed=removed, reordered=reordered)

--- a/app/models/mod_list.py
+++ b/app/models/mod_list.py
@@ -126,3 +126,76 @@ class ModList:
             for pid, indices in self._pid_index.items()
             if len(indices) > 1
         }
+
+    def insert(self, index: int, entry: ModEntry) -> None:
+        """Insert an entry at the given index.
+
+        :raises ValueError: If the path already exists in the list.
+        :raises IndexError: If index is out of range.
+        """
+        if entry.path in self._path_index:
+            raise ValueError(f"Path already exists: {entry.path}")
+        if index < 0 or index > len(self._entries):
+            raise IndexError(f"Index {index} out of range for list of length {len(self._entries)}")
+        self._entries.insert(index, entry)
+        self._rebuild_indices()
+
+    def remove_by_path(self, path: str) -> ModEntry:
+        """Remove and return the entry with the given path.
+
+        :raises KeyError: If the path is not in the list.
+        """
+        idx = self._path_index.get(path)
+        if idx is None:
+            raise KeyError(f"Path not found: {path}")
+        entry = self._entries.pop(idx)
+        self._rebuild_indices()
+        return entry
+
+    def reorder(self, path: str, new_index: int) -> None:
+        """Move an existing entry to a new position.
+
+        :raises KeyError: If the path is not in the list.
+        :raises IndexError: If new_index is out of range.
+        """
+        old_index = self._path_index.get(path)
+        if old_index is None:
+            raise KeyError(f"Path not found: {path}")
+        if new_index < 0 or new_index >= len(self._entries):
+            raise IndexError(
+                f"Index {new_index} out of range for list of length {len(self._entries)}"
+            )
+        entry = self._entries.pop(old_index)
+        self._entries.insert(new_index, entry)
+        self._rebuild_indices()
+
+    def move_batch(self, paths: list[str], target_index: int) -> None:
+        """Move multiple entries to a target position, preserving their relative order.
+
+        Entries are ordered by their current position (not the order in `paths`),
+        removed, then reinserted at `target_index` (clamped to list bounds).
+        """
+        current_positions = []
+        for p in paths:
+            idx = self._path_index.get(p)
+            if idx is not None:
+                current_positions.append((idx, self._entries[idx]))
+        current_positions.sort(key=lambda x: x[0])
+        moved_entries = [entry for _, entry in current_positions]
+        for entry in moved_entries:
+            self._entries.remove(entry)
+        insert_at = min(target_index, len(self._entries))
+        for i, entry in enumerate(moved_entries):
+            self._entries.insert(insert_at + i, entry)
+        self._rebuild_indices()
+
+    def replace_order(self, entries: list[ModEntry]) -> None:
+        """Replace all entries with a new ordered list. Full index rebuild."""
+        self._entries = list(entries)
+        self._rebuild_indices()
+
+    def clear(self) -> None:
+        """Remove all entries and clear indices."""
+        self._entries.clear()
+        self._path_index.clear()
+        self._pid_index.clear()

--- a/app/models/mod_list.py
+++ b/app/models/mod_list.py
@@ -1,0 +1,54 @@
+"""Domain model for ordered mod lists.
+
+Provides ModEntry (frozen identity handle), ModList (indexed ordered collection),
+and ModListDiff (change detection) — bridging PATH and packageId identity systems.
+No Qt dependency.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from app.models.metadata.metadata_structure import (
+    CaseInsensitiveStr,
+    ModType,
+)
+
+
+@dataclass(frozen=True)
+class ModEntry:
+    """Identifies a mod within an ordered list.
+
+    :param path: Canonical identifier (filesystem path as string), matches
+        MetadataController.mods_metadata keys.
+    :param package_id: RimWorld package ID for dependency lookups and
+        CompiledDependencyData bridging.
+    :param config_id: Serialization identity written to ModsConfig.xml.
+        Usually equals str(package_id) but includes '_steam' suffix for
+        Workshop copies when duplicates exist.
+    """
+
+    path: str
+    package_id: CaseInsensitiveStr
+    config_id: str
+
+
+def create_mod_entry(
+    path: str,
+    package_id: CaseInsensitiveStr,
+    mod_type: ModType,
+    has_duplicate: bool,
+) -> ModEntry:
+    """Build a ModEntry with correct config_id resolution.
+
+    :param path: Filesystem path to the mod.
+    :param package_id: The mod's package ID.
+    :param mod_type: Source type of the mod.
+    :param has_duplicate: Whether another copy of this packageId exists.
+    :return: A frozen ModEntry.
+    """
+    if has_duplicate and mod_type == ModType.STEAM_WORKSHOP:
+        config_id = f"{package_id}_steam"
+    else:
+        config_id = str(package_id)
+    return ModEntry(path=path, package_id=package_id, config_id=config_id)

--- a/app/models/mod_list.py
+++ b/app/models/mod_list.py
@@ -26,11 +26,19 @@ if TYPE_CHECKING:
 
 
 _STEAM_SUFFIX = "_steam"
+_SYNTHETIC_PID_PREFIX = "__path:"
 
-_SOURCE_PRIORITY_STEAM: list[ModType] = [ModType.STEAM_WORKSHOP, ModType.LOCAL]
+_SOURCE_PRIORITY_STEAM: list[ModType] = [
+    ModType.STEAM_WORKSHOP,
+    ModType.LOCAL,
+    ModType.STEAM_CMD,
+    ModType.GIT,
+]
 _SOURCE_PRIORITY_DEFAULT: list[ModType] = [
     ModType.LUDEON,
     ModType.LOCAL,
+    ModType.STEAM_CMD,
+    ModType.GIT,
     ModType.STEAM_WORKSHOP,
 ]
 
@@ -102,10 +110,15 @@ class ModList:
         self._rebuild_indices()
 
     def _rebuild_indices(self) -> None:
-        """Full index rebuild from _entries. O(n)."""
+        """Full index rebuild from _entries. O(n).
+
+        :raises ValueError: If duplicate paths are found in _entries.
+        """
         self._path_index = {}
         self._pid_index = {}
         for i, entry in enumerate(self._entries):
+            if entry.path in self._path_index:
+                raise ValueError(f"Duplicate path in entries: {entry.path}")
             self._path_index[entry.path] = i
             self._pid_index.setdefault(entry.package_id, []).append(i)
 
@@ -196,6 +209,7 @@ class ModList:
         Entries are ordered by their current position (not the order in `paths`),
         removed, then reinserted at `target_index` (clamped to list bounds).
         """
+        paths = list(dict.fromkeys(paths))
         current_positions = []
         for p in paths:
             idx = self._path_index.get(p)
@@ -205,7 +219,7 @@ class ModList:
         moved_entries = [entry for _, entry in current_positions]
         for entry in moved_entries:
             self._entries.remove(entry)
-        insert_at = min(target_index, len(self._entries))
+        insert_at = max(0, min(target_index, len(self._entries)))
         for i, entry in enumerate(moved_entries):
             self._entries.insert(insert_at + i, entry)
         self._rebuild_indices()
@@ -226,8 +240,16 @@ class ModList:
         self_paths = set(self._path_index.keys())
         other_paths = set(other._path_index.keys())
 
-        added = [other[other._path_index[p]] for p in other_paths - self_paths]
-        removed = [self[self._path_index[p]] for p in self_paths - other_paths]
+        added_paths = other_paths - self_paths
+        added = sorted(
+            [other[other._path_index[p]] for p in added_paths],
+            key=lambda e: other._path_index[e.path],
+        )
+        removed_paths = self_paths - other_paths
+        removed = sorted(
+            [self[self._path_index[p]] for p in removed_paths],
+            key=lambda e: self._path_index[e.path],
+        )
 
         common = self_paths & other_paths
         reordered = False
@@ -388,10 +410,8 @@ class ModList:
             if not isinstance(mod, AboutXmlMod):
                 entry = create_mod_entry(
                     path=path,
-                    package_id=CaseInsensitiveStr(""),
-                    mod_type=mod.mod_type
-                    if hasattr(mod, "mod_type")
-                    else ModType.UNKNOWN,
+                    package_id=CaseInsensitiveStr(f"{_SYNTHETIC_PID_PREFIX}{path}"),
+                    mod_type=mod.mod_type,
                     has_duplicate=False,
                 )
             else:

--- a/app/models/mod_list.py
+++ b/app/models/mod_list.py
@@ -9,14 +9,30 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from loguru import logger
+from natsort import natsorted
 
 from app.models.metadata.metadata_structure import (
+    AboutXmlMod,
     CaseInsensitiveStr,
     ModsConfig,
     ModType,
 )
+
+if TYPE_CHECKING:
+    from app.controllers.metadata_controller import MetadataController
+
+
+_STEAM_SUFFIX = "_steam"
+
+_SOURCE_PRIORITY_STEAM: list[ModType] = [ModType.STEAM_WORKSHOP, ModType.LOCAL]
+_SOURCE_PRIORITY_DEFAULT: list[ModType] = [
+    ModType.LUDEON,
+    ModType.LOCAL,
+    ModType.STEAM_WORKSHOP,
+]
 
 
 @dataclass(frozen=True)
@@ -257,3 +273,80 @@ class ModList:
             else:
                 logger.warning(f"from_sorted_paths: path not in source, skipping: {path}")
         return cls(entries)
+
+    @classmethod
+    def from_mods_config(
+        cls,
+        config: ModsConfig,
+        metadata_controller: MetadataController,
+    ) -> tuple[ModList, list[str]]:
+        """Resolve a ModsConfig into a ModList by mapping packageIds to paths.
+
+        Handles _steam suffix detection and source-priority resolution for
+        duplicate mods. Unresolved packageIds are returned in the missing list.
+
+        :param config: The ModsConfig loaded from XML.
+        :param metadata_controller: Provides mods_metadata and packageid_to_paths.
+        :return: (resolved ModList, list of missing packageId strings)
+        """
+        entries: list[ModEntry] = []
+        missing: list[str] = []
+        seen_paths: set[str] = set()
+        pid_to_paths = metadata_controller.packageid_to_paths
+
+        for config_id_ci in config.activeMods:
+            config_id_str = str(config_id_ci)
+            is_steam = config_id_str.endswith(_STEAM_SUFFIX)
+            raw_pid = config_id_str[: -len(_STEAM_SUFFIX)] if is_steam else config_id_str
+
+            candidate_paths = pid_to_paths.get(raw_pid, set())
+            if not candidate_paths:
+                missing.append(raw_pid)
+                continue
+
+            sources = _SOURCE_PRIORITY_STEAM if is_steam else _SOURCE_PRIORITY_DEFAULT
+            resolved_path = cls._resolve_path(
+                candidate_paths,
+                sources,
+                metadata_controller,
+                seen_paths,
+            )
+
+            if resolved_path is None:
+                missing.append(raw_pid)
+                continue
+
+            seen_paths.add(resolved_path)
+            mod = metadata_controller.mods_metadata[resolved_path]
+            has_duplicate = len(candidate_paths) > 1
+            entry = create_mod_entry(
+                path=resolved_path,
+                package_id=CaseInsensitiveStr(raw_pid),
+                mod_type=mod.mod_type,
+                has_duplicate=has_duplicate,
+            )
+            entries.append(entry)
+
+        return cls(entries), missing
+
+    @staticmethod
+    def _resolve_path(
+        candidate_paths: set[str],
+        source_priority: list[ModType],
+        metadata_controller: MetadataController,
+        seen_paths: set[str],
+    ) -> str | None:
+        """Pick the best path from candidates using source priority and natsort tiebreaking."""
+        for source_type in source_priority:
+            source_paths = [
+                p
+                for p in candidate_paths
+                if p not in seen_paths
+                and metadata_controller.mods_metadata[p].mod_type == source_type
+            ]
+            if source_paths:
+                return natsorted(source_paths)[0]
+        remaining = [p for p in candidate_paths if p not in seen_paths]
+        if remaining:
+            return natsorted(remaining)[0]
+        return None

--- a/app/models/mod_list.py
+++ b/app/models/mod_list.py
@@ -33,6 +33,20 @@ class ModEntry:
     config_id: str
 
 
+@dataclass
+class ModListDiff:
+    """Result of comparing two ModLists.
+
+    :param added: Entries in the other list but not this one.
+    :param removed: Entries in this list but not the other.
+    :param reordered: True if both lists have the same entries but in different order.
+    """
+
+    added: list[ModEntry]
+    removed: list[ModEntry]
+    reordered: bool
+
+
 def create_mod_entry(
     path: str,
     package_id: CaseInsensitiveStr,

--- a/tests/models/test_mod_list.py
+++ b/tests/models/test_mod_list.py
@@ -1,7 +1,7 @@
 """Tests for app.models.mod_list — ModEntry, create_mod_entry, ModListDiff, ModList."""
 
 from app.models.metadata.metadata_structure import CaseInsensitiveStr, ModType
-from app.models.mod_list import ModEntry, create_mod_entry
+from app.models.mod_list import ModEntry, ModListDiff, create_mod_entry
 
 
 class TestModEntry:
@@ -83,3 +83,19 @@ class TestCreateModEntry:
         )
         assert entry.path == "/some/path"
         assert entry.package_id == CaseInsensitiveStr("some.mod")
+
+
+class TestModListDiff:
+    def test_empty_diff(self) -> None:
+        diff = ModListDiff(added=[], removed=[], reordered=False)
+        assert len(diff.added) == 0
+        assert len(diff.removed) == 0
+        assert diff.reordered is False
+
+    def test_diff_fields(self) -> None:
+        a = ModEntry("/a", CaseInsensitiveStr("a"), "a")
+        b = ModEntry("/b", CaseInsensitiveStr("b"), "b")
+        diff = ModListDiff(added=[a], removed=[b], reordered=True)
+        assert diff.added == [a]
+        assert diff.removed == [b]
+        assert diff.reordered is True

--- a/tests/models/test_mod_list.py
+++ b/tests/models/test_mod_list.py
@@ -415,3 +415,127 @@ class TestFromSortedPaths:
         source = ModList([_entry("/a")])
         result = ModList.from_sorted_paths([], source)
         assert len(result) == 0
+
+
+from unittest.mock import MagicMock, PropertyMock
+
+from app.models.metadata.metadata_structure import AboutXmlMod, ListedMod
+
+
+def _make_mock_metadata_controller(
+    mods: dict[str, tuple[str, ModType]],
+) -> MagicMock:
+    """Build a mock MetadataController with mods_metadata and packageid_to_paths.
+
+    :param mods: dict of path -> (packageId, ModType)
+    """
+    mc = MagicMock()
+
+    mods_metadata: dict[str, ListedMod] = {}
+    pid_to_paths: dict[str, set[str]] = {}
+
+    for path, (pid, mod_type) in mods.items():
+        mod = MagicMock(spec=AboutXmlMod)
+        mod.package_id = CaseInsensitiveStr(pid)
+        mod.mod_type = mod_type
+        mods_metadata[path] = mod
+        pid_to_paths.setdefault(pid.lower(), set()).add(path)
+
+    mc.mods_metadata = mods_metadata
+    type(mc).packageid_to_paths = PropertyMock(return_value=pid_to_paths)
+    return mc
+
+
+class TestFromModsConfig:
+    def test_basic_resolution(self) -> None:
+        mc = _make_mock_metadata_controller({
+            "/local/mod_a": ("author.moda", ModType.LOCAL),
+            "/local/mod_b": ("author.modb", ModType.LOCAL),
+        })
+        config = ModsConfig("1.5", ["author.moda", "author.modb"], [])
+        mod_list, missing = ModList.from_mods_config(config, mc)
+        assert mod_list.paths() == ["/local/mod_a", "/local/mod_b"]
+        assert missing == []
+
+    def test_missing_mod(self) -> None:
+        mc = _make_mock_metadata_controller({
+            "/local/mod_a": ("author.moda", ModType.LOCAL),
+        })
+        config = ModsConfig("1.5", ["author.moda", "ghost.mod"], [])
+        mod_list, missing = ModList.from_mods_config(config, mc)
+        assert mod_list.paths() == ["/local/mod_a"]
+        assert "ghost.mod" in missing
+
+    def test_steam_suffix_prefers_workshop(self) -> None:
+        mc = _make_mock_metadata_controller({
+            "/local/mymod": ("author.mod", ModType.LOCAL),
+            "/workshop/mymod": ("author.mod", ModType.STEAM_WORKSHOP),
+        })
+        config = ModsConfig("1.5", ["author.mod_steam"], [])
+        mod_list, missing = ModList.from_mods_config(config, mc)
+        assert len(mod_list) == 1
+        assert mod_list[0].path == "/workshop/mymod"
+        assert mod_list[0].config_id == "author.mod_steam"
+
+    def test_no_suffix_prefers_expansion(self) -> None:
+        mc = _make_mock_metadata_controller({
+            "/game/Data/Core": ("ludeon.rimworld", ModType.LUDEON),
+            "/workshop/rimworld": ("ludeon.rimworld", ModType.STEAM_WORKSHOP),
+        })
+        config = ModsConfig("1.5", ["ludeon.rimworld"], [])
+        mod_list, missing = ModList.from_mods_config(config, mc)
+        assert mod_list[0].path == "/game/Data/Core"
+
+    def test_no_suffix_fallback_to_local(self) -> None:
+        mc = _make_mock_metadata_controller({
+            "/local/mymod": ("author.mod", ModType.LOCAL),
+            "/workshop/mymod": ("author.mod", ModType.STEAM_WORKSHOP),
+        })
+        config = ModsConfig("1.5", ["author.mod"], [])
+        mod_list, missing = ModList.from_mods_config(config, mc)
+        assert mod_list[0].path == "/local/mymod"
+
+    def test_preserves_order(self) -> None:
+        mc = _make_mock_metadata_controller({
+            "/a": ("mod.a", ModType.LOCAL),
+            "/b": ("mod.b", ModType.LOCAL),
+            "/c": ("mod.c", ModType.LOCAL),
+        })
+        config = ModsConfig("1.5", ["mod.c", "mod.a", "mod.b"], [])
+        mod_list, _ = ModList.from_mods_config(config, mc)
+        assert mod_list.package_ids() == [
+            CaseInsensitiveStr("mod.c"),
+            CaseInsensitiveStr("mod.a"),
+            CaseInsensitiveStr("mod.b"),
+        ]
+
+    def test_round_trip(self) -> None:
+        mc = _make_mock_metadata_controller({
+            "/a": ("mod.a", ModType.LOCAL),
+            "/b": ("mod.b", ModType.STEAM_WORKSHOP),
+        })
+        original_config = ModsConfig(
+            "1.5",
+            ["mod.a", "mod.b"],
+            [CaseInsensitiveStr("ludeon.rimworld")],
+        )
+        mod_list, _ = ModList.from_mods_config(original_config, mc)
+        roundtripped = mod_list.to_mods_config(
+            "1.5", [CaseInsensitiveStr("ludeon.rimworld")]
+        )
+        assert roundtripped.activeMods == original_config.activeMods
+        assert roundtripped.knownExpansions == original_config.knownExpansions
+
+    def test_empty_config(self) -> None:
+        mc = _make_mock_metadata_controller({})
+        config = ModsConfig("1.5", [], [])
+        mod_list, missing = ModList.from_mods_config(config, mc)
+        assert len(mod_list) == 0
+        assert missing == []
+
+    def test_all_missing(self) -> None:
+        mc = _make_mock_metadata_controller({})
+        config = ModsConfig("1.5", ["gone.a", "gone.b"], [])
+        mod_list, missing = ModList.from_mods_config(config, mc)
+        assert len(mod_list) == 0
+        assert set(missing) == {"gone.a", "gone.b"}

--- a/tests/models/test_mod_list.py
+++ b/tests/models/test_mod_list.py
@@ -1,8 +1,16 @@
 """Tests for app.models.mod_list — ModEntry, create_mod_entry, ModListDiff, ModList."""
 
+from unittest.mock import MagicMock, PropertyMock
+
 import pytest
 
-from app.models.metadata.metadata_structure import CaseInsensitiveStr, ModType
+from app.models.metadata.metadata_structure import (
+    AboutXmlMod,
+    CaseInsensitiveStr,
+    ListedMod,
+    ModsConfig,
+    ModType,
+)
 from app.models.mod_list import ModEntry, ModList, ModListDiff, create_mod_entry
 
 
@@ -172,7 +180,10 @@ class TestModListConstruction:
         ml = ModList([e1, e2, e3])
         dupes = ml.find_duplicate_package_ids()
         assert CaseInsensitiveStr("dup.mod") in dupes
-        assert set(dupes[CaseInsensitiveStr("dup.mod")]) == {"/local/mod", "/workshop/mod"}
+        assert set(dupes[CaseInsensitiveStr("dup.mod")]) == {
+            "/local/mod",
+            "/workshop/mod",
+        }
         assert CaseInsensitiveStr("unique.mod") not in dupes
 
     def test_iter(self) -> None:
@@ -366,9 +377,6 @@ class TestModListDiffMethod:
         assert d.reordered is False
 
 
-from app.models.metadata.metadata_structure import ModsConfig
-
-
 class TestToModsConfig:
     def test_basic(self) -> None:
         entries = [
@@ -378,7 +386,10 @@ class TestToModsConfig:
         ml = ModList(entries)
         config = ml.to_mods_config("1.5", [CaseInsensitiveStr("ludeon.rimworld")])
         assert config.version == "1.5"
-        assert config.activeMods == [CaseInsensitiveStr("pkg.a"), CaseInsensitiveStr("pkg.b")]
+        assert config.activeMods == [
+            CaseInsensitiveStr("pkg.a"),
+            CaseInsensitiveStr("pkg.b"),
+        ]
         assert config.knownExpansions == [CaseInsensitiveStr("ludeon.rimworld")]
 
     def test_uses_config_id(self) -> None:
@@ -417,11 +428,6 @@ class TestFromSortedPaths:
         assert len(result) == 0
 
 
-from unittest.mock import MagicMock, PropertyMock
-
-from app.models.metadata.metadata_structure import AboutXmlMod, ListedMod
-
-
 def _make_mock_metadata_controller(
     mods: dict[str, tuple[str, ModType]],
 ) -> MagicMock:
@@ -448,29 +454,35 @@ def _make_mock_metadata_controller(
 
 class TestFromModsConfig:
     def test_basic_resolution(self) -> None:
-        mc = _make_mock_metadata_controller({
-            "/local/mod_a": ("author.moda", ModType.LOCAL),
-            "/local/mod_b": ("author.modb", ModType.LOCAL),
-        })
+        mc = _make_mock_metadata_controller(
+            {
+                "/local/mod_a": ("author.moda", ModType.LOCAL),
+                "/local/mod_b": ("author.modb", ModType.LOCAL),
+            }
+        )
         config = ModsConfig("1.5", ["author.moda", "author.modb"], [])
         mod_list, missing = ModList.from_mods_config(config, mc)
         assert mod_list.paths() == ["/local/mod_a", "/local/mod_b"]
         assert missing == []
 
     def test_missing_mod(self) -> None:
-        mc = _make_mock_metadata_controller({
-            "/local/mod_a": ("author.moda", ModType.LOCAL),
-        })
+        mc = _make_mock_metadata_controller(
+            {
+                "/local/mod_a": ("author.moda", ModType.LOCAL),
+            }
+        )
         config = ModsConfig("1.5", ["author.moda", "ghost.mod"], [])
         mod_list, missing = ModList.from_mods_config(config, mc)
         assert mod_list.paths() == ["/local/mod_a"]
         assert "ghost.mod" in missing
 
     def test_steam_suffix_prefers_workshop(self) -> None:
-        mc = _make_mock_metadata_controller({
-            "/local/mymod": ("author.mod", ModType.LOCAL),
-            "/workshop/mymod": ("author.mod", ModType.STEAM_WORKSHOP),
-        })
+        mc = _make_mock_metadata_controller(
+            {
+                "/local/mymod": ("author.mod", ModType.LOCAL),
+                "/workshop/mymod": ("author.mod", ModType.STEAM_WORKSHOP),
+            }
+        )
         config = ModsConfig("1.5", ["author.mod_steam"], [])
         mod_list, missing = ModList.from_mods_config(config, mc)
         assert len(mod_list) == 1
@@ -478,29 +490,35 @@ class TestFromModsConfig:
         assert mod_list[0].config_id == "author.mod_steam"
 
     def test_no_suffix_prefers_expansion(self) -> None:
-        mc = _make_mock_metadata_controller({
-            "/game/Data/Core": ("ludeon.rimworld", ModType.LUDEON),
-            "/workshop/rimworld": ("ludeon.rimworld", ModType.STEAM_WORKSHOP),
-        })
+        mc = _make_mock_metadata_controller(
+            {
+                "/game/Data/Core": ("ludeon.rimworld", ModType.LUDEON),
+                "/workshop/rimworld": ("ludeon.rimworld", ModType.STEAM_WORKSHOP),
+            }
+        )
         config = ModsConfig("1.5", ["ludeon.rimworld"], [])
         mod_list, missing = ModList.from_mods_config(config, mc)
         assert mod_list[0].path == "/game/Data/Core"
 
     def test_no_suffix_fallback_to_local(self) -> None:
-        mc = _make_mock_metadata_controller({
-            "/local/mymod": ("author.mod", ModType.LOCAL),
-            "/workshop/mymod": ("author.mod", ModType.STEAM_WORKSHOP),
-        })
+        mc = _make_mock_metadata_controller(
+            {
+                "/local/mymod": ("author.mod", ModType.LOCAL),
+                "/workshop/mymod": ("author.mod", ModType.STEAM_WORKSHOP),
+            }
+        )
         config = ModsConfig("1.5", ["author.mod"], [])
         mod_list, missing = ModList.from_mods_config(config, mc)
         assert mod_list[0].path == "/local/mymod"
 
     def test_preserves_order(self) -> None:
-        mc = _make_mock_metadata_controller({
-            "/a": ("mod.a", ModType.LOCAL),
-            "/b": ("mod.b", ModType.LOCAL),
-            "/c": ("mod.c", ModType.LOCAL),
-        })
+        mc = _make_mock_metadata_controller(
+            {
+                "/a": ("mod.a", ModType.LOCAL),
+                "/b": ("mod.b", ModType.LOCAL),
+                "/c": ("mod.c", ModType.LOCAL),
+            }
+        )
         config = ModsConfig("1.5", ["mod.c", "mod.a", "mod.b"], [])
         mod_list, _ = ModList.from_mods_config(config, mc)
         assert mod_list.package_ids() == [
@@ -510,10 +528,12 @@ class TestFromModsConfig:
         ]
 
     def test_round_trip(self) -> None:
-        mc = _make_mock_metadata_controller({
-            "/a": ("mod.a", ModType.LOCAL),
-            "/b": ("mod.b", ModType.STEAM_WORKSHOP),
-        })
+        mc = _make_mock_metadata_controller(
+            {
+                "/a": ("mod.a", ModType.LOCAL),
+                "/b": ("mod.b", ModType.STEAM_WORKSHOP),
+            }
+        )
         original_config = ModsConfig(
             "1.5",
             ["mod.a", "mod.b"],
@@ -539,3 +559,46 @@ class TestFromModsConfig:
         mod_list, missing = ModList.from_mods_config(config, mc)
         assert len(mod_list) == 0
         assert set(missing) == {"gone.a", "gone.b"}
+
+
+class TestFromRemaining:
+    def test_basic(self) -> None:
+        mc = _make_mock_metadata_controller(
+            {
+                "/a": ("mod.a", ModType.LOCAL),
+                "/b": ("mod.b", ModType.LOCAL),
+                "/c": ("mod.c", ModType.STEAM_WORKSHOP),
+            }
+        )
+        active = ModList([_entry("/a", "mod.a")])
+        remaining = ModList.from_remaining({"/a", "/b", "/c"}, active, mc)
+        remaining_paths = set(remaining.paths())
+        assert remaining_paths == {"/b", "/c"}
+
+    def test_no_steam_suffix(self) -> None:
+        mc = _make_mock_metadata_controller(
+            {
+                "/a": ("dup.mod", ModType.LOCAL),
+                "/b": ("dup.mod", ModType.STEAM_WORKSHOP),
+            }
+        )
+        active = ModList()
+        remaining = ModList.from_remaining({"/a", "/b"}, active, mc)
+        for entry in remaining:
+            assert "_steam" not in entry.config_id
+
+    def test_all_active(self) -> None:
+        mc = _make_mock_metadata_controller(
+            {
+                "/a": ("mod.a", ModType.LOCAL),
+            }
+        )
+        active = ModList([_entry("/a", "mod.a")])
+        remaining = ModList.from_remaining({"/a"}, active, mc)
+        assert len(remaining) == 0
+
+    def test_empty_all(self) -> None:
+        mc = _make_mock_metadata_controller({})
+        active = ModList()
+        remaining = ModList.from_remaining(set(), active, mc)
+        assert len(remaining) == 0

--- a/tests/models/test_mod_list.py
+++ b/tests/models/test_mod_list.py
@@ -1,7 +1,7 @@
 """Tests for app.models.mod_list — ModEntry, create_mod_entry, ModListDiff, ModList."""
 
 from app.models.metadata.metadata_structure import CaseInsensitiveStr, ModType
-from app.models.mod_list import ModEntry, ModListDiff, create_mod_entry
+from app.models.mod_list import ModEntry, ModList, ModListDiff, create_mod_entry
 
 
 class TestModEntry:
@@ -85,6 +85,13 @@ class TestCreateModEntry:
         assert entry.package_id == CaseInsensitiveStr("some.mod")
 
 
+def _entry(path: str, pid: str = "", config_id: str = "") -> ModEntry:
+    """Helper to build ModEntry with sensible defaults."""
+    pid = pid or path.split("/")[-1]
+    config_id = config_id or pid
+    return ModEntry(path=path, package_id=CaseInsensitiveStr(pid), config_id=config_id)
+
+
 class TestModListDiff:
     def test_empty_diff(self) -> None:
         diff = ModListDiff(added=[], removed=[], reordered=False)
@@ -99,3 +106,74 @@ class TestModListDiff:
         assert diff.added == [a]
         assert diff.removed == [b]
         assert diff.reordered is True
+
+
+class TestModListConstruction:
+    def test_empty(self) -> None:
+        ml = ModList()
+        assert len(ml) == 0
+        assert list(ml) == []
+
+    def test_from_entries(self) -> None:
+        entries = [_entry("/a"), _entry("/b"), _entry("/c")]
+        ml = ModList(entries)
+        assert len(ml) == 3
+        assert ml[0] == entries[0]
+        assert ml[1] == entries[1]
+        assert ml[2] == entries[2]
+
+    def test_contains(self) -> None:
+        ml = ModList([_entry("/a"), _entry("/b")])
+        assert "/a" in ml
+        assert "/c" not in ml
+
+    def test_index_of_found(self) -> None:
+        ml = ModList([_entry("/a"), _entry("/b"), _entry("/c")])
+        assert ml.index_of("/b") == 1
+
+    def test_index_of_missing(self) -> None:
+        ml = ModList([_entry("/a")])
+        assert ml.index_of("/z") is None
+
+    def test_getitem_out_of_bounds(self) -> None:
+        ml = ModList([_entry("/a")])
+        try:
+            ml[5]
+            assert False, "Should have raised IndexError"
+        except IndexError:
+            pass
+
+    def test_paths(self) -> None:
+        ml = ModList([_entry("/a", "pkg.a"), _entry("/b", "pkg.b")])
+        assert ml.paths() == ["/a", "/b"]
+
+    def test_package_ids(self) -> None:
+        ml = ModList([_entry("/a", "pkg.a"), _entry("/b", "pkg.b")])
+        pids = ml.package_ids()
+        assert pids == [CaseInsensitiveStr("pkg.a"), CaseInsensitiveStr("pkg.b")]
+
+    def test_entries_for_package_id(self) -> None:
+        e1 = _entry("/local/mymod", "author.mod")
+        e2 = _entry("/workshop/mymod", "author.mod")
+        ml = ModList([e1, e2])
+        found = ml.entries_for_package_id(CaseInsensitiveStr("author.mod"))
+        assert found == [e1, e2]
+
+    def test_entries_for_package_id_missing(self) -> None:
+        ml = ModList([_entry("/a", "pkg.a")])
+        assert ml.entries_for_package_id(CaseInsensitiveStr("pkg.z")) == []
+
+    def test_find_duplicate_package_ids(self) -> None:
+        e1 = _entry("/local/mod", "dup.mod")
+        e2 = _entry("/workshop/mod", "dup.mod")
+        e3 = _entry("/other", "unique.mod")
+        ml = ModList([e1, e2, e3])
+        dupes = ml.find_duplicate_package_ids()
+        assert CaseInsensitiveStr("dup.mod") in dupes
+        assert set(dupes[CaseInsensitiveStr("dup.mod")]) == {"/local/mod", "/workshop/mod"}
+        assert CaseInsensitiveStr("unique.mod") not in dupes
+
+    def test_iter(self) -> None:
+        entries = [_entry("/a"), _entry("/b")]
+        ml = ModList(entries)
+        assert list(ml) == entries

--- a/tests/models/test_mod_list.py
+++ b/tests/models/test_mod_list.py
@@ -15,6 +15,19 @@ from app.models.metadata.metadata_structure import (
 from app.models.mod_list import ModEntry, ModList, ModListDiff, create_mod_entry
 
 
+def _config(
+    version: str,
+    active: list[str],
+    expansions: list[str] | None = None,
+) -> ModsConfig:
+    """Build a ModsConfig with plain strings (wraps to CaseInsensitiveStr for pyright)."""
+    return ModsConfig(
+        version=version,
+        activeMods=[CaseInsensitiveStr(s) for s in active],
+        knownExpansions=[CaseInsensitiveStr(s) for s in (expansions or [])],
+    )
+
+
 class TestModEntry:
     def test_frozen(self) -> None:
         entry = ModEntry(
@@ -461,7 +474,7 @@ class TestFromModsConfig:
                 "/local/mod_b": ("author.modb", ModType.LOCAL),
             }
         )
-        config = ModsConfig("1.5", ["author.moda", "author.modb"], [])
+        config = _config("1.5", ["author.moda", "author.modb"])
         mod_list, missing = ModList.from_mods_config(config, mc)
         assert mod_list.paths() == ["/local/mod_a", "/local/mod_b"]
         assert missing == []
@@ -472,7 +485,7 @@ class TestFromModsConfig:
                 "/local/mod_a": ("author.moda", ModType.LOCAL),
             }
         )
-        config = ModsConfig("1.5", ["author.moda", "ghost.mod"], [])
+        config = _config("1.5", ["author.moda", "ghost.mod"])
         mod_list, missing = ModList.from_mods_config(config, mc)
         assert mod_list.paths() == ["/local/mod_a"]
         assert "ghost.mod" in missing
@@ -484,7 +497,7 @@ class TestFromModsConfig:
                 "/workshop/mymod": ("author.mod", ModType.STEAM_WORKSHOP),
             }
         )
-        config = ModsConfig("1.5", ["author.mod_steam"], [])
+        config = _config("1.5", ["author.mod_steam"])
         mod_list, missing = ModList.from_mods_config(config, mc)
         assert len(mod_list) == 1
         assert mod_list[0].path == "/workshop/mymod"
@@ -497,7 +510,7 @@ class TestFromModsConfig:
                 "/workshop/rimworld": ("ludeon.rimworld", ModType.STEAM_WORKSHOP),
             }
         )
-        config = ModsConfig("1.5", ["ludeon.rimworld"], [])
+        config = _config("1.5", ["ludeon.rimworld"])
         mod_list, missing = ModList.from_mods_config(config, mc)
         assert mod_list[0].path == "/game/Data/Core"
 
@@ -508,7 +521,7 @@ class TestFromModsConfig:
                 "/workshop/mymod": ("author.mod", ModType.STEAM_WORKSHOP),
             }
         )
-        config = ModsConfig("1.5", ["author.mod"], [])
+        config = _config("1.5", ["author.mod"])
         mod_list, missing = ModList.from_mods_config(config, mc)
         assert mod_list[0].path == "/local/mymod"
 
@@ -520,7 +533,7 @@ class TestFromModsConfig:
                 "/c": ("mod.c", ModType.LOCAL),
             }
         )
-        config = ModsConfig("1.5", ["mod.c", "mod.a", "mod.b"], [])
+        config = _config("1.5", ["mod.c", "mod.a", "mod.b"])
         mod_list, _ = ModList.from_mods_config(config, mc)
         assert mod_list.package_ids() == [
             CaseInsensitiveStr("mod.c"),
@@ -535,11 +548,7 @@ class TestFromModsConfig:
                 "/b": ("mod.b", ModType.STEAM_WORKSHOP),
             }
         )
-        original_config = ModsConfig(
-            "1.5",
-            ["mod.a", "mod.b"],
-            [CaseInsensitiveStr("ludeon.rimworld")],
-        )
+        original_config = _config("1.5", ["mod.a", "mod.b"], ["ludeon.rimworld"])
         mod_list, _ = ModList.from_mods_config(original_config, mc)
         roundtripped = mod_list.to_mods_config(
             "1.5", [CaseInsensitiveStr("ludeon.rimworld")]
@@ -549,14 +558,14 @@ class TestFromModsConfig:
 
     def test_empty_config(self) -> None:
         mc = _make_mock_metadata_controller({})
-        config = ModsConfig("1.5", [], [])
+        config = _config("1.5", [])
         mod_list, missing = ModList.from_mods_config(config, mc)
         assert len(mod_list) == 0
         assert missing == []
 
     def test_all_missing(self) -> None:
         mc = _make_mock_metadata_controller({})
-        config = ModsConfig("1.5", ["gone.a", "gone.b"], [])
+        config = _config("1.5", ["gone.a", "gone.b"])
         mod_list, missing = ModList.from_mods_config(config, mc)
         assert len(mod_list) == 0
         assert set(missing) == {"gone.a", "gone.b"}

--- a/tests/models/test_mod_list.py
+++ b/tests/models/test_mod_list.py
@@ -10,6 +10,7 @@ from app.models.metadata.metadata_structure import (
     ListedMod,
     ModsConfig,
     ModType,
+    ScenarioMod,
 )
 from app.models.mod_list import ModEntry, ModList, ModListDiff, create_mod_entry
 
@@ -596,6 +597,28 @@ class TestFromRemaining:
         active = ModList([_entry("/a", "mod.a")])
         remaining = ModList.from_remaining({"/a"}, active, mc)
         assert len(remaining) == 0
+
+    def test_non_about_xml_mod_gets_synthetic_pid(self) -> None:
+        """ScenarioMod and invalid ListedMod entries get __path: prefixed package_id."""
+        mc = MagicMock()
+        scenario = MagicMock(spec=ScenarioMod)
+        scenario.mod_type = ModType.LOCAL
+        invalid = MagicMock(spec=ListedMod)
+        invalid.mod_type = ModType.UNKNOWN
+        mc.mods_metadata = {
+            "/scenarios/my_scenario": scenario,
+            "/invalid/leftover": invalid,
+        }
+        active = ModList()
+        remaining = ModList.from_remaining(
+            {"/scenarios/my_scenario", "/invalid/leftover"}, active, mc
+        )
+        assert len(remaining) == 2
+        for entry in remaining:
+            assert entry.package_id.startswith("__path:")
+            assert entry.path in str(entry.package_id)
+        dupes = remaining.find_duplicate_package_ids()
+        assert len(dupes) == 0
 
     def test_empty_all(self) -> None:
         mc = _make_mock_metadata_controller({})

--- a/tests/models/test_mod_list.py
+++ b/tests/models/test_mod_list.py
@@ -312,3 +312,55 @@ class TestModListIndexConsistency:
         ml.clear()
         ml.insert(0, _entry("/x"))
         self._check_indices(ml)
+
+
+class TestModListDiffMethod:
+    def test_identical_lists(self) -> None:
+        entries = [_entry("/a"), _entry("/b")]
+        a = ModList(entries)
+        b = ModList(entries)
+        d = a.diff(b)
+        assert d.added == []
+        assert d.removed == []
+        assert d.reordered is False
+
+    def test_added(self) -> None:
+        a = ModList([_entry("/a")])
+        new_entry = _entry("/b")
+        b = ModList([_entry("/a"), new_entry])
+        d = a.diff(b)
+        assert d.added == [new_entry]
+        assert d.removed == []
+
+    def test_removed(self) -> None:
+        removed_entry = _entry("/b")
+        a = ModList([_entry("/a"), removed_entry])
+        b = ModList([_entry("/a")])
+        d = a.diff(b)
+        assert d.added == []
+        assert d.removed == [removed_entry]
+
+    def test_reordered(self) -> None:
+        e1, e2 = _entry("/a"), _entry("/b")
+        a = ModList([e1, e2])
+        b = ModList([e2, e1])
+        d = a.diff(b)
+        assert d.added == []
+        assert d.removed == []
+        assert d.reordered is True
+
+    def test_both_empty(self) -> None:
+        d = ModList().diff(ModList())
+        assert d.added == []
+        assert d.removed == []
+        assert d.reordered is False
+
+    def test_added_and_removed(self) -> None:
+        ea = _entry("/a")
+        eb = _entry("/b")
+        a = ModList([ea])
+        b = ModList([eb])
+        d = a.diff(b)
+        assert d.added == [eb]
+        assert d.removed == [ea]
+        assert d.reordered is False

--- a/tests/models/test_mod_list.py
+++ b/tests/models/test_mod_list.py
@@ -1,5 +1,7 @@
 """Tests for app.models.mod_list — ModEntry, create_mod_entry, ModListDiff, ModList."""
 
+import pytest
+
 from app.models.metadata.metadata_structure import CaseInsensitiveStr, ModType
 from app.models.mod_list import ModEntry, ModList, ModListDiff, create_mod_entry
 
@@ -177,3 +179,136 @@ class TestModListConstruction:
         entries = [_entry("/a"), _entry("/b")]
         ml = ModList(entries)
         assert list(ml) == entries
+
+
+class TestModListMutations:
+    def test_insert(self) -> None:
+        ml = ModList([_entry("/a"), _entry("/c")])
+        ml.insert(1, _entry("/b"))
+        assert ml.paths() == ["/a", "/b", "/c"]
+        assert ml.index_of("/b") == 1
+
+    def test_insert_at_start(self) -> None:
+        ml = ModList([_entry("/b")])
+        ml.insert(0, _entry("/a"))
+        assert ml.paths() == ["/a", "/b"]
+
+    def test_insert_at_end(self) -> None:
+        ml = ModList([_entry("/a")])
+        ml.insert(1, _entry("/b"))
+        assert ml.paths() == ["/a", "/b"]
+
+    def test_insert_duplicate_path_raises(self) -> None:
+        ml = ModList([_entry("/a")])
+        with pytest.raises(ValueError):
+            ml.insert(0, _entry("/a"))
+
+    def test_remove_by_path(self) -> None:
+        ml = ModList([_entry("/a"), _entry("/b"), _entry("/c")])
+        removed = ml.remove_by_path("/b")
+        assert removed.path == "/b"
+        assert ml.paths() == ["/a", "/c"]
+        assert ml.index_of("/c") == 1
+        assert "/b" not in ml
+
+    def test_remove_missing_raises(self) -> None:
+        ml = ModList([_entry("/a")])
+        with pytest.raises(KeyError):
+            ml.remove_by_path("/z")
+
+    def test_reorder_forward(self) -> None:
+        ml = ModList([_entry("/a"), _entry("/b"), _entry("/c")])
+        ml.reorder("/a", 2)
+        assert ml.paths() == ["/b", "/c", "/a"]
+
+    def test_reorder_backward(self) -> None:
+        ml = ModList([_entry("/a"), _entry("/b"), _entry("/c")])
+        ml.reorder("/c", 0)
+        assert ml.paths() == ["/c", "/a", "/b"]
+
+    def test_reorder_missing_raises(self) -> None:
+        ml = ModList([_entry("/a")])
+        with pytest.raises(KeyError):
+            ml.reorder("/z", 0)
+
+    def test_reorder_out_of_bounds_raises(self) -> None:
+        ml = ModList([_entry("/a"), _entry("/b")])
+        with pytest.raises(IndexError):
+            ml.reorder("/a", 5)
+
+    def test_move_batch(self) -> None:
+        ml = ModList([_entry("/a"), _entry("/b"), _entry("/c"), _entry("/d")])
+        ml.move_batch(["/a", "/c"], 3)
+        assert ml.paths() == ["/b", "/d", "/a", "/c"]
+
+    def test_move_batch_to_start(self) -> None:
+        ml = ModList([_entry("/a"), _entry("/b"), _entry("/c")])
+        ml.move_batch(["/b", "/c"], 0)
+        assert ml.paths() == ["/b", "/c", "/a"]
+
+    def test_move_batch_preserves_relative_order(self) -> None:
+        ml = ModList([_entry("/a"), _entry("/b"), _entry("/c"), _entry("/d")])
+        ml.move_batch(["/c", "/a"], 1)
+        assert ml.paths() == ["/b", "/a", "/c", "/d"]
+
+    def test_replace_order(self) -> None:
+        entries = [_entry("/a"), _entry("/b"), _entry("/c")]
+        ml = ModList(entries)
+        ml.replace_order([entries[2], entries[0], entries[1]])
+        assert ml.paths() == ["/c", "/a", "/b"]
+
+    def test_clear(self) -> None:
+        ml = ModList([_entry("/a"), _entry("/b")])
+        ml.clear()
+        assert len(ml) == 0
+        assert ml.paths() == []
+        assert "/a" not in ml
+
+
+class TestModListIndexConsistency:
+    """Verify indices stay correct after every mutation type."""
+
+    def _check_indices(self, ml: ModList) -> None:
+        """Assert _path_index and _pid_index are consistent with _entries."""
+        for i, entry in enumerate(ml._entries):
+            assert ml._path_index[entry.path] == i, (
+                f"_path_index[{entry.path}] = {ml._path_index[entry.path]}, expected {i}"
+            )
+            assert i in ml._pid_index[entry.package_id], (
+                f"{i} not in _pid_index[{entry.package_id}]"
+            )
+        assert len(ml._path_index) == len(ml._entries)
+        total_pid_refs = sum(len(v) for v in ml._pid_index.values())
+        assert total_pid_refs == len(ml._entries)
+
+    def test_after_insert(self) -> None:
+        ml = ModList([_entry("/a"), _entry("/c")])
+        ml.insert(1, _entry("/b"))
+        self._check_indices(ml)
+
+    def test_after_remove(self) -> None:
+        ml = ModList([_entry("/a"), _entry("/b"), _entry("/c")])
+        ml.remove_by_path("/b")
+        self._check_indices(ml)
+
+    def test_after_reorder(self) -> None:
+        ml = ModList([_entry("/a"), _entry("/b"), _entry("/c")])
+        ml.reorder("/a", 2)
+        self._check_indices(ml)
+
+    def test_after_move_batch(self) -> None:
+        ml = ModList([_entry("/a"), _entry("/b"), _entry("/c"), _entry("/d")])
+        ml.move_batch(["/a", "/c"], 3)
+        self._check_indices(ml)
+
+    def test_after_replace_order(self) -> None:
+        entries = [_entry("/a"), _entry("/b"), _entry("/c")]
+        ml = ModList(entries)
+        ml.replace_order([entries[2], entries[0], entries[1]])
+        self._check_indices(ml)
+
+    def test_after_clear_and_reuse(self) -> None:
+        ml = ModList([_entry("/a"), _entry("/b")])
+        ml.clear()
+        ml.insert(0, _entry("/x"))
+        self._check_indices(ml)

--- a/tests/models/test_mod_list.py
+++ b/tests/models/test_mod_list.py
@@ -364,3 +364,54 @@ class TestModListDiffMethod:
         assert d.added == [eb]
         assert d.removed == [ea]
         assert d.reordered is False
+
+
+from app.models.metadata.metadata_structure import ModsConfig
+
+
+class TestToModsConfig:
+    def test_basic(self) -> None:
+        entries = [
+            _entry("/a", "pkg.a"),
+            _entry("/b", "pkg.b"),
+        ]
+        ml = ModList(entries)
+        config = ml.to_mods_config("1.5", [CaseInsensitiveStr("ludeon.rimworld")])
+        assert config.version == "1.5"
+        assert config.activeMods == [CaseInsensitiveStr("pkg.a"), CaseInsensitiveStr("pkg.b")]
+        assert config.knownExpansions == [CaseInsensitiveStr("ludeon.rimworld")]
+
+    def test_uses_config_id(self) -> None:
+        entry = ModEntry("/w/mod", CaseInsensitiveStr("author.mod"), "author.mod_steam")
+        ml = ModList([entry])
+        config = ml.to_mods_config("1.5", [])
+        assert config.activeMods == [CaseInsensitiveStr("author.mod_steam")]
+
+    def test_empty(self) -> None:
+        ml = ModList()
+        config = ml.to_mods_config("1.5", [])
+        assert config.activeMods == []
+
+
+class TestFromSortedPaths:
+    def test_reorders_from_source(self) -> None:
+        e1 = _entry("/a", "pkg.a")
+        e2 = _entry("/b", "pkg.b")
+        e3 = _entry("/c", "pkg.c")
+        source = ModList([e1, e2, e3])
+        result = ModList.from_sorted_paths(["/c", "/a", "/b"], source)
+        assert result.paths() == ["/c", "/a", "/b"]
+        assert result[0] is e3
+        assert result[1] is e1
+        assert result[2] is e2
+
+    def test_missing_path_skipped(self) -> None:
+        e1 = _entry("/a", "pkg.a")
+        source = ModList([e1])
+        result = ModList.from_sorted_paths(["/a", "/missing"], source)
+        assert result.paths() == ["/a"]
+
+    def test_empty_sort(self) -> None:
+        source = ModList([_entry("/a")])
+        result = ModList.from_sorted_paths([], source)
+        assert len(result) == 0

--- a/tests/models/test_mod_list.py
+++ b/tests/models/test_mod_list.py
@@ -1,0 +1,85 @@
+"""Tests for app.models.mod_list — ModEntry, create_mod_entry, ModListDiff, ModList."""
+
+from app.models.metadata.metadata_structure import CaseInsensitiveStr, ModType
+from app.models.mod_list import ModEntry, create_mod_entry
+
+
+class TestModEntry:
+    def test_frozen(self) -> None:
+        entry = ModEntry(
+            path="/mods/local_mod",
+            package_id=CaseInsensitiveStr("author.modname"),
+            config_id="author.modname",
+        )
+        try:
+            entry.path = "/other"  # type: ignore[misc]
+            assert False, "Should have raised FrozenInstanceError"
+        except AttributeError:
+            pass
+
+    def test_equality(self) -> None:
+        a = ModEntry("/mods/a", CaseInsensitiveStr("pkg.a"), "pkg.a")
+        b = ModEntry("/mods/a", CaseInsensitiveStr("pkg.a"), "pkg.a")
+        assert a == b
+
+    def test_hashable(self) -> None:
+        entry = ModEntry("/mods/a", CaseInsensitiveStr("pkg.a"), "pkg.a")
+        s = {entry}
+        assert entry in s
+
+
+class TestCreateModEntry:
+    def test_no_duplicate_local(self) -> None:
+        entry = create_mod_entry(
+            path="/mods/local_mod",
+            package_id=CaseInsensitiveStr("author.modname"),
+            mod_type=ModType.LOCAL,
+            has_duplicate=False,
+        )
+        assert entry.config_id == "author.modname"
+
+    def test_no_duplicate_workshop(self) -> None:
+        entry = create_mod_entry(
+            path="/mods/workshop_mod",
+            package_id=CaseInsensitiveStr("author.modname"),
+            mod_type=ModType.STEAM_WORKSHOP,
+            has_duplicate=False,
+        )
+        assert entry.config_id == "author.modname"
+
+    def test_duplicate_workshop_gets_steam_suffix(self) -> None:
+        entry = create_mod_entry(
+            path="/mods/workshop_mod",
+            package_id=CaseInsensitiveStr("author.modname"),
+            mod_type=ModType.STEAM_WORKSHOP,
+            has_duplicate=True,
+        )
+        assert entry.config_id == "author.modname_steam"
+
+    def test_duplicate_local_no_suffix(self) -> None:
+        entry = create_mod_entry(
+            path="/mods/local_mod",
+            package_id=CaseInsensitiveStr("author.modname"),
+            mod_type=ModType.LOCAL,
+            has_duplicate=True,
+        )
+        assert entry.config_id == "author.modname"
+
+    def test_duplicate_steamcmd_no_suffix(self) -> None:
+        entry = create_mod_entry(
+            path="/mods/steamcmd_mod",
+            package_id=CaseInsensitiveStr("author.modname"),
+            mod_type=ModType.STEAM_CMD,
+            has_duplicate=True,
+        )
+        assert entry.config_id == "author.modname"
+
+    def test_path_and_package_id_preserved(self) -> None:
+        entry = create_mod_entry(
+            path="/some/path",
+            package_id=CaseInsensitiveStr("Some.Mod"),
+            mod_type=ModType.LOCAL,
+            has_duplicate=False,
+        )
+        assert entry.path == "/some/path"
+        assert entry.package_id == CaseInsensitiveStr("some.mod")


### PR DESCRIPTION
## Summary

Introduces `ModEntry`, `ModListDiff`, and `ModList` as a pure-Python domain model for ordered mod lists, bridging the PATH and packageId identity systems. This is **PR 2.75** of the metadata migration (#2051) — hooking up to sorting and controllers/views will happen in a follow up PR.

- **`ModEntry`** — frozen dataclass identifying a mod by `path` (canonical), `package_id` (RimWorld identity), and `config_id` (serialization identity with `_steam` suffix handling)
- **`create_mod_entry`** — factory centralizing `_steam` suffix logic (Workshop duplicates only)
- **`ModList`** — indexed ordered collection with O(1) path/packageId lookups, mutations (insert, remove, reorder, move_batch, replace_order, clear), diff, and serialization to/from `ModsConfig.xml`
- **`ModListDiff`** — change detection (added, removed, reordered)

### Key design decisions

- **No Qt dependency** — pure Python, independently testable without standing up Qt
- **No MetadataManager dependency** — uses `MetadataController` only in classmethods
- **PATH as canonical identifier** — matches `MetadataController.mods_metadata` keys
- **`_steam` suffix centralized** — replaces scattered logic across `get_mods_from_list`, `ImportExportService`, and sort bridge code
- **Source priority for duplicates** — Expansion > Local > SteamCMD > Git > Workshop (no suffix); Workshop > Local > SteamCMD > Git (with `_steam` suffix)
- **Synthetic `__path:` packageId** — non-`AboutXmlMod` entries (ScenarioMods, invalid mods) get path-based synthetic IDs to prevent false duplicate detection
- **Passive (not observable)** — controllers call mutations directly; observable wrapper deferred to a future PR

## Test plan

- [x] 70 unit tests covering all public API surface (pure Python, no Qt)
- [x] Index consistency verified after every mutation type via dedicated test class
- [x] `from_mods_config` round-trip, source priority, `_steam` suffix, missing mod detection
- [x] ScenarioMod/invalid mod synthetic packageId handling
- [x] 828/828 full test suite passing (70 new + 758 baseline, zero regressions)
- [x] `just check` clean (ruff, ruff-format, mypy)
- [x] Max-effort code review with 9 finder angles + verification + sweep — all findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)