### PR TITLE
refactor: merge Auxiliary DB and Authentication tabs into Advanced tab

### DIFF
--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -326,14 +326,6 @@ class SettingsController(QObject):
         # Databases tab
         self._databases_tab.update_view_from_model()
 
-        # Auxiliary DB tab (kept inline — not extracted yet)
-        self.settings_dialog.aux_db_time_limit.setText(
-            str(self.settings.aux_db_time_limit)
-        )
-        self.settings_dialog.aux_db_time_limit.setEnabled(
-            self.settings.enable_aux_db_behavior_editing
-        )
-
         # Sorting tab
         self._sorting_tab.update_view_from_model()
 
@@ -387,15 +379,6 @@ class SettingsController(QObject):
 
         # Advanced tab
         self._advanced_tab.update_view_from_model()
-        self.settings_dialog.enable_aux_db_behavior_editing.setChecked(
-            self.settings.enable_aux_db_behavior_editing
-        )
-        self.settings_dialog.rentry_auth_code.setText(self.settings.rentry_auth_code)
-        self.settings_dialog.rentry_auth_code.setCursorPosition(0)
-        self.settings_dialog.github_username.setText(self.settings.github_username)
-        self.settings_dialog.github_username.setCursorPosition(0)
-        self.settings_dialog.github_token.setText(self.settings.github_token)
-        self.settings_dialog.github_token.setCursorPosition(0)
 
     def _update_model_from_view(self) -> None:
         """
@@ -410,15 +393,6 @@ class SettingsController(QObject):
 
         # Databases tab
         self._databases_tab.update_model_from_view()
-
-        # Auxiliary DB tab (kept inline — not extracted yet)
-        try:
-            self.settings.aux_db_time_limit = int(
-                self.settings_dialog.aux_db_time_limit.text()
-            )
-        except Exception:
-            logger.warning("Failed setting Aux DB time limit, falling back to -1")
-            self.settings.aux_db_time_limit = -1
 
         # Sorting tab
         self._sorting_tab.update_model_from_view()
@@ -467,12 +441,6 @@ class SettingsController(QObject):
 
         # Advanced tab
         self._advanced_tab.update_model_from_view()
-        self.settings.enable_aux_db_behavior_editing = (
-            self.settings_dialog.enable_aux_db_behavior_editing.isChecked()
-        )
-        self.settings.rentry_auth_code = self.settings_dialog.rentry_auth_code.text()
-        self.settings.github_username = self.settings_dialog.github_username.text()
-        self.settings.github_token = self.settings_dialog.github_token.text()
 
     @Slot()
     def _on_global_reset_to_defaults_button_clicked(self) -> None:

--- a/app/controllers/settings_tabs/advanced_tab_controller.py
+++ b/app/controllers/settings_tabs/advanced_tab_controller.py
@@ -1,3 +1,4 @@
+from loguru import logger
 from PySide6.QtCore import Slot
 
 from app.controllers.settings_tabs.base_tab_controller import BaseTabController
@@ -11,7 +12,8 @@ class AdvancedTabController(BaseTabController):
 
     Manages: debug logging, watchdog, clear/DLC behavior, mod update checks,
     rich text rendering, DB auto-update, mod name search scope, backup policy,
-    save-comparison indicators, mod coloring mode.
+    save-comparison indicators, mod coloring mode, Auxiliary DB settings,
+    and Authentication fields.
     """
 
     def __init__(
@@ -28,8 +30,6 @@ class AdvancedTabController(BaseTabController):
                 self._on_toggle_show_save_comparison_indicators
             )
         except (AttributeError, TypeError):
-            from loguru import logger
-
             logger.warning(
                 "show_save_comparison_indicators_checkbox not available for signal wiring"
             )
@@ -50,8 +50,6 @@ class AdvancedTabController(BaseTabController):
                 self.settings.show_save_comparison_indicators
             )
         except (AttributeError, TypeError):
-            from loguru import logger
-
             logger.warning(
                 "show_save_comparison_indicators_checkbox not available for view update"
             )
@@ -90,6 +88,20 @@ class AdvancedTabController(BaseTabController):
         )
         self.dialog.max_backups_spinbox.setValue(self.settings.max_backups)
 
+        # Auxiliary DB
+        self.dialog.aux_db_time_limit.setText(str(self.settings.aux_db_time_limit))
+        self.dialog.enable_aux_db_behavior_editing.setChecked(
+            self.settings.enable_aux_db_behavior_editing
+        )
+
+        # Authentication
+        self.dialog.rentry_auth_code.setText(self.settings.rentry_auth_code)
+        self.dialog.rentry_auth_code.setCursorPosition(0)
+        self.dialog.github_username.setText(self.settings.github_username)
+        self.dialog.github_username.setCursorPosition(0)
+        self.dialog.github_token.setText(self.settings.github_token)
+        self.dialog.github_token.setCursorPosition(0)
+
     def update_model_from_view(self) -> None:
         self.settings.debug_logging_enabled = (
             self.dialog.debug_logging_checkbox.isChecked()
@@ -124,6 +136,21 @@ class AdvancedTabController(BaseTabController):
             self.dialog.enable_backup_before_update_checkbox.isChecked()
         )
         self.settings.max_backups = self.dialog.max_backups_spinbox.value()
+
+        # Auxiliary DB
+        try:
+            self.settings.aux_db_time_limit = int(self.dialog.aux_db_time_limit.text())
+        except Exception:
+            logger.warning("Failed setting Aux DB time limit, falling back to -1")
+            self.settings.aux_db_time_limit = -1
+        self.settings.enable_aux_db_behavior_editing = (
+            self.dialog.enable_aux_db_behavior_editing.isChecked()
+        )
+
+        # Authentication
+        self.settings.rentry_auth_code = self.dialog.rentry_auth_code.text()
+        self.settings.github_username = self.dialog.github_username.text()
+        self.settings.github_token = self.dialog.github_token.text()
 
     @Slot(bool)
     def _on_toggle_show_save_comparison_indicators(self, checked: bool) -> None:

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -81,8 +81,6 @@ class SettingsDialog(QDialog):
         self._do_external_tools_tab()
         self._do_themes_tab()
         self._do_launch_state_tab()
-        self._do_authentication_tab()
-        self._do_aux_db_settings_tab()
         self._do_advanced_tab()
 
     def _do_locations_tab(self) -> None:
@@ -403,19 +401,6 @@ class SettingsDialog(QDialog):
         self._do_steam_workshop_db_group(tab_layout)
         self._do_no_version_warning_db_group(tab_layout)
         self._do_use_this_instead_db_group(tab_layout)
-
-    def _do_aux_db_settings_tab(self) -> None:
-        tab = QWidget()
-        self.tab_widget.addTab(tab, self.tr("Auxiliary DB"))
-
-        tab_layout = QVBoxLayout()
-        tab_layout.setAlignment(Qt.AlignmentFlag.AlignTop)
-        tab.setLayout(tab_layout)
-
-        self._do_aux_db_time_limit_group(tab_layout)
-        # New section for save-comparison feature
-        self._do_recent_save_integration_group(tab_layout)
-        self._do_backup_settings_group(tab_layout)
 
     def _do_backup_settings_group(self, tab_layout: QBoxLayout) -> None:
         backup_group_label = QLabel(self.tr("Backup Settings"))
@@ -1605,74 +1590,20 @@ This basically preserves your mod coloring, user notes etc. for this many second
         language_controller = LanguageController()
         language_controller.populate_languages_combobox
 
-    def _do_authentication_tab(self) -> None:
-        tab = QWidget()
-        self.tab_widget.addTab(tab, self.tr("Authentication"))
-
-        tab_layout = QVBoxLayout(tab)
-        tab_layout.setAlignment(Qt.AlignmentFlag.AlignTop)
-
-        auth_group = QGroupBox()
-        tab_layout.addWidget(auth_group)
-
-        auth_group_layout = QGridLayout()
-        auth_group.setLayout(auth_group_layout)
-
-        rentry_auth_label = QLabel(self.tr("Rentry Auth:"))
-        auth_group_layout.addWidget(
-            rentry_auth_label, 0, 0, alignment=Qt.AlignmentFlag.AlignRight
-        )
-
-        self.rentry_auth_code = QLineEdit()
-        self.rentry_auth_code.setTextMargins(GUIInfo().text_field_margins)
-        self.rentry_auth_code.setFixedHeight(GUIInfo().default_font_line_height * 2)
-        self.rentry_auth_code.setPlaceholderText(
-            self.tr("Obtain rentry auth code by emailing: support@rentry.co")
-        )
-        # TODO: If we add a rentry auth code with builds, we should change placeholder to clarify this code will be used instead of the provided one
-        auth_group_layout.addWidget(self.rentry_auth_code, 0, 1)
-
-        github_identity_group = QGroupBox()
-        tab_layout.addWidget(github_identity_group)
-
-        github_identity_layout = QGridLayout()
-        github_identity_group.setLayout(github_identity_layout)
-
-        github_username_label = QLabel(self.tr("GitHub username:"))
-        github_identity_layout.addWidget(
-            github_username_label, 0, 0, alignment=Qt.AlignmentFlag.AlignRight
-        )
-
-        self.github_username = QLineEdit()
-        self.github_username.setTextMargins(GUIInfo().text_field_margins)
-        self.github_username.setFixedHeight(GUIInfo().default_font_line_height * 2)
-        github_identity_layout.addWidget(self.github_username, 0, 1)
-
-        github_token_label = QLabel(self.tr("GitHub personal access token:"))
-        github_identity_layout.addWidget(
-            github_token_label, 1, 0, alignment=Qt.AlignmentFlag.AlignRight
-        )
-
-        self.github_token = QLineEdit()
-        self.github_token.setEchoMode(QLineEdit.EchoMode.Password)
-        self.github_token.setTextMargins(GUIInfo().text_field_margins)
-        self.github_token.setFixedHeight(GUIInfo().default_font_line_height * 2)
-        github_identity_layout.addWidget(self.github_token, 1, 1)
-
-        self.setTabOrder(self.github_username, self.github_token)
-
-        buttons_layout = QHBoxLayout()
-        tab_layout.addLayout(buttons_layout)
-
-        buttons_layout.addStretch()
-
     def _do_advanced_tab(self) -> None:
+        scroll_area = QScrollArea()
+        scroll_area.setWidgetResizable(True)
+        scroll_area.setFrameShape(QScrollArea.Shape.NoFrame)
+        self.tab_widget.addTab(scroll_area, self.tr("Advanced"))
+
         tab = QWidget()
-        self.tab_widget.addTab(tab, self.tr("Advanced"))
+        scroll_area.setWidget(tab)
+        tab.setAutoFillBackground(False)
+        scroll_area.viewport().setAutoFillBackground(False)
 
         tab_layout = QVBoxLayout(tab)
-        tab_layout.setAlignment(Qt.AlignmentFlag.AlignTop)
 
+        # === Advanced settings group ===
         group_box = QGroupBox()
         tab_layout.addWidget(group_box)
 
@@ -1692,7 +1623,6 @@ This basically preserves your mod coloring, user notes etc. for this many second
         )
         group_layout.addWidget(self.watchdog_checkbox)
 
-        # Clear button behavior
         self.clear_moves_dlc_checkbox = QCheckBox(self.tr("Clear also moves DLC"))
         group_layout.addWidget(self.clear_moves_dlc_checkbox)
 
@@ -1736,7 +1666,6 @@ This basically preserves your mod coloring, user notes etc. for this many second
         )
         group_layout.addWidget(self.include_mod_notes_in_mod_name_filter_checkbox)
 
-        # Put checkbox, label and spinbox on the same horizontal line
         backup_layout = QHBoxLayout()
         self.enable_backup_before_update_checkbox = QCheckBox(
             self.tr("Create backup before RimSort update")
@@ -1758,6 +1687,66 @@ This basically preserves your mod coloring, user notes etc. for this many second
         backup_layout.addWidget(self.max_backups_spinbox)
 
         group_layout.addLayout(backup_layout)
+
+        # === Auxiliary Metadata DB group ===
+        self._do_aux_db_time_limit_group(tab_layout)
+
+        # === Integration with recent save ===
+        self._do_recent_save_integration_group(tab_layout)
+
+        # === Backup Settings ===
+        self._do_backup_settings_group(tab_layout)
+
+        # === Authentication group ===
+        auth_group = QGroupBox()
+        tab_layout.addWidget(auth_group)
+
+        auth_group_layout = QGridLayout()
+        auth_group.setLayout(auth_group_layout)
+
+        rentry_auth_label = QLabel(self.tr("Rentry Auth:"))
+        auth_group_layout.addWidget(
+            rentry_auth_label, 0, 0, alignment=Qt.AlignmentFlag.AlignRight
+        )
+
+        self.rentry_auth_code = QLineEdit()
+        self.rentry_auth_code.setTextMargins(GUIInfo().text_field_margins)
+        self.rentry_auth_code.setFixedHeight(GUIInfo().default_font_line_height * 2)
+        self.rentry_auth_code.setPlaceholderText(
+            self.tr("Obtain rentry auth code by emailing: support@rentry.co")
+        )
+        auth_group_layout.addWidget(self.rentry_auth_code, 0, 1)
+
+        github_identity_group = QGroupBox()
+        tab_layout.addWidget(github_identity_group)
+
+        github_identity_layout = QGridLayout()
+        github_identity_group.setLayout(github_identity_layout)
+
+        github_username_label = QLabel(self.tr("GitHub username:"))
+        github_identity_layout.addWidget(
+            github_username_label, 0, 0, alignment=Qt.AlignmentFlag.AlignRight
+        )
+
+        self.github_username = QLineEdit()
+        self.github_username.setTextMargins(GUIInfo().text_field_margins)
+        self.github_username.setFixedHeight(GUIInfo().default_font_line_height * 2)
+        github_identity_layout.addWidget(self.github_username, 0, 1)
+
+        github_token_label = QLabel(self.tr("GitHub personal access token:"))
+        github_identity_layout.addWidget(
+            github_token_label, 1, 0, alignment=Qt.AlignmentFlag.AlignRight
+        )
+
+        self.github_token = QLineEdit()
+        self.github_token.setEchoMode(QLineEdit.EchoMode.Password)
+        self.github_token.setTextMargins(GUIInfo().text_field_margins)
+        self.github_token.setFixedHeight(GUIInfo().default_font_line_height * 2)
+        github_identity_layout.addWidget(self.github_token, 1, 1)
+
+        self.setTabOrder(self.github_username, self.github_token)
+
+        tab_layout.addStretch()
 
     def _find_tab_index(self, tab_name: str) -> int:
         for i in range(self.tab_widget.count()):


### PR DESCRIPTION
Merge the Auxiliary DB and Authentication standalone tabs into a single scrolling Advanced tab, following the QScrollArea pattern used by the Databases tab.

- Remove standalone Auxiliary DB and Authentication tab methods and their `_init_tabs` calls
- Rewrite `_do_advanced_tab` with `QScrollArea` (widget-resizable, no frame, auto-fill-background disabled)
- Relocate all Auxiliary DB widgets (aux DB time limit, backup settings, save-comparison indicators) and Authentication widgets (rentry auth, GitHub username/token) into the Advanced tab
- Add `aux_db_time_limit`, `enable_aux_db_behavior_editing`, `rentry_auth_code`, `github_username`, `github_token` to AdvancedTabController view/model sync
- Remove 32 lines of inline view/model sync from SettingsController

No behavior changes — all Auxiliary DB, Authentication, and Advanced settings logic is preserved identically.