### PR TITLE
refactor: extract Locations tab into reusable tab controller

### DIFF
--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -12,6 +12,7 @@ from app.controllers.language_controller import LanguageController
 from app.controllers.settings_tabs import (
     BaseTabController,
     DatabasesTabController,
+    LocationsTabController,
     SortingTabController,
 )
 from app.controllers.theme_controller import ThemeController
@@ -103,6 +104,18 @@ class SettingsController(QObject):
         )
         self._tab_controllers.append(self._databases_tab)
 
+        self._locations_tab = LocationsTabController(
+            self.settings,
+            self.settings_dialog,
+            validate_game_location=self._validate_game_location,
+            validate_config_folder_location=self._validate_config_folder_location,
+            on_path_selected=self._on_locations_path_selected,
+            on_autodetect=self._on_locations_autodetect_button_clicked,
+            on_instance_folder_choose=self._on_instance_folder_location_choose_button_clicked,
+            on_instance_folder_clear=self._on_instance_folder_location_clear_button_clicked,
+        )
+        self._tab_controllers.append(self._locations_tab)
+
         for tc in self._tab_controllers:
             tc.connect_signals()
 
@@ -155,79 +168,6 @@ class SettingsController(QObject):
             )
         except Exception:
             pass
-
-        # Locations tab
-        self.settings_dialog.game_location.textChanged.connect(
-            self._on_game_location_text_changed
-        )
-        self.settings_dialog.game_location_open_button.clicked.connect(
-            self._on_game_location_open_button_clicked
-        )
-        self.settings_dialog.game_location_choose_button.clicked.connect(
-            self._on_game_location_choose_button_clicked
-        )
-        self.settings_dialog.game_location_clear_button.clicked.connect(
-            self._on_game_location_clear_button_clicked
-        )
-
-        self.settings_dialog.config_folder_location.textChanged.connect(
-            self._on_config_folder_location_text_changed
-        )
-        self.settings_dialog.config_folder_location_open_button.clicked.connect(
-            self._on_config_folder_location_open_button_clicked
-        )
-        self.settings_dialog.config_folder_location_choose_button.clicked.connect(
-            self._on_config_folder_location_choose_button_clicked
-        )
-        self.settings_dialog.config_folder_location_clear_button.clicked.connect(
-            self._on_config_folder_location_clear_button_clicked
-        )
-
-        self.settings_dialog.steam_mods_folder_location.textChanged.connect(
-            self._on_steam_mods_folder_location_text_changed
-        )
-        self.settings_dialog.steam_mods_folder_location_open_button.clicked.connect(
-            self._on_steam_mods_folder_location_open_button_clicked
-        )
-        self.settings_dialog.steam_mods_folder_location_choose_button.clicked.connect(
-            self._on_steam_mods_folder_location_choose_button_clicked
-        )
-        self.settings_dialog.steam_mods_folder_location_clear_button.clicked.connect(
-            self._on_steam_mods_folder_location_clear_button_clicked
-        )
-
-        self.settings_dialog.local_mods_folder_location.textChanged.connect(
-            self._on_local_mods_folder_location_text_changed
-        )
-        self.settings_dialog.local_mods_folder_location_open_button.clicked.connect(
-            self._on_local_mods_folder_location_open_button_clicked
-        )
-        self.settings_dialog.local_mods_folder_location_choose_button.clicked.connect(
-            self._on_local_mods_folder_location_choose_button_clicked
-        )
-        self.settings_dialog.local_mods_folder_location_clear_button.clicked.connect(
-            self._on_local_mods_folder_location_clear_button_clicked
-        )
-
-        # Instance folder location (custom override)
-        try:
-            self.settings_dialog.instance_folder_location_choose_button.clicked.connect(
-                self._on_instance_folder_location_choose_button_clicked
-            )
-            self.settings_dialog.instance_folder_location_clear_button.clicked.connect(
-                self._on_instance_folder_location_clear_button_clicked
-            )
-        except AttributeError:
-            # Buttons may not exist if UI hasn't been updated yet
-            pass
-
-        self.settings_dialog.locations_clear_button.clicked.connect(
-            self._on_locations_clear_button_clicked
-        )
-
-        self.settings_dialog.locations_autodetect_button.clicked.connect(
-            self._on_locations_autodetect_button_clicked
-        )
 
         # Game Launch tab
         self.settings_dialog.run_args.textChanged.connect(
@@ -424,47 +364,7 @@ class SettingsController(QObject):
         """
 
         # Locations tab
-        self.settings_dialog.game_location.setText(
-            str(self.settings.instances[self.settings.current_instance].game_folder)
-        )
-        self.settings_dialog.game_location.setCursorPosition(0)
-        self.settings_dialog.game_location_open_button.setEnabled(
-            self.settings_dialog.game_location.text() != ""
-        )
-        self.settings_dialog.config_folder_location.setText(
-            str(self.settings.instances[self.settings.current_instance].config_folder)
-        )
-        self.settings_dialog.config_folder_location.setCursorPosition(0)
-        self.settings_dialog.config_folder_location_open_button.setEnabled(
-            self.settings_dialog.config_folder_location.text() != ""
-        )
-        self.settings_dialog.steam_mods_folder_location.setText(
-            str(self.settings.instances[self.settings.current_instance].workshop_folder)
-        )
-        self.settings_dialog.steam_mods_folder_location.setCursorPosition(0)
-        self.settings_dialog.steam_mods_folder_location_open_button.setEnabled(
-            self.settings_dialog.steam_mods_folder_location.text() != ""
-        )
-        self.settings_dialog.local_mods_folder_location.setText(
-            str(self.settings.instances[self.settings.current_instance].local_folder)
-        )
-        self.settings_dialog.local_mods_folder_location.setCursorPosition(0)
-        self.settings_dialog.local_mods_folder_location_open_button.setEnabled(
-            self.settings_dialog.local_mods_folder_location.text() != ""
-        )
-        self.settings_dialog.steam_client_integration_checkbox.setChecked(
-            self.settings.instances[
-                self.settings.current_instance
-            ].steam_client_integration
-        )
-        # Enable/disable Steam mods location fields based on checkbox state
-        checked = self.settings_dialog.steam_client_integration_checkbox.isChecked()
-        self.settings_dialog.steam_mods_folder_location.setEnabled(checked)
-        self.settings_dialog.steam_mods_folder_location_open_button.setEnabled(checked)
-        self.settings_dialog.steam_mods_folder_location_choose_button.setEnabled(
-            checked
-        )
-        self.settings_dialog.steam_mods_folder_location_clear_button.setEnabled(checked)
+        self._locations_tab.update_view_from_model()
 
         # Load Steam protocol launch option
         self.settings_dialog.launch_via_steam_protocol_checkbox.setChecked(
@@ -477,23 +377,6 @@ class SettingsController(QObject):
             self.settings.current_instance
         ].launch_via_steam_protocol
         self.settings_dialog.run_args_group.setEnabled(not launch_via_steam_protocol)
-
-        # Instance folder location (custom override)
-        # Only enable for Default instance
-        is_default_instance = self.settings.current_instance == DEFAULT_INSTANCE_NAME
-        self.settings_dialog.instance_folder_location.setText(
-            self.settings.instances[
-                self.settings.current_instance
-            ].instance_folder_override
-        )
-        self.settings_dialog.instance_folder_location.setCursorPosition(0)
-        self.settings_dialog.instance_folder_location.setEnabled(is_default_instance)
-        self.settings_dialog.instance_folder_location_choose_button.setEnabled(
-            is_default_instance
-        )
-        self.settings_dialog.instance_folder_location_clear_button.setEnabled(
-            is_default_instance
-        )
 
         # Databases tab
         self._databases_tab.update_view_from_model()
@@ -731,23 +614,7 @@ class SettingsController(QObject):
         """
 
         # Locations tab
-        self.settings.instances[
-            self.settings.current_instance
-        ].game_folder = self.settings_dialog.game_location.text()
-        self.settings.instances[
-            self.settings.current_instance
-        ].config_folder = self.settings_dialog.config_folder_location.text()
-        self.settings.instances[
-            self.settings.current_instance
-        ].workshop_folder = self.settings_dialog.steam_mods_folder_location.text()
-        self.settings.instances[
-            self.settings.current_instance
-        ].local_folder = self.settings_dialog.local_mods_folder_location.text()
-        self.settings.instances[
-            self.settings.current_instance
-        ].steam_client_integration = (
-            self.settings_dialog.steam_client_integration_checkbox.isChecked()
-        )
+        self._locations_tab.update_model_from_view()
 
         # Save Steam protocol launch option
         self.settings.instances[
@@ -965,6 +832,10 @@ class SettingsController(QObject):
         self.settings_dialog.close()
         self._update_view_from_model()
 
+    def _on_locations_path_selected(self, path: str) -> None:
+        """Update the last selected path for file dialog default directories."""
+        self._last_file_dialog_path = path
+
     def _validate_game_location(self, game_location: str) -> bool:
         """
         Validate the game location and show a warning if invalid.
@@ -1138,186 +1009,6 @@ class SettingsController(QObject):
         )
         # Do a full refresh after updating the settings
         EventBus().do_refresh_mods_lists.emit()
-
-    @Slot()
-    def _on_game_location_text_changed(self) -> None:
-        self.settings_dialog.game_location_open_button.setEnabled(
-            self.settings_dialog.game_location.text() != ""
-        )
-
-    @Slot()
-    def _on_game_location_open_button_clicked(self) -> None:
-        platform_specific_open(self.settings_dialog.game_location.text())
-
-    @Slot()
-    def _on_game_location_choose_button_clicked(self) -> None:
-        """
-        Open a file dialog to select the game location and handle the result.
-        """
-        if SystemInfo().operating_system == SystemInfo.OperatingSystem.MACOS:
-            game_location = self._on_game_location_choose_button_clicked_macos()
-        else:
-            game_location = self._on_game_location_choose_button_clicked_non_macos()
-        if game_location is None:
-            return
-        # Validate the selected game location immediately
-        if not self._validate_game_location(str(game_location)):
-            return
-        self.settings_dialog.game_location.setText(str(game_location))
-        self.settings_dialog.local_mods_folder_location.setText(
-            str(game_location / "Mods")
-        )
-        self._last_file_dialog_path = str(game_location)
-
-    def _on_game_location_choose_button_clicked_macos(self) -> Path | None:
-        """
-        Open a directory dialog to select the game location for macOS and handle the result.
-        """
-        game_location = show_dialogue_file(
-            mode="open_dir",
-            caption="Select Game Location",
-            _dir=str(self._last_file_dialog_path),
-        )
-        if not game_location:
-            return None
-
-        return Path(game_location)
-
-    def _on_game_location_choose_button_clicked_non_macos(self) -> Path | None:
-        """
-        Open a directory dialog to select the game location and handle the result.
-        """
-        game_location = show_dialogue_file(
-            mode="open_dir",
-            caption="Select Game Location",
-            _dir=str(self._last_file_dialog_path),
-        )
-        if not game_location:
-            return None
-
-        return Path(game_location).resolve()
-
-    @Slot()
-    def _on_game_location_clear_button_clicked(self) -> None:
-        self.settings_dialog.game_location.setText("")
-        self.settings_dialog.local_mods_folder_location.setText("")
-
-    @Slot()
-    def _on_config_folder_location_text_changed(self) -> None:
-        self.settings_dialog.config_folder_location_open_button.setEnabled(
-            self.settings_dialog.config_folder_location.text() != ""
-        )
-
-    @Slot()
-    def _on_config_folder_location_open_button_clicked(self) -> None:
-        platform_specific_open(self.settings_dialog.config_folder_location.text())
-
-    @Slot()
-    def _on_config_folder_location_choose_button_clicked(self) -> None:
-        """
-        Open a directory dialog to select the config folder and handle the result.
-        """
-        config_folder_location = show_dialogue_file(
-            mode="open_dir",
-            caption="Select Config Folder",
-            _dir=str(self._last_file_dialog_path),
-        )
-        if not config_folder_location:
-            return
-
-        if not self._validate_config_folder_location(config_folder_location):
-            return
-
-        self.settings_dialog.config_folder_location.setText(config_folder_location)
-        self._last_file_dialog_path = str(Path(config_folder_location).parent)
-
-    @Slot()
-    def _on_config_folder_location_clear_button_clicked(self) -> None:
-        self.settings_dialog.config_folder_location.setText("")
-
-    @Slot()
-    def _on_steam_mods_folder_location_text_changed(self) -> None:
-        self.settings_dialog.steam_mods_folder_location_open_button.setEnabled(
-            self.settings_dialog.steam_mods_folder_location.text() != ""
-        )
-
-    @Slot()
-    def _on_steam_mods_folder_location_open_button_clicked(self) -> None:
-        platform_specific_open(self.settings_dialog.steam_mods_folder_location.text())
-
-    @Slot()
-    def _on_steam_mods_folder_location_choose_button_clicked(self) -> None:
-        """
-        Open a directory dialog to select the Steam mods folder and handle the result.
-        """
-        steam_mods_folder_location = show_dialogue_file(
-            mode="open_dir",
-            caption="Select Steam Mods Folder",
-            _dir=str(self._last_file_dialog_path),
-        )
-        if not steam_mods_folder_location:
-            return
-
-        self.settings_dialog.steam_mods_folder_location.setText(
-            steam_mods_folder_location
-        )
-        self._last_file_dialog_path = str(Path(steam_mods_folder_location).parent)
-
-    @Slot()
-    def _on_steam_mods_folder_location_clear_button_clicked(self) -> None:
-        self.settings_dialog.steam_mods_folder_location.setText("")
-
-    @Slot()
-    def _on_local_mods_folder_location_choose_button_clicked(self) -> None:
-        """
-        Open a directory dialog to select the local mods folder and handle the result.
-        """
-        local_mods_folder_location = show_dialogue_file(
-            mode="open_dir",
-            caption="Select Local Mods Folder",
-            _dir=str(self._last_file_dialog_path),
-        )
-        if not local_mods_folder_location:
-            return
-
-        self.settings_dialog.local_mods_folder_location.setText(
-            local_mods_folder_location
-        )
-        self._last_file_dialog_path = str(Path(local_mods_folder_location).parent)
-
-    @Slot()
-    def _on_local_mods_folder_location_text_changed(self) -> None:
-        self.settings_dialog.local_mods_folder_location_open_button.setEnabled(
-            self.settings_dialog.local_mods_folder_location.text() != ""
-        )
-
-    @Slot()
-    def _on_local_mods_folder_location_open_button_clicked(self) -> None:
-        platform_specific_open(self.settings_dialog.local_mods_folder_location.text())
-
-    @Slot()
-    def _on_local_mods_folder_location_clear_button_clicked(self) -> None:
-        self.settings_dialog.local_mods_folder_location.setText("")
-
-    @Slot()
-    def _on_locations_clear_button_clicked(
-        self, skip_confirmation: bool = False
-    ) -> None:
-        """
-        Clear the settings dialog's location fields.
-        """
-        if not skip_confirmation:
-            answer = BinaryChoiceDialog(
-                title=self.tr("Clear all locations"),
-                text=self.tr("Are you sure you want to clear all locations?"),
-            )
-            if not answer.exec_is_positive():
-                return
-
-        self.settings_dialog.game_location.setText("")
-        self.settings_dialog.config_folder_location.setText("")
-        self.settings_dialog.steam_mods_folder_location.setText("")
-        self.settings_dialog.local_mods_folder_location.setText("")
 
     @staticmethod
     def _find_steam_root(candidates: list[Path]) -> Path | None:

--- a/app/controllers/settings_tabs/__init__.py
+++ b/app/controllers/settings_tabs/__init__.py
@@ -2,6 +2,14 @@ from app.controllers.settings_tabs.base_tab_controller import BaseTabController
 from app.controllers.settings_tabs.databases_tab_controller import (
     DatabasesTabController,
 )
+from app.controllers.settings_tabs.locations_tab_controller import (
+    LocationsTabController,
+)
 from app.controllers.settings_tabs.sorting_tab_controller import SortingTabController
 
-__all__ = ["BaseTabController", "DatabasesTabController", "SortingTabController"]
+__all__ = [
+    "BaseTabController",
+    "DatabasesTabController",
+    "LocationsTabController",
+    "SortingTabController",
+]

--- a/app/controllers/settings_tabs/locations_tab_controller.py
+++ b/app/controllers/settings_tabs/locations_tab_controller.py
@@ -109,15 +109,12 @@ class LocationsTabController(BaseTabController):
             group.connect_signals(self.dialog)
 
         # Instance folder location
-        try:
-            self.dialog.instance_folder_location_choose_button.clicked.connect(
-                self._on_instance_folder_choose_callback
-            )
-            self.dialog.instance_folder_location_clear_button.clicked.connect(
-                self._on_instance_folder_clear_callback
-            )
-        except AttributeError:
-            pass
+        self.dialog.instance_folder_location_choose_button.clicked.connect(
+            self._on_instance_folder_choose_callback
+        )
+        self.dialog.instance_folder_location_clear_button.clicked.connect(
+            self._on_instance_folder_clear_callback
+        )
 
         # Clear and autodetect buttons
         self.dialog.locations_clear_button.clicked.connect(

--- a/app/controllers/settings_tabs/locations_tab_controller.py
+++ b/app/controllers/settings_tabs/locations_tab_controller.py
@@ -1,0 +1,244 @@
+from pathlib import Path
+from typing import Callable
+
+from PySide6.QtCore import Slot
+
+from app.controllers.settings_tabs.base_tab_controller import BaseTabController
+from app.models.settings import Settings
+from app.utils.constants import DEFAULT_INSTANCE_NAME
+from app.utils.generic import platform_specific_open
+from app.utils.system_info import SystemInfo
+from app.views.dialogue import BinaryChoiceDialog, show_dialogue_file
+from app.views.settings_dialog import SettingsDialog
+
+
+class FolderPathGroup:
+    """Reusable helper for one folder-path row (text field + open/choose/clear buttons)."""
+
+    def __init__(
+        self,
+        prefix: str,
+        choose_callback: Callable[[SettingsDialog], str | None] | None = None,
+        clear_callback: Callable[[SettingsDialog], None] | None = None,
+    ) -> None:
+        self._prefix = prefix
+        self._choose_callback = choose_callback
+        self._clear_callback = clear_callback
+
+    def connect_signals(self, dialog: SettingsDialog) -> None:
+        location = getattr(dialog, f"{self._prefix}_location")
+        open_btn = getattr(dialog, f"{self._prefix}_location_open_button")
+        choose_btn = getattr(dialog, f"{self._prefix}_location_choose_button")
+        clear_btn = getattr(dialog, f"{self._prefix}_location_clear_button")
+
+        location.textChanged.connect(lambda: open_btn.setEnabled(location.text() != ""))
+        open_btn.clicked.connect(lambda: platform_specific_open(location.text()))
+        choose_btn.clicked.connect(lambda: self._on_choose(dialog))
+        clear_btn.clicked.connect(lambda: self._on_clear(dialog))
+
+    def update_view(self, dialog: SettingsDialog, path: str) -> None:
+        location = getattr(dialog, f"{self._prefix}_location")
+        open_btn = getattr(dialog, f"{self._prefix}_location_open_button")
+        location.setText(path)
+        location.setCursorPosition(0)
+        open_btn.setEnabled(path != "")
+
+    def _on_choose(self, dialog: SettingsDialog) -> None:
+        if self._choose_callback:
+            result = self._choose_callback(dialog)
+        else:
+            result = show_dialogue_file(mode="open_dir")
+        if result:
+            getattr(dialog, f"{self._prefix}_location").setText(result)
+
+    def _on_clear(self, dialog: SettingsDialog) -> None:
+        getattr(dialog, f"{self._prefix}_location").setText("")
+        if self._clear_callback:
+            self._clear_callback(dialog)
+
+
+class LocationsTabController(BaseTabController):
+    """Controller for the Locations settings tab.
+
+    Manages: game, config, steam mods, local mods folder paths,
+    steam integration checkbox, instance folder override, and
+    the clear/autodetect action buttons.
+    """
+
+    def __init__(
+        self,
+        settings: Settings,
+        dialog: SettingsDialog,
+        validate_game_location: Callable[[str], bool],
+        validate_config_folder_location: Callable[[str], bool],
+        on_path_selected: Callable[[str], None],
+        on_autodetect: Callable[[], None],
+        on_instance_folder_choose: Callable[[], None],
+        on_instance_folder_clear: Callable[[], None],
+    ) -> None:
+        super().__init__(settings, dialog)
+        self._validate_game_location = validate_game_location
+        self._validate_config_folder_location = validate_config_folder_location
+        self._on_path_selected = on_path_selected
+        self._on_autodetect_callback = on_autodetect
+        self._on_instance_folder_choose_callback = on_instance_folder_choose
+        self._on_instance_folder_clear_callback = on_instance_folder_clear
+
+        self._groups: list[FolderPathGroup] = [
+            FolderPathGroup(
+                prefix="game",
+                choose_callback=self._on_game_choose,
+                clear_callback=self._on_game_clear,
+            ),
+            FolderPathGroup(
+                prefix="config_folder",
+                choose_callback=self._on_config_choose,
+            ),
+            FolderPathGroup(
+                prefix="steam_mods_folder",
+                choose_callback=self._on_steam_mods_choose,
+            ),
+            FolderPathGroup(
+                prefix="local_mods_folder",
+                choose_callback=self._on_local_mods_choose,
+            ),
+        ]
+
+    def connect_signals(self) -> None:
+        for group in self._groups:
+            group.connect_signals(self.dialog)
+
+        # Instance folder location
+        try:
+            self.dialog.instance_folder_location_choose_button.clicked.connect(
+                self._on_instance_folder_choose_callback
+            )
+            self.dialog.instance_folder_location_clear_button.clicked.connect(
+                self._on_instance_folder_clear_callback
+            )
+        except AttributeError:
+            pass
+
+        # Clear and autodetect buttons
+        self.dialog.locations_clear_button.clicked.connect(
+            self._on_clear_all_button_clicked
+        )
+        self.dialog.locations_autodetect_button.clicked.connect(
+            self._on_autodetect_callback
+        )
+
+    def update_view_from_model(self) -> None:
+        instance = self.settings.instances[self.settings.current_instance]
+
+        self._groups[0].update_view(self.dialog, str(instance.game_folder))
+        self._groups[1].update_view(self.dialog, str(instance.config_folder))
+        self._groups[2].update_view(self.dialog, str(instance.workshop_folder))
+        self._groups[3].update_view(self.dialog, str(instance.local_folder))
+
+        self.dialog.steam_client_integration_checkbox.setChecked(
+            instance.steam_client_integration
+        )
+        checked = self.dialog.steam_client_integration_checkbox.isChecked()
+        self.dialog.steam_mods_folder_location.setEnabled(checked)
+        self.dialog.steam_mods_folder_location_open_button.setEnabled(checked)
+        self.dialog.steam_mods_folder_location_choose_button.setEnabled(checked)
+        self.dialog.steam_mods_folder_location_clear_button.setEnabled(checked)
+
+        is_default = self.settings.current_instance == DEFAULT_INSTANCE_NAME
+        self.dialog.instance_folder_location.setText(instance.instance_folder_override)
+        self.dialog.instance_folder_location.setCursorPosition(0)
+        self.dialog.instance_folder_location.setEnabled(is_default)
+        self.dialog.instance_folder_location_choose_button.setEnabled(is_default)
+        self.dialog.instance_folder_location_clear_button.setEnabled(is_default)
+
+    def update_model_from_view(self) -> None:
+        instance = self.settings.instances[self.settings.current_instance]
+        instance.game_folder = self.dialog.game_location.text()
+        instance.config_folder = self.dialog.config_folder_location.text()
+        instance.workshop_folder = self.dialog.steam_mods_folder_location.text()
+        instance.local_folder = self.dialog.local_mods_folder_location.text()
+        instance.steam_client_integration = (
+            self.dialog.steam_client_integration_checkbox.isChecked()
+        )
+
+    # --- Folder path group callbacks ---
+
+    def _on_game_choose(self, dialog: SettingsDialog) -> str | None:
+        if SystemInfo().operating_system == SystemInfo.OperatingSystem.MACOS:
+            game_location = show_dialogue_file(
+                mode="open_dir",
+                caption="Select Game Location",
+            )
+            if not game_location:
+                return None
+            result = Path(game_location)
+        else:
+            game_location = show_dialogue_file(
+                mode="open_dir",
+                caption="Select Game Location",
+            )
+            if not game_location:
+                return None
+            result = Path(game_location).resolve()
+
+        if not self._validate_game_location(str(result)):
+            return None
+
+        dialog.local_mods_folder_location.setText(str(result / "Mods"))
+        self._on_path_selected(str(result))
+        return str(result)
+
+    @staticmethod
+    def _on_game_clear(dialog: SettingsDialog) -> None:
+        dialog.local_mods_folder_location.setText("")
+
+    def _on_config_choose(self, dialog: SettingsDialog) -> str | None:
+        config_folder = show_dialogue_file(
+            mode="open_dir",
+            caption="Select Config Folder",
+        )
+        if not config_folder:
+            return None
+
+        if not self._validate_config_folder_location(config_folder):
+            return None
+
+        self._on_path_selected(str(Path(config_folder).parent))
+        return config_folder
+
+    def _on_steam_mods_choose(self, dialog: SettingsDialog) -> str | None:
+        steam_mods_folder = show_dialogue_file(
+            mode="open_dir",
+            caption="Select Steam Mods Folder",
+        )
+        if not steam_mods_folder:
+            return None
+        self._on_path_selected(str(Path(steam_mods_folder).parent))
+        return steam_mods_folder
+
+    def _on_local_mods_choose(self, dialog: SettingsDialog) -> str | None:
+        local_mods_folder = show_dialogue_file(
+            mode="open_dir",
+            caption="Select Local Mods Folder",
+        )
+        if not local_mods_folder:
+            return None
+        self._on_path_selected(str(Path(local_mods_folder).parent))
+        return local_mods_folder
+
+    # --- Clear all button ---
+
+    @Slot()
+    def _on_clear_all_button_clicked(self, skip_confirmation: bool = False) -> None:
+        if not skip_confirmation:
+            answer = BinaryChoiceDialog(
+                title=self.dialog.tr("Clear all locations"),
+                text=self.dialog.tr("Are you sure you want to clear all locations?"),
+            )
+            if not answer.exec_is_positive():
+                return
+
+        self.dialog.game_location.setText("")
+        self.dialog.config_folder_location.setText("")
+        self.dialog.steam_mods_folder_location.setText("")
+        self.dialog.local_mods_folder_location.setText("")


### PR DESCRIPTION
Introduce FolderPathGroup helper and LocationsTabController following the BaseTabController pattern established in PR #2086.

- FolderPathGroup: reusable helper encapsulating one folder-path row (text field + open/choose/clear buttons) with configurable callbacks for choose/clear special behavior
- LocationsTabController(BaseTabController): orchestrates 4 folder path groups (game, config, steam mods, local mods), instance folder override, steam integration checkbox, and clear/autodetect buttons
- SettingsController: delegate ~350 lines of signal wiring, view sync, model sync, and 22 handler methods to ~15 lines of delegate calls via callbacks for validation, autodetect, and instance folder ops

No behavior changes — all folder dialog, validation, open-in-file-manager, and clear logic is preserved identically.