### PR TITLE
feat: add Steam launch behavior controls and non-blocking launch

### DIFF
--- a/app/controllers/menu_bar_controller.py
+++ b/app/controllers/menu_bar_controller.py
@@ -5,8 +5,13 @@ from PySide6.QtGui import QAction
 from PySide6.QtWidgets import QApplication, QLineEdit, QPlainTextEdit, QTextEdit
 
 from app.controllers.settings_controller import SettingsController
+from app.utils.app_info import AppInfo
 from app.utils.event_bus import EventBus
 from app.utils.generic import open_url_browser
+from app.utils.steam.availability import (
+    is_steam_running,
+    run_steam_launch_with_progress,
+)
 from app.views.menu_bar import MenuBar
 
 
@@ -182,6 +187,11 @@ class MenuBarController(QObject):
         self.menu_bar.github_action.triggered.connect(
             self._on_menu_bar_github_triggered
         )
+        # Steam status actions
+        self.menu_bar.check_steam_connection_action.triggered.connect(
+            self._on_check_steam_connection
+        )
+        self.menu_bar.launch_steam_action.triggered.connect(self._on_launch_steam)
 
         # External signals
         EventBus().refresh_started.connect(self._on_refresh_started)
@@ -275,6 +285,45 @@ class MenuBarController(QObject):
     @Slot()
     def _on_menu_bar_github_triggered(self) -> None:
         open_url_browser("https://github.com/RimSort/RimSort")
+
+    @Slot()
+    def _on_check_steam_connection(self) -> None:
+        import app.views.dialogue as dialogue
+
+        if is_steam_running():
+            dialogue.show_information(
+                title=self.tr("Steam Status"),
+                text=self.tr("Steam is running"),
+                information=self.tr("Steam client is detected and available."),
+            )
+        else:
+            dialogue.show_warning(
+                title=self.tr("Steam Status"),
+                text=self.tr("Steam is not running"),
+                information=self.tr(
+                    "Steam client is not detected. Start Steam manually or use "
+                    "Help → Launch Steam."
+                ),
+            )
+
+    @Slot()
+    def _on_launch_steam(self) -> None:
+        import app.views.dialogue as dialogue
+
+        if is_steam_running():
+            dialogue.show_information(
+                title=self.tr("Steam Status"),
+                text=self.tr("Steam is already running"),
+                information=self.tr("Steam client is already detected and available."),
+            )
+            return
+
+        libs_path = str(AppInfo().libs_folder)
+        success = run_steam_launch_with_progress(libs_path)
+        if not success:
+            from app.utils.generic import show_no_steam_warning
+
+            show_no_steam_warning()
 
     @Slot()
     def _on_refresh_started(self) -> None:

--- a/app/controllers/settings_tabs/advanced_tab_controller.py
+++ b/app/controllers/settings_tabs/advanced_tab_controller.py
@@ -6,6 +6,8 @@ from app.models.settings import Settings
 from app.utils.event_bus import EventBus
 from app.views.settings_dialog import SettingsDialog
 
+_STEAM_LAUNCH_BEHAVIOR_OPTIONS = ["prompt", "always", "never"]
+
 
 class AdvancedTabController(BaseTabController):
     """Controller for the Advanced settings tab.
@@ -74,6 +76,13 @@ class AdvancedTabController(BaseTabController):
         self.dialog.show_mod_updates_checkbox.setChecked(
             self.settings.steam_mods_update_check
         )
+        behavior = self.settings.steam_launch_behavior
+        if behavior in _STEAM_LAUNCH_BEHAVIOR_OPTIONS:
+            self.dialog.steam_launch_behavior_combobox.setCurrentIndex(
+                _STEAM_LAUNCH_BEHAVIOR_OPTIONS.index(behavior)
+            )
+        else:
+            self.dialog.steam_launch_behavior_combobox.setCurrentIndex(0)
         self.dialog.render_unity_rich_text_checkbox.setChecked(
             self.settings.render_unity_rich_text
         )
@@ -123,6 +132,9 @@ class AdvancedTabController(BaseTabController):
         self.settings.steam_mods_update_check = (
             self.dialog.show_mod_updates_checkbox.isChecked()
         )
+        self.settings.steam_launch_behavior = _STEAM_LAUNCH_BEHAVIOR_OPTIONS[
+            self.dialog.steam_launch_behavior_combobox.currentIndex()
+        ]
         self.settings.render_unity_rich_text = (
             self.dialog.render_unity_rich_text_checkbox.isChecked()
         )

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -191,6 +191,7 @@ class Settings(QObject):
         self.auto_backup_compression_count: int = 10
         self.color_background_instead_of_text_toggle: bool = True
         self.steam_mods_update_check: bool = False
+        self.steam_launch_behavior: str = "prompt"
         self.render_unity_rich_text: bool = True
         self.update_databases_on_startup: bool = True
         self.include_mod_notes_in_mod_name_filter: bool = False

--- a/app/utils/steam/availability.py
+++ b/app/utils/steam/availability.py
@@ -249,16 +249,18 @@ def run_steam_launch_with_progress(libs: str) -> bool:
     worker = SteamLaunchWorker(libs)
     result = [False]
 
+    _tr = QCoreApplication.translate
+
     dialog = QDialog()
-    dialog.setWindowTitle("Launching Steam")
+    dialog.setWindowTitle(_tr("SteamAvailability", "Launching Steam"))
     dialog.setModal(True)
     dialog.setMinimumWidth(350)
 
     layout = QVBoxLayout(dialog)
-    status_label = QLabel("Starting Steam...")
+    status_label = QLabel(_tr("SteamAvailability", "Starting Steam..."))
     layout.addWidget(status_label)
 
-    cancel_button = QPushButton("Cancel")
+    cancel_button = QPushButton(_tr("SteamAvailability", "Cancel"))
     layout.addWidget(cancel_button)
 
     def on_progress(message: str) -> None:
@@ -276,6 +278,7 @@ def run_steam_launch_with_progress(libs: str) -> bool:
     worker.progress.connect(on_progress)
     worker.launch_finished.connect(on_finished)
     cancel_button.clicked.connect(on_cancel)
+    dialog.rejected.connect(on_cancel)
 
     worker.start()
     dialog.exec()
@@ -284,12 +287,32 @@ def run_steam_launch_with_progress(libs: str) -> bool:
     return result[0]
 
 
+_BUTTON_YES = "Yes"
+_BUTTON_YES_ALWAYS = "Yes, always"
+_BUTTON_NO = "No"
+_BUTTON_NO_NEVER = "No, never ask"
+
+_BUTTON_LABELS = [_BUTTON_YES, _BUTTON_YES_ALWAYS, _BUTTON_NO, _BUTTON_NO_NEVER]
+
+_BUTTON_TO_CHOICE = {
+    _BUTTON_YES: "yes",
+    _BUTTON_YES_ALWAYS: "yes_always",
+    _BUTTON_NO: "no",
+    _BUTTON_NO_NEVER: "no_never",
+}
+
+
 def _show_steam_launch_prompt() -> str:
     """
     Show a dialog asking the user what to do when Steam isn't running.
-    Returns one of: "yes", "yes_always", "no", "no_never".
+    Returns one of: "yes", "yes_always", "no", "no_never", "cancel".
     """
     import app.views.dialogue as dialogue
+
+    translated_to_key = {
+        QCoreApplication.translate("show_dialogue_conditional", label): label
+        for label in _BUTTON_LABELS
+    }
 
     response = dialogue.show_dialogue_conditional(
         title=QCoreApplication.translate("SteamAvailability", "Steam Not Running"),
@@ -301,17 +324,13 @@ def _show_steam_launch_prompt() -> str:
             "SteamAvailability",
             "Would you like to launch Steam?\n\n(You can also change this in Settings)",
         ),
-        button_text_override=["Yes", "Yes, always", "No", "No, never ask"],
+        button_text_override=_BUTTON_LABELS,
     )
     if isinstance(response, str):
-        response_lower = response.lower().strip()
-        if response_lower.startswith("yes, always"):
-            return "yes_always"
-        elif response_lower.startswith("yes"):
-            return "yes"
-        elif response_lower.startswith("no, never"):
-            return "no_never"
-    return "no"
+        original_label = translated_to_key.get(response)
+        if original_label is not None:
+            return _BUTTON_TO_CHOICE[original_label]
+    return "cancel"
 
 
 def check_steam_available(_libs: str, settings: "Settings") -> bool:
@@ -359,6 +378,8 @@ def check_steam_available(_libs: str, settings: "Settings") -> bool:
         settings.save()
         show_no_steam_warning()
         return False
-    else:
+    elif choice == "no":
         show_no_steam_warning()
+        return False
+    else:
         return False

--- a/app/utils/steam/availability.py
+++ b/app/utils/steam/availability.py
@@ -5,13 +5,16 @@ import sys
 from collections.abc import MutableMapping
 from pathlib import Path
 from time import sleep
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from loguru import logger
-from PySide6.QtCore import QThread, Signal
+from PySide6.QtCore import QCoreApplication, QThread, Signal
 from PySide6.QtWidgets import QDialog, QLabel, QPushButton, QVBoxLayout
 
 from app.utils.generic import show_no_steam_warning, show_snap_steam_warning
+
+if TYPE_CHECKING:
+    from app.models.settings import Settings
 
 # If we're running from a Python interpreter, Ensure SteamworksPy module is in Python path, sys.path ($PYTHONPATH)
 # Ensure that this is available by running via: git submodule update --init --recursive
@@ -27,6 +30,10 @@ MAX_ATTEMPTS = 10
 SNAP_STEAM_PATH = (
     Path.home() / "snap" / "steam" / "common" / ".local" / "share" / "Steam"
 )
+
+_STEAM_LAUNCH_BEHAVIOR_PROMPT = "prompt"
+_STEAM_LAUNCH_BEHAVIOR_ALWAYS = "always"
+_STEAM_LAUNCH_BEHAVIOR_NEVER = "never"
 
 
 def _find_steam_executable() -> Optional[Path]:
@@ -281,12 +288,16 @@ def _launch_steam(_libs: str) -> bool:
     """
     Launch Steam if it's not running and wait for it to start.
 
+    .. deprecated::
+        Will be removed in Task 7. Superseded by SteamLaunchWorker.
+
     Args:
         _libs: Path to the Steamworks library directory
 
     Returns:
         bool: True if Steam was launched successfully, False otherwise
     """
+    # jscpd:ignore-start
     try:
         steam_exe = _find_steam_executable()
         if steam_exe is None:
@@ -388,40 +399,84 @@ def _launch_steam(_libs: str) -> bool:
     except Exception as e:
         logger.warning(f"Error launching Steam: {e}")
         return False
+    # jscpd:ignore-end
 
 
-def check_steam_available(_libs: str) -> bool:
+def _show_steam_launch_prompt() -> str:
     """
-    Check if Steam is available and running.
-
-    Checks if Steam is running, and if not, attempts to launch it.
-    Also checks for snap Steam incompatibility.
-
-    Args:
-        _libs: Path to the Steamworks library directory
-
-    Returns:
-        bool: True if Steam is available, False otherwise
+    Show a dialog asking the user what to do when Steam isn't running.
+    Returns one of: "yes", "yes_always", "no", "no_never".
     """
-    # Check for snap Steam (incompatible with Steamworks)
-    is_snap_steam = SNAP_STEAM_PATH.exists()
+    import app.views.dialogue as dialogue
 
-    if is_snap_steam and sys.platform.startswith("linux"):
+    response = dialogue.show_dialogue_conditional(
+        title=QCoreApplication.translate("SteamAvailability", "Steam Not Running"),
+        text=QCoreApplication.translate(
+            "SteamAvailability",
+            "Steam is required for this operation but is not running.",
+        ),
+        information=QCoreApplication.translate(
+            "SteamAvailability",
+            "Would you like to launch Steam?\n\n(You can also change this in Settings)",
+        ),
+        button_text_override=["Yes", "Yes, always", "No", "No, never ask"],
+    )
+    if isinstance(response, str):
+        response_lower = response.lower().strip()
+        if response_lower.startswith("yes, always"):
+            return "yes_always"
+        elif response_lower.startswith("yes"):
+            return "yes"
+        elif response_lower.startswith("no, never"):
+            return "no_never"
+    return "no"
+
+
+def check_steam_available(_libs: str, settings: "Settings") -> bool:
+    """
+    Check if Steam is available and running. Respects user's launch behavior preference.
+
+    :param _libs: Path to the Steamworks library directory
+    :param settings: Application settings (for steam_launch_behavior and instance config)
+    :return: True if Steam is available, False otherwise
+    """
+    current = settings.instances.get(settings.current_instance)
+    if current is None or not current.steam_client_integration:
+        return True
+
+    if SNAP_STEAM_PATH.exists() and sys.platform.startswith("linux"):
         logger.warning(
-            "Snap Steam detected. Snap Steam is incompatible with Steamworks due to sandboxing. "
-            "Steam integration is unavailable."
+            "Snap Steam detected. Snap Steam is incompatible with Steamworks due to sandboxing."
         )
-        # Show snap steam warning
         show_snap_steam_warning()
         return False
 
-    # Check if Steam is running
-    if not is_steam_running():
-        logger.info("Steam is not running, attempting to launch...")
-        if not _launch_steam(_libs):
-            logger.error("Failed to launch Steam")
-            # Show no steam warning
-            show_no_steam_warning()
-            return False
+    if is_steam_running():
+        return True
 
-    return True
+    logger.info("Steam is not running")
+    behavior = settings.steam_launch_behavior
+
+    if behavior == _STEAM_LAUNCH_BEHAVIOR_NEVER:
+        show_no_steam_warning()
+        return False
+
+    if behavior == _STEAM_LAUNCH_BEHAVIOR_ALWAYS:
+        return run_steam_launch_with_progress(_libs)
+
+    choice = _show_steam_launch_prompt()
+
+    if choice == "yes_always":
+        settings.steam_launch_behavior = _STEAM_LAUNCH_BEHAVIOR_ALWAYS
+        settings.save()
+        return run_steam_launch_with_progress(_libs)
+    elif choice == "yes":
+        return run_steam_launch_with_progress(_libs)
+    elif choice == "no_never":
+        settings.steam_launch_behavior = _STEAM_LAUNCH_BEHAVIOR_NEVER
+        settings.save()
+        show_no_steam_warning()
+        return False
+    else:
+        show_no_steam_warning()
+        return False

--- a/app/utils/steam/availability.py
+++ b/app/utils/steam/availability.py
@@ -52,9 +52,10 @@ def _find_steam_executable() -> Optional[Path]:
         return None
 
 
-def _is_steam_running() -> bool:
+def is_steam_running() -> bool:
     """
     Check if Steam is currently running by looking for Steam processes.
+    Single-pass check with no retries — suitable for synchronous UI calls.
 
     Returns:
         bool: True if Steam is running, False otherwise
@@ -65,7 +66,6 @@ def _is_steam_running() -> bool:
         logger.warning("psutil not available, cannot check if Steam is running")
         return False
     try:
-        # Define platform-specific Steam process indicators once
         if sys.platform == "win32":
             steam_indicators = {
                 "steam.exe",
@@ -85,19 +85,14 @@ def _is_steam_running() -> bool:
                 "steamwebhelper",
             }
 
-        # Retry up to 5 times with 2 second delay to account for process startup time
-        for attempt in range(5):
-            for process in psutil.process_iter(attrs=["name"]):
-                try:
-                    name = process.info["name"]
-                    if name and name.lower() in steam_indicators:
-                        logger.debug(f"Found Steam process: {name}")
-                        return True
-                except (psutil.AccessDenied, psutil.NoSuchProcess):
-                    continue
-
-            if attempt < 4:
-                sleep(2)
+        for process in psutil.process_iter(attrs=["name"]):
+            try:
+                name = process.info["name"]
+                if name and name.lower() in steam_indicators:
+                    logger.debug(f"Found Steam process: {name}")
+                    return True
+            except (psutil.AccessDenied, psutil.NoSuchProcess):
+                continue
 
         return False
     except Exception as e:
@@ -180,7 +175,7 @@ def _launch_steam(_libs: str) -> bool:
         sleep(SLEEP_TIME)
 
         # First check if Steam processes are running after initial launch
-        if _is_steam_running():
+        if is_steam_running():
             logger.info("Steam processes detected after launch")
             # Give Steam a bit more time to fully initialize
             sleep(SLEEP_TIME)
@@ -190,7 +185,7 @@ def _launch_steam(_libs: str) -> bool:
         for attempt in range(MAX_ATTEMPTS):
             sleep(SLEEP_TIME)
             # Check both process detection and API initialization
-            if _is_steam_running():
+            if is_steam_running():
                 logger.info("Steam processes detected during API wait")
                 # Give Steam a bit more time to fully initialize
                 sleep(SLEEP_TIME)
@@ -257,7 +252,7 @@ def check_steam_available(_libs: str) -> bool:
         return False
 
     # Check if Steam is running
-    if not _is_steam_running():
+    if not is_steam_running():
         logger.info("Steam is not running, attempting to launch...")
         if not _launch_steam(_libs):
             logger.error("Failed to launch Steam")

--- a/app/utils/steam/availability.py
+++ b/app/utils/steam/availability.py
@@ -5,7 +5,7 @@ import sys
 from collections.abc import MutableMapping
 from pathlib import Path
 from time import sleep
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from loguru import logger
 from PySide6.QtCore import QCoreApplication, QThread, Signal
@@ -36,12 +36,12 @@ _STEAM_LAUNCH_BEHAVIOR_ALWAYS = "always"
 _STEAM_LAUNCH_BEHAVIOR_NEVER = "never"
 
 
-def _find_steam_executable() -> Optional[Path]:
+def _find_steam_executable() -> Path | None:
     """
     Find the Steam executable path based on the current platform.
 
     Returns:
-        Optional[Path]: Path to Steam executable, or None if not found
+        Path | None: Path to Steam executable, or None if not found
     """
     if sys.platform == "win32":
         from app.utils.win_find_steam import find_steam_folder
@@ -282,124 +282,6 @@ def run_steam_launch_with_progress(libs: str) -> bool:
     worker.wait()
 
     return result[0]
-
-
-def _launch_steam(_libs: str) -> bool:
-    """
-    Launch Steam if it's not running and wait for it to start.
-
-    .. deprecated::
-        Will be removed in Task 7. Superseded by SteamLaunchWorker.
-
-    Args:
-        _libs: Path to the Steamworks library directory
-
-    Returns:
-        bool: True if Steam was launched successfully, False otherwise
-    """
-    # jscpd:ignore-start
-    try:
-        steam_exe = _find_steam_executable()
-        if steam_exe is None:
-            if not sys.platform.startswith("linux"):
-                logger.warning("Steam executable not found")
-                return False
-
-            # For Linux, try to launch steam in a terminal emulator
-            logger.info("Launching Steam via 'steam' command in a terminal...")
-            env = os.environ.copy()
-            env["LD_LIBRARY_PATH"] = _libs + os.pathsep + env.get("LD_LIBRARY_PATH", "")
-
-            _setup_snap_steam_env(env)
-
-            terminal_candidates = [
-                "gnome-terminal",
-                "konsole",
-                "xfce4-terminal",
-                "mate-terminal",
-                "xterm",
-                "x-terminal-emulator",
-            ]
-            terminal = next((t for t in terminal_candidates if shutil.which(t)), None)
-
-            try:
-                if terminal:
-                    logger.debug(f"Using terminal emulator: {terminal}")
-                    if terminal == "gnome-terminal":
-                        subprocess.Popen([terminal, "--", "steam"], env=env)
-                    else:
-                        subprocess.Popen([terminal, "-e", "steam"], env=env)
-                else:
-                    logger.warning(
-                        "No terminal emulator found, falling back to direct launch"
-                    )
-                    subprocess.Popen(["steam"], env=env)
-            except FileNotFoundError:
-                logger.warning("Steam executable or terminal emulator not found")
-                return False
-        else:
-            if not steam_exe.exists():
-                logger.warning("Steam executable not found")
-                return False
-            logger.info("Launching Steam...")
-            env = os.environ.copy()
-            if sys.platform.startswith("linux"):
-                _setup_snap_steam_env(env)
-            subprocess.Popen([str(steam_exe)], env=env)
-        # Give Steam some initial time to start up before checking
-        sleep(SLEEP_TIME)
-
-        # First check if Steam processes are running after initial launch
-        if is_steam_running():
-            logger.info("Steam processes detected after launch")
-            # Give Steam a bit more time to fully initialize
-            sleep(SLEEP_TIME)
-            return True
-
-        # Wait for Steam to start checks every SLEEP_TIME (15 seconds), MAX_ATTEMPTS (10 attempts).
-        for attempt in range(MAX_ATTEMPTS):
-            sleep(SLEEP_TIME)
-            # Check both process detection and API initialization
-            if is_steam_running():
-                logger.info("Steam processes detected during API wait")
-                # Give Steam a bit more time to fully initialize
-                sleep(SLEEP_TIME)
-                return True
-            try:
-                # Try to create a temporary Steamworks instance to test if Steam is ready
-                from steamworks import STEAMWORKS  # type: ignore
-
-                test_steamworks = STEAMWORKS()
-                test_steamworks.initialize()
-                test_steamworks.unload()
-                logger.info("Steam launched and API initialized successfully")
-                # Give Steam a bit more time to fully initialize
-                sleep(SLEEP_TIME)
-                return True
-            except Exception as e:
-                error_msg = f"{e.__class__.__name__}: {e}"
-                logger.debug(
-                    f"Steam API not ready yet (attempt {attempt + 1}/{MAX_ATTEMPTS}): {error_msg}"
-                )
-                # Log more details on the last attempt
-                if attempt == MAX_ATTEMPTS - 1:
-                    total_time = SLEEP_TIME + (MAX_ATTEMPTS * SLEEP_TIME)
-                    logger.warning(
-                        f"Steamworks initialization failed after {total_time} seconds: {error_msg}"
-                    )
-                    if "snap" in str(Path.home()):
-                        logger.warning(
-                            "Snap Steam detected - ensure you have a native Steam installation for Steamworks support"
-                        )
-                continue
-
-        logger.warning("Steam failed to start within timeout")
-        return False
-
-    except Exception as e:
-        logger.warning(f"Error launching Steam: {e}")
-        return False
-    # jscpd:ignore-end
 
 
 def _show_steam_launch_prompt() -> str:

--- a/app/utils/steam/availability.py
+++ b/app/utils/steam/availability.py
@@ -8,6 +8,8 @@ from time import sleep
 from typing import Optional
 
 from loguru import logger
+from PySide6.QtCore import QThread, Signal
+from PySide6.QtWidgets import QDialog, QLabel, QPushButton, QVBoxLayout
 
 from app.utils.generic import show_no_steam_warning, show_snap_steam_warning
 
@@ -111,6 +113,168 @@ def _setup_snap_steam_env(env: MutableMapping[str, str]) -> None:
         logger.debug("Configuring environment for snap Steam...")
         env["STEAM_COMPAT_TOOL_PATHS"] = str(SNAP_STEAM_PATH)
         env["STEAMRUNTIME_PATH"] = str(SNAP_STEAM_PATH / "ubuntu12_32")
+
+
+class SteamLaunchWorker(QThread):
+    """Background worker that launches Steam and waits for it to be ready."""
+
+    launch_finished = Signal(bool)
+    progress = Signal(str)
+
+    def __init__(self, libs: str) -> None:
+        super().__init__()
+        self._libs = libs
+        self._cancelled = False
+
+    def cancel(self) -> None:
+        self._cancelled = True
+
+    def run(self) -> None:
+        try:
+            steam_exe = _find_steam_executable()
+            if steam_exe is None and not sys.platform.startswith("linux"):
+                logger.warning("Steam executable not found")
+                self.progress.emit("Steam executable not found")
+                self.launch_finished.emit(False)
+                return
+
+            self.progress.emit("Launching Steam...")
+            if not self._start_steam_process(steam_exe):
+                self.launch_finished.emit(False)
+                return
+
+            sleep(SLEEP_TIME)
+            if self._cancelled:
+                self.launch_finished.emit(False)
+                return
+
+            if is_steam_running():
+                self.progress.emit(
+                    "Steam processes detected, waiting for initialization..."
+                )
+                sleep(SLEEP_TIME)
+                self.launch_finished.emit(True)
+                return
+
+            for attempt in range(MAX_ATTEMPTS):
+                if self._cancelled:
+                    self.launch_finished.emit(False)
+                    return
+                self.progress.emit(
+                    f"Waiting for Steam to start ({attempt + 1}/{MAX_ATTEMPTS})..."
+                )
+                sleep(SLEEP_TIME)
+                if is_steam_running():
+                    self.progress.emit("Steam detected, finalizing...")
+                    sleep(SLEEP_TIME)
+                    self.launch_finished.emit(True)
+                    return
+
+            self.progress.emit("Steam failed to start within timeout")
+            logger.warning("Steam failed to start within timeout")
+            self.launch_finished.emit(False)
+
+        except Exception as e:
+            logger.warning(f"Error launching Steam: {e}")
+            self.progress.emit(f"Error: {e}")
+            self.launch_finished.emit(False)
+
+    def _start_steam_process(self, steam_exe: Path | None) -> bool:
+        try:
+            env = os.environ.copy()
+            if sys.platform.startswith("linux"):
+                env["LD_LIBRARY_PATH"] = (
+                    self._libs + os.pathsep + env.get("LD_LIBRARY_PATH", "")
+                )
+                _setup_snap_steam_env(env)
+
+            if steam_exe is None:
+                return self._launch_linux_steam(env)
+            if not steam_exe.exists():
+                logger.warning("Steam executable not found")
+                self.progress.emit("Steam executable not found")
+                return False
+            if sys.platform.startswith("linux"):
+                _setup_snap_steam_env(env)
+            subprocess.Popen([str(steam_exe)], env=env)
+            return True
+        except FileNotFoundError:
+            logger.warning("Steam executable not found")
+            self.progress.emit("Steam executable not found")
+            return False
+
+    def _launch_linux_steam(self, env: dict[str, str]) -> bool:
+        terminal_candidates = [
+            "gnome-terminal",
+            "konsole",
+            "xfce4-terminal",
+            "mate-terminal",
+            "xterm",
+            "x-terminal-emulator",
+        ]
+        terminal = next((t for t in terminal_candidates if shutil.which(t)), None)
+        try:
+            if terminal:
+                logger.debug(f"Using terminal emulator: {terminal}")
+                if terminal == "gnome-terminal":
+                    subprocess.Popen([terminal, "--", "steam"], env=env)
+                else:
+                    subprocess.Popen([terminal, "-e", "steam"], env=env)
+            else:
+                logger.warning(
+                    "No terminal emulator found, falling back to direct launch"
+                )
+                subprocess.Popen(["steam"], env=env)
+            return True
+        except FileNotFoundError:
+            logger.warning("Steam executable or terminal emulator not found")
+            self.progress.emit("Steam executable not found")
+            return False
+
+
+def run_steam_launch_with_progress(libs: str) -> bool:
+    """
+    Launch Steam on a background thread and show a modal progress dialog.
+
+    :param libs: Path to the Steamworks library directory
+    :return: True if Steam launched successfully
+    """
+    worker = SteamLaunchWorker(libs)
+    result = [False]
+
+    dialog = QDialog()
+    dialog.setWindowTitle("Launching Steam")
+    dialog.setModal(True)
+    dialog.setMinimumWidth(350)
+
+    layout = QVBoxLayout(dialog)
+    status_label = QLabel("Starting Steam...")
+    layout.addWidget(status_label)
+
+    cancel_button = QPushButton("Cancel")
+    layout.addWidget(cancel_button)
+
+    def on_progress(message: str) -> None:
+        status_label.setText(message)
+
+    def on_finished(success: bool) -> None:
+        result[0] = success
+        dialog.accept()
+
+    def on_cancel() -> None:
+        worker.cancel()
+        status_label.setText("Cancelling...")
+        cancel_button.setEnabled(False)
+
+    worker.progress.connect(on_progress)
+    worker.launch_finished.connect(on_finished)
+    cancel_button.clicked.connect(on_cancel)
+
+    worker.start()
+    dialog.exec()
+    worker.wait()
+
+    return result[0]
 
 
 def _launch_steam(_libs: str) -> bool:

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -2116,7 +2116,10 @@ class MainContent(QObject):
         # use prebuilt libs path
         libs_path = str(AppInfo().libs_folder)
         if not self.steamworks_in_use:
-            if not check_steam_available(_libs=libs_path):
+            if not check_steam_available(
+                _libs=libs_path,
+                settings=self.settings_controller.settings,
+            ):
                 logger.error("Steam is not available, skipping Steamworks API call")
                 return
             subscription_actions = ["resubscribe", "subscribe", "unsubscribe"]

--- a/app/views/menu_bar.py
+++ b/app/views/menu_bar.py
@@ -387,6 +387,11 @@ class MenuBar(QObject):
         self.wiki_action = self._add_action(help_menu, self.tr("RimSort Wiki…"))
         self.github_action = self._add_action(help_menu, self.tr("RimSort GitHub…"))
         help_menu.addSeparator()
+        self.check_steam_connection_action = self._add_action(
+            help_menu, self.tr("Check Steam Connection")
+        )
+        self.launch_steam_action = self._add_action(help_menu, self.tr("Launch Steam"))
+        help_menu.addSeparator()
         return help_menu
 
     def _create_menu_bar(self) -> None:

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -1495,6 +1495,29 @@ This basically preserves your mod coloring, user notes etc. for this many second
         )
         group_layout.addWidget(self.show_mod_updates_checkbox)
 
+        steam_launch_layout = QHBoxLayout()
+        steam_launch_label = QLabel(self.tr("When Steam is not running:"))
+        steam_launch_layout.addWidget(steam_launch_label)
+
+        self.steam_launch_behavior_combobox = QComboBox()
+        self.steam_launch_behavior_combobox.addItems(
+            [
+                self.tr("Ask me"),
+                self.tr("Launch automatically"),
+                self.tr("Show warning"),
+            ]
+        )
+        self.steam_launch_behavior_combobox.setToolTip(
+            self.tr(
+                "Controls what happens when a Steam operation is requested but Steam is not running. "
+                "'Ask me' shows a prompt each time. "
+                "'Launch automatically' starts Steam without asking. "
+                "'Show warning' skips the operation and shows a warning."
+            )
+        )
+        steam_launch_layout.addWidget(self.steam_launch_behavior_combobox)
+        group_layout.addLayout(steam_launch_layout)
+
         self.render_unity_rich_text_checkbox = QCheckBox(
             self.tr("Render Unity Rich Text in mod descriptions")
         )

--- a/tests/utils/steam/test_availability.py
+++ b/tests/utils/steam/test_availability.py
@@ -1,0 +1,49 @@
+import sys
+from unittest.mock import MagicMock, patch
+
+from app.utils.steam.availability import is_steam_running
+
+
+@patch("psutil.process_iter")
+def test_is_steam_running_returns_true_when_steam_process_found(
+    mock_process_iter: MagicMock,
+) -> None:
+    """Test that is_steam_running detects Steam process on current platform."""
+    # Use a platform-appropriate Steam process name
+    if sys.platform == "win32":
+        process_name = "steam.exe"
+    elif sys.platform == "darwin":
+        process_name = "steam_osx"
+    else:
+        process_name = "steam"
+
+    mock_process = MagicMock()
+    mock_process.info = {"name": process_name}
+    mock_process_iter.return_value = [mock_process]
+    assert is_steam_running() is True
+
+
+@patch("psutil.process_iter")
+def test_is_steam_running_returns_false_when_no_steam_process(
+    mock_process_iter: MagicMock,
+) -> None:
+    """Test that is_steam_running returns False when no Steam process exists."""
+    mock_process = MagicMock()
+    mock_process.info = {"name": "firefox"}
+    mock_process_iter.return_value = [mock_process]
+    assert is_steam_running() is False
+
+
+@patch("psutil.process_iter")
+def test_is_steam_running_handles_access_denied(
+    mock_process_iter: MagicMock,
+) -> None:
+    """Test that is_steam_running handles psutil exceptions gracefully."""
+    import psutil
+
+    mock_process = MagicMock()
+    mock_process.info.__getitem__ = MagicMock(
+        side_effect=psutil.AccessDenied(pid=1)
+    )
+    mock_process_iter.return_value = [mock_process]
+    assert is_steam_running() is False

--- a/tests/utils/steam/test_availability.py
+++ b/tests/utils/steam/test_availability.py
@@ -1,7 +1,12 @@
 import sys
 from unittest.mock import MagicMock, patch
 
-from app.utils.steam.availability import is_steam_running
+from app.utils.steam.availability import (
+    _STEAM_LAUNCH_BEHAVIOR_ALWAYS,  # noqa: F401
+    _STEAM_LAUNCH_BEHAVIOR_NEVER,  # noqa: F401
+    _STEAM_LAUNCH_BEHAVIOR_PROMPT,  # noqa: F401
+    is_steam_running,
+)
 
 
 @patch("psutil.process_iter")
@@ -42,8 +47,53 @@ def test_is_steam_running_handles_access_denied(
     import psutil
 
     mock_process = MagicMock()
-    mock_process.info.__getitem__ = MagicMock(
-        side_effect=psutil.AccessDenied(pid=1)
-    )
+    mock_process.info.__getitem__ = MagicMock(side_effect=psutil.AccessDenied(pid=1))
     mock_process_iter.return_value = [mock_process]
     assert is_steam_running() is False
+
+
+def _make_settings(
+    behavior: str = "prompt", steam_client_integration: bool = True
+) -> MagicMock:
+    """Create a mock Settings object with the given steam launch behavior."""
+    settings = MagicMock()
+    settings.steam_launch_behavior = behavior
+    settings.current_instance = "default"
+    instance = MagicMock()
+    instance.steam_client_integration = steam_client_integration
+    settings.instances = {"default": instance}
+    return settings
+
+
+@patch("app.utils.steam.availability.is_steam_running", return_value=True)
+def test_check_steam_available_returns_true_when_steam_running(
+    mock_running: MagicMock,
+) -> None:
+    from app.utils.steam.availability import check_steam_available
+
+    settings = _make_settings()
+    assert check_steam_available(_libs="/fake", settings=settings) is True
+
+
+@patch("app.utils.steam.availability.is_steam_running", return_value=True)
+def test_check_steam_available_skips_check_when_integration_disabled(
+    mock_running: MagicMock,
+) -> None:
+    from app.utils.steam.availability import check_steam_available
+
+    settings = _make_settings(steam_client_integration=False)
+    assert check_steam_available(_libs="/fake", settings=settings) is True
+    mock_running.assert_not_called()
+
+
+@patch("app.utils.steam.availability.is_steam_running", return_value=False)
+@patch("app.utils.steam.availability.show_no_steam_warning")
+def test_check_steam_available_never_shows_warning(
+    mock_warning: MagicMock,
+    mock_running: MagicMock,
+) -> None:
+    from app.utils.steam.availability import check_steam_available
+
+    settings = _make_settings(behavior="never")
+    assert check_steam_available(_libs="/fake", settings=settings) is False
+    mock_warning.assert_called_once()


### PR DESCRIPTION
## Summary

Follow-up to PR #2120 which added basic Steam availability checking. This PR adds the missing user controls and fixes the blocking UI issue.

- **User-configurable launch behavior**: New `steam_launch_behavior` setting ("Ask me" / "Launch automatically" / "Show warning") in Advanced settings, controlling what happens when Steam isn't running during a Steamworks operation
- **Non-blocking Steam launch**: Moves Steam launch+retry logic from the main thread onto a `SteamLaunchWorker(QThread)` with a modal progress dialog (cancelable), preventing up to ~165 seconds of UI freeze
- **4-button choice dialog**: When set to "Ask me", shows "Yes" / "Yes, always" / "No" / "No, never ask" with a Settings hint — "always"/"never" choices persist the preference
- **Help menu actions**: "Check Steam Connection" (diagnostic only) and "Launch Steam" (explicit launch regardless of setting)
- **Instance guard**: Steam availability check skipped entirely when `steam_client_integration` is disabled on the current instance
- **i18n-safe button matching**: Handles translated button text correctly in non-English locales

Closes #1976

## Test plan

- [x] All 1054 existing tests pass
- [x] New unit tests for `is_steam_running` (3 tests) and `check_steam_available` (3 tests)
- [x] `just ci` passes (ruff, ruff-format, mypy, pyright, jscpd, all tests)
- [x] Adversarial code review completed — fixed translation safety, Cancel handling, dialog X-close worker cancellation, and i18n for progress dialog strings
- [ ] Manual: verify Steam detection on each platform
- [ ] Manual: verify combo box persists setting across restarts
- [ ] Manual: verify "Yes, always" and "No, never ask" persist preference
- [ ] Manual: verify Help menu actions work correctly
- [ ] Manual: verify progress dialog cancel button stops launch attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)