### PR TITLE
fix(macos): discover .app bundle name instead of hardcoding it

### DIFF
--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -686,9 +686,7 @@ class SettingsController(QObject):
                 game_folder = self._find_mac_app_bundle(Path(game_folder_str))
                 logger.debug(f"VDF parsing found RimWorld at: {game_folder}")
             else:
-                fallback = (
-                    steam_root / "steamapps" / "common" / "RimWorld"
-                )
+                fallback = steam_root / "steamapps" / "common" / "RimWorld"
                 game_folder = self._find_mac_app_bundle(fallback)
                 logger.debug(
                     f"VDF parsing did not find RimWorld, using fallback: {game_folder}"

--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -683,12 +683,13 @@ class SettingsController(QObject):
         if steam_root:
             game_folder_str = find_steam_rimworld(steam_root)
             if game_folder_str:
-                game_folder = Path(game_folder_str) / "RimworldMac.app"
+                game_folder = self._find_mac_app_bundle(Path(game_folder_str))
                 logger.debug(f"VDF parsing found RimWorld at: {game_folder}")
             else:
-                game_folder = (
-                    steam_root / "steamapps" / "common" / "Rimworld" / "RimworldMac.app"
+                fallback = (
+                    steam_root / "steamapps" / "common" / "RimWorld"
                 )
+                game_folder = self._find_mac_app_bundle(fallback)
                 logger.debug(
                     f"VDF parsing did not find RimWorld, using fallback: {game_folder}"
                 )
@@ -705,16 +706,16 @@ class SettingsController(QObject):
                     Path(steam_mods_folder_str) / "workshop" / "content" / "294100"
                 )
         else:
-            game_folder = (
+            fallback = (
                 user_home
                 / "Library"
                 / "Application Support"
                 / "Steam"
                 / "steamapps"
                 / "common"
-                / "Rimworld"
-                / "RimworldMac.app"
+                / "RimWorld"
             )
+            game_folder = self._find_mac_app_bundle(fallback)
             steam_mods_folder = (
                 user_home
                 / "Library"
@@ -731,6 +732,19 @@ class SettingsController(QObject):
         )
 
         return game_folder, config_folder, steam_mods_folder
+
+    @staticmethod
+    def _find_mac_app_bundle(rimworld_dir: Path) -> Path:
+        """Find the .app bundle in a RimWorld directory.
+
+        Discovers the actual filesystem-cased name instead of hardcoding it,
+        since macOS is case-insensitive but path comparisons are case-sensitive.
+        """
+        if rimworld_dir.is_dir():
+            apps = list(rimworld_dir.glob("*.app"))
+            if apps:
+                return apps[0]
+        return rimworld_dir / "RimWorldMac.app"
 
     def __get_linux_paths(self) -> tuple[Path, Path, Path]:
         """

--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -686,10 +686,10 @@ class SettingsController(QObject):
                 game_folder = self._find_mac_app_bundle(Path(game_folder_str))
                 logger.debug(f"VDF parsing found RimWorld at: {game_folder}")
             else:
-                fallback = steam_root / "steamapps" / "common" / "RimWorld"
-                game_folder = self._find_mac_app_bundle(fallback)
+                fallback_game_folder = steam_root / "steamapps" / "common" / "RimWorld"
+                game_folder = self._find_mac_app_bundle(fallback_game_folder)
                 logger.debug(
-                    f"VDF parsing did not find RimWorld, using fallback: {game_folder}"
+                    f"VDF parsing did not find RimWorld, using fallback_game_folder: {game_folder}"
                 )
 
             steam_mods_folder_str = get_path_up_to_string(
@@ -704,7 +704,7 @@ class SettingsController(QObject):
                     Path(steam_mods_folder_str) / "workshop" / "content" / "294100"
                 )
         else:
-            fallback = (
+            fallback_game_folder = (
                 user_home
                 / "Library"
                 / "Application Support"
@@ -713,7 +713,7 @@ class SettingsController(QObject):
                 / "common"
                 / "RimWorld"
             )
-            game_folder = self._find_mac_app_bundle(fallback)
+            game_folder = self._find_mac_app_bundle(fallback_game_folder)
             steam_mods_folder = (
                 user_home
                 / "Library"

--- a/tests/controllers/test_path_autodetection.py
+++ b/tests/controllers/test_path_autodetection.py
@@ -263,9 +263,9 @@ class TestGetDarwinPaths:
         with patch("pathlib.Path.home", return_value=tmp_path):
             result = self._call(_make_controller())
 
-        # Fallback uses "Rimworld" (lowercase w) — matches existing behavior
+        # Fallback uses canonical "RimWorld" casing when no .app bundle found on disk
         expected_game = (
-            steam_root / "steamapps" / "common" / "Rimworld" / "RimworldMac.app"
+            steam_root / "steamapps" / "common" / "RimWorld" / "RimWorldMac.app"
         )
         assert result[0] == expected_game
 
@@ -292,7 +292,7 @@ class TestGetDarwinPaths:
         with patch("pathlib.Path.home", return_value=tmp_path):
             result = self._call(_make_controller())
 
-        assert "RimworldMac.app" in str(result[0])
+        assert "RimWorldMac.app" in str(result[0])
         assert "Config" in str(result[1])
         assert "294100" in str(result[2])
 


### PR DESCRIPTION
## Summary
- macOS autodetect hardcoded `RimworldMac.app` (lowercase `w`) but the actual filesystem name is `RimWorldMac.app` (capital `W`)
- Since macOS/APFS is case-insensitive, file operations worked fine, but string-based path comparisons (e.g. in the watchdog file monitor's `resolve_data_source`) failed silently — watchdog couldn't detect mod additions/deletions
- Now globs for `*.app` in the RimWorld directory to discover the actual bundle name, falling back to `RimWorldMac.app` if the directory doesn't exist yet

## Test plan
- [x] On macOS, clear settings and run autodetect — verify the game folder path uses the correct `.app` casing
- [x] With watchdog enabled, copy a mod folder into the local mods directory — verify it appears in the inactive list automatically
- [x] Delete that mod folder externally — verify it disappears from the list automatically
- [x] Existing tests updated to expect canonical casing

🤖 Generated with [Claude Code](https://claude.com/claude-code)