### PR TITLE
refactor: break up SettingsController into per-tab controllers

### DIFF
--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -5,7 +5,6 @@ from loguru import logger
 from PySide6.QtCore import QObject, Slot
 from PySide6.QtWidgets import QApplication
 
-from app.controllers.instance_controller import InstanceController
 from app.controllers.language_controller import LanguageController
 from app.controllers.settings_tabs import (
     AdvancedTabController,
@@ -23,7 +22,6 @@ from app.controllers.settings_tabs import (
 from app.controllers.theme_controller import ThemeController
 from app.models.settings import Instance, Settings
 from app.utils.app_info import AppInfo
-from app.utils.constants import DEFAULT_INSTANCE_NAME
 from app.utils.event_bus import EventBus
 from app.utils.generic import extract_git_dir_name
 from app.utils.http_downloader import (
@@ -31,12 +29,7 @@ from app.utils.http_downloader import (
     DownloadResult,
     HttpDownloadWorker,
 )
-from app.views.dialogue import (
-    BinaryChoiceDialog,
-    show_dialogue_file,
-    show_settings_error,
-    show_warning,
-)
+from app.views.dialogue import BinaryChoiceDialog, show_settings_error, show_warning
 from app.views.settings_dialog import SettingsDialog
 
 
@@ -101,8 +94,6 @@ class SettingsController(QObject):
             self.settings,
             self.settings_dialog,
             file_dialog_state=self._file_dialog_state,
-            on_instance_folder_choose=self._on_instance_folder_location_choose_button_clicked,
-            on_instance_folder_clear=self._on_instance_folder_location_clear_button_clicked,
         )
         self._tab_controllers.append(self._locations_tab)
 
@@ -463,68 +454,6 @@ class SettingsController(QObject):
             except Exception as e:
                 logger.debug(f"Error during HTTP worker cleanup: {e}")
             self._http_download_worker = None
-
-    @Slot()
-    def _on_instance_folder_location_choose_button_clicked(self) -> None:
-        """Open folder dialog to select custom instance folder location."""
-        # Only allow changing instance folder location for Default instance
-        if self.settings.current_instance != DEFAULT_INSTANCE_NAME:
-            show_warning(
-                title="Cannot Modify Instance Folder",
-                text="Only the Default instance can have a custom folder location.",
-                information="Custom instance folder location is managed by the Default instance.",
-            )
-            return
-
-        instance_folder_location = show_dialogue_file(
-            mode="open_dir",
-            caption="Select Instance Folder Location",
-            _dir=self._file_dialog_state.last_path,
-        )
-        if not instance_folder_location:
-            return
-
-        # Validate the path before setting it
-
-        test_controller = InstanceController(
-            self.settings.instances[self.settings.current_instance]
-        )
-        test_controller.instance.instance_folder_override = instance_folder_location
-        is_valid, error_msg = test_controller.validate_instance_folder_override()
-
-        if not is_valid:
-            show_warning(
-                title="Invalid Instance Folder",
-                text="Cannot use selected folder as instance location.",
-                information=error_msg,
-            )
-            return
-
-        # Update the instance and UI
-        self.settings.instances[
-            self.settings.current_instance
-        ].instance_folder_override = instance_folder_location
-        self.settings_dialog.instance_folder_location.setText(instance_folder_location)
-        self._file_dialog_state.last_path = str(Path(instance_folder_location).parent)
-        self.settings.save()
-
-    @Slot()
-    def _on_instance_folder_location_clear_button_clicked(self) -> None:
-        """Clear custom instance folder and use default location."""
-        # Only allow changing instance folder location for Default instance
-        if self.settings.current_instance != DEFAULT_INSTANCE_NAME:
-            show_warning(
-                title="Cannot Modify Instance Folder",
-                text="Only the Default instance can have a custom folder location.",
-                information="Custom instance folder location is managed by the Default instance.",
-            )
-            return
-
-        self.settings.instances[
-            self.settings.current_instance
-        ].instance_folder_override = ""
-        self.settings_dialog.instance_folder_location.setText("")
-        self.settings.save()
 
     @Slot()
     def _do_reset_settings_file(self) -> None:

--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from loguru import logger
 from PySide6.QtCore import QObject, Slot
-from PySide6.QtWidgets import QApplication, QLineEdit, QMessageBox
+from PySide6.QtWidgets import QApplication, QLineEdit
 
 from app.controllers.instance_controller import InstanceController
 from app.controllers.language_controller import LanguageController
@@ -24,7 +24,6 @@ from app.controllers.settings_tabs import (
 )
 from app.controllers.theme_controller import ThemeController
 from app.models.settings import Instance, Settings
-from app.utils.acf_utils import validate_acf_file_exists
 from app.utils.app_info import AppInfo
 from app.utils.constants import DEFAULT_INSTANCE_NAME
 from app.utils.event_bus import EventBus
@@ -32,7 +31,6 @@ from app.utils.generic import (
     extract_git_dir_name,
     find_steam_rimworld,
     get_path_up_to_string,
-    validate_game_executable,
 )
 from app.utils.http_downloader import (
     DatabaseDownloadTask,
@@ -112,8 +110,6 @@ class SettingsController(QObject):
             self.settings,
             self.settings_dialog,
             file_dialog_state=self._file_dialog_state,
-            validate_game_location=self._validate_game_location,
-            validate_config_folder_location=self._validate_config_folder_location,
             on_autodetect=self._on_locations_autodetect_button_clicked,
             on_instance_folder_choose=self._on_instance_folder_location_choose_button_clicked,
             on_instance_folder_clear=self._on_instance_folder_location_clear_button_clicked,
@@ -384,165 +380,11 @@ class SettingsController(QObject):
         self.settings_dialog.close()
         self._update_view_from_model()
 
-    def _validate_game_location(self, game_location: str) -> bool:
-        """
-        Validate the game location and show a warning if invalid.
-
-        :param game_location: Path to the game folder as a string.
-        :return: True if valid, False otherwise.
-        """
-        if not validate_game_executable(game_location):
-            QMessageBox.information(
-                self.settings_dialog,
-                self.tr("Invalid Game Location"),
-                self.tr(
-                    "The selected game folder does not contain a valid RimWorld executable. Please select a valid game location."
-                ),
-            )
-            return False
-        return True
-
-    def _validate_config_folder_location(self, config_folder: str) -> bool:
-        """
-        Validate the config folder location and show a warning if invalid.
-
-        :param config_folder: Path to the config folder as a string.
-        :return: True if valid, False otherwise.
-        """
-        if not (Path(config_folder) / "ModsConfig.xml").exists():
-            QMessageBox.warning(
-                self.settings_dialog,
-                self.tr("Invalid Config Folder"),
-                self.tr(
-                    "The selected config folder does not contain ModsConfig.xml. Please select a valid config folder."
-                ),
-            )
-            return False
-        return True
-
-    def _check_steam_integration_validity(
-        self, steam_client_integration: bool, steam_mods_location: str
-    ) -> bool:
-        """
-        Check if Steam client integration and Steam mods location are valid.
-
-        Validation rules:
-        - If both disabled: valid
-        - If steam_client_integration enabled but steam_mods_location empty: invalid
-        - If steam_mods_location set: must have valid ACF file
-        - If steam_mods_location set but ACF missing: invalid
-
-        :param steam_client_integration: Whether Steam client integration is enabled.
-        :param steam_mods_location: Path to the Steam mods folder.
-        :return: True if valid configuration, False if invalid.
-        """
-        # If integration disabled, no location validation needed
-        if not steam_client_integration and not steam_mods_location:
-            return True
-
-        # If integration enabled but no location, invalid
-        if steam_client_integration and not steam_mods_location:
-            return False
-
-        # If location set (with or without integration), check ACF file
-        if steam_mods_location:
-            return validate_acf_file_exists(steam_mods_location)
-
-        return True
-
-    def _disable_steam_integration_ui(self) -> None:
-        """
-        Clear all Steam integration dependent UI settings.
-        Disables Steam client integration, clears workshop folder, and disables Steam protocol launch.
-        """
-        self.settings_dialog.steam_client_integration_checkbox.setChecked(False)
-        self.settings_dialog.steam_mods_folder_location.setText("")
-        self.settings_dialog.launch_via_steam_protocol_checkbox.setChecked(False)
-
-    def _validate_steam_integration(self) -> bool:
-        """
-        Validate Steam client integration and Steam mods location configuration.
-        Shows appropriate warnings if validation fails and prevents saving.
-
-        Ensures that Steam protocol launch is only enabled when Steam integration is enabled.
-
-        :return: True if valid configuration, False if invalid.
-        """
-        steam_client_integration = (
-            self.settings_dialog.steam_client_integration_checkbox.isChecked()
-        )
-        steam_mods_location = (
-            self.settings_dialog.steam_mods_folder_location.text().strip()
-        )
-
-        # Handle user explicitly disabling Steam integration
-        if not steam_client_integration:
-            QMessageBox.warning(
-                self.settings_dialog,
-                self.tr("Steam Client Integration Disabled"),
-                self.tr(
-                    "Steam client integration is disabled. Steam mods location and Steam protocol launch will be cleared."
-                ),
-            )
-            # Clear dependent settings when integration is disabled
-            self.settings_dialog.steam_mods_folder_location.setText("")
-            self.settings_dialog.launch_via_steam_protocol_checkbox.setChecked(False)
-
-        # Validate Steam integration configuration
-        is_valid = self._check_steam_integration_validity(
-            steam_client_integration, steam_mods_location
-        )
-
-        if not is_valid:
-            # Disable all Steam integration settings if validation fails
-            self._disable_steam_integration_ui()
-
-            # Determine which validation failed for appropriate error message
-            if steam_client_integration and not steam_mods_location:
-                QMessageBox.warning(
-                    self.settings_dialog,
-                    self.tr("Steam Mods Location Required"),
-                    self.tr(
-                        "Steam client integration requires a Steam mods location to be configured. "
-                        "Steam client integration, Steam mods location, and Steam protocol launch have been disabled."
-                    ),
-                )
-            elif steam_mods_location and not validate_acf_file_exists(
-                steam_mods_location
-            ):
-                QMessageBox.warning(
-                    self.settings_dialog,
-                    self.tr("Steam Workshop File Not Found"),
-                    self.tr(
-                        "The Steam Workshop file 'appworkshop_294100.acf' was not found at the expected location. "
-                        "Steam client integration, Steam mods location, and Steam protocol launch have been disabled. "
-                        "Please ensure Steam is properly installed and has downloaded RimWorld Workshop data."
-                    ),
-                )
-
-        return is_valid
-
     @Slot()
     def _on_global_ok_button_clicked(self) -> None:
-        """
-        Close the settings dialog, update the model from the view, and save the settings.
-        """
-        # Validate game folder if set
-        game_folder_text = self.settings_dialog.game_location.text().strip()
-        if game_folder_text and not self._validate_game_location(game_folder_text):
+        """Close the settings dialog, update the model from the view, and save the settings."""
+        if not all(tc.validate_before_save() for tc in self._tab_controllers):
             return
-
-        # Validate config folder if set
-        config_folder_text = self.settings_dialog.config_folder_location.text().strip()
-        if config_folder_text and not self._validate_config_folder_location(
-            config_folder_text
-        ):
-            return
-
-        # Validate Steam integration if enabled
-        if self.settings_dialog.steam_client_integration_checkbox.isChecked():
-            if not self._validate_steam_integration():
-                return
 
         self.settings_dialog.close()
         self._update_model_from_view()

--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -21,15 +21,8 @@ from app.controllers.settings_tabs import (
 )
 from app.controllers.theme_controller import ThemeController
 from app.models.settings import Instance, Settings
-from app.utils.app_info import AppInfo
 from app.utils.event_bus import EventBus
-from app.utils.generic import extract_git_dir_name
-from app.utils.http_downloader import (
-    DatabaseDownloadTask,
-    DownloadResult,
-    HttpDownloadWorker,
-)
-from app.views.dialogue import BinaryChoiceDialog, show_settings_error, show_warning
+from app.views.dialogue import BinaryChoiceDialog, show_settings_error
 from app.views.settings_dialog import SettingsDialog
 
 
@@ -75,8 +68,6 @@ class SettingsController(QObject):
 
         self.app_instance = QApplication.instance()
 
-        self._http_download_worker: HttpDownloadWorker | None = None
-
         # Initialize per-tab controllers (registry pattern)
         self._tab_controllers: list[BaseTabController] = []
 
@@ -86,7 +77,6 @@ class SettingsController(QObject):
         self._databases_tab = DatabasesTabController(
             self.settings,
             self.settings_dialog,
-            self._do_http_download_from_dialog,
         )
         self._tab_controllers.append(self._databases_tab)
 
@@ -380,80 +370,6 @@ class SettingsController(QObject):
         )
         # Do a full refresh after updating the settings
         EventBus().do_refresh_mods_lists.emit()
-
-    @Slot(bool)
-    def _do_http_download_from_dialog(
-        self, url: str, repo_url: str, display_name: str
-    ) -> None:
-        """Download a database via HTTP using the URL currently in the settings dialog."""
-        if not url:
-            show_warning(
-                title="No URL configured",
-                text=f"No URL is configured for {display_name}.",
-                information="Please enter a URL in the text field.",
-            )
-            return
-
-        repo_name = (
-            extract_git_dir_name(repo_url)
-            if repo_url
-            else display_name.replace(" ", "-")
-        )
-        task = DatabaseDownloadTask(
-            url=url,
-            target_dir=AppInfo().databases_folder,
-            repo_name=repo_name,
-            display_name=display_name,
-        )
-
-        if self._http_download_worker is not None:
-            try:
-                self._http_download_worker.download_finished.disconnect()
-                self._http_download_worker.quit()
-                self._http_download_worker.wait()
-            except Exception as e:
-                logger.debug(f"Error during HTTP worker cleanup: {e}")
-            self._http_download_worker = None
-
-        self._http_download_worker = HttpDownloadWorker([task])
-        self._http_download_worker.download_finished.connect(
-            self._on_http_download_from_dialog_finished
-        )
-        self._http_download_worker.start()
-
-    @Slot(dict)
-    def _on_http_download_from_dialog_finished(
-        self, results: dict[str, DownloadResult]
-    ) -> None:
-        updated = [name for name, r in results.items() if r == DownloadResult.UPDATED]
-        up_to_date = [
-            name for name, r in results.items() if r == DownloadResult.UP_TO_DATE
-        ]
-        failed = [name for name, r in results.items() if r == DownloadResult.FAILED]
-
-        if failed:
-            show_warning(
-                title="Download failed",
-                text=f"Failed to download: {', '.join(failed)}",
-                information="Please check your internet connection and the configured URL.",
-            )
-        elif updated:
-            show_warning(
-                title="Download complete",
-                text=f"Downloaded successfully: {', '.join(updated)}",
-            )
-        elif up_to_date:
-            show_warning(
-                title="Already up to date",
-                text=f"Already up to date: {', '.join(up_to_date)}",
-            )
-
-        if self._http_download_worker:
-            try:
-                self._http_download_worker.download_finished.disconnect()
-            except Exception as e:
-                logger.debug(f"Error during HTTP worker cleanup: {e}")
-            self._http_download_worker = None
 
     @Slot()
     def _do_reset_settings_file(self) -> None:

--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -1,11 +1,9 @@
-import sys
-from dataclasses import dataclass
 from json import JSONDecodeError
 from pathlib import Path
 
 from loguru import logger
 from PySide6.QtCore import QObject, Slot
-from PySide6.QtWidgets import QApplication, QLineEdit
+from PySide6.QtWidgets import QApplication
 
 from app.controllers.instance_controller import InstanceController
 from app.controllers.language_controller import LanguageController
@@ -27,17 +25,12 @@ from app.models.settings import Instance, Settings
 from app.utils.app_info import AppInfo
 from app.utils.constants import DEFAULT_INSTANCE_NAME
 from app.utils.event_bus import EventBus
-from app.utils.generic import (
-    extract_git_dir_name,
-    find_steam_rimworld,
-    get_path_up_to_string,
-)
+from app.utils.generic import extract_git_dir_name
 from app.utils.http_downloader import (
     DatabaseDownloadTask,
     DownloadResult,
     HttpDownloadWorker,
 )
-from app.utils.system_info import SystemInfo
 from app.views.dialogue import (
     BinaryChoiceDialog,
     show_dialogue_file,
@@ -91,8 +84,6 @@ class SettingsController(QObject):
 
         self._http_download_worker: HttpDownloadWorker | None = None
 
-        self._detected_steam_root: Path | None = None
-
         # Initialize per-tab controllers (registry pattern)
         self._tab_controllers: list[BaseTabController] = []
 
@@ -110,7 +101,6 @@ class SettingsController(QObject):
             self.settings,
             self.settings_dialog,
             file_dialog_state=self._file_dialog_state,
-            on_autodetect=self._on_locations_autodetect_button_clicked,
             on_instance_folder_choose=self._on_instance_folder_location_choose_button_clicked,
             on_instance_folder_clear=self._on_instance_folder_location_clear_button_clicked,
         )
@@ -399,319 +389,6 @@ class SettingsController(QObject):
         )
         # Do a full refresh after updating the settings
         EventBus().do_refresh_mods_lists.emit()
-
-    @staticmethod
-    def _find_steam_root(candidates: list[Path]) -> Path | None:
-        """
-        Find the Steam installation root from a prioritized list of candidate paths.
-
-        A candidate is valid if it exists as a directory and contains either
-        a ``steamapps/`` directory or ``config/libraryfolders.vdf``.
-
-        :param candidates: Ordered list of candidate Steam root paths
-        :return: First valid Steam root, or None if no candidate matches
-        """
-        for candidate in candidates:
-            if not candidate.is_dir():
-                logger.debug(f"Steam root candidate does not exist: {candidate}")
-                continue
-            has_steamapps = (candidate / "steamapps").is_dir()
-            has_vdf = (candidate / "config" / "libraryfolders.vdf").is_file()
-            if has_steamapps or has_vdf:
-                logger.info(f"Found Steam root: {candidate}")
-                return candidate
-            logger.debug(
-                f"Steam root candidate exists but has no steamapps/ or config/libraryfolders.vdf: {candidate}"
-            )
-        logger.warning("No valid Steam root found from any candidate path")
-        return None
-
-    @Slot()
-    def _on_locations_autodetect_button_clicked(self) -> None:
-        """
-        This function tries to autodetect Rimworld paths based on the
-        defaults typically found per-platform, and set them in the client.
-        """
-        logger.info("USER ACTION: starting autodetect paths")
-
-        os_paths: tuple[Path, Path, Path]  # Initialize os_paths
-        if SystemInfo().operating_system == SystemInfo.OperatingSystem.MACOS:
-            os_paths = self.__get_darwin_paths()
-            logger.info(f"Running on MacOS with the following paths: {os_paths}")
-        elif SystemInfo().operating_system == SystemInfo.OperatingSystem.LINUX:
-            os_paths = self.__get_linux_paths()
-            logger.info(f"Running on Linux with the following paths: {os_paths}")
-            if (
-                self._detected_steam_root is not None
-                and "snap" in self._detected_steam_root.parts
-            ):
-                show_warning(
-                    title="Unsupported Steam installation",
-                    text="Snap-based Steam installation detected.",
-                    information=(
-                        "Steam installed via Snap is not officially supported and may cause issues. "
-                        "We recommend installing Steam via your distribution's native package manager "
-                        "or Flatpak instead.\n\n"
-                        "Autodetection will continue, but some paths may not work correctly."
-                    ),
-                )
-        elif sys.platform == "win32":
-            os_paths = self.__get_windows_paths()
-            logger.info(f"Running on Windows with the following paths: {os_paths}")
-        else:
-            logger.error("Attempting to autodetect paths on an unknown system")
-            return
-
-        @dataclass
-        class _PathGroup:
-            folder: Path
-            settings_line: QLineEdit
-            name: str
-
-        path_groups = [
-            _PathGroup(os_paths[0], self.settings_dialog.game_location, "game"),
-            _PathGroup(
-                os_paths[1], self.settings_dialog.config_folder_location, "config"
-            ),
-            _PathGroup(
-                os_paths[2],
-                self.settings_dialog.steam_mods_folder_location,
-                "workshop mods",
-            ),
-            _PathGroup(
-                os_paths[0] / "Mods",
-                self.settings_dialog.local_mods_folder_location,
-                "local mods",
-            ),
-        ]
-
-        for group in path_groups:
-            if group.folder.exists():
-                logger.info(
-                    f"Auto-detected {group.name} folder path exists: {group.folder}"
-                )
-                if not group.settings_line.text():
-                    logger.info(
-                        f"No value set currently for {group.name} folder. Overwriting with auto-detected path"
-                    )
-                    group.settings_line.setText(str(group.folder))
-                else:
-                    logger.info(f"Value already set for {group.name} folder. Passing")
-            else:
-                logger.warning(
-                    f"Auto-detected {group.name} folder path does not exist: {group.folder}"
-                )
-
-    def __get_darwin_paths(self) -> tuple[Path, Path, Path]:
-        """
-        Get paths for macOS. Uses VDF parsing to locate RimWorld in non-default
-        Steam library folders, with hardcoded fallback.
-
-        :return: (game_folder, config_folder, steam_mods_folder)
-        """
-        user_home = Path.home()
-        candidates = [
-            user_home / "Library" / "Application Support" / "Steam",
-        ]
-
-        steam_root = self._find_steam_root(candidates)
-        self._detected_steam_root = steam_root
-
-        if steam_root:
-            game_folder_str = find_steam_rimworld(steam_root)
-            if game_folder_str:
-                game_folder = Path(game_folder_str) / "RimworldMac.app"
-                logger.debug(f"VDF parsing found RimWorld at: {game_folder}")
-            else:
-                game_folder = (
-                    steam_root / "steamapps" / "common" / "Rimworld" / "RimworldMac.app"
-                )
-                logger.debug(
-                    f"VDF parsing did not find RimWorld, using fallback: {game_folder}"
-                )
-
-            steam_mods_folder_str = get_path_up_to_string(
-                game_folder.parent, "common", exclude=True
-            )
-            if steam_mods_folder_str == "":
-                steam_mods_folder: Path = (
-                    steam_root / "steamapps" / "workshop" / "content" / "294100"
-                )
-            else:
-                steam_mods_folder = (
-                    Path(steam_mods_folder_str) / "workshop" / "content" / "294100"
-                )
-        else:
-            game_folder = (
-                user_home
-                / "Library"
-                / "Application Support"
-                / "Steam"
-                / "steamapps"
-                / "common"
-                / "Rimworld"
-                / "RimworldMac.app"
-            )
-            steam_mods_folder = (
-                user_home
-                / "Library"
-                / "Application Support"
-                / "Steam"
-                / "steamapps"
-                / "workshop"
-                / "content"
-                / "294100"
-            )
-
-        config_folder = (
-            user_home / "Library" / "Application Support" / "Rimworld" / "Config"
-        )
-
-        return game_folder, config_folder, steam_mods_folder
-
-    def __get_linux_paths(self) -> tuple[Path, Path, Path]:
-        """
-        Get paths for Linux by discovering the Steam root across distribution methods.
-
-        Checks Debian, native, Flatpak, and Snap Steam installations in priority
-        order. Uses VDF parsing to locate RimWorld in non-default library folders.
-        Detects Proton prefix for config folder.
-
-        :return: (game_folder, config_folder, steam_mods_folder)
-        """
-        user_home = Path.home()
-        candidates = [
-            user_home / ".steam" / "debian-installation",
-            user_home / ".steam" / "steam",
-            user_home / ".local" / "share" / "Steam",
-            user_home
-            / ".var"
-            / "app"
-            / "com.valvesoftware.Steam"
-            / ".local"
-            / "share"
-            / "Steam",
-            user_home / "snap" / "steam" / "common" / ".local" / "share" / "Steam",
-        ]
-
-        steam_root = self._find_steam_root(candidates)
-        self._detected_steam_root = steam_root
-
-        if steam_root:
-            game_folder_str = find_steam_rimworld(steam_root)
-            if game_folder_str:
-                game_folder = Path(game_folder_str)
-                logger.debug(f"VDF parsing found RimWorld at: {game_folder}")
-            else:
-                game_folder = steam_root / "steamapps" / "common" / "RimWorld"
-                logger.debug(
-                    f"VDF parsing did not find RimWorld, using fallback: {game_folder}"
-                )
-
-            steam_mods_folder_str = get_path_up_to_string(
-                game_folder, "common", exclude=True
-            )
-            if steam_mods_folder_str == "":
-                steam_mods_folder = (
-                    steam_root / "steamapps" / "workshop" / "content" / "294100"
-                )
-            else:
-                steam_mods_folder = (
-                    Path(steam_mods_folder_str) / "workshop" / "content" / "294100"
-                )
-        else:
-            game_folder = (
-                user_home / ".steam" / "steam" / "steamapps" / "common" / "RimWorld"
-            )
-            steam_mods_folder = (
-                user_home
-                / ".steam"
-                / "steam"
-                / "steamapps"
-                / "workshop"
-                / "content"
-                / "294100"
-            )
-
-        # Config folder: check Proton prefix first, then native
-        native_config = (
-            user_home
-            / ".config"
-            / "unity3d"
-            / "Ludeon Studios"
-            / "RimWorld by Ludeon Studios"
-            / "Config"
-        )
-        if steam_root:
-            proton_config = (
-                steam_root
-                / "steamapps"
-                / "compatdata"
-                / "294100"
-                / "pfx"
-                / "drive_c"
-                / "users"
-                / "steamuser"
-                / "AppData"
-                / "LocalLow"
-                / "Ludeon Studios"
-                / "RimWorld by Ludeon Studios"
-                / "Config"
-            )
-            if proton_config.exists():
-                logger.info(f"Proton prefix detected for config: {proton_config}")
-                config_folder = proton_config
-            else:
-                config_folder = native_config
-        else:
-            config_folder = native_config
-
-        return game_folder, config_folder, steam_mods_folder
-
-    def __get_windows_paths(self) -> tuple[Path, Path, Path]:
-        """
-        Get the default paths for Windows.
-
-        Returns:
-            tuple[Path, Path, Path]: game_folder, config_folder, steam_mods_folder
-        """
-        if sys.platform == "win32":
-            user_home = Path.home()
-            from app.utils.win_find_steam import find_steam_folder
-
-            steam_folder, found = find_steam_folder()
-
-            if not found:
-                logger.error(
-                    "[win32] Could not find Steam folder. Using fallback assumptions"
-                )
-                steam_folder = "C:/Program Files (x86)/Steam"
-
-            game_folder: str | Path = find_steam_rimworld(steam_folder)
-
-            # Fallback game folder
-            if game_folder == "":
-                game_folder = f"{steam_folder}/steamapps/common/RimWorld"
-            game_folder = Path(game_folder)
-
-            config_folder = Path(
-                f"{user_home}/AppData/LocalLow/Ludeon Studios/RimWorld by Ludeon Studios/Config"
-            )
-
-            steam_mods_folder = get_path_up_to_string(
-                game_folder, "common", exclude=True
-            )
-            if steam_mods_folder == "":
-                # Fallback steam mods path
-                steam_mods_folder = Path(
-                    f"{steam_folder}/steamapps/workshop/content/294100"
-                )
-            else:
-                steam_mods_folder = Path(steam_mods_folder) / "workshop/content/294100"
-
-            return game_folder, config_folder, steam_mods_folder
-        else:
-            raise ValueError("This function should only be called on Windows")
 
     @Slot(bool)
     def _do_http_download_from_dialog(

--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 from loguru import logger
 from PySide6.QtCore import QObject, Slot
-from PySide6.QtWidgets import QApplication
 
 from app.controllers.language_controller import LanguageController
 from app.controllers.settings_tabs import (
@@ -19,7 +18,6 @@ from app.controllers.settings_tabs import (
     SharedFileDialogState,
     SortingTabController,
 )
-from app.controllers.theme_controller import ThemeController
 from app.models.settings import Instance, Settings
 from app.utils.event_bus import EventBus
 from app.views.dialogue import BinaryChoiceDialog, show_settings_error
@@ -61,12 +59,6 @@ class SettingsController(QObject):
         self.settings_dialog = view
 
         self._file_dialog_state = SharedFileDialogState(str(Path.home()))
-
-        self.theme_controller = ThemeController()
-
-        self.language_controller = LanguageController()
-
-        self.app_instance = QApplication.instance()
 
         # Initialize per-tab controllers (registry pattern)
         self._tab_controllers: list[BaseTabController] = []
@@ -256,6 +248,11 @@ class SettingsController(QObject):
         self.settings.instances[instance.name] = instance
 
     @property
+    def language_controller(self) -> LanguageController:
+        """Delegate to AppearanceTabController (accessed by AppController)."""
+        return self._appearance_tab.language_controller
+
+    @property
     def active_instance(self) -> Instance:
         """
         Get the active instance.
@@ -263,68 +260,12 @@ class SettingsController(QObject):
         return self.settings.instances[self.settings.current_instance]
 
     def _update_view_from_model(self) -> None:
-        """
-        Update the view from the settings model.
-        """
-
-        # Locations tab
-        self._locations_tab.update_view_from_model()
-
-        # Game Launch tab
-        self._game_launch_tab.update_view_from_model()
-
-        # Databases tab
-        self._databases_tab.update_view_from_model()
-
-        # Sorting tab
-        self._sorting_tab.update_view_from_model()
-
-        # Database Builder tab
-        self._db_builder_tab.update_view_from_model()
-
-        # Internal Tools tab
-        self._internal_tools_tab.update_view_from_model()
-
-        # External Tools tab
-        self._external_tools_tab.update_view_from_model()
-
-        # Appearance tab
-        self._appearance_tab.update_view_from_model()
-
-        # Advanced tab
-        self._advanced_tab.update_view_from_model()
+        for tc in self._tab_controllers:
+            tc.update_view_from_model()
 
     def _update_model_from_view(self) -> None:
-        """
-        Update the settings model from the view.
-        """
-
-        # Locations tab
-        self._locations_tab.update_model_from_view()
-
-        # Game Launch tab
-        self._game_launch_tab.update_model_from_view()
-
-        # Databases tab
-        self._databases_tab.update_model_from_view()
-
-        # Sorting tab
-        self._sorting_tab.update_model_from_view()
-
-        # Database Builder tab
-        self._db_builder_tab.update_model_from_view()
-
-        # Internal Tools tab
-        self._internal_tools_tab.update_model_from_view()
-
-        # External Tools tab
-        self._external_tools_tab.update_model_from_view()
-
-        # Appearance tab
-        self._appearance_tab.update_model_from_view()
-
-        # Advanced tab
-        self._advanced_tab.update_model_from_view()
+        for tc in self._tab_controllers:
+            tc.update_model_from_view()
 
     @Slot()
     def _on_global_reset_to_defaults_button_clicked(self) -> None:
@@ -360,11 +301,9 @@ class SettingsController(QObject):
         self.settings_dialog.close()
         self._update_model_from_view()
         self.settings.save()
-        self.theme_controller.set_font(
+        self._appearance_tab.apply_theme_and_font(
             self.settings.font_family,
             self.settings.font_size,
-        )
-        self.theme_controller.apply_selected_theme(
             self.settings.enable_themes,
             self.settings.theme_name,
         )

--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -19,6 +19,7 @@ from app.controllers.settings_tabs import (
     GameLaunchTabController,
     InternalToolsTabController,
     LocationsTabController,
+    SharedFileDialogState,
     SortingTabController,
 )
 from app.controllers.theme_controller import ThemeController
@@ -82,7 +83,7 @@ class SettingsController(QObject):
         self.settings = model
         self.settings_dialog = view
 
-        self._last_file_dialog_path = str(Path.home())
+        self._file_dialog_state = SharedFileDialogState(str(Path.home()))
 
         self.theme_controller = ThemeController()
 
@@ -110,9 +111,9 @@ class SettingsController(QObject):
         self._locations_tab = LocationsTabController(
             self.settings,
             self.settings_dialog,
+            file_dialog_state=self._file_dialog_state,
             validate_game_location=self._validate_game_location,
             validate_config_folder_location=self._validate_config_folder_location,
-            on_path_selected=self._on_locations_path_selected,
             on_autodetect=self._on_locations_autodetect_button_clicked,
             on_instance_folder_choose=self._on_instance_folder_location_choose_button_clicked,
             on_instance_folder_clear=self._on_instance_folder_location_clear_button_clicked,
@@ -132,16 +133,14 @@ class SettingsController(QObject):
         self._internal_tools_tab = InternalToolsTabController(
             self.settings,
             self.settings_dialog,
-            last_file_dialog_path=str(self._last_file_dialog_path),
-            on_path_selected=self._on_locations_path_selected,
+            file_dialog_state=self._file_dialog_state,
         )
         self._tab_controllers.append(self._internal_tools_tab)
 
         self._external_tools_tab = ExternalToolsTabController(
             self.settings,
             self.settings_dialog,
-            last_file_dialog_path=str(self._last_file_dialog_path),
-            on_path_selected=self._on_locations_path_selected,
+            file_dialog_state=self._file_dialog_state,
         )
         self._tab_controllers.append(self._external_tools_tab)
 
@@ -384,10 +383,6 @@ class SettingsController(QObject):
         """
         self.settings_dialog.close()
         self._update_view_from_model()
-
-    def _on_locations_path_selected(self, path: str) -> None:
-        """Update the last selected path for file dialog default directories."""
-        self._last_file_dialog_path = path
 
     def _validate_game_location(self, game_location: str) -> bool:
         """
@@ -965,7 +960,7 @@ class SettingsController(QObject):
         instance_folder_location = show_dialogue_file(
             mode="open_dir",
             caption="Select Instance Folder Location",
-            _dir=str(self._last_file_dialog_path),
+            _dir=self._file_dialog_state.last_path,
         )
         if not instance_folder_location:
             return
@@ -991,7 +986,7 @@ class SettingsController(QObject):
             self.settings.current_instance
         ].instance_folder_override = instance_folder_location
         self.settings_dialog.instance_folder_location.setText(instance_folder_location)
-        self._last_file_dialog_path = str(Path(instance_folder_location).parent)
+        self._file_dialog_state.last_path = str(Path(instance_folder_location).parent)
         self.settings.save()
 
     @Slot()

--- a/app/controllers/settings_tabs/__init__.py
+++ b/app/controllers/settings_tabs/__init__.py
@@ -4,7 +4,10 @@ from app.controllers.settings_tabs.advanced_tab_controller import (
 from app.controllers.settings_tabs.appearance_tab_controller import (
     AppearanceTabController,
 )
-from app.controllers.settings_tabs.base_tab_controller import BaseTabController
+from app.controllers.settings_tabs.base_tab_controller import (
+    BaseTabController,
+    SharedFileDialogState,
+)
 from app.controllers.settings_tabs.database_builder_tab_controller import (
     DatabaseBuilderTabController,
 )
@@ -35,5 +38,6 @@ __all__ = [
     "GameLaunchTabController",
     "InternalToolsTabController",
     "LocationsTabController",
+    "SharedFileDialogState",
     "SortingTabController",
 ]

--- a/app/controllers/settings_tabs/appearance_tab_controller.py
+++ b/app/controllers/settings_tabs/appearance_tab_controller.py
@@ -184,6 +184,22 @@ class AppearanceTabController(BaseTabController):
             self.dialog.settings_custom_height_spinbox.value()
         )
 
+    def apply_theme_and_font(
+        self,
+        font_family: str,
+        font_size: int,
+        enable_themes: bool,
+        theme_name: str,
+    ) -> None:
+        """Apply theme and font settings (called by SettingsController on OK)."""
+        self._theme_controller.set_font(font_family, font_size)
+        self._theme_controller.apply_selected_theme(enable_themes, theme_name)
+
+    @property
+    def language_controller(self) -> LanguageController:
+        """Public access to the language controller (used by AppController)."""
+        return self._language_controller
+
     @Slot()
     def _on_theme_location_open_button_clicked(self) -> None:
         selected_theme_name = self.dialog.themes_combobox.currentText()

--- a/app/controllers/settings_tabs/base_tab_controller.py
+++ b/app/controllers/settings_tabs/base_tab_controller.py
@@ -1,39 +1,47 @@
-from abc import ABC, abstractmethod
-from typing import Callable, Optional
+from PySide6.QtCore import QObject
 
 from app.models.settings import Settings
 from app.views.settings_dialog import SettingsDialog
 
 
-class BaseTabController(ABC):
+class SharedFileDialogState:
+    """Mutable container for the last file-dialog path, shared across tab controllers."""
+
+    def __init__(self, last_path: str) -> None:
+        self.last_path = last_path
+
+
+class BaseTabController(QObject):
     """Base class for per-tab settings controllers.
 
     :param settings: The shared settings model.
     :param dialog: The settings dialog containing all tab widgets.
-    :param last_file_dialog_path: Initial file dialog directory.
-    :param on_path_selected: Callback fired when a file dialog path is chosen.
+    :param file_dialog_state: Shared mutable state for file dialog paths.
     """
 
     def __init__(
         self,
         settings: Settings,
         dialog: SettingsDialog,
-        last_file_dialog_path: Optional[str] = None,
-        on_path_selected: Optional[Callable[[str], None]] = None,
+        file_dialog_state: SharedFileDialogState | None = None,
     ) -> None:
+        super().__init__()
         self.settings = settings
         self.dialog = dialog
-        self._last_file_dialog_path = last_file_dialog_path
-        self._on_path_selected = on_path_selected
+        self._file_dialog_state = file_dialog_state
 
-    @abstractmethod
     def connect_signals(self) -> None:
         """Wire up all signals/slots for this tab's widgets."""
+        raise NotImplementedError
 
-    @abstractmethod
     def update_view_from_model(self) -> None:
         """Push settings model values into this tab's widgets."""
+        raise NotImplementedError
 
-    @abstractmethod
     def update_model_from_view(self) -> None:
         """Read this tab's widget values back into the settings model."""
+        raise NotImplementedError
+
+    def validate_before_save(self) -> bool:
+        """Run validations before saving. Returns True if OK to save."""
+        return True

--- a/app/controllers/settings_tabs/databases_tab_controller.py
+++ b/app/controllers/settings_tabs/databases_tab_controller.py
@@ -1,12 +1,20 @@
 from typing import Callable
 
 from loguru import logger
+from PySide6.QtCore import Slot
 from PySide6.QtWidgets import QApplication
 
 from app.controllers.settings_tabs.base_tab_controller import BaseTabController
 from app.models.settings import Settings
+from app.utils.app_info import AppInfo
 from app.utils.event_bus import EventBus
-from app.views.dialogue import show_dialogue_file
+from app.utils.generic import extract_git_dir_name
+from app.utils.http_downloader import (
+    DatabaseDownloadTask,
+    DownloadResult,
+    HttpDownloadWorker,
+)
+from app.views.dialogue import show_dialogue_file, show_warning
 from app.views.settings_dialog import SettingsDialog
 
 
@@ -191,10 +199,9 @@ class DatabasesTabController(BaseTabController):
         self,
         settings: Settings,
         dialog: SettingsDialog,
-        http_download_callback: Callable[[str, str, str], None],
     ) -> None:
         super().__init__(settings, dialog)
-        self._http_download_callback = http_download_callback
+        self._http_download_worker: HttpDownloadWorker | None = None
         self._groups = [
             DatabaseSourceGroup(
                 prefix="community_rules_db",
@@ -241,7 +248,7 @@ class DatabasesTabController(BaseTabController):
 
     def connect_signals(self) -> None:
         for group in self._groups:
-            group.connect_signals(self.dialog, self._http_download_callback)
+            group.connect_signals(self.dialog, self._do_http_download)
 
     def update_view_from_model(self) -> None:
         for group in self._groups:
@@ -256,3 +263,73 @@ class DatabasesTabController(BaseTabController):
         except Exception:
             logger.warning("Failed setting database_expiry, falling back to 0")
             self.settings.database_expiry = 0
+
+    @Slot()
+    def _do_http_download(self, url: str, repo_url: str, display_name: str) -> None:
+        """Download a database via HTTP using the URL currently in the settings dialog."""
+        if not url:
+            show_warning(
+                title="No URL configured",
+                text=f"No URL is configured for {display_name}.",
+                information="Please enter a URL in the text field.",
+            )
+            return
+
+        repo_name = (
+            extract_git_dir_name(repo_url)
+            if repo_url
+            else display_name.replace(" ", "-")
+        )
+        task = DatabaseDownloadTask(
+            url=url,
+            target_dir=AppInfo().databases_folder,
+            repo_name=repo_name,
+            display_name=display_name,
+        )
+
+        if self._http_download_worker is not None:
+            try:
+                self._http_download_worker.download_finished.disconnect()
+                self._http_download_worker.quit()
+                self._http_download_worker.wait()
+            except Exception as e:
+                logger.debug(f"Error during HTTP worker cleanup: {e}")
+            self._http_download_worker = None
+
+        self._http_download_worker = HttpDownloadWorker([task])
+        self._http_download_worker.download_finished.connect(
+            self._on_http_download_finished
+        )
+        self._http_download_worker.start()
+
+    @Slot(dict)
+    def _on_http_download_finished(self, results: dict[str, DownloadResult]) -> None:
+        updated = [name for name, r in results.items() if r == DownloadResult.UPDATED]
+        up_to_date = [
+            name for name, r in results.items() if r == DownloadResult.UP_TO_DATE
+        ]
+        failed = [name for name, r in results.items() if r == DownloadResult.FAILED]
+
+        if failed:
+            show_warning(
+                title="Download failed",
+                text=f"Failed to download: {', '.join(failed)}",
+                information="Please check your internet connection and the configured URL.",
+            )
+        elif updated:
+            show_warning(
+                title="Download complete",
+                text=f"Downloaded successfully: {', '.join(updated)}",
+            )
+        elif up_to_date:
+            show_warning(
+                title="Already up to date",
+                text=f"Already up to date: {', '.join(up_to_date)}",
+            )
+
+        if self._http_download_worker:
+            try:
+                self._http_download_worker.download_finished.disconnect()
+            except Exception as e:
+                logger.debug(f"Error during HTTP worker cleanup: {e}")
+            self._http_download_worker = None

--- a/app/controllers/settings_tabs/databases_tab_controller.py
+++ b/app/controllers/settings_tabs/databases_tab_controller.py
@@ -264,7 +264,7 @@ class DatabasesTabController(BaseTabController):
             logger.warning("Failed setting database_expiry, falling back to 0")
             self.settings.database_expiry = 0
 
-    @Slot()
+    @Slot(str, str, str)
     def _do_http_download(self, url: str, repo_url: str, display_name: str) -> None:
         """Download a database via HTTP using the URL currently in the settings dialog."""
         if not url:

--- a/app/controllers/settings_tabs/external_tools_tab_controller.py
+++ b/app/controllers/settings_tabs/external_tools_tab_controller.py
@@ -32,11 +32,11 @@ class ExternalToolsTabController(BaseTabController):
         text_editor_location = show_dialogue_file(
             mode="open",
             caption="Select Text Editor Command",
-            _dir=str(self._last_file_dialog_path),
+            _dir=self._file_dialog_state.last_path if self._file_dialog_state else "",
         )
         if not text_editor_location:
             return
 
         self.dialog.text_editor_location.setText(text_editor_location)
-        if self._on_path_selected:
-            self._on_path_selected(str(Path(text_editor_location).parent))
+        if self._file_dialog_state:
+            self._file_dialog_state.last_path = str(Path(text_editor_location).parent)

--- a/app/controllers/settings_tabs/internal_tools_tab_controller.py
+++ b/app/controllers/settings_tabs/internal_tools_tab_controller.py
@@ -113,14 +113,16 @@ class InternalToolsTabController(BaseTabController):
         steamcmd_install_location = show_dialogue_file(
             mode="open_dir",
             caption="Select Steamcmd Install Location",
-            _dir=str(self._last_file_dialog_path),
+            _dir=self._file_dialog_state.last_path if self._file_dialog_state else "",
         )
         if not steamcmd_install_location:
             return
 
         self.dialog.steamcmd_install_location.setText(steamcmd_install_location)
-        if self._on_path_selected:
-            self._on_path_selected(str(Path(steamcmd_install_location).parent))
+        if self._file_dialog_state:
+            self._file_dialog_state.last_path = str(
+                Path(steamcmd_install_location).parent
+            )
 
     @Slot()
     def _on_clear_depot_cache(self) -> None:

--- a/app/controllers/settings_tabs/locations_tab_controller.py
+++ b/app/controllers/settings_tabs/locations_tab_controller.py
@@ -6,6 +6,7 @@ from loguru import logger
 from PySide6.QtCore import Slot
 from PySide6.QtWidgets import QLineEdit, QMessageBox
 
+from app.controllers.instance_controller import InstanceController
 from app.controllers.settings_tabs.base_tab_controller import (
     BaseTabController,
     SharedFileDialogState,
@@ -78,12 +79,8 @@ class LocationsTabController(BaseTabController):
         settings: Settings,
         dialog: SettingsDialog,
         file_dialog_state: SharedFileDialogState,
-        on_instance_folder_choose: Callable[[], None],
-        on_instance_folder_clear: Callable[[], None],
     ) -> None:
         super().__init__(settings, dialog, file_dialog_state=file_dialog_state)
-        self._on_instance_folder_choose_callback = on_instance_folder_choose
-        self._on_instance_folder_clear_callback = on_instance_folder_clear
 
         self._groups: list[FolderPathGroup] = [
             FolderPathGroup(
@@ -111,10 +108,10 @@ class LocationsTabController(BaseTabController):
 
         # Instance folder location
         self.dialog.instance_folder_location_choose_button.clicked.connect(
-            self._on_instance_folder_choose_callback
+            self._on_instance_folder_choose
         )
         self.dialog.instance_folder_location_clear_button.clicked.connect(
-            self._on_instance_folder_clear_callback
+            self._on_instance_folder_clear
         )
 
         # Clear and autodetect buttons
@@ -326,6 +323,68 @@ class LocationsTabController(BaseTabController):
                 logger.warning(
                     f"Auto-detected {group.name} folder path does not exist: {group.folder}"
                 )
+
+    # --- Instance folder ---
+
+    @Slot()
+    def _on_instance_folder_choose(self) -> None:
+        """Open folder dialog to select custom instance folder location."""
+        if self.settings.current_instance != DEFAULT_INSTANCE_NAME:
+            show_warning(
+                title="Cannot Modify Instance Folder",
+                text="Only the Default instance can have a custom folder location.",
+                information="Custom instance folder location is managed by the Default instance.",
+            )
+            return
+
+        instance_folder_location = show_dialogue_file(
+            mode="open_dir",
+            caption="Select Instance Folder Location",
+            _dir=self._file_dialog_state.last_path if self._file_dialog_state else "",
+        )
+        if not instance_folder_location:
+            return
+
+        test_controller = InstanceController(
+            self.settings.instances[self.settings.current_instance]
+        )
+        test_controller.instance.instance_folder_override = instance_folder_location
+        is_valid, error_msg = test_controller.validate_instance_folder_override()
+
+        if not is_valid:
+            show_warning(
+                title="Invalid Instance Folder",
+                text="Cannot use selected folder as instance location.",
+                information=error_msg,
+            )
+            return
+
+        self.settings.instances[
+            self.settings.current_instance
+        ].instance_folder_override = instance_folder_location
+        self.dialog.instance_folder_location.setText(instance_folder_location)
+        if self._file_dialog_state:
+            self._file_dialog_state.last_path = str(
+                Path(instance_folder_location).parent
+            )
+        self.settings.save()
+
+    @Slot()
+    def _on_instance_folder_clear(self) -> None:
+        """Clear custom instance folder and use default location."""
+        if self.settings.current_instance != DEFAULT_INSTANCE_NAME:
+            show_warning(
+                title="Cannot Modify Instance Folder",
+                text="Only the Default instance can have a custom folder location.",
+                information="Custom instance folder location is managed by the Default instance.",
+            )
+            return
+
+        self.settings.instances[
+            self.settings.current_instance
+        ].instance_folder_override = ""
+        self.dialog.instance_folder_location.setText("")
+        self.settings.save()
 
     # --- Validation ---
 

--- a/app/controllers/settings_tabs/locations_tab_controller.py
+++ b/app/controllers/settings_tabs/locations_tab_controller.py
@@ -2,14 +2,16 @@ from pathlib import Path
 from typing import Callable
 
 from PySide6.QtCore import Slot
+from PySide6.QtWidgets import QMessageBox
 
 from app.controllers.settings_tabs.base_tab_controller import (
     BaseTabController,
     SharedFileDialogState,
 )
 from app.models.settings import Settings
+from app.utils.acf_utils import validate_acf_file_exists
 from app.utils.constants import DEFAULT_INSTANCE_NAME
-from app.utils.generic import platform_specific_open
+from app.utils.generic import platform_specific_open, validate_game_executable
 from app.utils.system_info import SystemInfo
 from app.views.dialogue import BinaryChoiceDialog, show_dialogue_file
 from app.views.settings_dialog import SettingsDialog
@@ -73,15 +75,11 @@ class LocationsTabController(BaseTabController):
         settings: Settings,
         dialog: SettingsDialog,
         file_dialog_state: SharedFileDialogState,
-        validate_game_location: Callable[[str], bool],
-        validate_config_folder_location: Callable[[str], bool],
         on_autodetect: Callable[[], None],
         on_instance_folder_choose: Callable[[], None],
         on_instance_folder_clear: Callable[[], None],
     ) -> None:
         super().__init__(settings, dialog, file_dialog_state=file_dialog_state)
-        self._validate_game_location = validate_game_location
-        self._validate_config_folder_location = validate_config_folder_location
         self._on_autodetect_callback = on_autodetect
         self._on_instance_folder_choose_callback = on_instance_folder_choose
         self._on_instance_folder_clear_callback = on_instance_folder_clear
@@ -159,6 +157,23 @@ class LocationsTabController(BaseTabController):
         instance.steam_client_integration = (
             self.dialog.steam_client_integration_checkbox.isChecked()
         )
+
+    def validate_before_save(self) -> bool:
+        game_folder_text = self.dialog.game_location.text().strip()
+        if game_folder_text and not self._validate_game_location(game_folder_text):
+            return False
+
+        config_folder_text = self.dialog.config_folder_location.text().strip()
+        if config_folder_text and not self._validate_config_folder_location(
+            config_folder_text
+        ):
+            return False
+
+        if self.dialog.steam_client_integration_checkbox.isChecked():
+            if not self._validate_steam_integration():
+                return False
+
+        return True
 
     # --- Folder path group callbacks ---
 
@@ -245,3 +260,99 @@ class LocationsTabController(BaseTabController):
         self.dialog.config_folder_location.setText("")
         self.dialog.steam_mods_folder_location.setText("")
         self.dialog.local_mods_folder_location.setText("")
+
+    # --- Validation ---
+
+    def _validate_game_location(self, game_location: str) -> bool:
+        """Validate the game location and show a warning if invalid."""
+        if not validate_game_executable(game_location):
+            QMessageBox.information(
+                self.dialog,
+                self.dialog.tr("Invalid Game Location"),
+                self.dialog.tr(
+                    "The selected game folder does not contain a valid RimWorld executable. Please select a valid game location."
+                ),
+            )
+            return False
+        return True
+
+    def _validate_config_folder_location(self, config_folder: str) -> bool:
+        """Validate the config folder location and show a warning if invalid."""
+        if not (Path(config_folder) / "ModsConfig.xml").exists():
+            QMessageBox.warning(
+                self.dialog,
+                self.dialog.tr("Invalid Config Folder"),
+                self.dialog.tr(
+                    "The selected config folder does not contain ModsConfig.xml. Please select a valid config folder."
+                ),
+            )
+            return False
+        return True
+
+    @staticmethod
+    def _check_steam_integration_validity(
+        steam_client_integration: bool, steam_mods_location: str
+    ) -> bool:
+        """Check if Steam client integration and Steam mods location are valid."""
+        if not steam_client_integration and not steam_mods_location:
+            return True
+        if steam_client_integration and not steam_mods_location:
+            return False
+        if steam_mods_location:
+            return validate_acf_file_exists(steam_mods_location)
+        return True
+
+    def _disable_steam_integration_ui(self) -> None:
+        """Clear all Steam integration dependent UI settings."""
+        self.dialog.steam_client_integration_checkbox.setChecked(False)
+        self.dialog.steam_mods_folder_location.setText("")
+        self.dialog.launch_via_steam_protocol_checkbox.setChecked(False)
+
+    def _validate_steam_integration(self) -> bool:
+        """Validate Steam client integration and Steam mods location configuration."""
+        steam_client_integration = (
+            self.dialog.steam_client_integration_checkbox.isChecked()
+        )
+        steam_mods_location = self.dialog.steam_mods_folder_location.text().strip()
+
+        if not steam_client_integration:
+            QMessageBox.warning(
+                self.dialog,
+                self.dialog.tr("Steam Client Integration Disabled"),
+                self.dialog.tr(
+                    "Steam client integration is disabled. Steam mods location and Steam protocol launch will be cleared."
+                ),
+            )
+            self.dialog.steam_mods_folder_location.setText("")
+            self.dialog.launch_via_steam_protocol_checkbox.setChecked(False)
+
+        is_valid = self._check_steam_integration_validity(
+            steam_client_integration, steam_mods_location
+        )
+
+        if not is_valid:
+            self._disable_steam_integration_ui()
+
+            if steam_client_integration and not steam_mods_location:
+                QMessageBox.warning(
+                    self.dialog,
+                    self.dialog.tr("Steam Mods Location Required"),
+                    self.dialog.tr(
+                        "Steam client integration requires a Steam mods location to be configured. "
+                        "Steam client integration, Steam mods location, and Steam protocol launch have been disabled."
+                    ),
+                )
+            elif steam_mods_location and not validate_acf_file_exists(
+                steam_mods_location
+            ):
+                QMessageBox.warning(
+                    self.dialog,
+                    self.dialog.tr("Steam Workshop File Not Found"),
+                    self.dialog.tr(
+                        "The Steam Workshop file 'appworkshop_294100.acf' was not found at the expected location. "
+                        "Steam client integration, Steam mods location, and Steam protocol launch have been disabled. "
+                        "Please ensure Steam is properly installed and has downloaded RimWorld Workshop data."
+                    ),
+                )
+
+        return is_valid

--- a/app/controllers/settings_tabs/locations_tab_controller.py
+++ b/app/controllers/settings_tabs/locations_tab_controller.py
@@ -3,7 +3,10 @@ from typing import Callable
 
 from PySide6.QtCore import Slot
 
-from app.controllers.settings_tabs.base_tab_controller import BaseTabController
+from app.controllers.settings_tabs.base_tab_controller import (
+    BaseTabController,
+    SharedFileDialogState,
+)
 from app.models.settings import Settings
 from app.utils.constants import DEFAULT_INSTANCE_NAME
 from app.utils.generic import platform_specific_open
@@ -69,17 +72,16 @@ class LocationsTabController(BaseTabController):
         self,
         settings: Settings,
         dialog: SettingsDialog,
+        file_dialog_state: SharedFileDialogState,
         validate_game_location: Callable[[str], bool],
         validate_config_folder_location: Callable[[str], bool],
-        on_path_selected: Callable[[str], None],
         on_autodetect: Callable[[], None],
         on_instance_folder_choose: Callable[[], None],
         on_instance_folder_clear: Callable[[], None],
     ) -> None:
-        super().__init__(settings, dialog)
+        super().__init__(settings, dialog, file_dialog_state=file_dialog_state)
         self._validate_game_location = validate_game_location
         self._validate_config_folder_location = validate_config_folder_location
-        self._path_selected_callback = on_path_selected
         self._on_autodetect_callback = on_autodetect
         self._on_instance_folder_choose_callback = on_instance_folder_choose
         self._on_instance_folder_clear_callback = on_instance_folder_clear
@@ -182,7 +184,8 @@ class LocationsTabController(BaseTabController):
             return None
 
         dialog.local_mods_folder_location.setText(str(result / "Mods"))
-        self._path_selected_callback(str(result))
+        if self._file_dialog_state:
+            self._file_dialog_state.last_path = str(result)
         return str(result)
 
     @staticmethod
@@ -200,7 +203,8 @@ class LocationsTabController(BaseTabController):
         if not self._validate_config_folder_location(config_folder):
             return None
 
-        self._path_selected_callback(str(Path(config_folder).parent))
+        if self._file_dialog_state:
+            self._file_dialog_state.last_path = str(Path(config_folder).parent)
         return config_folder
 
     def _on_steam_mods_choose(self, dialog: SettingsDialog) -> str | None:
@@ -210,7 +214,8 @@ class LocationsTabController(BaseTabController):
         )
         if not steam_mods_folder:
             return None
-        self._path_selected_callback(str(Path(steam_mods_folder).parent))
+        if self._file_dialog_state:
+            self._file_dialog_state.last_path = str(Path(steam_mods_folder).parent)
         return steam_mods_folder
 
     def _on_local_mods_choose(self, dialog: SettingsDialog) -> str | None:
@@ -220,7 +225,8 @@ class LocationsTabController(BaseTabController):
         )
         if not local_mods_folder:
             return None
-        self._path_selected_callback(str(Path(local_mods_folder).parent))
+        if self._file_dialog_state:
+            self._file_dialog_state.last_path = str(Path(local_mods_folder).parent)
         return local_mods_folder
 
     # --- Clear all button ---

--- a/app/controllers/settings_tabs/locations_tab_controller.py
+++ b/app/controllers/settings_tabs/locations_tab_controller.py
@@ -1,8 +1,10 @@
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
 
+from loguru import logger
 from PySide6.QtCore import Slot
-from PySide6.QtWidgets import QMessageBox
+from PySide6.QtWidgets import QLineEdit, QMessageBox
 
 from app.controllers.settings_tabs.base_tab_controller import (
     BaseTabController,
@@ -12,8 +14,9 @@ from app.models.settings import Settings
 from app.utils.acf_utils import validate_acf_file_exists
 from app.utils.constants import DEFAULT_INSTANCE_NAME
 from app.utils.generic import platform_specific_open, validate_game_executable
+from app.utils.steam_path_detection import detect_platform_paths
 from app.utils.system_info import SystemInfo
-from app.views.dialogue import BinaryChoiceDialog, show_dialogue_file
+from app.views.dialogue import BinaryChoiceDialog, show_dialogue_file, show_warning
 from app.views.settings_dialog import SettingsDialog
 
 
@@ -75,12 +78,10 @@ class LocationsTabController(BaseTabController):
         settings: Settings,
         dialog: SettingsDialog,
         file_dialog_state: SharedFileDialogState,
-        on_autodetect: Callable[[], None],
         on_instance_folder_choose: Callable[[], None],
         on_instance_folder_clear: Callable[[], None],
     ) -> None:
         super().__init__(settings, dialog, file_dialog_state=file_dialog_state)
-        self._on_autodetect_callback = on_autodetect
         self._on_instance_folder_choose_callback = on_instance_folder_choose
         self._on_instance_folder_clear_callback = on_instance_folder_clear
 
@@ -121,7 +122,7 @@ class LocationsTabController(BaseTabController):
             self._on_clear_all_button_clicked
         )
         self.dialog.locations_autodetect_button.clicked.connect(
-            self._on_autodetect_callback
+            self._on_autodetect_button_clicked
         )
 
     def update_view_from_model(self) -> None:
@@ -260,6 +261,71 @@ class LocationsTabController(BaseTabController):
         self.dialog.config_folder_location.setText("")
         self.dialog.steam_mods_folder_location.setText("")
         self.dialog.local_mods_folder_location.setText("")
+
+    # --- Autodetect ---
+
+    @Slot()
+    def _on_autodetect_button_clicked(self) -> None:
+        """Autodetect RimWorld paths based on platform defaults."""
+        logger.info("USER ACTION: starting autodetect paths")
+
+        try:
+            paths = detect_platform_paths()
+        except RuntimeError:
+            logger.error("Attempting to autodetect paths on an unknown system")
+            return
+
+        if paths.steam_root is not None and "snap" in paths.steam_root.parts:
+            show_warning(
+                title="Unsupported Steam installation",
+                text="Snap-based Steam installation detected.",
+                information=(
+                    "Steam installed via Snap is not officially supported and may cause issues. "
+                    "We recommend installing Steam via your distribution's native package manager "
+                    "or Flatpak instead.\n\n"
+                    "Autodetection will continue, but some paths may not work correctly."
+                ),
+            )
+
+        @dataclass
+        class _PathGroup:
+            folder: Path
+            settings_line: QLineEdit
+            name: str
+
+        path_groups = [
+            _PathGroup(paths.game_folder, self.dialog.game_location, "game"),
+            _PathGroup(
+                paths.config_folder, self.dialog.config_folder_location, "config"
+            ),
+            _PathGroup(
+                paths.steam_mods_folder,
+                self.dialog.steam_mods_folder_location,
+                "workshop mods",
+            ),
+            _PathGroup(
+                paths.game_folder / "Mods",
+                self.dialog.local_mods_folder_location,
+                "local mods",
+            ),
+        ]
+
+        for group in path_groups:
+            if group.folder.exists():
+                logger.info(
+                    f"Auto-detected {group.name} folder path exists: {group.folder}"
+                )
+                if not group.settings_line.text():
+                    logger.info(
+                        f"No value set currently for {group.name} folder. Overwriting with auto-detected path"
+                    )
+                    group.settings_line.setText(str(group.folder))
+                else:
+                    logger.info(f"Value already set for {group.name} folder. Passing")
+            else:
+                logger.warning(
+                    f"Auto-detected {group.name} folder path does not exist: {group.folder}"
+                )
 
     # --- Validation ---
 

--- a/app/utils/steam_path_detection.py
+++ b/app/utils/steam_path_detection.py
@@ -221,9 +221,7 @@ def get_windows_paths() -> DetectedPaths:
                 f"{steam_folder}/steamapps/workshop/content/294100"
             )
         else:
-            steam_mods_folder = (
-                Path(steam_mods_folder_str) / "workshop/content/294100"
-            )
+            steam_mods_folder = Path(steam_mods_folder_str) / "workshop/content/294100"
 
         return DetectedPaths(game_folder, config_folder, steam_mods_folder)
     else:

--- a/app/utils/steam_path_detection.py
+++ b/app/utils/steam_path_detection.py
@@ -1,0 +1,252 @@
+"""Platform-specific Steam and RimWorld path detection.
+
+Pure filesystem logic with no UI dependencies. Used by LocationsTabController
+for autodetect functionality.
+"""
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from loguru import logger
+
+from app.utils.generic import find_steam_rimworld, get_path_up_to_string
+
+
+@dataclass
+class DetectedPaths:
+    """Result of platform-specific path autodetection."""
+
+    game_folder: Path
+    config_folder: Path
+    steam_mods_folder: Path
+    steam_root: Path | None = None
+
+
+def find_steam_root(candidates: list[Path]) -> Path | None:
+    """Find the Steam installation root from a prioritized list of candidate paths.
+
+    :param candidates: Ordered list of candidate Steam root paths
+    :return: First valid Steam root, or None
+    """
+    for candidate in candidates:
+        if not candidate.is_dir():
+            logger.debug(f"Steam root candidate does not exist: {candidate}")
+            continue
+        has_steamapps = (candidate / "steamapps").is_dir()
+        has_vdf = (candidate / "config" / "libraryfolders.vdf").is_file()
+        if has_steamapps or has_vdf:
+            logger.info(f"Found Steam root: {candidate}")
+            return candidate
+        logger.debug(
+            f"Steam root candidate exists but has no steamapps/ or config/libraryfolders.vdf: {candidate}"
+        )
+    logger.warning("No valid Steam root found from any candidate path")
+    return None
+
+
+def get_darwin_paths() -> DetectedPaths:
+    """Detect RimWorld paths on macOS."""
+    user_home = Path.home()
+    candidates = [
+        user_home / "Library" / "Application Support" / "Steam",
+    ]
+
+    steam_root = find_steam_root(candidates)
+
+    if steam_root:
+        game_folder_str = find_steam_rimworld(steam_root)
+        if game_folder_str:
+            game_folder = Path(game_folder_str) / "RimworldMac.app"
+        else:
+            game_folder = (
+                steam_root / "steamapps" / "common" / "Rimworld" / "RimworldMac.app"
+            )
+
+        steam_mods_folder_str = get_path_up_to_string(
+            game_folder.parent, "common", exclude=True
+        )
+        if steam_mods_folder_str == "":
+            steam_mods_folder = (
+                steam_root / "steamapps" / "workshop" / "content" / "294100"
+            )
+        else:
+            steam_mods_folder = (
+                Path(steam_mods_folder_str) / "workshop" / "content" / "294100"
+            )
+    else:
+        game_folder = (
+            user_home
+            / "Library"
+            / "Application Support"
+            / "Steam"
+            / "steamapps"
+            / "common"
+            / "Rimworld"
+            / "RimworldMac.app"
+        )
+        steam_mods_folder = (
+            user_home
+            / "Library"
+            / "Application Support"
+            / "Steam"
+            / "steamapps"
+            / "workshop"
+            / "content"
+            / "294100"
+        )
+
+    config_folder = (
+        user_home / "Library" / "Application Support" / "Rimworld" / "Config"
+    )
+
+    return DetectedPaths(game_folder, config_folder, steam_mods_folder, steam_root)
+
+
+def get_linux_paths() -> DetectedPaths:
+    """Detect RimWorld paths on Linux."""
+    user_home = Path.home()
+    candidates = [
+        user_home / ".steam" / "debian-installation",
+        user_home / ".steam" / "steam",
+        user_home / ".local" / "share" / "Steam",
+        user_home
+        / ".var"
+        / "app"
+        / "com.valvesoftware.Steam"
+        / ".local"
+        / "share"
+        / "Steam",
+        user_home / "snap" / "steam" / "common" / ".local" / "share" / "Steam",
+    ]
+
+    steam_root = find_steam_root(candidates)
+
+    if steam_root:
+        game_folder_str = find_steam_rimworld(steam_root)
+        if game_folder_str:
+            game_folder = Path(game_folder_str)
+        else:
+            game_folder = steam_root / "steamapps" / "common" / "RimWorld"
+
+        steam_mods_folder_str = get_path_up_to_string(
+            game_folder, "common", exclude=True
+        )
+        if steam_mods_folder_str == "":
+            steam_mods_folder = (
+                steam_root / "steamapps" / "workshop" / "content" / "294100"
+            )
+        else:
+            steam_mods_folder = (
+                Path(steam_mods_folder_str) / "workshop" / "content" / "294100"
+            )
+    else:
+        game_folder = (
+            user_home / ".steam" / "steam" / "steamapps" / "common" / "RimWorld"
+        )
+        steam_mods_folder = (
+            user_home
+            / ".steam"
+            / "steam"
+            / "steamapps"
+            / "workshop"
+            / "content"
+            / "294100"
+        )
+
+    native_config = (
+        user_home
+        / ".config"
+        / "unity3d"
+        / "Ludeon Studios"
+        / "RimWorld by Ludeon Studios"
+        / "Config"
+    )
+    if steam_root:
+        proton_config = (
+            steam_root
+            / "steamapps"
+            / "compatdata"
+            / "294100"
+            / "pfx"
+            / "drive_c"
+            / "users"
+            / "steamuser"
+            / "AppData"
+            / "LocalLow"
+            / "Ludeon Studios"
+            / "RimWorld by Ludeon Studios"
+            / "Config"
+        )
+        if proton_config.exists():
+            logger.info(f"Proton prefix detected for config: {proton_config}")
+            config_folder = proton_config
+        else:
+            config_folder = native_config
+    else:
+        config_folder = native_config
+
+    return DetectedPaths(game_folder, config_folder, steam_mods_folder, steam_root)
+
+
+def get_windows_paths() -> DetectedPaths:
+    """Detect RimWorld paths on Windows."""
+    if sys.platform == "win32":
+        user_home = Path.home()
+        from app.utils.win_find_steam import find_steam_folder
+
+        steam_folder, found = find_steam_folder()
+
+        if not found:
+            logger.error(
+                "[win32] Could not find Steam folder. Using fallback assumptions"
+            )
+            steam_folder = "C:/Program Files (x86)/Steam"
+
+        game_folder_str: str | Path = find_steam_rimworld(steam_folder)
+
+        if game_folder_str == "":
+            game_folder_str = f"{steam_folder}/steamapps/common/RimWorld"
+        game_folder = Path(game_folder_str)
+
+        config_folder = Path(
+            f"{user_home}/AppData/LocalLow/Ludeon Studios/RimWorld by Ludeon Studios/Config"
+        )
+
+        steam_mods_folder_str = get_path_up_to_string(
+            game_folder, "common", exclude=True
+        )
+        if steam_mods_folder_str == "":
+            steam_mods_folder = Path(
+                f"{steam_folder}/steamapps/workshop/content/294100"
+            )
+        else:
+            steam_mods_folder = (
+                Path(steam_mods_folder_str) / "workshop/content/294100"
+            )
+
+        return DetectedPaths(game_folder, config_folder, steam_mods_folder)
+    else:
+        raise ValueError("This function should only be called on Windows")
+
+
+def detect_platform_paths() -> DetectedPaths:
+    """Detect RimWorld paths for the current platform.
+
+    :return: DetectedPaths with game, config, and workshop folder paths
+    :raises RuntimeError: If running on an unsupported platform
+    """
+    from app.utils.system_info import SystemInfo
+
+    if SystemInfo().operating_system == SystemInfo.OperatingSystem.MACOS:
+        paths = get_darwin_paths()
+        logger.info(f"Running on MacOS with the following paths: {paths}")
+    elif SystemInfo().operating_system == SystemInfo.OperatingSystem.LINUX:
+        paths = get_linux_paths()
+        logger.info(f"Running on Linux with the following paths: {paths}")
+    elif sys.platform == "win32":
+        paths = get_windows_paths()
+        logger.info(f"Running on Windows with the following paths: {paths}")
+    else:
+        raise RuntimeError("Attempting to autodetect paths on an unknown system")
+    return paths

--- a/tests/controllers/test_path_autodetection.py
+++ b/tests/controllers/test_path_autodetection.py
@@ -1,7 +1,11 @@
 from pathlib import Path
 from unittest.mock import patch
 
-from app.controllers.settings_controller import SettingsController
+from app.utils.steam_path_detection import (
+    find_steam_root,
+    get_darwin_paths,
+    get_linux_paths,
+)
 
 
 def _vdf_escape(path: Path) -> str:
@@ -18,24 +22,15 @@ def _setup_steam_root(tmp_path: Path, subdir: str) -> Path:
     return steam_root
 
 
-def _make_controller() -> SettingsController:
-    """Create a SettingsController without __init__ (which requires Qt widgets).
-
-    Safe because the path detection methods only use Path.home(), static
-    methods, and module-level utility functions — no instance attributes.
-    """
-    return SettingsController.__new__(SettingsController)
-
-
 class TestFindSteamRoot:
-    """Tests for SettingsController._find_steam_root()."""
+    """Tests for find_steam_root()."""
 
     def test_returns_first_valid_candidate_with_steamapps(self, tmp_path: Path) -> None:
         candidate = tmp_path / ".steam" / "steam"
         candidate.mkdir(parents=True)
         (candidate / "steamapps").mkdir()
 
-        result = SettingsController._find_steam_root([candidate])
+        result = find_steam_root([candidate])
         assert result == candidate
 
     def test_returns_first_valid_candidate_with_vdf(self, tmp_path: Path) -> None:
@@ -43,7 +38,7 @@ class TestFindSteamRoot:
         (candidate / "config").mkdir(parents=True)
         (candidate / "config" / "libraryfolders.vdf").touch()
 
-        result = SettingsController._find_steam_root([candidate])
+        result = find_steam_root([candidate])
         assert result == candidate
 
     def test_skips_nonexistent_candidates(self, tmp_path: Path) -> None:
@@ -52,18 +47,18 @@ class TestFindSteamRoot:
         valid.mkdir()
         (valid / "steamapps").mkdir()
 
-        result = SettingsController._find_steam_root([nonexistent, valid])
+        result = find_steam_root([nonexistent, valid])
         assert result == valid
 
     def test_skips_candidates_without_steamapps_or_vdf(self, tmp_path: Path) -> None:
         empty_dir = tmp_path / "empty"
         empty_dir.mkdir()
 
-        result = SettingsController._find_steam_root([empty_dir])
+        result = find_steam_root([empty_dir])
         assert result is None
 
     def test_returns_none_when_no_candidates_match(self, tmp_path: Path) -> None:
-        result = SettingsController._find_steam_root([tmp_path / "a", tmp_path / "b"])
+        result = find_steam_root([tmp_path / "a", tmp_path / "b"])
         assert result is None
 
     def test_respects_priority_order(self, tmp_path: Path) -> None:
@@ -75,44 +70,44 @@ class TestFindSteamRoot:
         second.mkdir()
         (second / "steamapps").mkdir()
 
-        result = SettingsController._find_steam_root([first, second])
+        result = find_steam_root([first, second])
         assert result == first
 
     def test_returns_none_for_empty_list(self) -> None:
-        result = SettingsController._find_steam_root([])
+        result = find_steam_root([])
         assert result is None
 
 
 class TestGetLinuxPaths:
-    """Tests for SettingsController.__get_linux_paths() via the name-mangled accessor."""
-
-    def _call(self, controller: SettingsController) -> tuple[Path, Path, Path]:
-        return controller._SettingsController__get_linux_paths()  # type: ignore[attr-defined]
+    """Tests for get_linux_paths()."""
 
     def test_debian_installation_path(self, tmp_path: Path) -> None:
         steam_root = _setup_steam_root(tmp_path, ".steam/debian-installation")
 
         with patch("pathlib.Path.home", return_value=tmp_path):
-            result = self._call(_make_controller())
+            result = get_linux_paths()
 
-        assert result[0] == steam_root / "steamapps" / "common" / "RimWorld"
-        assert result[2] == steam_root / "steamapps" / "workshop" / "content" / "294100"
+        assert result.game_folder == steam_root / "steamapps" / "common" / "RimWorld"
+        assert (
+            result.steam_mods_folder
+            == steam_root / "steamapps" / "workshop" / "content" / "294100"
+        )
 
     def test_native_steam_path(self, tmp_path: Path) -> None:
         steam_root = _setup_steam_root(tmp_path, ".steam/steam")
 
         with patch("pathlib.Path.home", return_value=tmp_path):
-            result = self._call(_make_controller())
+            result = get_linux_paths()
 
-        assert result[0] == steam_root / "steamapps" / "common" / "RimWorld"
+        assert result.game_folder == steam_root / "steamapps" / "common" / "RimWorld"
 
     def test_local_share_path(self, tmp_path: Path) -> None:
         steam_root = _setup_steam_root(tmp_path, ".local/share/Steam")
 
         with patch("pathlib.Path.home", return_value=tmp_path):
-            result = self._call(_make_controller())
+            result = get_linux_paths()
 
-        assert result[0] == steam_root / "steamapps" / "common" / "RimWorld"
+        assert result.game_folder == steam_root / "steamapps" / "common" / "RimWorld"
 
     def test_flatpak_path(self, tmp_path: Path) -> None:
         steam_root = _setup_steam_root(
@@ -121,17 +116,17 @@ class TestGetLinuxPaths:
         )
 
         with patch("pathlib.Path.home", return_value=tmp_path):
-            result = self._call(_make_controller())
+            result = get_linux_paths()
 
-        assert result[0] == steam_root / "steamapps" / "common" / "RimWorld"
+        assert result.game_folder == steam_root / "steamapps" / "common" / "RimWorld"
 
     def test_snap_path(self, tmp_path: Path) -> None:
         steam_root = _setup_steam_root(tmp_path, "snap/steam/common/.local/share/Steam")
 
         with patch("pathlib.Path.home", return_value=tmp_path):
-            result = self._call(_make_controller())
+            result = get_linux_paths()
 
-        assert result[0] == steam_root / "steamapps" / "common" / "RimWorld"
+        assert result.game_folder == steam_root / "steamapps" / "common" / "RimWorld"
 
     def test_vdf_finds_rimworld_in_secondary_library(self, tmp_path: Path) -> None:
         steam_root = tmp_path / ".steam" / "steam"
@@ -150,11 +145,12 @@ class TestGetLinuxPaths:
         (vdf_dir / "libraryfolders.vdf").write_text(vdf_content)
 
         with patch("pathlib.Path.home", return_value=tmp_path):
-            result = self._call(_make_controller())
+            result = get_linux_paths()
 
-        assert result[0] == secondary_lib / "steamapps" / "common" / "RimWorld"
+        assert result.game_folder == secondary_lib / "steamapps" / "common" / "RimWorld"
         assert (
-            result[2] == secondary_lib / "steamapps" / "workshop" / "content" / "294100"
+            result.steam_mods_folder
+            == secondary_lib / "steamapps" / "workshop" / "content" / "294100"
         )
 
     def test_proton_config_takes_priority(self, tmp_path: Path) -> None:
@@ -177,9 +173,9 @@ class TestGetLinuxPaths:
         proton_config.mkdir(parents=True)
 
         with patch("pathlib.Path.home", return_value=tmp_path):
-            result = self._call(_make_controller())
+            result = get_linux_paths()
 
-        assert result[1] == proton_config
+        assert result.config_folder == proton_config
 
     def test_native_config_when_no_proton(self, tmp_path: Path) -> None:
         _setup_steam_root(tmp_path, ".steam/steam")
@@ -193,39 +189,36 @@ class TestGetLinuxPaths:
         )
 
         with patch("pathlib.Path.home", return_value=tmp_path):
-            result = self._call(_make_controller())
+            result = get_linux_paths()
 
-        assert result[1] == native_config
+        assert result.config_folder == native_config
 
     def test_no_steam_root_returns_fallback_paths(self, tmp_path: Path) -> None:
         with patch("pathlib.Path.home", return_value=tmp_path):
-            result = self._call(_make_controller())
+            result = get_linux_paths()
 
-        assert "steamapps" in str(result[0])
-        assert "Config" in str(result[1])
-        assert "294100" in str(result[2])
+        assert "steamapps" in str(result.game_folder)
+        assert "Config" in str(result.config_folder)
+        assert "294100" in str(result.steam_mods_folder)
 
     def test_priority_debian_over_native(self, tmp_path: Path) -> None:
         debian_root = _setup_steam_root(tmp_path, ".steam/debian-installation")
         _setup_steam_root(tmp_path, ".steam/steam")
 
         with patch("pathlib.Path.home", return_value=tmp_path):
-            result = self._call(_make_controller())
+            result = get_linux_paths()
 
-        assert result[0] == debian_root / "steamapps" / "common" / "RimWorld"
+        assert result.game_folder == debian_root / "steamapps" / "common" / "RimWorld"
 
 
 class TestGetDarwinPaths:
-    """Tests for SettingsController.__get_darwin_paths().
+    """Tests for get_darwin_paths().
 
     Note: macOS uses "Rimworld" (lowercase w) in hardcoded fallback paths,
     while VDF parsing returns "RimWorld" (capital W). This is fine because
     macOS has a case-insensitive filesystem by default. Tests assert the
     exact casing each code path produces.
     """
-
-    def _call(self, controller: SettingsController) -> tuple[Path, Path, Path]:
-        return controller._SettingsController__get_darwin_paths()  # type: ignore[attr-defined]
 
     @staticmethod
     def _make_darwin_steam_root(tmp_path: Path) -> Path:
@@ -249,11 +242,10 @@ class TestGetDarwinPaths:
         (vdf_dir / "libraryfolders.vdf").write_text(vdf_content)
 
         with patch("pathlib.Path.home", return_value=tmp_path):
-            result = self._call(_make_controller())
+            result = get_darwin_paths()
 
-        # VDF returns "RimWorld" (capital W)
         assert (
-            result[0]
+            result.game_folder
             == steam_root / "steamapps" / "common" / "RimWorld" / "RimworldMac.app"
         )
 
@@ -261,79 +253,71 @@ class TestGetDarwinPaths:
         steam_root = self._make_darwin_steam_root(tmp_path)
 
         with patch("pathlib.Path.home", return_value=tmp_path):
-            result = self._call(_make_controller())
+            result = get_darwin_paths()
 
-        # Fallback uses "Rimworld" (lowercase w) — matches existing behavior
         expected_game = (
             steam_root / "steamapps" / "common" / "Rimworld" / "RimworldMac.app"
         )
-        assert result[0] == expected_game
+        assert result.game_folder == expected_game
 
     def test_config_folder_unchanged(self, tmp_path: Path) -> None:
         self._make_darwin_steam_root(tmp_path)
 
         with patch("pathlib.Path.home", return_value=tmp_path):
-            result = self._call(_make_controller())
+            result = get_darwin_paths()
 
         expected_config = (
             tmp_path / "Library" / "Application Support" / "Rimworld" / "Config"
         )
-        assert result[1] == expected_config
+        assert result.config_folder == expected_config
 
     def test_workshop_folder_derived_from_game(self, tmp_path: Path) -> None:
         self._make_darwin_steam_root(tmp_path)
 
         with patch("pathlib.Path.home", return_value=tmp_path):
-            result = self._call(_make_controller())
+            result = get_darwin_paths()
 
-        assert result[2].parts[-3:] == ("workshop", "content", "294100")
+        assert result.steam_mods_folder.parts[-3:] == ("workshop", "content", "294100")
 
     def test_no_steam_root_returns_hardcoded_paths(self, tmp_path: Path) -> None:
         with patch("pathlib.Path.home", return_value=tmp_path):
-            result = self._call(_make_controller())
+            result = get_darwin_paths()
 
-        assert "RimworldMac.app" in str(result[0])
-        assert "Config" in str(result[1])
-        assert "294100" in str(result[2])
+        assert "RimworldMac.app" in str(result.game_folder)
+        assert "Config" in str(result.config_folder)
+        assert "294100" in str(result.steam_mods_folder)
 
 
 class TestSnapWarning:
-    """Tests for Snap detection via _detected_steam_root."""
+    """Tests for Snap detection via steam_root in DetectedPaths."""
 
     def test_snap_steam_root_detected(self, tmp_path: Path) -> None:
         _setup_steam_root(tmp_path, "snap/steam/common/.local/share/Steam")
-        controller = _make_controller()
 
         with patch("pathlib.Path.home", return_value=tmp_path):
-            controller._SettingsController__get_linux_paths()  # type: ignore[attr-defined]
+            result = get_linux_paths()
 
-        assert controller._detected_steam_root is not None
-        assert "snap" in controller._detected_steam_root.parts
+        assert result.steam_root is not None
+        assert "snap" in result.steam_root.parts
 
     def test_native_steam_root_not_flagged(self, tmp_path: Path) -> None:
         _setup_steam_root(tmp_path, ".steam/steam")
-        controller = _make_controller()
 
         with patch("pathlib.Path.home", return_value=tmp_path):
-            controller._SettingsController__get_linux_paths()  # type: ignore[attr-defined]
+            result = get_linux_paths()
 
-        assert controller._detected_steam_root is not None
-        assert "snap" not in controller._detected_steam_root.parts
+        assert result.steam_root is not None
+        assert "snap" not in result.steam_root.parts
 
     def test_no_steam_root_not_flagged(self, tmp_path: Path) -> None:
-        controller = _make_controller()
-
         with patch("pathlib.Path.home", return_value=tmp_path):
-            controller._SettingsController__get_linux_paths()  # type: ignore[attr-defined]
+            result = get_linux_paths()
 
-        assert controller._detected_steam_root is None
+        assert result.steam_root is None
 
 
 class TestVdfEdgeCases:
     """Tests for VDF parsing edge cases in path autodetection."""
-
-    def _call_linux(self, controller: SettingsController) -> tuple[Path, Path, Path]:
-        return controller._SettingsController__get_linux_paths()  # type: ignore[attr-defined]
 
     def test_malformed_vdf_falls_back_to_default(self, tmp_path: Path) -> None:
         steam_root = tmp_path / ".steam" / "steam"
@@ -344,10 +328,13 @@ class TestVdfEdgeCases:
         (vdf_dir / "libraryfolders.vdf").write_text("this is not valid vdf {{{")
 
         with patch("pathlib.Path.home", return_value=tmp_path):
-            result = self._call_linux(_make_controller())
+            result = get_linux_paths()
 
-        assert result[0] == steam_root / "steamapps" / "common" / "RimWorld"
-        assert result[2] == steam_root / "steamapps" / "workshop" / "content" / "294100"
+        assert result.game_folder == steam_root / "steamapps" / "common" / "RimWorld"
+        assert (
+            result.steam_mods_folder
+            == steam_root / "steamapps" / "workshop" / "content" / "294100"
+        )
 
     def test_vdf_without_rimworld_falls_back(self, tmp_path: Path) -> None:
         steam_root = tmp_path / ".steam" / "steam"
@@ -371,6 +358,6 @@ class TestVdfEdgeCases:
         (vdf_dir / "libraryfolders.vdf").write_text(vdf_content)
 
         with patch("pathlib.Path.home", return_value=tmp_path):
-            result = self._call_linux(_make_controller())
+            result = get_linux_paths()
 
-        assert result[0] == steam_root / "steamapps" / "common" / "RimWorld"
+        assert result.game_folder == steam_root / "steamapps" / "common" / "RimWorld"


### PR DESCRIPTION
## Summary

- **Decomposes `settings_controller.py`** from 1019 lines down to 317 lines (69% reduction) by moving tab-specific logic into the existing per-tab controllers in `app/controllers/settings_tabs/`
- **Extracts platform path detection** into a new pure-utility module `app/utils/steam_path_detection.py` (250 lines, zero Qt dependencies)
- **Eliminates all callback-injection anti-patterns** — tab controllers now own their handlers directly instead of receiving callbacks from SettingsController
- **Introduces `SharedFileDialogState`** to fix a pre-existing desync bug where `_last_file_dialog_path` was passed by value (string snapshot) to tab controllers, causing stale file dialog directories
- **Promotes `BaseTabController` to `QObject`** so tab controllers can safely own `QThread`s and use `@Slot` decorators
- **Adds `validate_before_save()` hook** on `BaseTabController` (default `True`), replacing hard-coded validation in the OK button handler with a generic loop

### What moved where

| Logic | From | To |
|-------|------|----|
| 5 validation methods + `validate_before_save` | `SettingsController` | `LocationsTabController` |
| Autodetect button handler | `SettingsController` | `LocationsTabController` |
| Platform path detection (4 methods) | `SettingsController` | `app/utils/steam_path_detection.py` |
| Instance folder choose/clear handlers | `SettingsController` | `LocationsTabController` |
| HTTP download worker + handlers | `SettingsController` | `DatabasesTabController` |
| Theme/language application | `SettingsController` (direct) | `AppearanceTabController` (delegated) |

### What was eliminated
- `self.app_instance = QApplication.instance()` — dead code, never read
- Duplicate `ThemeController()` / `LanguageController()` instances — consolidated in `AppearanceTabController`
- `_on_locations_path_selected` callback — replaced by `SharedFileDialogState`
- All 6 callback parameters across tab controller `__init__`s
- Repetitive `_update_view_from_model` / `_update_model_from_view` (9 lines each → 2-line loops)

### Known follow-up
Translation `.ts` files need updating — moved methods change their `tr()` context from `"SettingsController"` to `"SettingsDialog"`. Non-English validation dialog strings will show English fallback until the `.ts` files are regenerated. This was an accepted tradeoff during planning and will be addressed in a follow-up PR.

## Test plan

- [x] All 1048 tests pass (`just test`)
- [x] mypy strict mode clean (`just typecheck`)
- [x] Pyright 0 errors (`just pyright`)
- [x] Ruff lint + format clean
- [x] `test_path_autodetection.py` migrated to use utility functions directly (no more name-mangled `_SettingsController__get_*` calls)
- [x] 14-agent adversarial review: 3 findings, all addressed (2 known/deferred tr() context, 1 @Slot fix applied)
- [ ] Manual smoke test: open Settings dialog, verify each tab loads, autodetect works, file dialogs open to correct directory, OK/Cancel/Reset function

🤖 Generated with [Claude Code](https://claude.com/claude-code)