### PR TITLE
refactor: extract todds tab into ToddsTabController

### DIFF
--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -200,8 +200,10 @@ class SettingsController(QObject):
             self.settings_dialog.show_save_comparison_indicators_checkbox.toggled.connect(
                 self._on_toggle_show_save_comparison_indicators
             )
-        except Exception:
-            pass
+        except (AttributeError, TypeError):
+            logger.warning(
+                "show_save_comparison_indicators_checkbox not available for signal wiring"
+            )
 
         # Advanced tab
         self.settings_dialog.color_background_instead_of_text_checkbox.stateChanged.connect(
@@ -438,8 +440,10 @@ class SettingsController(QObject):
             self.settings_dialog.show_save_comparison_indicators_checkbox.setChecked(
                 self.settings.show_save_comparison_indicators
             )
-        except Exception:
-            pass
+        except (AttributeError, TypeError):
+            logger.warning(
+                "show_save_comparison_indicators_checkbox not available for view update"
+            )
 
         # Advanced tab
         self.settings_dialog.debug_logging_checkbox.setChecked(

--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -15,6 +15,7 @@ from app.controllers.settings_tabs import (
     GameLaunchTabController,
     LocationsTabController,
     SortingTabController,
+    ToddsTabController,
     WindowLayoutTabController,
 )
 from app.controllers.theme_controller import ThemeController
@@ -128,6 +129,9 @@ class SettingsController(QObject):
         )
         self._tab_controllers.append(self._game_launch_tab)
 
+        self._todds_tab = ToddsTabController(self.settings, self.settings_dialog)
+        self._tab_controllers.append(self._todds_tab)
+
         for tc in self._tab_controllers:
             tc.connect_signals()
 
@@ -146,14 +150,6 @@ class SettingsController(QObject):
         self.settings_dialog.global_ok_button.clicked.connect(
             self._on_global_ok_button_clicked
         )
-
-        # Advanced: wiring for save-comparison indicator toggle
-        try:
-            self.settings_dialog.show_save_comparison_indicators_checkbox.toggled.connect(
-                self._on_toggle_show_save_comparison_indicators
-            )
-        except Exception:
-            pass
 
         # Build DB tab
         self.settings_dialog.db_builder_download_all_mods_via_steamcmd_button.clicked.connect(
@@ -198,6 +194,14 @@ class SettingsController(QObject):
         self.settings_dialog.theme_location_open_button.clicked.connect(
             self._on_theme_location_open_button_clicked
         )
+
+        # Advanced: wiring for save-comparison indicator toggle
+        try:
+            self.settings_dialog.show_save_comparison_indicators_checkbox.toggled.connect(
+                self._on_toggle_show_save_comparison_indicators
+            )
+        except Exception:
+            pass
 
         # Advanced tab
         self.settings_dialog.color_background_instead_of_text_checkbox.stateChanged.connect(
@@ -400,34 +404,7 @@ class SettingsController(QObject):
         )
 
         # todds tab
-        if self.settings.todds_preset == "optimized":
-            self.settings_dialog.todds_preset_optimized_radio.setChecked(True)
-            self.settings_dialog.todds_custom_command_lineedit.setEnabled(False)
-        elif self.settings.todds_preset == "custom":
-            self.settings_dialog.todds_preset_custom_radio.setChecked(True)
-            self.settings_dialog.todds_custom_command_lineedit.setEnabled(True)
-        else:
-            self.settings_dialog.todds_preset_optimized_radio.setChecked(True)
-            self.settings_dialog.todds_custom_command_lineedit.setEnabled(False)
-        if self.settings.todds_active_mods_target:
-            self.settings_dialog.todds_active_mods_only_radio.setChecked(True)
-        else:
-            self.settings_dialog.todds_all_mods_radio.setChecked(True)
-        self.settings_dialog.todds_dry_run_checkbox.setChecked(
-            self.settings.todds_dry_run
-        )
-        self.settings_dialog.todds_overwrite_checkbox.setChecked(
-            self.settings.todds_overwrite
-        )
-        self.settings_dialog.todds_custom_command_lineedit.setText(
-            self.settings.todds_custom_command
-        )
-        self.settings_dialog.auto_delete_orphaned_dds_checkbox.setChecked(
-            self.settings.auto_delete_orphaned_dds
-        )
-        self.settings_dialog.auto_run_todds_before_launch_checkbox.setChecked(
-            self.settings.auto_run_todds_before_launch
-        )
+        self._todds_tab.update_view_from_model()
 
         # External Tools Tab
         self.settings_dialog.text_editor_location.setText(
@@ -568,29 +545,7 @@ class SettingsController(QObject):
         ].steamcmd_install_path = self.settings_dialog.steamcmd_install_location.text()
 
         # todds tab
-        if self.settings_dialog.todds_preset_custom_radio.isChecked():
-            self.settings.todds_preset = "custom"
-            self.settings.todds_custom_command = (
-                self.settings_dialog.todds_custom_command_lineedit.text()
-            )
-        else:
-            self.settings.todds_preset = "optimized"
-        if self.settings_dialog.todds_active_mods_only_radio.isChecked():
-            self.settings.todds_active_mods_target = True
-        elif self.settings_dialog.todds_all_mods_radio.isChecked():
-            self.settings.todds_active_mods_target = False
-        self.settings.todds_dry_run = (
-            self.settings_dialog.todds_dry_run_checkbox.isChecked()
-        )
-        self.settings.todds_overwrite = (
-            self.settings_dialog.todds_overwrite_checkbox.isChecked()
-        )
-        self.settings.auto_delete_orphaned_dds = (
-            self.settings_dialog.auto_delete_orphaned_dds_checkbox.isChecked()
-        )
-        self.settings.auto_run_todds_before_launch = (
-            self.settings_dialog.auto_run_todds_before_launch_checkbox.isChecked()
-        )
+        self._todds_tab.update_model_from_view()
 
         # Other External Tools Tab
         self.settings.text_editor_location = (

--- a/app/controllers/settings_tabs/__init__.py
+++ b/app/controllers/settings_tabs/__init__.py
@@ -9,6 +9,7 @@ from app.controllers.settings_tabs.locations_tab_controller import (
     LocationsTabController,
 )
 from app.controllers.settings_tabs.sorting_tab_controller import SortingTabController
+from app.controllers.settings_tabs.todds_tab_controller import ToddsTabController
 from app.controllers.settings_tabs.window_layout_tab_controller import (
     WindowLayoutTabController,
 )
@@ -19,5 +20,6 @@ __all__ = [
     "GameLaunchTabController",
     "LocationsTabController",
     "SortingTabController",
+    "ToddsTabController",
     "WindowLayoutTabController",
 ]

--- a/app/controllers/settings_tabs/todds_tab_controller.py
+++ b/app/controllers/settings_tabs/todds_tab_controller.py
@@ -1,0 +1,68 @@
+from app.controllers.settings_tabs.base_tab_controller import BaseTabController
+from app.models.settings import Settings
+from app.views.settings_dialog import SettingsDialog
+
+
+class ToddsTabController(BaseTabController):
+    """Controller for the todds settings tab.
+
+    Manages: quality preset (optimized/custom), target mods scope,
+    dry-run/overwrite toggles, orphaned DDS cleanup, auto-run on launch.
+    """
+
+    def __init__(
+        self,
+        settings: Settings,
+        dialog: SettingsDialog,
+    ) -> None:
+        super().__init__(settings, dialog)
+
+    def connect_signals(self) -> None:
+        pass  # All signal wiring is internal to the view
+
+    def update_view_from_model(self) -> None:
+        if self.settings.todds_preset == "optimized":
+            self.dialog.todds_preset_optimized_radio.setChecked(True)
+            self.dialog.todds_custom_command_lineedit.setEnabled(False)
+        elif self.settings.todds_preset == "custom":
+            self.dialog.todds_preset_custom_radio.setChecked(True)
+            self.dialog.todds_custom_command_lineedit.setEnabled(True)
+        else:
+            self.dialog.todds_preset_optimized_radio.setChecked(True)
+            self.dialog.todds_custom_command_lineedit.setEnabled(False)
+        if self.settings.todds_active_mods_target:
+            self.dialog.todds_active_mods_only_radio.setChecked(True)
+        else:
+            self.dialog.todds_all_mods_radio.setChecked(True)
+        self.dialog.todds_dry_run_checkbox.setChecked(self.settings.todds_dry_run)
+        self.dialog.todds_overwrite_checkbox.setChecked(self.settings.todds_overwrite)
+        self.dialog.todds_custom_command_lineedit.setText(
+            self.settings.todds_custom_command
+        )
+        self.dialog.auto_delete_orphaned_dds_checkbox.setChecked(
+            self.settings.auto_delete_orphaned_dds
+        )
+        self.dialog.auto_run_todds_before_launch_checkbox.setChecked(
+            self.settings.auto_run_todds_before_launch
+        )
+
+    def update_model_from_view(self) -> None:
+        if self.dialog.todds_preset_custom_radio.isChecked():
+            self.settings.todds_preset = "custom"
+            self.settings.todds_custom_command = (
+                self.dialog.todds_custom_command_lineedit.text()
+            )
+        else:
+            self.settings.todds_preset = "optimized"
+        if self.dialog.todds_active_mods_only_radio.isChecked():
+            self.settings.todds_active_mods_target = True
+        elif self.dialog.todds_all_mods_radio.isChecked():
+            self.settings.todds_active_mods_target = False
+        self.settings.todds_dry_run = self.dialog.todds_dry_run_checkbox.isChecked()
+        self.settings.todds_overwrite = self.dialog.todds_overwrite_checkbox.isChecked()
+        self.settings.auto_delete_orphaned_dds = (
+            self.dialog.auto_delete_orphaned_dds_checkbox.isChecked()
+        )
+        self.settings.auto_run_todds_before_launch = (
+            self.dialog.auto_run_todds_before_launch_checkbox.isChecked()
+        )


### PR DESCRIPTION
Introduce ToddsTabController following the BaseTabController ABC pattern.

- ToddsTabController(BaseTabController): manages quality preset (optimized/custom), target mods scope, dry-run/overwrite toggles, orphaned DDS cleanup, and auto-run on launch
- SettingsController: delegate todds view sync and model sync to the tab controller
- Fix empty \xcept Exception: pass\ blocks for \show_save_comparison_indicators_checkbox\: narrow to \(AttributeError, TypeError)\ with warning log

No behavior changes — all todds quality preset, target scope, dry-run, overwrite, orphaned DDS cleanup, and auto-run logic is preserved identically.