### PR TITLE
fix: remove dead settings_window_launch_state from model

### DIFF
--- a/app/controllers/settings_tabs/appearance_tab_controller.py
+++ b/app/controllers/settings_tabs/appearance_tab_controller.py
@@ -47,7 +47,7 @@ class AppearanceTabController(BaseTabController):
             self.dialog.enable_browser_custom_size_spinboxes
         )
 
-        # Settings Window (only custom option, spinboxes always enabled)
+        # Settings Window (modal dialog — spinboxes always enabled)
         self.dialog.settings_custom_width_spinbox.setEnabled(True)
         self.dialog.settings_custom_height_spinbox.setEnabled(True)
 
@@ -119,7 +119,7 @@ class AppearanceTabController(BaseTabController):
         else:
             self.dialog.browser_launch_maximized_radio.setChecked(True)
 
-        # Settings Window (only custom option)
+        # Settings Window (only custom option — modal dialog)
         self.dialog.settings_custom_width_spinbox.setValue(
             self.settings.settings_window_custom_width
         )
@@ -176,7 +176,7 @@ class AppearanceTabController(BaseTabController):
         else:
             self.settings.browser_window_launch_state = "maximized"
 
-        # Settings Window (only custom option)
+        # Settings Window (only custom option — modal dialog)
         self.settings.settings_window_custom_width = (
             self.dialog.settings_custom_width_spinbox.value()
         )

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -177,7 +177,6 @@ class Settings(QObject):
         self.browser_window_custom_height: int = 600
 
         # Settings Window
-        self.settings_window_launch_state: str = "custom"
         self.settings_window_custom_width: int = 900
         self.settings_window_custom_height: int = 600
 

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -1376,7 +1376,7 @@ This basically preserves your mod coloring, user notes etc. for this many second
         group_layout.addWidget(browser_window_title_label)
         group_layout.addWidget(self.browser_window_group)
 
-        # Settings Window (only custom option)
+        # Settings Window (modal dialog — only custom sizing)
         settings_window_title_label = self._make_section_label(
             "Settings Window Launch State"
         )


### PR DESCRIPTION
- settings_window_launch_state was declared in the model but never read or written by any controller or view
- SettingsDialog is a modal dialog that only supports custom sizing, not maximized/normal
- The field survived JSON save/load via generic _to_dict/_from_dict but had no behavioral effect

No behavior changes