### PR TITLE
fix: log fatal errors at error level instead of info

### DIFF
--- a/app/views/dialogue.py
+++ b/app/views/dialogue.py
@@ -266,8 +266,8 @@ def show_fatal_error(
     :param details: text to pass to setDetailedText
     :param parent: The parent widget
     """
-    logger.info(
-        f"Showing fatal error box with input: [{title}], [{text}], [{information}], [{details}]"
+    logger.error(
+        f"Fatal error: [{title}] [{text}] [{information}] [{details}]"
     )
 
     parent = _get_parent_if_constrain_enabled(parent)

--- a/app/views/dialogue.py
+++ b/app/views/dialogue.py
@@ -266,9 +266,7 @@ def show_fatal_error(
     :param details: text to pass to setDetailedText
     :param parent: The parent widget
     """
-    logger.error(
-        f"Fatal error: [{title}] [{text}] [{information}] [{details}]"
-    )
+    logger.error(f"Fatal error: [{title}] [{text}] [{information}] [{details}]")
 
     parent = _get_parent_if_constrain_enabled(parent)
 


### PR DESCRIPTION
## Summary

- `show_fatal_error()` was logging at `logger.info()`, so fatal error details were invisible on stderr (filtered at WARNING+) and easy to miss when scanning logs for errors
- Upgraded to `logger.error()` so every fatal error dialog always produces an ERROR-level entry in both the log file and stderr

## Test plan

- [x] Trigger a fatal error dialog (e.g., corrupt settings file) and verify the error appears in `RimSort.log` at `[ERROR]` level
- [x] Confirm the error also appears on stderr output

🤖 Generated with [Claude Code](https://claude.com/claude-code)