### PR TITLE
fix(metadata): don't crash on startup when local mods folder is unset

### DIFF
--- a/app/models/metadata/metadata_factory.py
+++ b/app/models/metadata/metadata_factory.py
@@ -362,7 +362,7 @@ def _parse_optional(
 
 
 def _set_mod_type(
-    mod: ListedMod, local_path: Path, rimworld_path: Path, workshop_path: Path | None
+    mod: ListedMod, local_path: Path | None, rimworld_path: Path, workshop_path: Path | None
 ) -> ListedMod:
     """
     Set the mod type based on the paths given.
@@ -715,7 +715,7 @@ def create_rules_from_external_rules(external_rule: ExternalRule) -> Rules:
 def create_listed_mod_from_path(
     path: Path,
     target_version: str,
-    local_path: Path,
+    local_path: Path | None,
     rimworld_path: Path,
     workshop_path: Path | None,
     prefer_versioned: bool = True,

--- a/app/models/metadata/metadata_factory.py
+++ b/app/models/metadata/metadata_factory.py
@@ -362,7 +362,10 @@ def _parse_optional(
 
 
 def _set_mod_type(
-    mod: ListedMod, local_path: Path | None, rimworld_path: Path, workshop_path: Path | None
+    mod: ListedMod,
+    local_path: Path | None,
+    rimworld_path: Path,
+    workshop_path: Path | None,
 ) -> ListedMod:
     """
     Set the mod type based on the paths given.

--- a/app/models/metadata/metadata_mediator.py
+++ b/app/models/metadata/metadata_mediator.py
@@ -152,11 +152,10 @@ class MetadataMediator:
             ByVersion keys are ignored and only base values are used.
         """
 
-        for path in {self.local_mods_path, self.game_path}:
-            if path is None or not path.exists() or not path.is_dir():
-                raise ValueError(
-                    "Essential paths are missing, invalid, or not directories"
-                )
+        if self.game_path is None or not self.game_path.exists() or not self.game_path.is_dir():
+            raise ValueError(
+                "Game path is missing, invalid, or not a directory"
+            )
 
         self._refresh_game_version()
 
@@ -202,7 +201,6 @@ class MetadataMediator:
             mod_paths[i : i + batch_size] for i in range(0, len(mod_paths), batch_size)
         ]
 
-        assert self.local_mods_path is not None
         assert self.game_path is not None
 
         metadata_mutex = QMutex()
@@ -265,7 +263,7 @@ class MetadataMediator:
             self,
             mod_path: Path | str | list[Path] | list[str],
             target_version: str,
-            local_path: Path,
+            local_path: Path | None,
             rimworld_path: Path,
             workshop_path: Path | None,
             user_rules: ExternalRulesSchema | None,

--- a/app/models/metadata/metadata_mediator.py
+++ b/app/models/metadata/metadata_mediator.py
@@ -152,10 +152,12 @@ class MetadataMediator:
             ByVersion keys are ignored and only base values are used.
         """
 
-        if self.game_path is None or not self.game_path.exists() or not self.game_path.is_dir():
-            raise ValueError(
-                "Game path is missing, invalid, or not a directory"
-            )
+        if (
+            self.game_path is None
+            or not self.game_path.exists()
+            or not self.game_path.is_dir()
+        ):
+            raise ValueError("Game path is missing, invalid, or not a directory")
 
         self._refresh_game_version()
 


### PR DESCRIPTION
## Summary

- Fixes fatal `ValueError: Essential paths are missing, invalid, or not directories` crash on startup when the local mods folder path is not configured
- The UI guard (`check_if_essential_paths_are_set`) only validates `game_folder` + `config_folder`, but `MetadataMediator.refresh_metadata` also required `local_mods_path` — which defaults to `""` in the Instance model and becomes `None` after path conversion
- Makes `local_mods_path` optional throughout the metadata pipeline (`MetadataMediator`, `_ParserWorker`, `create_listed_mod_from_path`, `_set_mod_type`) since it is not truly essential — the mod search loop already skipped `None` paths, and the type classification comparison handles `None` safely

## Test plan

- [x] `just typecheck` — 0 issues
- [x] `just pyright` — 0 errors
- [x] `just test` — 1054 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)