### PR TITLE
fix: honor exclude options in file search (Skip translations, .git, Source, Textures)

### DIFF
--- a/app/controllers/file_search_controller.py
+++ b/app/controllers/file_search_controller.py
@@ -517,28 +517,6 @@ class SearchWorker(QThread):
             scope == "inactive mods" and not is_active
         )
 
-    def _should_exclude(self, file_path: str) -> bool:
-        """Check if a file or directory should be excluded based on exclude_options."""
-        exclude_options = self.options.get("exclude_options", {})
-
-        # Skip translations
-        if exclude_options.get("skip_translations") and "Languages" in file_path:
-            return True
-
-        # Skip .git folders
-        if exclude_options.get("skip_git") and ".git" in file_path:
-            return True
-
-        # Skip Source folders
-        if exclude_options.get("skip_source") and "Source" in file_path:
-            return True
-
-        # Skip Textures folders
-        if exclude_options.get("skip_textures") and "Textures" in file_path:
-            return True
-
-        return False
-
     def run(self) -> None:
         try:
             logger.info(f"Starting search with text: {self.pattern}")

--- a/app/utils/file_search.py
+++ b/app/utils/file_search.py
@@ -86,8 +86,21 @@ class FileSearch:
         preview = options.get("preview", False)
         return_dict = options.get("return_dict", False)
 
+        exclude_options = options.get("exclude_options", {})
+        excluded_dirs: set[str] = set()
+        if exclude_options.get("skip_translations"):
+            excluded_dirs.add("Languages")
+        if exclude_options.get("skip_git"):
+            excluded_dirs.add(".git")
+        if exclude_options.get("skip_source"):
+            excluded_dirs.add("Source")
+        if exclude_options.get("skip_textures"):
+            excluded_dirs.add("Textures")
+
         for root_path in root_paths:
-            for dirpath, _, filenames in os.walk(root_path):
+            for dirpath, dirnames, filenames in os.walk(root_path):
+                if excluded_dirs:
+                    dirnames[:] = [d for d in dirnames if d not in excluded_dirs]
                 if self.stop_requested:
                     logger.info("Search stopped by user.")
                     return

--- a/tests/controllers/test_file_search.py
+++ b/tests/controllers/test_file_search.py
@@ -2,7 +2,7 @@
 
 import tempfile
 from pathlib import Path
-from typing import Generator
+from typing import Any, Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -335,3 +335,144 @@ def test_xml_search_only_xml_files(setup_test_files: str) -> None:
 
         # Ensure results are not empty
         assert results, "No results found, but .xml files exist in the test setup."
+
+
+def test_skip_translations_excludes_language_files(setup_test_files: str) -> None:
+    """Test that skip_translations actually excludes files in Languages/ directories."""
+    from app.utils.file_search import FileSearch
+
+    file_search = FileSearch(metadata_manager=MagicMock())
+
+    search_text = "test"
+    root_paths = [setup_test_files]
+
+    # Search WITHOUT skip_translations — should find Languages files
+    options_no_skip: dict[str, Any] = {"file_extensions": [".xml"]}
+    results_no_skip = list(
+        file_search.xml_search(search_text, root_paths, options_no_skip)
+    )
+    language_files_no_skip = [
+        (mod, fname, path)
+        for mod, fname, path in results_no_skip
+        if "Languages" in Path(path).parts
+    ]
+    assert len(language_files_no_skip) > 0, (
+        "Expected to find at least one file in Languages/ when skip is off"
+    )
+
+    # Search WITH skip_translations — should NOT find Languages files
+    file_search.reset()
+    options_skip: dict[str, Any] = {
+        "file_extensions": [".xml"],
+        "exclude_options": {"skip_translations": True},
+    }
+    results_skip = list(file_search.xml_search(search_text, root_paths, options_skip))
+    language_files_skip = [
+        (mod, fname, path)
+        for mod, fname, path in results_skip
+        if "Languages" in Path(path).parts
+    ]
+    assert len(language_files_skip) == 0, (
+        f"Expected no files in Languages/ when skip is on, got {language_files_skip}"
+    )
+
+
+def test_skip_directories_excludes_matching_folders(setup_test_files: str) -> None:
+    """Test that skip_git, skip_source, and skip_textures exclude their directories."""
+    from app.utils.file_search import FileSearch
+
+    # Create additional test directories with searchable XML files
+    test_mod = Path(setup_test_files) / "TestMod1"
+
+    git_dir = test_mod / ".git"
+    git_dir.mkdir(exist_ok=True)
+    (git_dir / "config.xml").write_text("<git>test searchable content</git>")
+
+    source_dir = test_mod / "Source"
+    source_dir.mkdir(exist_ok=True)
+    (source_dir / "Main.xml").write_text("<source>test searchable content</source>")
+
+    textures_dir = test_mod / "Textures"
+    textures_dir.mkdir(exist_ok=True)
+    (textures_dir / "info.xml").write_text(
+        "<textures>test searchable content</textures>"
+    )
+
+    file_search = FileSearch(metadata_manager=MagicMock())
+    search_text = "searchable"
+    root_paths = [setup_test_files]
+
+    # Search WITHOUT excludes — should find files in all dirs
+    options_no_skip: dict[str, Any] = {"file_extensions": [".xml"]}
+    results_no_skip = list(
+        file_search.xml_search(search_text, root_paths, options_no_skip)
+    )
+    found_dirs = {
+        "git": any(".git" in Path(p).parts for _, _, p in results_no_skip),
+        "source": any("Source" in Path(p).parts for _, _, p in results_no_skip),
+        "textures": any("Textures" in Path(p).parts for _, _, p in results_no_skip),
+    }
+    assert all(found_dirs.values()), (
+        f"Expected to find files in .git, Source, Textures when skips are off: {found_dirs}"
+    )
+
+    # Search WITH all excludes
+    file_search.reset()
+    options_skip: dict[str, Any] = {
+        "file_extensions": [".xml"],
+        "exclude_options": {
+            "skip_git": True,
+            "skip_source": True,
+            "skip_textures": True,
+        },
+    }
+    results_skip = list(file_search.xml_search(search_text, root_paths, options_skip))
+    excluded_files = [
+        (mod, fname, path)
+        for mod, fname, path in results_skip
+        if set(Path(path).parts) & {".git", "Source", "Textures"}
+    ]
+    assert len(excluded_files) == 0, (
+        f"Expected no files from excluded dirs, got {excluded_files}"
+    )
+
+
+def test_skip_translations_works_with_standard_search(setup_test_files: str) -> None:
+    """Test that exclude_options work through standard_search, not just xml_search."""
+    from app.utils.file_search import FileSearch
+
+    file_search = FileSearch(metadata_manager=MagicMock())
+
+    search_text = "test"
+    root_paths = [setup_test_files]
+
+    # standard_search WITHOUT skip — should find Languages files
+    options_no_skip: dict[str, Any] = {}
+    results_no_skip = list(
+        file_search.standard_search(search_text, root_paths, options_no_skip)
+    )
+    language_files_no_skip = [
+        (mod, fname, path)
+        for mod, fname, path in results_no_skip
+        if "Languages" in Path(path).parts
+    ]
+    assert len(language_files_no_skip) > 0, (
+        "Expected Languages/ files in standard_search when skip is off"
+    )
+
+    # standard_search WITH skip — should NOT find Languages files
+    file_search.reset()
+    options_skip: dict[str, Any] = {
+        "exclude_options": {"skip_translations": True},
+    }
+    results_skip = list(
+        file_search.standard_search(search_text, root_paths, options_skip)
+    )
+    language_files_skip = [
+        (mod, fname, path)
+        for mod, fname, path in results_skip
+        if "Languages" in Path(path).parts
+    ]
+    assert len(language_files_skip) == 0, (
+        f"Expected no Languages/ files in standard_search when skip is on, got {language_files_skip}"
+    )


### PR DESCRIPTION
## Summary

- Fix broken "Skip translations", "Skip .git folder", "Skip Source folder", and "Skip Textures folder" toggles in the file search dialog — the UI collected preferences correctly but `FileSearch._generic_search()` ignored `exclude_options` entirely
- Add directory pruning via `os.walk()` in-place `dirnames` modification so excluded directories are never descended into
- Remove dead `_should_exclude()` method from `SearchWorker` (was defined but never called)

## Details

The exclude toggles in the file search dialog were wired up correctly in the view (`get_search_options()` builds `exclude_options` dict) and passed through the controller to the search worker, but `_generic_search()` in `app/utils/file_search.py` discarded directory names from `os.walk()` (used `_` instead of `dirnames`) and never checked `exclude_options`.

The fix builds a set of excluded directory names once before the walk loop, then prunes them in-place with `dirnames[:] = [d for d in dirnames if d not in excluded_dirs]` — the standard Python idiom for preventing `os.walk` from descending into subdirectories. This is both correct and more performant than post-filtering results.

Closes #913

## Test plan

- [x] 3 new tests added covering all exclude options across `xml_search` and `standard_search` paths
- [x] 1029/1029 tests pass
- [x] Manual smoke test: toggling "Skip translations" on/off correctly shows/hides `Languages/` results

🤖 Generated with [Claude Code](https://claude.com/claude-code)