### PR TITLE
refactor: extract Game Launch tab into GameLaunchTabController

### DIFF
--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -12,6 +12,7 @@ from app.controllers.language_controller import LanguageController
 from app.controllers.settings_tabs import (
     BaseTabController,
     DatabasesTabController,
+    GameLaunchTabController,
     LocationsTabController,
     SortingTabController,
     WindowLayoutTabController,
@@ -122,6 +123,11 @@ class SettingsController(QObject):
         )
         self._tab_controllers.append(self._window_layout_tab)
 
+        self._game_launch_tab = GameLaunchTabController(
+            self.settings, self.settings_dialog
+        )
+        self._tab_controllers.append(self._game_launch_tab)
+
         for tc in self._tab_controllers:
             tc.connect_signals()
 
@@ -148,11 +154,6 @@ class SettingsController(QObject):
             )
         except Exception:
             pass
-
-        # Game Launch tab
-        self.settings_dialog.run_args.textChanged.connect(
-            self._on_run_args_text_changed
-        )
 
         # Build DB tab
         self.settings_dialog.db_builder_download_all_mods_via_steamcmd_button.clicked.connect(
@@ -346,17 +347,8 @@ class SettingsController(QObject):
         # Locations tab
         self._locations_tab.update_view_from_model()
 
-        # Load Steam protocol launch option
-        self.settings_dialog.launch_via_steam_protocol_checkbox.setChecked(
-            self.settings.instances[
-                self.settings.current_instance
-            ].launch_via_steam_protocol
-        )
-        # Update run_args group enabled state based on Steam protocol setting
-        launch_via_steam_protocol = self.settings.instances[
-            self.settings.current_instance
-        ].launch_via_steam_protocol
-        self.settings_dialog.run_args_group.setEnabled(not launch_via_steam_protocol)
+        # Game Launch tab
+        self._game_launch_tab.update_view_from_model()
 
         # Databases tab
         self._databases_tab.update_view_from_model()
@@ -520,12 +512,6 @@ class SettingsController(QObject):
         self.settings_dialog.github_token.setText(self.settings.github_token)
         self.settings_dialog.github_token.setCursorPosition(0)
 
-        # run_args is a plain string — no migration needed at display time
-        self.settings_dialog.run_args.setText(
-            self.settings.instances[self.settings.current_instance].run_args
-        )
-        self.settings_dialog.run_args.setCursorPosition(0)
-
     def _update_model_from_view(self) -> None:
         """
         Update the settings model from the view.
@@ -534,12 +520,8 @@ class SettingsController(QObject):
         # Locations tab
         self._locations_tab.update_model_from_view()
 
-        # Save Steam protocol launch option
-        self.settings.instances[
-            self.settings.current_instance
-        ].launch_via_steam_protocol = (
-            self.settings_dialog.launch_via_steam_protocol_checkbox.isChecked()
-        )
+        # Game Launch tab
+        self._game_launch_tab.update_model_from_view()
 
         # Databases tab
         self._databases_tab.update_model_from_view()
@@ -677,9 +659,6 @@ class SettingsController(QObject):
         self.settings.rentry_auth_code = self.settings_dialog.rentry_auth_code.text()
         self.settings.github_username = self.settings_dialog.github_username.text()
         self.settings.github_token = self.settings_dialog.github_token.text()
-        self.settings_dialog.run_args.setText(
-            self.settings.instances[self.settings.current_instance].run_args
-        )
 
     @Slot()
     def _on_global_reset_to_defaults_button_clicked(self) -> None:
@@ -1418,11 +1397,6 @@ class SettingsController(QObject):
 
         self.settings_dialog.global_ok_button.click()
         EventBus().do_build_steam_workshop_database.emit()
-
-    @Slot(str)
-    def _on_run_args_text_changed(self, text: str = "") -> None:
-        self.settings.instances[self.settings.current_instance].run_args = text
-        self.settings.save()
 
     @Slot()
     def _on_instance_folder_location_choose_button_clicked(self) -> None:

--- a/app/controllers/settings_tabs/__init__.py
+++ b/app/controllers/settings_tabs/__init__.py
@@ -2,6 +2,9 @@ from app.controllers.settings_tabs.base_tab_controller import BaseTabController
 from app.controllers.settings_tabs.databases_tab_controller import (
     DatabasesTabController,
 )
+from app.controllers.settings_tabs.game_launch_tab_controller import (
+    GameLaunchTabController,
+)
 from app.controllers.settings_tabs.locations_tab_controller import (
     LocationsTabController,
 )
@@ -13,6 +16,7 @@ from app.controllers.settings_tabs.window_layout_tab_controller import (
 __all__ = [
     "BaseTabController",
     "DatabasesTabController",
+    "GameLaunchTabController",
     "LocationsTabController",
     "SortingTabController",
     "WindowLayoutTabController",

--- a/app/controllers/settings_tabs/game_launch_tab_controller.py
+++ b/app/controllers/settings_tabs/game_launch_tab_controller.py
@@ -1,0 +1,49 @@
+from PySide6.QtCore import Slot
+
+from app.controllers.settings_tabs.base_tab_controller import BaseTabController
+from app.models.settings import Settings
+from app.views.settings_dialog import SettingsDialog
+
+
+class GameLaunchTabController(BaseTabController):
+    """Controller for the Game Launch settings tab.
+
+    Manages: Steam protocol launch toggle, run arguments text field.
+    """
+
+    def __init__(
+        self,
+        settings: Settings,
+        dialog: SettingsDialog,
+    ) -> None:
+        super().__init__(settings, dialog)
+
+    def connect_signals(self) -> None:
+        self.dialog.run_args.textChanged.connect(self._on_run_args_text_changed)
+
+    def update_view_from_model(self) -> None:
+        instance = self.settings.instances[self.settings.current_instance]
+
+        self.dialog.launch_via_steam_protocol_checkbox.setChecked(
+            instance.launch_via_steam_protocol
+        )
+        self.dialog.run_args_group.setEnabled(not instance.launch_via_steam_protocol)
+
+        self.dialog.run_args.setText(instance.run_args)
+        self.dialog.run_args.setCursorPosition(0)
+
+    def update_model_from_view(self) -> None:
+        self.settings.instances[
+            self.settings.current_instance
+        ].launch_via_steam_protocol = (
+            self.dialog.launch_via_steam_protocol_checkbox.isChecked()
+        )
+
+        self.settings.instances[
+            self.settings.current_instance
+        ].run_args = self.dialog.run_args.text()
+
+    @Slot(str)
+    def _on_run_args_text_changed(self, text: str = "") -> None:
+        self.settings.instances[self.settings.current_instance].run_args = text
+        self.settings.save()


### PR DESCRIPTION
Introduce GameLaunchTabController following the BaseTabController ABC pattern.

- GameLaunchTabController(BaseTabController): manages Steam protocol launch toggle, run arguments text field, and live-save handler
- SettingsController: delegate Game Launch signal wiring, view sync, model sync, and handler to ~4 lines of delegate calls
- Fix dead code in \_update_model_from_view\: replaced \setText\ (model→view) with \	ext()\ read (view→model); no behavioral impact since the live-save handler kept the model in sync

No behavior changes — all Steam protocol enable/disable and run_args live-save logic is preserved identically.