### PR TITLE
refactor: merge Theme and Launch State tabs into Appearance tab

### DIFF
--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -11,6 +11,7 @@ from app.controllers.instance_controller import InstanceController
 from app.controllers.language_controller import LanguageController
 from app.controllers.settings_tabs import (
     AdvancedTabController,
+    AppearanceTabController,
     BaseTabController,
     DatabasesTabController,
     GameLaunchTabController,
@@ -18,7 +19,6 @@ from app.controllers.settings_tabs import (
     SortingTabController,
     SteamcmdTabController,
     ToddsTabController,
-    WindowLayoutTabController,
 )
 from app.controllers.theme_controller import ThemeController
 from app.models.settings import Instance, Settings
@@ -30,7 +30,6 @@ from app.utils.generic import (
     extract_git_dir_name,
     find_steam_rimworld,
     get_path_up_to_string,
-    platform_specific_open,
     validate_game_executable,
 )
 from app.utils.http_downloader import (
@@ -119,10 +118,10 @@ class SettingsController(QObject):
         )
         self._tab_controllers.append(self._locations_tab)
 
-        self._window_layout_tab = WindowLayoutTabController(
+        self._appearance_tab = AppearanceTabController(
             self.settings, self.settings_dialog
         )
-        self._tab_controllers.append(self._window_layout_tab)
+        self._tab_controllers.append(self._appearance_tab)
 
         self._game_launch_tab = GameLaunchTabController(
             self.settings, self.settings_dialog
@@ -182,11 +181,6 @@ class SettingsController(QObject):
         # Other External Tools Tab
         self.settings_dialog.text_editor_location_choose_button.clicked.connect(
             self._on_text_editor_location_choose_button_clicked
-        )
-
-        # Theme tab
-        self.settings_dialog.theme_location_open_button.clicked.connect(
-            self._on_theme_location_open_button_clicked
         )
 
         # Connect signals from dialogs
@@ -361,21 +355,8 @@ class SettingsController(QObject):
             self.settings.text_editor_file_arg
         )
 
-        # Themes tab
-        self.settings_dialog.enable_themes_checkbox.setChecked(
-            self.settings.enable_themes
-        )
-        self.theme_controller.populate_themes_combobox(
-            self.settings_dialog.themes_combobox
-        )
-        self.theme_controller.setup_theme_dialog(self.settings_dialog, self.settings)
-
-        self.language_controller.populate_languages_combobox(
-            self.settings_dialog.language_combobox
-        )
-        self.language_controller.setup_language_dialog(
-            self.settings_dialog, self.settings
-        )
+        # Appearance tab
+        self._appearance_tab.update_view_from_model()
 
         # Advanced tab
         self._advanced_tab.update_view_from_model()
@@ -427,17 +408,8 @@ class SettingsController(QObject):
             self.settings_dialog.text_editor_file_arg.text()
         )
 
-        # Themes tab
-        self.settings.enable_themes = (
-            self.settings_dialog.enable_themes_checkbox.isChecked()
-        )
-        self.settings.theme_name = self.settings_dialog.themes_combobox.currentText()
-
-        self.settings.font_family = (
-            self.settings_dialog.font_family_combobox.currentText()
-        )
-        self.settings.font_size = self.settings_dialog.font_size_spinbox.value()
-        self.settings.language = self.settings_dialog.language_combobox.currentData()
+        # Appearance tab
+        self._appearance_tab.update_model_from_view()
 
         # Advanced tab
         self._advanced_tab.update_model_from_view()
@@ -1200,21 +1172,3 @@ class SettingsController(QObject):
         logger.info("Resetting settings file and retrying load")
         self.settings.save()
         self._load_settings()
-
-    @Slot()
-    def _on_theme_location_open_button_clicked(self) -> None:
-        """
-        Open the location of the selected theme.
-        """
-        selected_theme_name = self.settings_dialog.themes_combobox.currentText()
-        logger.info(f"Opening theme location: {selected_theme_name}")
-        stylesheet_path = self.theme_controller.get_theme_stylesheet_path(
-            selected_theme_name
-        )
-
-        if stylesheet_path and stylesheet_path.exists():
-            platform_specific_open(stylesheet_path.parent)
-        else:
-            logger.warning(
-                f"Failed to open theme location: {stylesheet_path} not found or does not exist"
-            )

--- a/app/controllers/settings_tabs/__init__.py
+++ b/app/controllers/settings_tabs/__init__.py
@@ -1,6 +1,9 @@
 from app.controllers.settings_tabs.advanced_tab_controller import (
     AdvancedTabController,
 )
+from app.controllers.settings_tabs.appearance_tab_controller import (
+    AppearanceTabController,
+)
 from app.controllers.settings_tabs.base_tab_controller import BaseTabController
 from app.controllers.settings_tabs.databases_tab_controller import (
     DatabasesTabController,
@@ -14,12 +17,10 @@ from app.controllers.settings_tabs.locations_tab_controller import (
 from app.controllers.settings_tabs.sorting_tab_controller import SortingTabController
 from app.controllers.settings_tabs.steamcmd_tab_controller import SteamcmdTabController
 from app.controllers.settings_tabs.todds_tab_controller import ToddsTabController
-from app.controllers.settings_tabs.window_layout_tab_controller import (
-    WindowLayoutTabController,
-)
 
 __all__ = [
     "AdvancedTabController",
+    "AppearanceTabController",
     "BaseTabController",
     "DatabasesTabController",
     "GameLaunchTabController",
@@ -27,5 +28,4 @@ __all__ = [
     "SortingTabController",
     "SteamcmdTabController",
     "ToddsTabController",
-    "WindowLayoutTabController",
 ]

--- a/app/controllers/settings_tabs/appearance_tab_controller.py
+++ b/app/controllers/settings_tabs/appearance_tab_controller.py
@@ -1,13 +1,19 @@
+from loguru import logger
+from PySide6.QtCore import Slot
+
+from app.controllers.language_controller import LanguageController
 from app.controllers.settings_tabs.base_tab_controller import BaseTabController
+from app.controllers.theme_controller import ThemeController
 from app.models.settings import Settings
+from app.utils.generic import platform_specific_open
 from app.views.settings_dialog import SettingsDialog
 
 
-class WindowLayoutTabController(BaseTabController):
-    """Controller for the Window Launch State settings tab.
+class AppearanceTabController(BaseTabController):
+    """Controller for the Appearance settings tab.
 
-    Manages: main window launch state, browser window launch state,
-    settings window custom size, and dialogue positioning constraint.
+    Manages: theme settings, font settings, language selection,
+    main/browser/settings window launch states, and dialogue positioning.
     """
 
     def __init__(
@@ -16,6 +22,8 @@ class WindowLayoutTabController(BaseTabController):
         dialog: SettingsDialog,
     ) -> None:
         super().__init__(settings, dialog)
+        self._theme_controller = ThemeController()
+        self._language_controller = LanguageController()
 
     def connect_signals(self) -> None:
         # Main window radio buttons toggle custom size spinboxes
@@ -43,7 +51,23 @@ class WindowLayoutTabController(BaseTabController):
         self.dialog.settings_custom_width_spinbox.setEnabled(True)
         self.dialog.settings_custom_height_spinbox.setEnabled(True)
 
+        # Theme location open button
+        self.dialog.theme_location_open_button.clicked.connect(
+            self._on_theme_location_open_button_clicked
+        )
+
     def update_view_from_model(self) -> None:
+        # Theme
+        self.dialog.enable_themes_checkbox.setChecked(self.settings.enable_themes)
+        self._theme_controller.populate_themes_combobox(self.dialog.themes_combobox)
+        self._theme_controller.setup_theme_dialog(self.dialog, self.settings)
+
+        # Language
+        self._language_controller.populate_languages_combobox(
+            self.dialog.language_combobox
+        )
+        self._language_controller.setup_language_dialog(self.dialog, self.settings)
+
         # Dialogue positioning
         self.dialog.constrain_dialogues_to_main_window_monitor_checkbox.setChecked(
             self.settings.constrain_dialogues_to_main_window_monitor
@@ -104,6 +128,17 @@ class WindowLayoutTabController(BaseTabController):
         )
 
     def update_model_from_view(self) -> None:
+        # Theme
+        self.settings.enable_themes = self.dialog.enable_themes_checkbox.isChecked()
+        self.settings.theme_name = self.dialog.themes_combobox.currentText()
+
+        # Font
+        self.settings.font_family = self.dialog.font_family_combobox.currentText()
+        self.settings.font_size = self.dialog.font_size_spinbox.value()
+
+        # Language
+        self.settings.language = self.dialog.language_combobox.currentData()
+
         # Dialogue positioning
         self.settings.constrain_dialogues_to_main_window_monitor = (
             self.dialog.constrain_dialogues_to_main_window_monitor_checkbox.isChecked()
@@ -148,3 +183,18 @@ class WindowLayoutTabController(BaseTabController):
         self.settings.settings_window_custom_height = (
             self.dialog.settings_custom_height_spinbox.value()
         )
+
+    @Slot()
+    def _on_theme_location_open_button_clicked(self) -> None:
+        selected_theme_name = self.dialog.themes_combobox.currentText()
+        logger.info(f"Opening theme location: {selected_theme_name}")
+        stylesheet_path = self._theme_controller.get_theme_stylesheet_path(
+            selected_theme_name
+        )
+
+        if stylesheet_path and stylesheet_path.exists():
+            platform_specific_open(stylesheet_path.parent)
+        else:
+            logger.warning(
+                f"Failed to open theme location: {stylesheet_path} not found or does not exist"
+            )

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -79,8 +79,7 @@ class SettingsDialog(QDialog):
         self._do_steamcmd_tab()
         self._do_todds_tab()
         self._do_external_tools_tab()
-        self._do_themes_tab()
-        self._do_launch_state_tab()
+        self._do_appearance_tab()
         self._do_advanced_tab()
 
     def _do_locations_tab(self) -> None:
@@ -1306,14 +1305,20 @@ This basically preserves your mod coloring, user notes etc. for this many second
         checked = self.launch_via_steam_protocol_checkbox.isChecked()
         self.run_args_group.setEnabled(not checked)
 
-    def _do_themes_tab(self) -> None:
+    def _do_appearance_tab(self) -> None:
+        scroll_area = QScrollArea()
+        scroll_area.setWidgetResizable(True)
+        scroll_area.setFrameShape(QScrollArea.Shape.NoFrame)
+        self.tab_widget.addTab(scroll_area, self.tr("Appearance"))
+
         tab = QWidget()
-        self.tab_widget.addTab(tab, self.tr("Theme"))
+        scroll_area.setWidget(tab)
+        tab.setAutoFillBackground(False)
+        scroll_area.viewport().setAutoFillBackground(False)
 
         tab_layout = QVBoxLayout(tab)
-        tab_layout.setAlignment(Qt.AlignmentFlag.AlignTop)
 
-        # Theme settings group
+        # === Theme settings group ===
         theme_group_label = QLabel(self.tr("Theme Settings"))
         theme_group_label.setFont(GUIInfo().emphasis_font)
         tab_layout.addWidget(theme_group_label)
@@ -1351,7 +1356,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
         self.theme_location_open_button.setText(self.tr("Open Theme Location"))
         theme_layout.addWidget(self.theme_location_open_button)
 
-        # Font settings group
+        # === Font settings group ===
         font_group_label = QLabel(self.tr("Font Settings"))
         font_group_label.setFont(GUIInfo().emphasis_font)
         tab_layout.addWidget(font_group_label)
@@ -1398,14 +1403,11 @@ This basically preserves your mod coloring, user notes etc. for this many second
         font_layout.addLayout(reset_button_layout)
         reset_button.clicked.connect(self.reset_font_settings)
 
-        if self.enable_themes_checkbox.isChecked():
-            self.enable_themes_checkbox.stateChanged.connect(
-                self.connect_populate_themes_combobox
-            )
-        else:
-            self.themes_combobox.clear()
+        self.enable_themes_checkbox.stateChanged.connect(
+            self.connect_populate_themes_combobox
+        )
 
-        # Language configuration group
+        # === Language setting group ===
         language_group_label = QLabel(self.tr("Language Setting"))
         language_group_label.setFont(GUIInfo().emphasis_font)
         tab_layout.addWidget(language_group_label)
@@ -1430,14 +1432,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
 
         self.connect_populate_languages_combobox()
 
-    def _do_launch_state_tab(self) -> None:
-        tab = QWidget()
-        self.tab_widget.addTab(tab, self.tr("Launch State"))
-
-        tab_layout = QVBoxLayout(tab)
-        tab_layout.setAlignment(Qt.AlignmentFlag.AlignTop)
-
-        # Windows launch state group
+        # === Launch state group ===
         group_box = QGroupBox()
         tab_layout.addWidget(group_box)
 
@@ -1480,7 +1475,6 @@ This basically preserves your mod coloring, user notes etc. for this many second
             Settings.DEFAULT_WIDTH,
             Settings.DEFAULT_HEIGHT,
         )
-        # Add QLabel as title for Main Window Launch State
         main_window_title_label = QLabel(self.tr("Main Window Launch State"))
         main_window_title_label.setFont(GUIInfo().emphasis_font)
         group_layout.addWidget(main_window_title_label)
@@ -1503,7 +1497,6 @@ This basically preserves your mod coloring, user notes etc. for this many second
             Settings.DEFAULT_WIDTH,
             Settings.DEFAULT_HEIGHT,
         )
-        # Add QLabel as title for Browser Window Launch State
         browser_window_title_label = QLabel(self.tr("Browser Window Launch State"))
         browser_window_title_label.setFont(GUIInfo().emphasis_font)
         group_layout.addWidget(browser_window_title_label)
@@ -1526,7 +1519,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
         self.settings_custom_width_spinbox.setSuffix(" px")
         self.settings_custom_width_spinbox.setFixedWidth(100)
         custom_width_label = QLabel(self.tr("Custom Width:"))
-        custom_width_label.setFont(GUIInfo().emphasis_font)  # Set font for label
+        custom_width_label.setFont(GUIInfo().emphasis_font)
         settings_window_layout.addWidget(custom_width_label)
         settings_window_layout.addWidget(self.settings_custom_width_spinbox)
 
@@ -1538,11 +1531,13 @@ This basically preserves your mod coloring, user notes etc. for this many second
         self.settings_custom_height_spinbox.setSuffix(" px")
         self.settings_custom_height_spinbox.setFixedWidth(100)
         custom_height_label = QLabel(self.tr("Custom Height:"))
-        custom_height_label.setFont(GUIInfo().emphasis_font)  # Set font for label
+        custom_height_label.setFont(GUIInfo().emphasis_font)
         settings_window_layout.addWidget(custom_height_label)
         settings_window_layout.addWidget(self.settings_custom_height_spinbox)
 
         group_layout.addWidget(settings_window_group)
+
+        tab_layout.addStretch()
 
     def disable_main_custom_size_spinboxes(self) -> None:
         """Disable main window custom size spinboxes when 'Maximized' or 'Normal' radio buttons are checked"""


### PR DESCRIPTION
Create a single Appearance tab (with QScrollArea) replacing the former Theme and Launch State standalone tabs.

- Remove standalone Theme and Launch State tab methods and their `_init_tabs` calls
- Create `AppearanceTabController(BaseTabController)` combining WindowLayout + Theme logic:
  - Theme settings (enable, combobox, location button)
  - Font settings (family combobox, size spinbox, reset button)
  - Language selection combobox
  - Full launch state management (main/browser/settings window, dialogue positioning)
- Rewrite `_do_appearance_tab` with QScrollArea
- Remove inline Theme view/model sync and `_on_theme_location_open_button_clicked` handler from SettingsController

No behavior changes — all theme, font, language, and launch state logic is preserved identically.