### PR TITLE
refactor: extract SteamCMD tab into SteamcmdTabController

### DIFF
--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -16,6 +16,7 @@ from app.controllers.settings_tabs import (
     GameLaunchTabController,
     LocationsTabController,
     SortingTabController,
+    SteamcmdTabController,
     ToddsTabController,
     WindowLayoutTabController,
 )
@@ -134,6 +135,14 @@ class SettingsController(QObject):
         self._advanced_tab = AdvancedTabController(self.settings, self.settings_dialog)
         self._tab_controllers.append(self._advanced_tab)
 
+        self._steamcmd_tab = SteamcmdTabController(
+            self.settings,
+            self.settings_dialog,
+            last_file_dialog_path=str(self._last_file_dialog_path),
+            on_path_selected=self._on_locations_path_selected,
+        )
+        self._tab_controllers.append(self._steamcmd_tab)
+
         for tc in self._tab_controllers:
             tc.connect_signals()
 
@@ -168,23 +177,6 @@ class SettingsController(QObject):
         )
         self.settings_dialog.db_builder_build_database_button.clicked.connect(
             self._on_db_builder_build_database_button_clicked
-        )
-
-        # SteamCMD tab
-        self.settings_dialog.steamcmd_install_location_choose_button.clicked.connect(
-            self._on_steamcmd_install_location_choose_button_clicked
-        )
-        self.settings_dialog.steamcmd_clear_depot_cache_button.clicked.connect(
-            self._on_steamcmd_clear_depot_cache_button_clicked
-        )
-        self.settings_dialog.steamcmd_import_acf_button.clicked.connect(
-            self._on_steamcmd_import_acf_button_clicked
-        )
-        self.settings_dialog.steamcmd_delete_acf_button.clicked.connect(
-            self._on_steamcmd_delete_acf_button_clicked
-        )
-        self.settings_dialog.steamcmd_install_button.clicked.connect(
-            self._on_steamcmd_install_button_clicked
         )
 
         # Other External Tools Tab
@@ -361,24 +353,7 @@ class SettingsController(QObject):
         )
 
         # SteamCMD tab
-        self.settings_dialog.steamcmd_validate_downloads_checkbox.setChecked(
-            self.settings.steamcmd_validate_downloads
-        )
-        self.settings_dialog.steamcmd_auto_clear_depot_cache_checkbox.setChecked(
-            self.settings.instances[
-                self.settings.current_instance
-            ].steamcmd_auto_clear_depot_cache
-        )
-        self.settings_dialog.steamcmd_delete_before_update_checkbox.setChecked(
-            self.settings.steamcmd_delete_before_update
-        )
-        self.settings_dialog.steamcmd_install_location.setText(
-            str(
-                self.settings.instances[
-                    self.settings.current_instance
-                ].steamcmd_install_path
-            )
-        )
+        self._steamcmd_tab.update_view_from_model()
 
         # todds tab
         self._todds_tab.update_view_from_model()
@@ -462,20 +437,7 @@ class SettingsController(QObject):
         )
 
         # SteamCMD tab
-        self.settings.steamcmd_validate_downloads = (
-            self.settings_dialog.steamcmd_validate_downloads_checkbox.isChecked()
-        )
-        self.settings.steamcmd_delete_before_update = (
-            self.settings_dialog.steamcmd_delete_before_update_checkbox.isChecked()
-        )
-        self.settings.instances[
-            self.settings.current_instance
-        ].steamcmd_auto_clear_depot_cache = (
-            self.settings_dialog.steamcmd_auto_clear_depot_cache_checkbox.isChecked()
-        )
-        self.settings.instances[
-            self.settings.current_instance
-        ].steamcmd_install_path = self.settings_dialog.steamcmd_install_location.text()
+        self._steamcmd_tab.update_model_from_view()
 
         # todds tab
         self._todds_tab.update_model_from_view()
@@ -1101,53 +1063,6 @@ class SettingsController(QObject):
             except Exception as e:
                 logger.debug(f"Error during HTTP worker cleanup: {e}")
             self._http_download_worker = None
-
-    @Slot()
-    @Slot()
-    def _on_steamcmd_install_location_choose_button_clicked(self) -> None:
-        """
-        Open a file dialog to select the Steamcmd install location and handle the result.
-        """
-        steamcmd_install_location = show_dialogue_file(
-            mode="open_dir",
-            caption="Select Steamcmd Install Location",
-            _dir=str(self._last_file_dialog_path),
-        )
-        if not steamcmd_install_location:
-            return
-
-        self.settings_dialog.steamcmd_install_location.setText(
-            steamcmd_install_location
-        )
-        self._last_file_dialog_path = str(Path(steamcmd_install_location).parent)
-
-    @Slot()
-    def _on_steamcmd_clear_depot_cache_button_clicked(self) -> None:
-        EventBus().do_clear_steamcmd_depot_cache.emit()
-
-    @Slot()
-    def _on_steamcmd_import_acf_button_clicked(self) -> None:
-        """
-        Handle the Steamcmd import ACF button click.
-        """
-        self.settings_dialog.global_ok_button.click()
-        EventBus().do_import_acf.emit()
-
-    @Slot()
-    def _on_steamcmd_delete_acf_button_clicked(self) -> None:
-        """
-        Handle the Steamcmd delete ACF button click.
-        """
-        self.settings_dialog.global_ok_button.click()
-        EventBus().do_delete_acf.emit()
-
-    @Slot()
-    def _on_steamcmd_install_button_clicked(self) -> None:
-        """
-        Handle the Steamcmd install button click.
-        """
-        self.settings_dialog.global_ok_button.click()
-        EventBus().do_install_steamcmd.emit()
 
     @Slot()
     def _on_text_editor_location_choose_button_clicked(self) -> None:

--- a/app/controllers/settings_tabs/__init__.py
+++ b/app/controllers/settings_tabs/__init__.py
@@ -12,6 +12,7 @@ from app.controllers.settings_tabs.locations_tab_controller import (
     LocationsTabController,
 )
 from app.controllers.settings_tabs.sorting_tab_controller import SortingTabController
+from app.controllers.settings_tabs.steamcmd_tab_controller import SteamcmdTabController
 from app.controllers.settings_tabs.todds_tab_controller import ToddsTabController
 from app.controllers.settings_tabs.window_layout_tab_controller import (
     WindowLayoutTabController,
@@ -24,6 +25,7 @@ __all__ = [
     "GameLaunchTabController",
     "LocationsTabController",
     "SortingTabController",
+    "SteamcmdTabController",
     "ToddsTabController",
     "WindowLayoutTabController",
 ]

--- a/app/controllers/settings_tabs/steamcmd_tab_controller.py
+++ b/app/controllers/settings_tabs/steamcmd_tab_controller.py
@@ -1,0 +1,103 @@
+from pathlib import Path
+from typing import Callable
+
+from PySide6.QtCore import Slot
+
+from app.controllers.settings_tabs.base_tab_controller import BaseTabController
+from app.models.settings import Settings
+from app.utils.event_bus import EventBus
+from app.views.dialogue import show_dialogue_file
+from app.views.settings_dialog import SettingsDialog
+
+
+class SteamcmdTabController(BaseTabController):
+    """Controller for the SteamCMD settings tab.
+
+    Manages: validate downloads toggle, auto-clear depot cache toggle,
+    delete-before-update toggle, install location path with file chooser,
+    and 4 action buttons (clear cache, import ACF, delete ACF, install).
+    """
+
+    def __init__(
+        self,
+        settings: Settings,
+        dialog: SettingsDialog,
+        last_file_dialog_path: str,
+        on_path_selected: Callable[[str], None],
+    ) -> None:
+        super().__init__(settings, dialog)
+        self._last_file_dialog_path = last_file_dialog_path
+        self._on_path_selected = on_path_selected
+
+    def connect_signals(self) -> None:
+        self.dialog.steamcmd_install_location_choose_button.clicked.connect(
+            self._on_install_location_choose
+        )
+        self.dialog.steamcmd_clear_depot_cache_button.clicked.connect(
+            self._on_clear_depot_cache
+        )
+        self.dialog.steamcmd_import_acf_button.clicked.connect(self._on_import_acf)
+        self.dialog.steamcmd_delete_acf_button.clicked.connect(self._on_delete_acf)
+        self.dialog.steamcmd_install_button.clicked.connect(self._on_install)
+
+    def update_view_from_model(self) -> None:
+        instance = self.settings.instances[self.settings.current_instance]
+
+        self.dialog.steamcmd_validate_downloads_checkbox.setChecked(
+            self.settings.steamcmd_validate_downloads
+        )
+        self.dialog.steamcmd_auto_clear_depot_cache_checkbox.setChecked(
+            instance.steamcmd_auto_clear_depot_cache
+        )
+        self.dialog.steamcmd_delete_before_update_checkbox.setChecked(
+            self.settings.steamcmd_delete_before_update
+        )
+        self.dialog.steamcmd_install_location.setText(
+            str(instance.steamcmd_install_path)
+        )
+
+    def update_model_from_view(self) -> None:
+        instance = self.settings.instances[self.settings.current_instance]
+
+        self.settings.steamcmd_validate_downloads = (
+            self.dialog.steamcmd_validate_downloads_checkbox.isChecked()
+        )
+        self.settings.steamcmd_delete_before_update = (
+            self.dialog.steamcmd_delete_before_update_checkbox.isChecked()
+        )
+        instance.steamcmd_auto_clear_depot_cache = (
+            self.dialog.steamcmd_auto_clear_depot_cache_checkbox.isChecked()
+        )
+        instance.steamcmd_install_path = self.dialog.steamcmd_install_location.text()
+
+    @Slot()
+    def _on_install_location_choose(self) -> None:
+        steamcmd_install_location = show_dialogue_file(
+            mode="open_dir",
+            caption="Select Steamcmd Install Location",
+            _dir=str(self._last_file_dialog_path),
+        )
+        if not steamcmd_install_location:
+            return
+
+        self.dialog.steamcmd_install_location.setText(steamcmd_install_location)
+        self._on_path_selected(str(Path(steamcmd_install_location).parent))
+
+    @Slot()
+    def _on_clear_depot_cache(self) -> None:
+        EventBus().do_clear_steamcmd_depot_cache.emit()
+
+    @Slot()
+    def _on_import_acf(self) -> None:
+        self.dialog.global_ok_button.click()
+        EventBus().do_import_acf.emit()
+
+    @Slot()
+    def _on_delete_acf(self) -> None:
+        self.dialog.global_ok_button.click()
+        EventBus().do_delete_acf.emit()
+
+    @Slot()
+    def _on_install(self) -> None:
+        self.dialog.global_ok_button.click()
+        EventBus().do_install_steamcmd.emit()


### PR DESCRIPTION
Introduce SteamcmdTabController following the BaseTabController ABC pattern.

- SteamcmdTabController(BaseTabController): manages validate downloads, auto-clear depot cache, delete-before-update, install location with file chooser, and 4 action buttons (clear cache, import ACF, delete ACF, install)
- SettingsController: delegate SteamCMD tab signal wiring, view sync, model sync, and 5 handler methods to the tab controller

No behavior changes — all SteamCMD logic is preserved identically.