### PR TITLE
feat: add Stable/Beta/Edge update streams

### DIFF
--- a/.github/workflows/auto_build.yml
+++ b/.github/workflows/auto_build.yml
@@ -1,8 +1,10 @@
 # Auto build on push to main and PR.
-# Pushes to main also create an Edge release on GitHub.
+# Scheduled builds every 12 hours create Edge releases on GitHub.
 
 name: Auto Build
 on:
+  schedule:
+    - cron: '0 */12 * * *'
   pull_request:
     types: [opened, synchronize]
   push:
@@ -44,6 +46,12 @@ jobs:
             CHANGED=$(git diff --name-only "$PR_BASE"..."$PR_HEAD")
           elif [[ "$GH_EVENT" == "merge_group" ]]; then
             CHANGED=$(git diff --name-only "$MG_BASE"..."$MG_HEAD")
+          elif [[ "$GH_EVENT" == "schedule" ]]; then
+            # For scheduled builds, always consider app changed
+            # (check-edge-needed job gates whether we actually build)
+            echo "app_changed=true" >> "$GITHUB_OUTPUT"
+            echo "Scheduled build — skipping change detection"
+            exit 0
           else
             CHANGED=$(git diff --name-only "$PUSH_BEFORE" "$PUSH_SHA")
           fi
@@ -65,6 +73,37 @@ jobs:
             echo "Only documentation files changed — builds will be skipped"
           fi
 
+  check-edge-needed:
+    name: Check if Edge Release Needed
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule'
+    permissions:
+      contents: read
+    outputs:
+      should_build: ${{ steps.check.outputs.should_build }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Compare HEAD with last Edge release
+        id: check
+        # TODO: This compares commit SHAs, so docs-only changes will trigger
+        # a rebuild with identical app code. Could be improved to compare only
+        # app-relevant paths (app/, libs/, submodules/, themes/).
+        run: |
+          CURRENT_SHA=$(git rev-parse HEAD)
+          EDGE_SHA=$(gh release view Edge --json targetCommitish -q '.targetCommitish' 2>/dev/null || echo "none")
+          if [[ "$CURRENT_SHA" == "$EDGE_SHA" ]]; then
+            echo "should_build=false" >> "$GITHUB_OUTPUT"
+            echo "No new commits since last Edge release ($CURRENT_SHA)"
+          else
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+            echo "New commits detected: Edge=$EDGE_SHA, HEAD=$CURRENT_SHA"
+          fi
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   pre-pyright:
     permissions:
       contents: read
@@ -78,8 +117,8 @@ jobs:
   pre-build:
     uses: ./.github/workflows/get_version_info.yml
     with:
-      type: ${{ github.event_name == 'push' && 'Edge' || 'Auto-Build' }}
-      format_only: ${{ github.event_name != 'push' }}
+      type: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && 'Edge' || 'Auto-Build' }}
+      format_only: ${{ github.event_name != 'push' && github.event_name != 'schedule' }}
 
   attested-build:
     needs: [detect-changes, pre-build]
@@ -112,9 +151,10 @@ jobs:
       attest: false
 
   edge-release:
-    needs: [attested-build, pre-build, pre-pyright, pre-test]
+    needs: [attested-build, pre-build, pre-pyright, pre-test, check-edge-needed]
     if: >-
-      github.event_name == 'push'
+      github.event_name == 'schedule'
+      && needs.check-edge-needed.outputs.should_build == 'true'
       && needs.attested-build.result == 'success'
       && needs.pre-pyright.result == 'success'
       && needs.pre-test.result == 'success'
@@ -204,6 +244,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - detect-changes
+      - check-edge-needed
       - pre-pyright
       - pre-test
       - pre-build
@@ -218,6 +259,7 @@ jobs:
             echo "No app-relevant changes detected — builds were skipped."
           fi
           results=(
+            "${{ needs.check-edge-needed.result }}"
             "${{ needs.pre-pyright.result }}"
             "${{ needs.pre-test.result }}"
             "${{ needs.pre-build.result }}"

--- a/.github/workflows/get_version_info.yml
+++ b/.github/workflows/get_version_info.yml
@@ -71,6 +71,9 @@ jobs:
           if [[ "${{ inputs.type }}" == "Stable" ]]; then
               v_format="v\${major}.\${minor}.\${patch}"
               prerelease=false
+          elif [[ "${{ inputs.type }}" == "Beta" ]]; then
+              v_format="v\${major}.\${minor}.\${patch}-beta\${increment}"
+              prerelease=true
           elif [[ "${{ inputs.type }}" == "Edge" ]]; then
               v_format="v\${major}.\${minor}.\${patch}-edge\${increment}"
               prerelease=true
@@ -110,7 +113,7 @@ jobs:
       - name: Get version string
         id: version
         run: |
-          if [[ "${{ github.event.inputs.type }}" == "Stable" ]]; then
+          if [[ "${{ inputs.type }}" == "Stable" || "${{ inputs.type }}" == "Beta" ]]; then
                     version="${{ steps.sem_version.outputs.version}}"
           else
             version="${{ steps.sem_version.outputs.version}}+${{steps.short_sha.outputs.short_sha}}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
         type: choice
         options:
           - "Stable"
+          - "Beta"
           - "Edge"
       draft:
         description: "Draft release"
@@ -86,6 +87,8 @@ jobs:
         id: tag
         run: |
           if [[ "${{ github.event.inputs.type }}" == "Stable" ]]; then
+            tag="${{needs.pre-build.outputs.version_tag}}"
+          elif [[ "${{ github.event.inputs.type }}" == "Beta" ]]; then
             tag="${{needs.pre-build.outputs.version_tag}}"
           elif [[ "${{ github.event.inputs.type }}" == "Edge" ]]; then
             tag="Edge"

--- a/app/controllers/main_window_controller.py
+++ b/app/controllers/main_window_controller.py
@@ -6,6 +6,7 @@ from PySide6.QtCore import QObject, Slot
 from PySide6.QtWidgets import QPushButton
 
 from app.models.divider import is_divider_uuid
+from app.utils.app_info import AppInfo
 from app.utils.event_bus import EventBus
 from app.utils.metadata import MetadataManager
 from app.views.main_window import MainWindow
@@ -62,6 +63,7 @@ class MainWindowController(QObject):
         )  # Save btn animation
         EventBus().refresh_started.connect(self.on_refresh_started)
         EventBus().refresh_finished.connect(self.on_refresh_finished)
+        EventBus().settings_have_changed.connect(self._update_rimsort_version_label)
 
     def _parse_workshop_id(self, url: str) -> str | None:
         """Extract a Steam Workshop ID from a dependency URL."""
@@ -398,6 +400,7 @@ class MainWindowController(QObject):
         self.main_window.game_version_label.setText(
             "RimWorld version " + MetadataManager.instance().game_version
         )
+        self._update_rimsort_version_label()
 
     @Slot()
     def on_save_button_animation_start(self) -> None:
@@ -429,6 +432,17 @@ class MainWindowController(QObject):
             self.main_window.save_button.setObjectName("")
             self.main_window.save_button.style().unpolish(self.main_window.save_button)
             self.main_window.save_button.style().polish(self.main_window.save_button)
+
+    def _update_rimsort_version_label(self) -> None:
+        version_str = f"RimSort {AppInfo().app_version}"
+        stream = self.main_window.settings_controller.settings.update_stream
+
+        if stream == "beta":
+            self.main_window.rimsort_version_label.setText(f"{version_str}  [BETA]")
+        elif stream == "edge":
+            self.main_window.rimsort_version_label.setText(f"{version_str}  [EDGE]")
+        else:
+            self.main_window.rimsort_version_label.setText(version_str)
 
     def set_buttons_enabled(self, enabled: bool) -> None:
         for btn in self.buttons:

--- a/app/controllers/settings_tabs/advanced_tab_controller.py
+++ b/app/controllers/settings_tabs/advanced_tab_controller.py
@@ -1,5 +1,6 @@
 from loguru import logger
 from PySide6.QtCore import Slot
+from PySide6.QtWidgets import QMessageBox
 
 from app.controllers.settings_tabs.base_tab_controller import BaseTabController
 from app.models.settings import Settings
@@ -15,6 +16,8 @@ class AdvancedTabController(BaseTabController):
     save-comparison indicators, mod coloring mode, Auxiliary DB settings,
     and Authentication fields.
     """
+
+    STREAM_OPTIONS: tuple[str, ...] = ("stable", "beta", "edge")
 
     def __init__(
         self,
@@ -40,6 +43,10 @@ class AdvancedTabController(BaseTabController):
 
         self.dialog.include_mod_notes_in_mod_name_filter_checkbox.stateChanged.connect(
             self._on_include_mod_notes_in_mod_name_filter_changed
+        )
+
+        self.dialog.update_stream_combo.currentIndexChanged.connect(
+            self._on_update_stream_changed
         )
 
         EventBus().settings_have_changed.connect(self._handle_mod_coloring_mode_changed)
@@ -87,6 +94,14 @@ class AdvancedTabController(BaseTabController):
             self.settings.enable_backup_before_update
         )
         self.dialog.max_backups_spinbox.setValue(self.settings.max_backups)
+
+        self.dialog.update_stream_combo.blockSignals(True)
+        try:
+            idx = self.STREAM_OPTIONS.index(self.settings.update_stream)
+        except ValueError:
+            idx = 0
+        self.dialog.update_stream_combo.setCurrentIndex(idx)
+        self.dialog.update_stream_combo.blockSignals(False)
 
         # Auxiliary DB
         self.dialog.aux_db_time_limit.setText(str(self.settings.aux_db_time_limit))
@@ -137,6 +152,11 @@ class AdvancedTabController(BaseTabController):
         )
         self.settings.max_backups = self.dialog.max_backups_spinbox.value()
 
+        idx = self.dialog.update_stream_combo.currentIndex()
+        self.settings.update_stream = (
+            self.STREAM_OPTIONS[idx] if idx < len(self.STREAM_OPTIONS) else "stable"
+        )
+
         # Auxiliary DB
         try:
             self.settings.aux_db_time_limit = int(self.dialog.aux_db_time_limit.text())
@@ -166,6 +186,46 @@ class AdvancedTabController(BaseTabController):
         self.settings.include_mod_notes_in_mod_name_filter = (
             self.dialog.include_mod_notes_in_mod_name_filter_checkbox.isChecked()
         )
+
+    @Slot(int)
+    def _on_update_stream_changed(self, index: int) -> None:
+        new_stream = (
+            self.STREAM_OPTIONS[index] if index < len(self.STREAM_OPTIONS) else "stable"
+        )
+        old_stream = self.settings.update_stream
+
+        if self.STREAM_OPTIONS.index(new_stream) > self.STREAM_OPTIONS.index(
+            old_stream
+        ):
+            if new_stream == "beta":
+                message = self.dialog.tr(
+                    "Beta builds are release candidates meant as a means to test "
+                    "new features and find bugs before a stable release. They may "
+                    "receive less testing than stable releases. If you find any bugs, "
+                    "please report them as a Github issue or create a thread in the "
+                    "#troubleshooting channel in the discord.\n\n"
+                    "Are you sure you want to switch?"
+                )
+            else:
+                message = self.dialog.tr(
+                    "Edge builds are created automatically from the latest "
+                    "development code every 12 hours. They may contain incomplete "
+                    "features, breaking changes, and bugs.\n\n"
+                    "Are you sure you want to switch?"
+                )
+
+            result = QMessageBox.warning(
+                self.dialog,
+                self.dialog.tr("Switch Update Channel"),
+                message,
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                QMessageBox.StandardButton.No,
+            )
+            if result != QMessageBox.StandardButton.Yes:
+                old_idx = self.STREAM_OPTIONS.index(old_stream)
+                self.dialog.update_stream_combo.blockSignals(True)
+                self.dialog.update_stream_combo.setCurrentIndex(old_idx)
+                self.dialog.update_stream_combo.blockSignals(False)
 
     @Slot()
     def _handle_mod_coloring_mode_changed(self) -> None:

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -203,6 +203,9 @@ class Settings(QObject):
         self.enable_backup_before_update: bool = True
         self.max_backups: int = 3
 
+        # Update stream: "stable", "beta", or "edge"
+        self.update_stream: str = "stable"
+
         # Authentication
         self.rentry_auth_code: str = ""
         self.github_username: str = ""

--- a/app/utils/update_utils.py
+++ b/app/utils/update_utils.py
@@ -41,7 +41,7 @@ VERSION_PATTERN = re.compile(r"v?\d+[\.\-_]\d+")
 TAG_PREFIX_PATTERN = re.compile(r"^v", re.IGNORECASE)
 
 # API and network constants
-GITHUB_API_URL = "https://api.github.com/repos/RimSort/RimSort/releases/latest"
+GITHUB_API_URL = "https://api.github.com/repos/RimSort/RimSort/releases"
 API_TIMEOUT = 15
 DOWNLOAD_TIMEOUT = 30
 
@@ -736,8 +736,13 @@ class UpdateManager(QObject):
         logger.info(f"Current RimSort version: {current_version}")
 
         # Get the latest release info
-        logger.info("Fetching latest release information from GitHub API...")
-        latest_release_info = self._get_latest_release_info(needs_elevation)
+        stream = self.settings_controller.settings.update_stream
+        logger.info(
+            f"Fetching latest release information from GitHub API (stream: {stream})..."
+        )
+        latest_release_info = self._get_latest_release_info(
+            needs_elevation, stream=stream
+        )
         if not latest_release_info:
             logger.warning("Failed to retrieve latest release information")
             return None
@@ -751,7 +756,25 @@ class UpdateManager(QObject):
 
         # Compare versions
         current_version_parsed = self._parse_current_version(current_version)
-        if current_version_parsed >= latest_version:
+        if current_version_parsed > latest_version:
+            result = dialogue.show_dialogue_conditional(
+                title=self.tr("Downgrade Available"),
+                text=self.tr(
+                    "You're currently on {current} but the latest {stream} release is {latest}. "
+                    "Downgrading may require reconfiguring some settings."
+                ).format(
+                    current=current_version,
+                    stream=stream.capitalize(),
+                    latest=str(latest_version),
+                ),
+                information=self.tr(
+                    "Do you want to downgrade now, or wait for a newer release?"
+                ),
+                button_text_override=["Downgrade Now", "Wait"],
+            )
+            if result != "Downgrade Now":
+                return None
+        elif current_version_parsed == latest_version:
             logger.info("Already running the latest version")
             return None
 
@@ -851,28 +874,32 @@ class UpdateManager(QObject):
             raise UpdateError(f"Update failed: {e}") from e
 
     def _get_latest_release_info(
-        self, needs_elevation: bool = False
+        self, needs_elevation: bool = False, stream: str = "stable"
     ) -> ReleaseInfo | None:
         """
-        Get the latest release information from GitHub API.
+        Get the latest release information from GitHub API for the given stream.
 
-        Args:
-            needs_elevation: Whether elevation is needed (affects Windows asset selection)
-
-        Returns:
-            Dictionary containing version, tag_name, download_url, and is_msi flag, or None if failed
+        :param needs_elevation: Whether elevation is needed (affects Windows asset selection)
+        :param stream: Update stream - "stable", "beta", or "edge"
+        :return: Dictionary containing version, tag_name, download_url, and format flags, or None
         """
         try:
-            # Use releases API for better asset information
             response = http.get(GITHUB_API_URL, timeout=API_TIMEOUT)
             response.raise_for_status()
-            release_data = response.json()
+            releases = response.json()
+
+            release_data = filter_releases_by_stream(releases, stream)
+            if not release_data:
+                logger.warning(f"No matching release found for stream '{stream}'")
+                self.show_update_error()
+                return None
 
             tag_name = release_data.get("tag_name", "")
-            # Normalize tag name by removing prefix 'v' if present
-            normalized_tag = TAG_PREFIX_PATTERN.sub("", str(tag_name))
+            if tag_name == "Edge":
+                normalized_tag = extract_version_from_edge_release(release_data)
+            else:
+                normalized_tag = TAG_PREFIX_PATTERN.sub("", str(tag_name))
 
-            # Parse version
             try:
                 latest_version = version.parse(normalized_tag)
             except Exception as e:
@@ -880,7 +907,6 @@ class UpdateManager(QObject):
                 self.show_update_error()
                 return None
 
-            # Get platform-specific download URL
             download_info = self._get_platform_download_url(
                 release_data.get("assets", []), needs_elevation
             )

--- a/app/utils/update_utils.py
+++ b/app/utils/update_utils.py
@@ -96,6 +96,68 @@ ERR_UPDATE_FAILED_TEXT = "An unexpected error occurred during the update process
 ERR_RETRIEVE_RELEASE_TITLE = "Unable to retrieve latest release information"
 ERR_RETRIEVE_RELEASE_TEXT = "Please check your internet connection and try again, You can also check 'https://github.com/RimSort/RimSort/releases' directly."
 
+
+def filter_releases_by_stream(
+    releases: list[dict[str, Any]], stream: str
+) -> dict[str, Any] | None:
+    """
+    Filter GitHub releases list to find the best match for the given update stream.
+
+    Fallback chain: edge -> beta -> stable, beta -> stable.
+
+    :param releases: List of release dicts from GitHub API
+    :param stream: One of "stable", "beta", "edge"
+    :return: The matching release dict, or None if no releases available
+    """
+    non_draft = [r for r in releases if not r.get("draft", False)]
+
+    if stream == "edge":
+        for r in non_draft:
+            if r.get("tag_name") == "Edge":
+                return r
+        return filter_releases_by_stream(non_draft, "beta")
+
+    if stream == "beta":
+        for r in non_draft:
+            tag = r.get("tag_name", "")
+            if "-beta" in tag.lower():
+                return r
+        return filter_releases_by_stream(non_draft, "stable")
+
+    # Stable (default): first non-prerelease
+    for r in non_draft:
+        if not r.get("prerelease", False):
+            return r
+
+    return None
+
+
+def extract_version_from_edge_release(release_data: dict[str, Any]) -> str:
+    """
+    Extract a PEP 440-compatible version string from an Edge release.
+
+    Edge releases use a rolling 'Edge' tag, so the actual version
+    (e.g., 'v1.2.3-edge5+abc1234') is in the release body or asset filenames.
+    The '-edge' suffix is normalized to '.dev' for PEP 440 compatibility.
+
+    :param release_data: Release dict from GitHub API
+    :return: PEP 440-compatible version string (e.g., '1.2.3.dev5')
+    """
+    for asset in release_data.get("assets", []):
+        name = asset.get("name", "")
+        match = re.search(r"v?(\d+\.\d+\.\d+)-edge(\d+)", name)
+        if match:
+            return f"{match.group(1)}.dev{match.group(2)}"
+
+    body = release_data.get("body", "")
+    match = re.search(r"v?(\d+\.\d+\.\d+)-edge(\d+)", body)
+    if match:
+        return f"{match.group(1)}.dev{match.group(2)}"
+
+    logger.warning("Could not extract version from Edge release, using 0.0.0")
+    return "0.0.0"
+
+
 if TYPE_CHECKING:
     from app.utils.metadata import SettingsController
 

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -133,6 +133,11 @@ class MainWindow(QMainWindow):
         self.game_version_label.setEnabled(False)
         button_layout.addWidget(self.game_version_label)
 
+        self.rimsort_version_label = QLabel()
+        self.rimsort_version_label.setFont(GUIInfo().smaller_font)
+        self.rimsort_version_label.setEnabled(False)
+        button_layout.addWidget(self.rimsort_version_label)
+
         button_layout.addStretch()
 
         # Define button attributes

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -1552,6 +1552,25 @@ This basically preserves your mod coloring, user notes etc. for this many second
 
         group_layout.addLayout(backup_layout)
 
+        # Update channel
+        update_channel_layout = QHBoxLayout()
+        update_channel_label = QLabel(self.tr("Update channel:"))
+        update_channel_layout.addWidget(update_channel_label)
+
+        self.update_stream_combo = QComboBox()
+        self.update_stream_combo.addItems(["Stable", "Beta", "Edge"])
+        self.update_stream_combo.setToolTip(
+            self.tr(
+                "Choose which update channel to receive updates from.\n"
+                "Stable: Production releases (recommended)\n"
+                "Beta: Release candidates, may contain bugs\n"
+                "Edge: Bleeding-edge development builds, expect breakage"
+            )
+        )
+        update_channel_layout.addWidget(self.update_stream_combo)
+        update_channel_layout.addStretch()
+        group_layout.addLayout(update_channel_layout)
+
         # === Auxiliary Metadata DB group ===
         self._do_aux_db_time_limit_group(tab_layout)
 

--- a/tests/utils/test_update_streams.py
+++ b/tests/utils/test_update_streams.py
@@ -171,6 +171,33 @@ def test_extract_version_prefers_asset_over_body() -> None:
 
 # --- Tests for UpdateManager downgrade handling ---
 
+MOCK_DOWNGRADE_RESPONSE: list[dict[str, Any]] = [
+    {
+        "tag_name": "v1.0.0",
+        "prerelease": False,
+        "draft": False,
+        "assets": [
+            {
+                "name": "RimSort-v1.0.0-Linux_x86_64.tar.gz",
+                "browser_download_url": "https://example.com/dl",
+            }
+        ],
+    },
+]
+
+
+def _setup_downgrade_mocks(
+    mock_get: MagicMock,
+    mock_app_info: MagicMock,
+    mock_update_manager: UpdateManager,
+) -> None:
+    mock_app_info.return_value.app_version = "2.0.0"
+    mock_update_manager.settings_controller.settings.update_stream = "stable"
+    mock_get.return_value = MagicMock(
+        status_code=200,
+        json=MagicMock(return_value=MOCK_DOWNGRADE_RESPONSE),
+    )
+
 
 @pytest.fixture
 def mock_update_manager() -> UpdateManager:
@@ -182,9 +209,7 @@ def mock_update_manager() -> UpdateManager:
         mgr._system = "Linux"
         mgr._arch = "x86_64"
         mgr._cached_patterns = UpdateManager._platform_patterns.get("Linux")
-        # Mock QObject methods that aren't available without proper init
         mgr.tr = lambda s: s  # type: ignore[assignment,method-assign,misc]
-        # Mock _check_needs_elevation since it inspects filesystem paths
         mgr._check_needs_elevation = MagicMock(return_value=False)  # type: ignore[method-assign]
     return mgr
 
@@ -202,26 +227,7 @@ def test_downgrade_declined_returns_none(
     mock_update_manager: UpdateManager,
 ) -> None:
     """When user declines downgrade, no update is returned."""
-    mock_app_info.return_value.app_version = "2.0.0"
-    mock_update_manager.settings_controller.settings.update_stream = "stable"
-    mock_get.return_value = MagicMock(
-        status_code=200,
-        json=MagicMock(
-            return_value=[
-                {
-                    "tag_name": "v1.0.0",
-                    "prerelease": False,
-                    "draft": False,
-                    "assets": [
-                        {
-                            "name": "RimSort-v1.0.0-Linux_x86_64.tar.gz",
-                            "browser_download_url": "https://example.com/dl",
-                        }
-                    ],
-                },
-            ]
-        ),
-    )
+    _setup_downgrade_mocks(mock_get, mock_app_info, mock_update_manager)
     with patch.object(mock_update_manager, "_parse_current_version") as mock_parse:
         from packaging import version as pkg_version
 
@@ -243,26 +249,7 @@ def test_downgrade_accepted_returns_update_info(
     mock_update_manager: UpdateManager,
 ) -> None:
     """When user accepts downgrade, update info is returned."""
-    mock_app_info.return_value.app_version = "2.0.0"
-    mock_update_manager.settings_controller.settings.update_stream = "stable"
-    mock_get.return_value = MagicMock(
-        status_code=200,
-        json=MagicMock(
-            return_value=[
-                {
-                    "tag_name": "v1.0.0",
-                    "prerelease": False,
-                    "draft": False,
-                    "assets": [
-                        {
-                            "name": "RimSort-v1.0.0-Linux_x86_64.tar.gz",
-                            "browser_download_url": "https://example.com/dl",
-                        }
-                    ],
-                },
-            ]
-        ),
-    )
+    _setup_downgrade_mocks(mock_get, mock_app_info, mock_update_manager)
     with (
         patch.object(mock_update_manager, "_parse_current_version") as mock_parse,
         patch.object(mock_update_manager, "_prompt_user_for_update", return_value=True),

--- a/tests/utils/test_update_streams.py
+++ b/tests/utils/test_update_streams.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -10,7 +11,7 @@ from app.utils.update_utils import (
     filter_releases_by_stream,
 )
 
-MOCK_RELEASES = [
+MOCK_RELEASES: list[dict[str, Any]] = [
     {
         "tag_name": "Edge",
         "prerelease": True,
@@ -182,9 +183,9 @@ def mock_update_manager() -> UpdateManager:
         mgr._arch = "x86_64"
         mgr._cached_patterns = UpdateManager._platform_patterns.get("Linux")
         # Mock QObject methods that aren't available without proper init
-        mgr.tr = lambda s: s  # type: ignore[assignment]
+        mgr.tr = lambda s: s  # type: ignore[assignment,method-assign,misc]
         # Mock _check_needs_elevation since it inspects filesystem paths
-        mgr._check_needs_elevation = MagicMock(return_value=False)  # type: ignore[assignment]
+        mgr._check_needs_elevation = MagicMock(return_value=False)  # type: ignore[method-assign]
     return mgr
 
 

--- a/tests/utils/test_update_streams.py
+++ b/tests/utils/test_update_streams.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+from unittest.mock import MagicMock, patch
+
+import pytest
+
 from app.utils.update_utils import (
+    UpdateManager,
     extract_version_from_edge_release,
     filter_releases_by_stream,
 )
@@ -161,3 +166,109 @@ def test_extract_version_prefers_asset_over_body() -> None:
         "body": "Edge release v1.2.0-edge3.",
     }
     assert extract_version_from_edge_release(release) == "1.3.0.dev7"
+
+
+# --- Tests for UpdateManager downgrade handling ---
+
+
+@pytest.fixture
+def mock_update_manager() -> UpdateManager:
+    """Create an UpdateManager with mocked dependencies."""
+    with patch.object(UpdateManager, "__init__", lambda self, *a, **kw: None):
+        mgr = UpdateManager.__new__(UpdateManager)
+        mgr.settings_controller = MagicMock()
+        mgr.settings_controller.settings.update_stream = "stable"
+        mgr._system = "Linux"
+        mgr._arch = "x86_64"
+        mgr._cached_patterns = UpdateManager._platform_patterns.get("Linux")
+        # Mock QObject methods that aren't available without proper init
+        mgr.tr = lambda s: s  # type: ignore[assignment]
+        # Mock _check_needs_elevation since it inspects filesystem paths
+        mgr._check_needs_elevation = MagicMock(return_value=False)  # type: ignore[assignment]
+    return mgr
+
+
+@patch("app.utils.update_utils.AppInfo")
+@patch(
+    "app.utils.update_utils.dialogue.show_dialogue_conditional",
+    return_value="Wait",
+)
+@patch("app.utils.update_utils.http.get")
+def test_downgrade_declined_returns_none(
+    mock_get: MagicMock,
+    mock_dialogue: MagicMock,
+    mock_app_info: MagicMock,
+    mock_update_manager: UpdateManager,
+) -> None:
+    """When user declines downgrade, no update is returned."""
+    mock_app_info.return_value.app_version = "2.0.0"
+    mock_update_manager.settings_controller.settings.update_stream = "stable"
+    mock_get.return_value = MagicMock(
+        status_code=200,
+        json=MagicMock(
+            return_value=[
+                {
+                    "tag_name": "v1.0.0",
+                    "prerelease": False,
+                    "draft": False,
+                    "assets": [
+                        {
+                            "name": "RimSort-v1.0.0-Linux_x86_64.tar.gz",
+                            "browser_download_url": "https://example.com/dl",
+                        }
+                    ],
+                },
+            ]
+        ),
+    )
+    with patch.object(mock_update_manager, "_parse_current_version") as mock_parse:
+        from packaging import version as pkg_version
+
+        mock_parse.return_value = pkg_version.parse("2.0.0")
+        result = mock_update_manager._fetch_and_compare_versions()
+    assert result is None
+
+
+@patch("app.utils.update_utils.AppInfo")
+@patch(
+    "app.utils.update_utils.dialogue.show_dialogue_conditional",
+    return_value="Downgrade Now",
+)
+@patch("app.utils.update_utils.http.get")
+def test_downgrade_accepted_returns_update_info(
+    mock_get: MagicMock,
+    mock_dialogue: MagicMock,
+    mock_app_info: MagicMock,
+    mock_update_manager: UpdateManager,
+) -> None:
+    """When user accepts downgrade, update info is returned."""
+    mock_app_info.return_value.app_version = "2.0.0"
+    mock_update_manager.settings_controller.settings.update_stream = "stable"
+    mock_get.return_value = MagicMock(
+        status_code=200,
+        json=MagicMock(
+            return_value=[
+                {
+                    "tag_name": "v1.0.0",
+                    "prerelease": False,
+                    "draft": False,
+                    "assets": [
+                        {
+                            "name": "RimSort-v1.0.0-Linux_x86_64.tar.gz",
+                            "browser_download_url": "https://example.com/dl",
+                        }
+                    ],
+                },
+            ]
+        ),
+    )
+    with (
+        patch.object(mock_update_manager, "_parse_current_version") as mock_parse,
+        patch.object(mock_update_manager, "_prompt_user_for_update", return_value=True),
+    ):
+        from packaging import version as pkg_version
+
+        mock_parse.return_value = pkg_version.parse("2.0.0")
+        result = mock_update_manager._fetch_and_compare_versions()
+    assert result is not None
+    assert result["download_url"] == "https://example.com/dl"

--- a/tests/utils/test_update_streams.py
+++ b/tests/utils/test_update_streams.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from app.utils.update_utils import (
+    extract_version_from_edge_release,
+    filter_releases_by_stream,
+)
+
+MOCK_RELEASES = [
+    {
+        "tag_name": "Edge",
+        "prerelease": True,
+        "draft": False,
+        "assets": [
+            {
+                "name": "RimSort-v1.3.0-edge7-Linux.tar.gz",
+                "browser_download_url": "https://example.com/edge.tar.gz",
+            }
+        ],
+    },
+    {
+        "tag_name": "v1.2.4-beta2",
+        "prerelease": True,
+        "draft": False,
+        "assets": [
+            {
+                "name": "RimSort-v1.2.4-beta2-Linux.tar.gz",
+                "browser_download_url": "https://example.com/beta2.tar.gz",
+            }
+        ],
+    },
+    {
+        "tag_name": "v1.2.4-beta1",
+        "prerelease": True,
+        "draft": False,
+        "assets": [
+            {
+                "name": "RimSort-v1.2.4-beta1-Linux.tar.gz",
+                "browser_download_url": "https://example.com/beta1.tar.gz",
+            }
+        ],
+    },
+    {
+        "tag_name": "v1.2.3",
+        "prerelease": False,
+        "draft": False,
+        "assets": [
+            {
+                "name": "RimSort-v1.2.3-Linux.tar.gz",
+                "browser_download_url": "https://example.com/stable.tar.gz",
+            }
+        ],
+    },
+    {
+        "tag_name": "v1.2.2",
+        "prerelease": False,
+        "draft": False,
+        "assets": [
+            {
+                "name": "RimSort-v1.2.2-Linux.tar.gz",
+                "browser_download_url": "https://example.com/old.tar.gz",
+            }
+        ],
+    },
+]
+
+
+def test_stable_stream_returns_first_non_prerelease() -> None:
+    result = filter_releases_by_stream(MOCK_RELEASES, "stable")
+    assert result is not None
+    assert result["tag_name"] == "v1.2.3"
+
+
+def test_beta_stream_returns_first_beta_tag() -> None:
+    result = filter_releases_by_stream(MOCK_RELEASES, "beta")
+    assert result is not None
+    assert result["tag_name"] == "v1.2.4-beta2"
+
+
+def test_edge_stream_returns_edge_tag() -> None:
+    result = filter_releases_by_stream(MOCK_RELEASES, "edge")
+    assert result is not None
+    assert result["tag_name"] == "Edge"
+
+
+def test_beta_falls_back_to_stable_when_no_betas() -> None:
+    releases_no_beta = [r for r in MOCK_RELEASES if "-beta" not in r["tag_name"]]
+    result = filter_releases_by_stream(releases_no_beta, "beta")
+    assert result is not None
+    assert result["tag_name"] == "v1.2.3"
+
+
+def test_edge_falls_back_to_beta_then_stable() -> None:
+    releases_no_edge = [r for r in MOCK_RELEASES if r["tag_name"] != "Edge"]
+    result = filter_releases_by_stream(releases_no_edge, "edge")
+    assert result is not None
+    assert result["tag_name"] == "v1.2.4-beta2"
+
+
+def test_edge_falls_back_to_stable_when_no_edge_or_beta() -> None:
+    releases_stable_only = [r for r in MOCK_RELEASES if not r["prerelease"]]
+    result = filter_releases_by_stream(releases_stable_only, "edge")
+    assert result is not None
+    assert result["tag_name"] == "v1.2.3"
+
+
+def test_returns_none_for_empty_releases() -> None:
+    result = filter_releases_by_stream([], "stable")
+    assert result is None
+
+
+def test_skips_draft_releases() -> None:
+    releases_with_draft = [
+        {"tag_name": "v2.0.0", "prerelease": False, "draft": True, "assets": []},
+    ] + MOCK_RELEASES
+    result = filter_releases_by_stream(releases_with_draft, "stable")
+    assert result is not None
+    assert result["tag_name"] == "v1.2.3"
+
+
+def test_unknown_stream_defaults_to_stable() -> None:
+    result = filter_releases_by_stream(MOCK_RELEASES, "unknown")
+    assert result is not None
+    assert result["tag_name"] == "v1.2.3"
+
+
+# --- Tests for extract_version_from_edge_release ---
+
+
+def test_extract_version_from_edge_asset_name() -> None:
+    release = {
+        "assets": [{"name": "RimSort-v1.3.0-edge7-Linux_x86_64.tar.gz"}],
+        "body": "",
+    }
+    assert extract_version_from_edge_release(release) == "1.3.0.dev7"
+
+
+def test_extract_version_from_edge_asset_with_commit_suffix() -> None:
+    release = {
+        "assets": [{"name": "RimSort-v1.3.0-edge7+abc1234-Linux_x86_64.tar.gz"}],
+        "body": "",
+    }
+    assert extract_version_from_edge_release(release) == "1.3.0.dev7"
+
+
+def test_extract_version_from_edge_body_fallback() -> None:
+    release = {
+        "assets": [{"name": "some-unrelated-file.zip"}],
+        "body": "Edge release v1.3.0-edge7.\nThe latest commit is abc1234.",
+    }
+    assert extract_version_from_edge_release(release) == "1.3.0.dev7"
+
+
+def test_extract_version_returns_0_0_0_when_no_match() -> None:
+    release = {"assets": [{"name": "unknown.zip"}], "body": "No version here."}
+    assert extract_version_from_edge_release(release) == "0.0.0"
+
+
+def test_extract_version_prefers_asset_over_body() -> None:
+    release = {
+        "assets": [{"name": "RimSort-v1.3.0-edge7-Linux.tar.gz"}],
+        "body": "Edge release v1.2.0-edge3.",
+    }
+    assert extract_version_from_edge_release(release) == "1.3.0.dev7"


### PR DESCRIPTION
## Summary

- Adds opt-in update streams (Stable / Beta / Edge) so users can choose their update cadence and risk tolerance
- Switches edge builds from push-triggered to a 12-hour scheduled cron, skipping builds when there are no new commits
- Adds Beta release type to CI workflows for manually dispatched release candidates
- Update checker now queries `/releases` (instead of `/releases/latest`) and filters by the user's selected stream, with fallback chain: edge → beta → stable
- Downgrade handling: when switching to a less-bleeding-edge stream, prompts the user before installing an older version
- Version badge (`[BETA]` / `[EDGE]`) displayed next to the game version at the bottom of the main window

## Changes

| Area | Files | What |
|------|-------|------|
| Settings model | `app/models/settings.py` | `update_stream: str = "stable"` |
| Settings UI | `settings_dialog.py`, `advanced_tab_controller.py` | Update Channel dropdown in Advanced tab with escalation warning |
| Update checker | `app/utils/update_utils.py` | `filter_releases_by_stream()`, `extract_version_from_edge_release()` (normalizes `-edge` → `.dev` for PEP 440), stream-aware release lookup, downgrade dialog |
| Version display | `main_window.py`, `main_window_controller.py` | RimSort version label with stream badge |
| CI - Edge | `auto_build.yml` | 12h cron schedule, `check-edge-needed` job, schedule-aware change detection |
| CI - Beta | `get_version_info.yml`, `release.yml` | Beta version format, release type option |
| Tests | `tests/utils/test_update_streams.py` | 16 tests: stream filtering, edge version extraction, downgrade outcomes |

## Design spec

`docs/superpowers/specs/2026-06-13-update-streams-design.md`

## Test plan

- [x] 1070 tests passing (16 new)
- [x] ruff lint clean
- [x] ruff format clean
- [x] mypy clean
- [x] Manual UI verification: dropdown appears in Advanced tab, escalation warnings show/revert correctly, version badge updates live
- [ ] Verify edge cron schedule fires correctly (requires merge to main)
- [ ] Test Beta release dispatch via workflow_dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)