### PR TITLE
refactor: extract External Tools tab into ExternalToolsTabController

### DIFF
--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -14,6 +14,7 @@ from app.controllers.settings_tabs import (
     AppearanceTabController,
     BaseTabController,
     DatabasesTabController,
+    ExternalToolsTabController,
     GameLaunchTabController,
     InternalToolsTabController,
     LocationsTabController,
@@ -135,6 +136,14 @@ class SettingsController(QObject):
         )
         self._tab_controllers.append(self._internal_tools_tab)
 
+        self._external_tools_tab = ExternalToolsTabController(
+            self.settings,
+            self.settings_dialog,
+            last_file_dialog_path=str(self._last_file_dialog_path),
+            on_path_selected=self._on_locations_path_selected,
+        )
+        self._tab_controllers.append(self._external_tools_tab)
+
         self._advanced_tab = AdvancedTabController(self.settings, self.settings_dialog)
         self._tab_controllers.append(self._advanced_tab)
 
@@ -172,11 +181,6 @@ class SettingsController(QObject):
         )
         self.settings_dialog.db_builder_build_database_button.clicked.connect(
             self._on_db_builder_build_database_button_clicked
-        )
-
-        # Other External Tools Tab
-        self.settings_dialog.text_editor_location_choose_button.clicked.connect(
-            self._on_text_editor_location_choose_button_clicked
         )
 
         # Connect signals from dialogs
@@ -337,16 +341,8 @@ class SettingsController(QObject):
         # Internal Tools tab
         self._internal_tools_tab.update_view_from_model()
 
-        # External Tools Tab
-        self.settings_dialog.text_editor_location.setText(
-            self.settings.text_editor_location
-        )
-        self.settings_dialog.text_editor_folder_arg.setText(
-            self.settings.text_editor_folder_arg
-        )
-        self.settings_dialog.text_editor_file_arg.setText(
-            self.settings.text_editor_file_arg
-        )
+        # External Tools tab
+        self._external_tools_tab.update_view_from_model()
 
         # Appearance tab
         self._appearance_tab.update_view_from_model()
@@ -387,16 +383,8 @@ class SettingsController(QObject):
         # Internal Tools tab
         self._internal_tools_tab.update_model_from_view()
 
-        # Other External Tools Tab
-        self.settings.text_editor_location = (
-            self.settings_dialog.text_editor_location.text()
-        )
-        self.settings.text_editor_folder_arg = (
-            self.settings_dialog.text_editor_folder_arg.text()
-        )
-        self.settings.text_editor_file_arg = (
-            self.settings_dialog.text_editor_file_arg.text()
-        )
+        # External Tools tab
+        self._external_tools_tab.update_model_from_view()
 
         # Appearance tab
         self._appearance_tab.update_model_from_view()
@@ -993,22 +981,6 @@ class SettingsController(QObject):
             except Exception as e:
                 logger.debug(f"Error during HTTP worker cleanup: {e}")
             self._http_download_worker = None
-
-    @Slot()
-    def _on_text_editor_location_choose_button_clicked(self) -> None:
-        """
-        Open a file dialog to select the Steamcmd install location and handle the result.
-        """
-        text_editor_location = show_dialogue_file(
-            mode="open",
-            caption="Select Text Editor Command",
-            _dir=str(self._last_file_dialog_path),
-        )
-        if not text_editor_location:
-            return
-
-        self.settings_dialog.text_editor_location.setText(text_editor_location)
-        self._last_file_dialog_path = str(Path(text_editor_location).parent)
 
     @Slot()
     def _on_db_builder_download_all_mods_via_steamcmd_button_clicked(self) -> None:

--- a/app/controllers/settings_tabs/__init__.py
+++ b/app/controllers/settings_tabs/__init__.py
@@ -8,6 +8,9 @@ from app.controllers.settings_tabs.base_tab_controller import BaseTabController
 from app.controllers.settings_tabs.databases_tab_controller import (
     DatabasesTabController,
 )
+from app.controllers.settings_tabs.external_tools_tab_controller import (
+    ExternalToolsTabController,
+)
 from app.controllers.settings_tabs.game_launch_tab_controller import (
     GameLaunchTabController,
 )
@@ -24,6 +27,7 @@ __all__ = [
     "AppearanceTabController",
     "BaseTabController",
     "DatabasesTabController",
+    "ExternalToolsTabController",
     "GameLaunchTabController",
     "InternalToolsTabController",
     "LocationsTabController",

--- a/app/controllers/settings_tabs/base_tab_controller.py
+++ b/app/controllers/settings_tabs/base_tab_controller.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from typing import Callable, Optional
 
 from app.models.settings import Settings
 from app.views.settings_dialog import SettingsDialog
@@ -9,15 +10,21 @@ class BaseTabController(ABC):
 
     :param settings: The shared settings model.
     :param dialog: The settings dialog containing all tab widgets.
+    :param last_file_dialog_path: Initial file dialog directory.
+    :param on_path_selected: Callback fired when a file dialog path is chosen.
     """
 
     def __init__(
         self,
         settings: Settings,
         dialog: SettingsDialog,
+        last_file_dialog_path: Optional[str] = None,
+        on_path_selected: Optional[Callable[[str], None]] = None,
     ) -> None:
         self.settings = settings
         self.dialog = dialog
+        self._last_file_dialog_path = last_file_dialog_path
+        self._on_path_selected = on_path_selected
 
     @abstractmethod
     def connect_signals(self) -> None:

--- a/app/controllers/settings_tabs/external_tools_tab_controller.py
+++ b/app/controllers/settings_tabs/external_tools_tab_controller.py
@@ -1,12 +1,9 @@
 from pathlib import Path
-from typing import Callable
 
 from PySide6.QtCore import Slot
 
 from app.controllers.settings_tabs.base_tab_controller import BaseTabController
-from app.models.settings import Settings
 from app.views.dialogue import show_dialogue_file
-from app.views.settings_dialog import SettingsDialog
 
 
 class ExternalToolsTabController(BaseTabController):
@@ -14,17 +11,6 @@ class ExternalToolsTabController(BaseTabController):
 
     Manages: text editor command location and its additional arguments.
     """
-
-    def __init__(
-        self,
-        settings: Settings,
-        dialog: SettingsDialog,
-        last_file_dialog_path: str,
-        on_path_selected: Callable[[str], None],
-    ) -> None:
-        super().__init__(settings, dialog)
-        self._last_file_dialog_path = last_file_dialog_path
-        self._on_path_selected = on_path_selected
 
     def connect_signals(self) -> None:
         self.dialog.text_editor_location_choose_button.clicked.connect(
@@ -52,4 +38,5 @@ class ExternalToolsTabController(BaseTabController):
             return
 
         self.dialog.text_editor_location.setText(text_editor_location)
-        self._on_path_selected(str(Path(text_editor_location).parent))
+        if self._on_path_selected:
+            self._on_path_selected(str(Path(text_editor_location).parent))

--- a/app/controllers/settings_tabs/external_tools_tab_controller.py
+++ b/app/controllers/settings_tabs/external_tools_tab_controller.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+from typing import Callable
+
+from PySide6.QtCore import Slot
+
+from app.controllers.settings_tabs.base_tab_controller import BaseTabController
+from app.models.settings import Settings
+from app.views.dialogue import show_dialogue_file
+from app.views.settings_dialog import SettingsDialog
+
+
+class ExternalToolsTabController(BaseTabController):
+    """Controller for the External Tools settings tab.
+
+    Manages: text editor command location and its additional arguments.
+    """
+
+    def __init__(
+        self,
+        settings: Settings,
+        dialog: SettingsDialog,
+        last_file_dialog_path: str,
+        on_path_selected: Callable[[str], None],
+    ) -> None:
+        super().__init__(settings, dialog)
+        self._last_file_dialog_path = last_file_dialog_path
+        self._on_path_selected = on_path_selected
+
+    def connect_signals(self) -> None:
+        self.dialog.text_editor_location_choose_button.clicked.connect(
+            self._on_text_editor_location_choose
+        )
+
+    def update_view_from_model(self) -> None:
+        self.dialog.text_editor_location.setText(self.settings.text_editor_location)
+        self.dialog.text_editor_folder_arg.setText(self.settings.text_editor_folder_arg)
+        self.dialog.text_editor_file_arg.setText(self.settings.text_editor_file_arg)
+
+    def update_model_from_view(self) -> None:
+        self.settings.text_editor_location = self.dialog.text_editor_location.text()
+        self.settings.text_editor_folder_arg = self.dialog.text_editor_folder_arg.text()
+        self.settings.text_editor_file_arg = self.dialog.text_editor_file_arg.text()
+
+    @Slot()
+    def _on_text_editor_location_choose(self) -> None:
+        text_editor_location = show_dialogue_file(
+            mode="open",
+            caption="Select Text Editor Command",
+            _dir=str(self._last_file_dialog_path),
+        )
+        if not text_editor_location:
+            return
+
+        self.dialog.text_editor_location.setText(text_editor_location)
+        self._on_path_selected(str(Path(text_editor_location).parent))

--- a/app/controllers/settings_tabs/internal_tools_tab_controller.py
+++ b/app/controllers/settings_tabs/internal_tools_tab_controller.py
@@ -1,13 +1,10 @@
 from pathlib import Path
-from typing import Callable
 
 from PySide6.QtCore import Slot
 
 from app.controllers.settings_tabs.base_tab_controller import BaseTabController
-from app.models.settings import Settings
 from app.utils.event_bus import EventBus
 from app.views.dialogue import show_dialogue_file
-from app.views.settings_dialog import SettingsDialog
 
 
 class InternalToolsTabController(BaseTabController):
@@ -17,17 +14,6 @@ class InternalToolsTabController(BaseTabController):
     install location, action buttons) and todds texture optimization settings
     (quality preset, target scope, dry-run, overwrite, orphaned DDS, auto-run).
     """
-
-    def __init__(
-        self,
-        settings: Settings,
-        dialog: SettingsDialog,
-        last_file_dialog_path: str,
-        on_path_selected: Callable[[str], None],
-    ) -> None:
-        super().__init__(settings, dialog)
-        self._last_file_dialog_path = last_file_dialog_path
-        self._on_path_selected = on_path_selected
 
     def connect_signals(self) -> None:
         # SteamCMD signals
@@ -133,7 +119,8 @@ class InternalToolsTabController(BaseTabController):
             return
 
         self.dialog.steamcmd_install_location.setText(steamcmd_install_location)
-        self._on_path_selected(str(Path(steamcmd_install_location).parent))
+        if self._on_path_selected:
+            self._on_path_selected(str(Path(steamcmd_install_location).parent))
 
     @Slot()
     def _on_clear_depot_cache(self) -> None:

--- a/app/controllers/settings_tabs/locations_tab_controller.py
+++ b/app/controllers/settings_tabs/locations_tab_controller.py
@@ -79,7 +79,7 @@ class LocationsTabController(BaseTabController):
         super().__init__(settings, dialog)
         self._validate_game_location = validate_game_location
         self._validate_config_folder_location = validate_config_folder_location
-        self._on_path_selected = on_path_selected
+        self._path_selected_callback = on_path_selected
         self._on_autodetect_callback = on_autodetect
         self._on_instance_folder_choose_callback = on_instance_folder_choose
         self._on_instance_folder_clear_callback = on_instance_folder_clear
@@ -182,7 +182,7 @@ class LocationsTabController(BaseTabController):
             return None
 
         dialog.local_mods_folder_location.setText(str(result / "Mods"))
-        self._on_path_selected(str(result))
+        self._path_selected_callback(str(result))
         return str(result)
 
     @staticmethod
@@ -200,7 +200,7 @@ class LocationsTabController(BaseTabController):
         if not self._validate_config_folder_location(config_folder):
             return None
 
-        self._on_path_selected(str(Path(config_folder).parent))
+        self._path_selected_callback(str(Path(config_folder).parent))
         return config_folder
 
     def _on_steam_mods_choose(self, dialog: SettingsDialog) -> str | None:
@@ -210,7 +210,7 @@ class LocationsTabController(BaseTabController):
         )
         if not steam_mods_folder:
             return None
-        self._on_path_selected(str(Path(steam_mods_folder).parent))
+        self._path_selected_callback(str(Path(steam_mods_folder).parent))
         return steam_mods_folder
 
     def _on_local_mods_choose(self, dialog: SettingsDialog) -> str | None:
@@ -220,7 +220,7 @@ class LocationsTabController(BaseTabController):
         )
         if not local_mods_folder:
             return None
-        self._on_path_selected(str(Path(local_mods_folder).parent))
+        self._path_selected_callback(str(Path(local_mods_folder).parent))
         return local_mods_folder
 
     # --- Clear all button ---


### PR DESCRIPTION
Create ExternalToolsTabController(BaseTabController) for the External Tools settings tab.

- ExternalToolsTabController handles text_editor_location (file-chooser), text_editor_folder_arg, text_editor_file_arg
- Uses the same last_file_dialog_path / on_path_selected callback pattern as InternalToolsTabController
- Removes inline _on_text_editor_location_choose_button_clicked from settings_controller.py
- Registers via _tab_controllers and delegates update_view_from_model / update_model_from_view

No behavior changes.