### PR TITLE
fix(metadata): handle malformed external JSON databases gracefully

### DIFF
--- a/app/models/metadata/metadata_factory.py
+++ b/app/models/metadata/metadata_factory.py
@@ -795,13 +795,19 @@ def read_rules_db(
         logger.info(
             "DB exists!",
         )
-        with open(path, encoding="utf-8") as f:
-            json_string = f.read()
-            logger.info("Reading info from rules DB")
-            rule_data = msgspec.json.decode(json_string, type=ExternalRulesSchema)
-            rule_data.rules = {k.lower(): v for k, v in rule_data.rules.items()}
-            logger.info(f"Loaded {len(rule_data.rules)} additional rules")
-            return rule_data
+        try:
+            with open(path, encoding="utf-8") as f:
+                json_string = f.read()
+                logger.info("Reading info from rules DB")
+                rule_data = msgspec.json.decode(json_string, type=ExternalRulesSchema)
+                rule_data.rules = {k.lower(): v for k, v in rule_data.rules.items()}
+                logger.info(f"Loaded {len(rule_data.rules)} additional rules")
+                return rule_data
+        except msgspec.DecodeError as e:
+            logger.error(
+                f"Rules DB at {path} could not be decoded: {e}. Try re-downloading the database."
+            )
+            return None
     else:  # Assume db_data_missing
         logger.warning("Rules DB not found at specified path.")
         return None
@@ -842,15 +848,21 @@ def read_steam_db(path: Path) -> SteamDbSchema | None:
         logger.info(
             "DB exists!",
         )
-        with open(path, encoding="utf-8") as f:
-            json_string = f.read()
-            logger.info("Reading info from SteamDB")
-            steam_db = msgspec.json.decode(json_string, type=SteamDbSchema)
-            steam_db.database = {k.lower(): v for k, v in steam_db.database.items()}
-            logger.info(
-                f"Loaded {len(steam_db.database)} mods from SteamDB version: {steam_db.version}"
+        try:
+            with open(path, encoding="utf-8") as f:
+                json_string = f.read()
+                logger.info("Reading info from SteamDB")
+                steam_db = msgspec.json.decode(json_string, type=SteamDbSchema)
+                steam_db.database = {k.lower(): v for k, v in steam_db.database.items()}
+                logger.info(
+                    f"Loaded {len(steam_db.database)} mods from SteamDB version: {steam_db.version}"
+                )
+                return steam_db
+        except msgspec.DecodeError as e:
+            logger.error(
+                f"SteamDB at {path} could not be decoded: {e}. Try re-downloading the database."
             )
-            return steam_db
+            return None
     else:  # Assume db_data_missing
         logger.warning("SteamDB not found at specified path.")
         return None

--- a/app/models/metadata/metadata_structure.py
+++ b/app/models/metadata/metadata_structure.py
@@ -614,7 +614,7 @@ class CompiledDependencyData:
 
 
 class SubExternalRule(msgspec.Struct, omit_defaults=True):
-    name: list[str] | str
+    name: list[str] | str = msgspec.field(default_factory=str)
     comment: list[str] | str = msgspec.field(default_factory=str)
 
 
@@ -631,13 +631,13 @@ class ExternalRule(msgspec.Struct, omit_defaults=True):
 
 
 class ExternalRulesSchema(msgspec.Struct, omit_defaults=True):
-    timestamp: int
-    rules: dict[str, ExternalRule]
+    timestamp: int = 0
+    rules: dict[str, ExternalRule] = msgspec.field(default_factory=dict)
 
 
 class SteamDbEntryDependency(msgspec.Struct, omit_defaults=True):
-    name: str
-    url: str
+    name: str = msgspec.field(default_factory=str)
+    url: str = msgspec.field(default_factory=str)
 
 
 class SteamDbEntryBlacklist(msgspec.Struct, omit_defaults=True):
@@ -662,5 +662,5 @@ class SteamDbEntry(msgspec.Struct, omit_defaults=True):
 
 
 class SteamDbSchema(msgspec.Struct):
-    version: int
+    version: int = 0
     database: dict[str, SteamDbEntry] = msgspec.field(default_factory=dict)

--- a/tests/models/metadata/test_metadata_factory.py
+++ b/tests/models/metadata/test_metadata_factory.py
@@ -631,6 +631,46 @@ def test_read_write_mod_config_valid_1(tmp_path: Path) -> None:
     assert new_mods_config_1.version == mods_config.version
 
 
+def test_read_rules_db_missing_fields(tmp_path: Path) -> None:
+    path = tmp_path / "rules.json"
+    path.write_bytes(b'{"rules": {}}')
+    assert read_rules_db(path) is not None
+
+    path.write_bytes(b"{}")
+    assert read_rules_db(path) is not None
+
+
+def test_read_rules_db_invalid_json(tmp_path: Path) -> None:
+    path = tmp_path / "rules.json"
+    path.write_bytes(b"not json")
+    assert read_rules_db(path) is None
+
+
+def test_read_rules_db_missing_file(tmp_path: Path) -> None:
+    path = tmp_path / "nonexistent.json"
+    assert read_rules_db(path) is None
+
+
+def test_read_steam_db_missing_fields(tmp_path: Path) -> None:
+    path = tmp_path / "steam.json"
+    path.write_bytes(b'{"database": {}}')
+    assert read_steam_db(path) is not None
+
+    path.write_bytes(b"{}")
+    assert read_steam_db(path) is not None
+
+
+def test_read_steam_db_invalid_json(tmp_path: Path) -> None:
+    path = tmp_path / "steam.json"
+    path.write_bytes(b"not json")
+    assert read_steam_db(path) is None
+
+
+def test_read_steam_db_missing_file(tmp_path: Path) -> None:
+    path = tmp_path / "nonexistent.json"
+    assert read_steam_db(path) is None
+
+
 def test_read_mod_config_invalid_1() -> None:
     path = Path("tests/data/modconfigs/invalid_1/ModConfig.xml")
     mods_config = read_mods_config(path)


### PR DESCRIPTION
## Summary

- Add default values to all required fields in msgspec structs that decode external JSON (`ExternalRulesSchema`, `SteamDbSchema`, `SubExternalRule`, `SteamDbEntryDependency`) so missing fields don't crash with `ValidationError`
- Wrap `msgspec.json.decode()` calls in `read_rules_db()` and `read_steam_db()` with `try/except msgspec.DecodeError` for graceful degradation on malformed or corrupted data
- Add 6 regression tests covering missing fields, invalid JSON, and missing files for both database readers

Fixes a crash-on-startup reported by a user on Discord running v1.3.0:
```
msgspec.ValidationError: Object missing required field timestamp
```

## Test plan

- [x] All 1018 tests pass (6 new)
- [x] ruff, ruff-format, mypy, pyright all clean
- [x] Verify manually: delete or corrupt `communityRules.json` / `steamDB.json` on disk, confirm app starts without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)