### PR TITLE
feat: bidirectional incompatibility flagging (#996)

### DIFF
--- a/app/models/metadata/metadata_structure.py
+++ b/app/models/metadata/metadata_structure.py
@@ -501,6 +501,7 @@ class CompiledDependencyData:
     tier_one_mods: set[str] = field(default_factory=set)
     tier_three_mods: set[str] = field(default_factory=set)
     incompatibilities: dict[str, set[str]] = field(default_factory=dict)
+    declared_incompatibilities: dict[str, set[str]] = field(default_factory=dict)
 
     @classmethod
     def build(
@@ -562,6 +563,8 @@ class CompiledDependencyData:
                 if incompat not in all_package_ids:
                     continue
                 compiled.incompatibilities.setdefault(pid, set()).add(incompat)
+                compiled.incompatibilities.setdefault(incompat, set()).add(pid)
+                compiled.declared_incompatibilities.setdefault(pid, set()).add(incompat)
 
             if rules.load_first and pid not in compiled.tier_zero_mods:
                 compiled.tier_one_mods.add(pid)

--- a/app/utils/metadata.py
+++ b/app/utils/metadata.py
@@ -740,6 +740,7 @@ class MetadataManager(QObject):
                         self.internal_local_metadata[uuid],
                         matched_versioned_incompat,
                         self.internal_local_metadata,
+                        self.packageid_to_uuids,
                     )
                 else:
                     logger.debug(
@@ -754,6 +755,7 @@ class MetadataManager(QObject):
                         self.internal_local_metadata[uuid],
                         base_incompat,
                         self.internal_local_metadata,
+                        self.packageid_to_uuids,
                     )
                 # prefer_versioned is disabled: ignore versioned incompat entries
             # Current mod should be loaded AFTER these mods. These mods can be thought
@@ -1087,6 +1089,7 @@ class MetadataManager(QObject):
                                     self.internal_local_metadata[uuid],
                                     incompatibilities,
                                     self.internal_local_metadata,
+                                    self.packageid_to_uuids,
                                 )
                     load_this_top = self.external_community_rules[package_id].get(
                         "loadTop"
@@ -1179,6 +1182,7 @@ class MetadataManager(QObject):
                                     self.internal_local_metadata[uuid],
                                     incompatibilities,
                                     self.internal_local_metadata,
+                                    self.packageid_to_uuids,
                                 )
                     load_this_top = self.external_user_rules[package_id].get("loadTop")
                     if load_this_top:
@@ -2149,42 +2153,64 @@ def add_incompatibility_to_mod(
     mod_data: dict[str, Any],
     dependency_or_dependency_ids: Any,
     all_mods: dict[str, Any],
+    packageid_to_uuids: dict[str, Any],
 ) -> None:
     """
-    Incompatibility data is collected only if that incompatibility is in `all_mods`.
+    Incompatibility data is collected only if that incompatibility is in ``all_mods``.
     There's no need to surface incompatibilities if they aren't even downloaded.
+
+    Adds bidirectional incompatibilities: if mod A is incompatible with mod B,
+    mod B is also marked as incompatible with mod A. Tracks which mod declared
+    the incompatibility in ``declared_incompatibilities``.
     """
     logger.debug(
-        f"Adding incompatibilities for packages [{dependency_or_dependency_ids}] to mod data: {mod_data} (and reverse direction too)"
+        f"Adding incompatibilities for packages [{dependency_or_dependency_ids}] "
+        f"to mod data: {mod_data}"
     )
-    if mod_data:
-        # Create a new key with empty set as value by default
-        mod_data.setdefault("incompatibilities", set())
+    if not mod_data:
+        return
 
-        all_package_ids = set(all_mods[uuid]["packageid"] for uuid in all_mods)
+    mod_data.setdefault("incompatibilities", set())
+    mod_data.setdefault("declared_incompatibilities", set())
 
-        # If the value is a single string...
-        if isinstance(dependency_or_dependency_ids, str):
-            dependency_id = dependency_or_dependency_ids.lower()
-            if dependency_id in all_package_ids:
-                mod_data["incompatibilities"].add(dependency_id)
+    all_package_ids = set(all_mods[uuid]["packageid"] for uuid in all_mods)
+    declaring_package_id = mod_data.get("packageid", "")
 
-        # If the value is a LIST of strings
-        elif isinstance(dependency_or_dependency_ids, list):
-            if isinstance(dependency_or_dependency_ids[0], str):
-                for dependency in dependency_or_dependency_ids:
-                    if dependency:  # Sometimes, this can be None or an empty string if XML syntax error/extra elements
-                        dependency_id = dependency.lower()
-                        if dependency_id in all_package_ids:
-                            mod_data["incompatibilities"].add(dependency_id)
-            else:
-                logger.error(
-                    f"List of incompatibilities does not contain strings: [{dependency_or_dependency_ids}]"
-                )
-        else:
+    # Normalize to list
+    if isinstance(dependency_or_dependency_ids, str):
+        ids_to_process = [dependency_or_dependency_ids]
+    elif isinstance(dependency_or_dependency_ids, list):
+        if dependency_or_dependency_ids and not isinstance(
+            dependency_or_dependency_ids[0], str
+        ):
             logger.error(
-                f"Incompatibilities is not a single string or a list of strings: [{dependency_or_dependency_ids}]"
+                f"List of incompatibilities does not contain strings: "
+                f"[{dependency_or_dependency_ids}]"
             )
+            return
+        ids_to_process = [d for d in dependency_or_dependency_ids if d]
+    else:
+        logger.error(
+            f"Incompatibilities is not a single string or a list of strings: "
+            f"[{dependency_or_dependency_ids}]"
+        )
+        return
+
+    for dep_id_raw in ids_to_process:
+        dependency_id = dep_id_raw.lower()
+        if dependency_id not in all_package_ids:
+            continue
+
+        # Forward: declaring mod -> target
+        mod_data["incompatibilities"].add(dependency_id)
+        mod_data["declared_incompatibilities"].add(dependency_id)
+
+        # Reverse: target -> declaring mod
+        if declaring_package_id:
+            for target_uuid in packageid_to_uuids.get(dependency_id, []):
+                target_data = all_mods[target_uuid]
+                target_data.setdefault("incompatibilities", set())
+                target_data["incompatibilities"].add(declaring_package_id)
 
 
 def add_load_rule_to_mod(

--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -3161,13 +3161,26 @@ class ModListWidget(QListWidget):
 
     def _check_incompatibilities(
         self, mod_data: ModMetadata, package_ids_set: set[str]
-    ) -> set[str]:
-        """Check for conflicting incompatibilities."""
-        return {
+    ) -> tuple[set[str], set[str]]:
+        """Check for conflicting incompatibilities.
+
+        :return: (declared, reverse_only) — declared are incompatibilities this
+            mod declared itself; reverse_only are ones only declared by the
+            other mod.
+        """
+        all_incomp = {
             incomp
             for incomp in mod_data.get("incompatibilities", [])
             if incomp in package_ids_set
         }
+        own_declared = {
+            incomp
+            for incomp in mod_data.get("declared_incompatibilities", [])
+            if incomp in package_ids_set
+        }
+        declared = all_incomp & own_declared
+        reverse_only = all_incomp - own_declared
+        return declared, reverse_only
 
     def _check_load_order_violations(
         self,
@@ -3227,6 +3240,9 @@ class ModListWidget(QListWidget):
                 if self.list_type == "Active"
                 else None,
                 "conflicting_incompatibilities": (
+                    set() if self.list_type == "Active" else None
+                ),
+                "reverse_incompatibilities": (
                     set() if self.list_type == "Active" else None
                 ),
                 "load_before_violations": set() if self.list_type == "Active" else None,
@@ -3316,9 +3332,10 @@ class ModListWidget(QListWidget):
                     mod_errors["missing_dependencies"],
                     mod_errors["alternative_dependencies"],
                 ) = self._check_missing_dependencies(mod_data, package_ids_set)
-                mod_errors["conflicting_incompatibilities"] = (
-                    self._check_incompatibilities(mod_data, package_ids_set)
-                )
+                (
+                    mod_errors["conflicting_incompatibilities"],
+                    mod_errors["reverse_incompatibilities"],
+                ) = self._check_incompatibilities(mod_data, package_ids_set)
                 (
                     mod_errors["load_before_violations"],
                     mod_errors["load_after_violations"],
@@ -3331,6 +3348,10 @@ class ModListWidget(QListWidget):
             tooltip_sections = [
                 ("missing_dependencies", self.tr("\nMissing Dependencies:")),
                 ("conflicting_incompatibilities", self.tr("\nIncompatibilities:")),
+                (
+                    "reverse_incompatibilities",
+                    self.tr("\nIncompatible (per other mod's rules):"),
+                ),
             ]
             if self.metadata_manager.settings_controller.settings.use_alternative_package_ids_as_satisfying_dependencies:
                 tooltip_sections.insert(
@@ -3400,6 +3421,7 @@ class ModListWidget(QListWidget):
                     for key in [
                         "missing_dependencies",
                         "conflicting_incompatibilities",
+                        "reverse_incompatibilities",
                     ]
                 ]
             ):

--- a/tests/controllers/test_metadata_controller_compile.py
+++ b/tests/controllers/test_metadata_controller_compile.py
@@ -130,6 +130,62 @@ def test_compile_empty_mods() -> None:
     assert compiled.rev_deps_graph == {}
     assert compiled.tier_three_mods == set()
     assert compiled.incompatibilities == {}
+    assert compiled.declared_incompatibilities == {}
+
+
+def test_compile_incompatibility_is_bidirectional() -> None:
+    """When mod.a declares incompatibility with mod.b, mod.b also gets mod.a."""
+    mods: dict[str, ListedMod] = {
+        "/mods/a": _make_mod("mod.a", "/mods/a", incompatible_with=["mod.b"]),
+        "/mods/b": _make_mod("mod.b", "/mods/b"),
+    }
+    compiled = _compile(mods)
+
+    assert "mod.b" in compiled.incompatibilities.get("mod.a", set())
+    assert "mod.a" in compiled.incompatibilities.get("mod.b", set())
+
+
+def test_compile_declared_incompatibilities_tracked() -> None:
+    """declared_incompatibilities tracks what each mod explicitly declared.
+
+    mod.a declares incompat with mod.b -> mod.a has mod.b in
+    declared_incompatibilities, but mod.b does NOT have mod.a.
+    """
+    mods: dict[str, ListedMod] = {
+        "/mods/a": _make_mod("mod.a", "/mods/a", incompatible_with=["mod.b"]),
+        "/mods/b": _make_mod("mod.b", "/mods/b"),
+    }
+    compiled = _compile(mods)
+
+    assert "mod.b" in compiled.declared_incompatibilities.get("mod.a", set())
+    assert "mod.a" not in compiled.declared_incompatibilities.get("mod.b", set())
+
+
+def test_compile_mutual_incompatibility_both_declared() -> None:
+    """When both mods declare each other incompatible, both appear everywhere."""
+    mods: dict[str, ListedMod] = {
+        "/mods/a": _make_mod("mod.a", "/mods/a", incompatible_with=["mod.b"]),
+        "/mods/b": _make_mod("mod.b", "/mods/b", incompatible_with=["mod.a"]),
+    }
+    compiled = _compile(mods)
+
+    # Both in incompatibilities (bidirectional)
+    assert "mod.b" in compiled.incompatibilities.get("mod.a", set())
+    assert "mod.a" in compiled.incompatibilities.get("mod.b", set())
+    # Both in declared_incompatibilities (each declared it)
+    assert "mod.b" in compiled.declared_incompatibilities.get("mod.a", set())
+    assert "mod.a" in compiled.declared_incompatibilities.get("mod.b", set())
+
+
+def test_compile_incompatibility_reverse_skips_nonexistent() -> None:
+    """Reverse not added for mods not in the mod set."""
+    mods: dict[str, ListedMod] = {
+        "/mods/a": _make_mod("mod.a", "/mods/a", incompatible_with=["mod.nonexistent"]),
+    }
+    compiled = _compile(mods)
+
+    assert compiled.incompatibilities == {}
+    assert compiled.declared_incompatibilities == {}
 
 
 def test_compile_nonexistent_deps_not_in_graph() -> None:

--- a/tests/controllers/test_metadata_parity.py
+++ b/tests/controllers/test_metadata_parity.py
@@ -143,3 +143,31 @@ def test_game_version_is_parsed(parity_mediator: MetadataMediator) -> None:
     assert "1.5" in parity_mediator.game_version, (
         f"Expected version to contain '1.5', got: {parity_mediator.game_version}"
     )
+
+
+def test_compile_incompatibilities_are_bidirectional(
+    parity_mods: dict[str, ListedMod],
+) -> None:
+    """Every incompatibility edge has a reverse edge."""
+    compiled = CompiledDependencyData.build(parity_mods)
+
+    for pkg_id, incompatibles in compiled.incompatibilities.items():
+        for incompat in incompatibles:
+            assert pkg_id in compiled.incompatibilities.get(incompat, set()), (
+                f"incompatibilities has {pkg_id} -> {incompat}, "
+                f"but missing reverse {incompat} -> {pkg_id}"
+            )
+
+
+def test_compile_declared_is_subset_of_incompatibilities(
+    parity_mods: dict[str, ListedMod],
+) -> None:
+    """declared_incompatibilities is always a subset of incompatibilities."""
+    compiled = CompiledDependencyData.build(parity_mods)
+
+    for pkg_id, declared in compiled.declared_incompatibilities.items():
+        full = compiled.incompatibilities.get(pkg_id, set())
+        assert declared <= full, (
+            f"declared_incompatibilities[{pkg_id}] has entries not in "
+            f"incompatibilities: {declared - full}"
+        )

--- a/tests/test_add_incompatibility.py
+++ b/tests/test_add_incompatibility.py
@@ -1,0 +1,99 @@
+"""Tests for add_incompatibility_to_mod() in the old metadata system."""
+
+import sys
+from typing import Any
+from unittest.mock import MagicMock
+
+if "steamworks" not in sys.modules:
+    sys.modules["steamworks"] = MagicMock()
+
+from app.utils.metadata import add_incompatibility_to_mod
+
+
+def _make_all_mods(
+    *package_ids: str,
+) -> tuple[dict[str, dict[str, Any]], dict[str, list[str]]]:
+    """Create a minimal all_mods dict and packageid_to_uuids lookup.
+
+    Returns (all_mods, packageid_to_uuids).
+    """
+    all_mods = {f"uuid-{pid}": {"packageid": pid} for pid in package_ids}
+    packageid_to_uuids: dict[str, list[str]] = {}
+    for uuid, data in all_mods.items():
+        packageid_to_uuids.setdefault(data["packageid"], []).append(uuid)
+    return all_mods, packageid_to_uuids
+
+
+def test_adds_incompatibility_to_declaring_mod() -> None:
+    """Basic: declaring mod gets the incompatibility."""
+    all_mods, p2u = _make_all_mods("mod.a", "mod.b")
+    mod_data = all_mods["uuid-mod.a"]
+
+    add_incompatibility_to_mod(mod_data, "mod.b", all_mods, p2u)
+
+    assert "mod.b" in mod_data["incompatibilities"]
+
+
+def test_adds_reverse_incompatibility() -> None:
+    """Reverse: target mod also gets flagged as incompatible with declaring mod."""
+    all_mods, p2u = _make_all_mods("mod.a", "mod.b")
+    mod_a = all_mods["uuid-mod.a"]
+    mod_b = all_mods["uuid-mod.b"]
+
+    add_incompatibility_to_mod(mod_a, "mod.b", all_mods, p2u)
+
+    assert "mod.a" in mod_b.get("incompatibilities", set())
+
+
+def test_declared_incompatibilities_tracked() -> None:
+    """declared_incompatibilities tracks what the declaring mod declared."""
+    all_mods, p2u = _make_all_mods("mod.a", "mod.b")
+    mod_a = all_mods["uuid-mod.a"]
+    mod_b = all_mods["uuid-mod.b"]
+
+    add_incompatibility_to_mod(mod_a, "mod.b", all_mods, p2u)
+
+    # mod.a declared it
+    assert "mod.b" in mod_a.get("declared_incompatibilities", set())
+    # mod.b did NOT declare it
+    assert "mod.a" not in mod_b.get("declared_incompatibilities", set())
+
+
+def test_reverse_with_list_of_ids() -> None:
+    """Reverse works when given a list of incompatible package IDs."""
+    all_mods, p2u = _make_all_mods("mod.a", "mod.b", "mod.c")
+    mod_a = all_mods["uuid-mod.a"]
+    mod_b = all_mods["uuid-mod.b"]
+    mod_c = all_mods["uuid-mod.c"]
+
+    add_incompatibility_to_mod(mod_a, ["mod.b", "mod.c"], all_mods, p2u)
+
+    assert "mod.a" in mod_b.get("incompatibilities", set())
+    assert "mod.a" in mod_c.get("incompatibilities", set())
+    assert mod_a.get("declared_incompatibilities", set()) == {"mod.b", "mod.c"}
+
+
+def test_reverse_skips_nonexistent_mods() -> None:
+    """Reverse is not added for mods not present in all_mods."""
+    all_mods, p2u = _make_all_mods("mod.a")
+    mod_a = all_mods["uuid-mod.a"]
+
+    add_incompatibility_to_mod(mod_a, "mod.nonexistent", all_mods, p2u)
+
+    assert mod_a.get("incompatibilities", set()) == set()
+
+
+def test_no_duplicate_on_mutual_declaration() -> None:
+    """When both mods declare each other, no duplicate entries (sets)."""
+    all_mods, p2u = _make_all_mods("mod.a", "mod.b")
+    mod_a = all_mods["uuid-mod.a"]
+    mod_b = all_mods["uuid-mod.b"]
+
+    add_incompatibility_to_mod(mod_a, "mod.b", all_mods, p2u)
+    add_incompatibility_to_mod(mod_b, "mod.a", all_mods, p2u)
+
+    assert mod_a["incompatibilities"] == {"mod.b"}
+    assert mod_b["incompatibilities"] == {"mod.a"}
+    # Both declared — both tracked
+    assert "mod.b" in mod_a.get("declared_incompatibilities", set())
+    assert "mod.a" in mod_b.get("declared_incompatibilities", set())


### PR DESCRIPTION
## Summary

Closes #996

When a mod declares an incompatibility rule, **both** mods are now flagged with an error — not just the one that declared the rule. This makes it easy to find and remove either incompatible mod using the error filter.

- **Bidirectional incompatibilities**: If Mod A declares incompatibility with Mod B, Mod B also gets flagged as incompatible with Mod A (in both the old `MetadataManager` and new `CompiledDependencyData` systems)
- **Tooltip differentiation**: The declaring mod shows "Incompatibilities: [other mod]" while the non-declaring mod shows "Incompatible (per other mod's rules): [declaring mod]" — so users can tell which mod owns the rule
- **Direction tracking**: A `declared_incompatibilities` field tracks what each mod explicitly declared, enabling the tooltip split. Mutual declarations (both mods declare each other) correctly show both under "Incompatibilities:"
- **Performance**: `add_incompatibility_to_mod()` now takes `packageid_to_uuids` as a parameter (matching `add_load_rule_to_mod` pattern) instead of rebuilding the lookup on every call

### Files changed

| File | What changed |
|------|-------------|
| `app/models/metadata/metadata_structure.py` | Added `declared_incompatibilities` field + reverse entry in `CompiledDependencyData.build()` |
| `app/utils/metadata.py` | Rewrote `add_incompatibility_to_mod()` with reverse logic + direction tracking + `packageid_to_uuids` param; updated 4 callsites |
| `app/views/mods_panel.py` | `_check_incompatibilities()` returns `(declared, reverse_only)` tuple; new tooltip section; reverse entries count as errors |

## Test plan

- [x] 12 new tests covering bidirectional behavior, direction tracking, mutual declarations, nonexistent mods, and parity invariants
- [x] All 1038 tests pass
- [x] ruff, ruff-format, mypy clean
- [x] Manual smoke test: both mods flagged, tooltips differentiated, error filter shows both
- [x] Verify with known incompatible mod pair (e.g., Regrowth Core + Animated Marshes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)