### PR TITLE
refactor: extract Launch State tab into WindowLayoutTabController

### DIFF
--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -14,6 +14,7 @@ from app.controllers.settings_tabs import (
     DatabasesTabController,
     LocationsTabController,
     SortingTabController,
+    WindowLayoutTabController,
 )
 from app.controllers.theme_controller import ThemeController
 from app.models.settings import Instance, Settings
@@ -116,6 +117,11 @@ class SettingsController(QObject):
         )
         self._tab_controllers.append(self._locations_tab)
 
+        self._window_layout_tab = WindowLayoutTabController(
+            self.settings, self.settings_dialog
+        )
+        self._tab_controllers.append(self._window_layout_tab)
+
         for tc in self._tab_controllers:
             tc.connect_signals()
 
@@ -134,32 +140,6 @@ class SettingsController(QObject):
         self.settings_dialog.global_ok_button.clicked.connect(
             self._on_global_ok_button_clicked
         )
-
-        # Connect launch state radio buttons to update spinbox enabled/disabled state
-        # Main Window
-        self.settings_dialog.main_launch_maximized_radio.toggled.connect(
-            self.settings_dialog.disable_main_custom_size_spinboxes
-        )
-        self.settings_dialog.main_launch_normal_radio.toggled.connect(
-            self.settings_dialog.disable_main_custom_size_spinboxes
-        )
-        self.settings_dialog.main_launch_custom_radio.toggled.connect(
-            self.settings_dialog.enable_main_custom_size_spinboxes
-        )
-        # Browser Window
-        self.settings_dialog.browser_launch_maximized_radio.toggled.connect(
-            self.settings_dialog.disable_browser_custom_size_spinboxes
-        )
-        self.settings_dialog.browser_launch_normal_radio.toggled.connect(
-            self.settings_dialog.disable_browser_custom_size_spinboxes
-        )
-        self.settings_dialog.browser_launch_custom_radio.toggled.connect(
-            self.settings_dialog.enable_browser_custom_size_spinboxes
-        )
-
-        # Settings Window (only custom option, spinboxes always enabled)
-        self.settings_dialog.settings_custom_width_spinbox.setEnabled(True)
-        self.settings_dialog.settings_custom_height_spinbox.setEnabled(True)
 
         # Advanced: wiring for save-comparison indicator toggle
         try:
@@ -492,68 +472,6 @@ class SettingsController(QObject):
         except Exception:
             pass
 
-        # Launch State tab
-        # Dialogue positioning
-        self.settings_dialog.constrain_dialogues_to_main_window_monitor_checkbox.setChecked(
-            self.settings.constrain_dialogues_to_main_window_monitor
-        )
-
-        # Windows launch state
-        # Main Window
-        main_window_launch_state = self.settings.main_window_launch_state
-        if main_window_launch_state == "maximized":
-            self.settings_dialog.main_launch_maximized_radio.setChecked(True)
-            self.settings_dialog.disable_main_custom_size_spinboxes()
-        elif main_window_launch_state == "normal":
-            self.settings_dialog.main_launch_normal_radio.setChecked(True)
-            self.settings_dialog.disable_main_custom_size_spinboxes()
-        elif main_window_launch_state == "custom":
-            self.settings_dialog.main_launch_custom_radio.setChecked(True)
-            self.settings_dialog.enable_main_custom_size_spinboxes()
-            # Validate main window custom width and height before setting
-            min_size, max_size = 400, 1600
-            width = self.settings.main_window_custom_width
-            height = self.settings.main_window_custom_height
-            if not (min_size <= width <= max_size):
-                width = 900
-            if not (min_size <= height <= max_size):
-                height = 600
-            self.settings_dialog.main_custom_width_spinbox.setValue(width)
-            self.settings_dialog.main_custom_height_spinbox.setValue(height)
-        else:
-            self.settings_dialog.main_launch_maximized_radio.setChecked(True)
-        # Browser Window
-        browser_window_launch_state = self.settings.browser_window_launch_state
-        if browser_window_launch_state == "maximized":
-            self.settings_dialog.browser_launch_maximized_radio.setChecked(True)
-            self.settings_dialog.disable_browser_custom_size_spinboxes()
-        if browser_window_launch_state == "normal":
-            self.settings_dialog.browser_launch_normal_radio.setChecked(True)
-            self.settings_dialog.disable_browser_custom_size_spinboxes()
-        elif browser_window_launch_state == "custom":
-            self.settings_dialog.browser_launch_custom_radio.setChecked(True)
-            self.settings_dialog.enable_browser_custom_size_spinboxes()
-            # Validate custom width and height before setting
-            min_size, max_size = 400, 1600
-            width = self.settings.browser_window_custom_width
-            height = self.settings.browser_window_custom_height
-            if not (min_size <= width <= max_size):
-                width = 900
-            if not (min_size <= height <= max_size):
-                height = 600
-            self.settings_dialog.browser_custom_width_spinbox.setValue(width)
-            self.settings_dialog.browser_custom_height_spinbox.setValue(height)
-        else:
-            self.settings_dialog.browser_launch_maximized_radio.setChecked(True)
-
-        # Settings Window (only custom option)
-        self.settings_dialog.settings_custom_width_spinbox.setValue(
-            self.settings.settings_window_custom_width
-        )
-        self.settings_dialog.settings_custom_height_spinbox.setValue(
-            self.settings.settings_window_custom_height
-        )
-
         # Advanced tab
         self.settings_dialog.debug_logging_checkbox.setChecked(
             self.settings.debug_logging_enabled
@@ -714,50 +632,6 @@ class SettingsController(QObject):
         )
         self.settings.font_size = self.settings_dialog.font_size_spinbox.value()
         self.settings.language = self.settings_dialog.language_combobox.currentData()
-
-        # Launch State tab
-        # Dialogue positioning
-        self.settings.constrain_dialogues_to_main_window_monitor = self.settings_dialog.constrain_dialogues_to_main_window_monitor_checkbox.isChecked()
-
-        # Windows launch state
-        # Main Window
-        if self.settings_dialog.main_launch_maximized_radio.isChecked():
-            self.settings.main_window_launch_state = "maximized"
-        elif self.settings_dialog.main_launch_normal_radio.isChecked():
-            self.settings.main_window_launch_state = "normal"
-        elif self.settings_dialog.main_launch_custom_radio.isChecked():
-            self.settings.main_window_launch_state = "custom"
-            self.settings.main_window_custom_width = (
-                self.settings_dialog.main_custom_width_spinbox.value()
-            )
-            self.settings.main_window_custom_height = (
-                self.settings_dialog.main_custom_height_spinbox.value()
-            )
-        else:
-            self.settings.main_window_launch_state = "maximized"
-        # Browser Window
-        if self.settings_dialog.browser_launch_maximized_radio.isChecked():
-            self.settings.browser_window_launch_state = "maximized"
-        elif self.settings_dialog.browser_launch_normal_radio.isChecked():
-            self.settings.browser_window_launch_state = "normal"
-        elif self.settings_dialog.browser_launch_custom_radio.isChecked():
-            self.settings.browser_window_launch_state = "custom"
-            self.settings.browser_window_custom_width = (
-                self.settings_dialog.browser_custom_width_spinbox.value()
-            )
-            self.settings.browser_window_custom_height = (
-                self.settings_dialog.browser_custom_height_spinbox.value()
-            )
-        else:
-            self.settings.browser_window_launch_state = "maximized"
-
-        # Settings Window (only custom option)
-        self.settings.settings_window_custom_width = (
-            self.settings_dialog.settings_custom_width_spinbox.value()
-        )
-        self.settings.settings_window_custom_height = (
-            self.settings_dialog.settings_custom_height_spinbox.value()
-        )
 
         # Advanced tab
         self.settings.debug_logging_enabled = (

--- a/app/controllers/settings_tabs/__init__.py
+++ b/app/controllers/settings_tabs/__init__.py
@@ -6,10 +6,14 @@ from app.controllers.settings_tabs.locations_tab_controller import (
     LocationsTabController,
 )
 from app.controllers.settings_tabs.sorting_tab_controller import SortingTabController
+from app.controllers.settings_tabs.window_layout_tab_controller import (
+    WindowLayoutTabController,
+)
 
 __all__ = [
     "BaseTabController",
     "DatabasesTabController",
     "LocationsTabController",
     "SortingTabController",
+    "WindowLayoutTabController",
 ]

--- a/app/controllers/settings_tabs/window_layout_tab_controller.py
+++ b/app/controllers/settings_tabs/window_layout_tab_controller.py
@@ -1,0 +1,150 @@
+from app.controllers.settings_tabs.base_tab_controller import BaseTabController
+from app.models.settings import Settings
+from app.views.settings_dialog import SettingsDialog
+
+
+class WindowLayoutTabController(BaseTabController):
+    """Controller for the Window Launch State settings tab.
+
+    Manages: main window launch state, browser window launch state,
+    settings window custom size, and dialogue positioning constraint.
+    """
+
+    def __init__(
+        self,
+        settings: Settings,
+        dialog: SettingsDialog,
+    ) -> None:
+        super().__init__(settings, dialog)
+
+    def connect_signals(self) -> None:
+        # Main window radio buttons toggle custom size spinboxes
+        self.dialog.main_launch_maximized_radio.toggled.connect(
+            self.dialog.disable_main_custom_size_spinboxes
+        )
+        self.dialog.main_launch_normal_radio.toggled.connect(
+            self.dialog.disable_main_custom_size_spinboxes
+        )
+        self.dialog.main_launch_custom_radio.toggled.connect(
+            self.dialog.enable_main_custom_size_spinboxes
+        )
+        # Browser window radio buttons toggle custom size spinboxes
+        self.dialog.browser_launch_maximized_radio.toggled.connect(
+            self.dialog.disable_browser_custom_size_spinboxes
+        )
+        self.dialog.browser_launch_normal_radio.toggled.connect(
+            self.dialog.disable_browser_custom_size_spinboxes
+        )
+        self.dialog.browser_launch_custom_radio.toggled.connect(
+            self.dialog.enable_browser_custom_size_spinboxes
+        )
+
+        # Settings Window (only custom option, spinboxes always enabled)
+        self.dialog.settings_custom_width_spinbox.setEnabled(True)
+        self.dialog.settings_custom_height_spinbox.setEnabled(True)
+
+    def update_view_from_model(self) -> None:
+        # Dialogue positioning
+        self.dialog.constrain_dialogues_to_main_window_monitor_checkbox.setChecked(
+            self.settings.constrain_dialogues_to_main_window_monitor
+        )
+
+        # Main Window launch state
+        main_state = self.settings.main_window_launch_state
+        if main_state == "maximized":
+            self.dialog.main_launch_maximized_radio.setChecked(True)
+            self.dialog.disable_main_custom_size_spinboxes()
+        elif main_state == "normal":
+            self.dialog.main_launch_normal_radio.setChecked(True)
+            self.dialog.disable_main_custom_size_spinboxes()
+        elif main_state == "custom":
+            self.dialog.main_launch_custom_radio.setChecked(True)
+            self.dialog.enable_main_custom_size_spinboxes()
+            min_size, max_size = 400, 1600
+            width = self.settings.main_window_custom_width
+            height = self.settings.main_window_custom_height
+            if not (min_size <= width <= max_size):
+                width = 900
+            if not (min_size <= height <= max_size):
+                height = 600
+            self.dialog.main_custom_width_spinbox.setValue(width)
+            self.dialog.main_custom_height_spinbox.setValue(height)
+        else:
+            self.dialog.main_launch_maximized_radio.setChecked(True)
+
+        # Browser Window launch state
+        browser_state = self.settings.browser_window_launch_state
+        if browser_state == "maximized":
+            self.dialog.browser_launch_maximized_radio.setChecked(True)
+            self.dialog.disable_browser_custom_size_spinboxes()
+        if browser_state == "normal":
+            self.dialog.browser_launch_normal_radio.setChecked(True)
+            self.dialog.disable_browser_custom_size_spinboxes()
+        elif browser_state == "custom":
+            self.dialog.browser_launch_custom_radio.setChecked(True)
+            self.dialog.enable_browser_custom_size_spinboxes()
+            min_size, max_size = 400, 1600
+            width = self.settings.browser_window_custom_width
+            height = self.settings.browser_window_custom_height
+            if not (min_size <= width <= max_size):
+                width = 900
+            if not (min_size <= height <= max_size):
+                height = 600
+            self.dialog.browser_custom_width_spinbox.setValue(width)
+            self.dialog.browser_custom_height_spinbox.setValue(height)
+        else:
+            self.dialog.browser_launch_maximized_radio.setChecked(True)
+
+        # Settings Window (only custom option)
+        self.dialog.settings_custom_width_spinbox.setValue(
+            self.settings.settings_window_custom_width
+        )
+        self.dialog.settings_custom_height_spinbox.setValue(
+            self.settings.settings_window_custom_height
+        )
+
+    def update_model_from_view(self) -> None:
+        # Dialogue positioning
+        self.settings.constrain_dialogues_to_main_window_monitor = (
+            self.dialog.constrain_dialogues_to_main_window_monitor_checkbox.isChecked()
+        )
+
+        # Main Window
+        if self.dialog.main_launch_maximized_radio.isChecked():
+            self.settings.main_window_launch_state = "maximized"
+        elif self.dialog.main_launch_normal_radio.isChecked():
+            self.settings.main_window_launch_state = "normal"
+        elif self.dialog.main_launch_custom_radio.isChecked():
+            self.settings.main_window_launch_state = "custom"
+            self.settings.main_window_custom_width = (
+                self.dialog.main_custom_width_spinbox.value()
+            )
+            self.settings.main_window_custom_height = (
+                self.dialog.main_custom_height_spinbox.value()
+            )
+        else:
+            self.settings.main_window_launch_state = "maximized"
+
+        # Browser Window
+        if self.dialog.browser_launch_maximized_radio.isChecked():
+            self.settings.browser_window_launch_state = "maximized"
+        elif self.dialog.browser_launch_normal_radio.isChecked():
+            self.settings.browser_window_launch_state = "normal"
+        elif self.dialog.browser_launch_custom_radio.isChecked():
+            self.settings.browser_window_launch_state = "custom"
+            self.settings.browser_window_custom_width = (
+                self.dialog.browser_custom_width_spinbox.value()
+            )
+            self.settings.browser_window_custom_height = (
+                self.dialog.browser_custom_height_spinbox.value()
+            )
+        else:
+            self.settings.browser_window_launch_state = "maximized"
+
+        # Settings Window (only custom option)
+        self.settings.settings_window_custom_width = (
+            self.dialog.settings_custom_width_spinbox.value()
+        )
+        self.settings.settings_window_custom_height = (
+            self.dialog.settings_custom_height_spinbox.value()
+        )

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -1501,17 +1501,6 @@ This basically preserves your mod coloring, user notes etc. for this many second
         group_layout.addWidget(main_window_title_label)
         group_layout.addWidget(self.main_window_group)
 
-        # Connect main window radio buttons to enable/disable custom size spinboxes dynamically
-        self.main_launch_maximized_radio.toggled.connect(
-            self.disable_main_custom_size_spinboxes
-        )
-        self.main_launch_normal_radio.toggled.connect(
-            self.disable_main_custom_size_spinboxes
-        )
-        self.main_launch_custom_radio.toggled.connect(
-            self.enable_main_custom_size_spinboxes
-        )
-
         # Browser Window
         (
             self.browser_window_group,
@@ -1534,17 +1523,6 @@ This basically preserves your mod coloring, user notes etc. for this many second
         browser_window_title_label.setFont(GUIInfo().emphasis_font)
         group_layout.addWidget(browser_window_title_label)
         group_layout.addWidget(self.browser_window_group)
-
-        # Connect browser window radio buttons to enable/disable custom size spinboxes dynamically
-        self.browser_launch_maximized_radio.toggled.connect(
-            self.disable_browser_custom_size_spinboxes
-        )
-        self.browser_launch_normal_radio.toggled.connect(
-            self.disable_browser_custom_size_spinboxes
-        )
-        self.browser_launch_custom_radio.toggled.connect(
-            self.enable_browser_custom_size_spinboxes
-        )
 
         # Settings Window (only custom option)
         settings_window_title_label = QLabel(self.tr("Settings Window Launch State"))


### PR DESCRIPTION
Introduce WindowLayoutTabController following the BaseTabController ABC pattern.

- WindowLayoutTabController(BaseTabController): manages main/browser/settings window launch state, custom size validation, and dialogue positioning constraint
- SettingsController: delegate Launch State signal wiring, view sync, and model sync to the tab controller
- Remove duplicate signal connections: radio button toggles were wired in both SettingsController.__init__ and SettingsDialog._do_launch_state_tab — now connected once in the tab controller

No behavior changes — all window state, size validation, and dialogue positioning logic is preserved identically.