### PR TITLE
Add ability to sort inactive mods by the date they were updated on the Steam Workshop

### DIFF
--- a/app/sort/mod_sorting.py
+++ b/app/sort/mod_sorting.py
@@ -287,7 +287,7 @@ def uuid_to_mod_updated(
     else:
         metadata = get_mod_metadata(uuid)
 
-    return metadata.get("internal_time_updated") if metadata else None
+    return metadata.get("internal_time_updated") if metadata else 0
 
 
 def get_dir_size(path: str) -> int:

--- a/app/sort/mod_sorting.py
+++ b/app/sort/mod_sorting.py
@@ -287,7 +287,7 @@ def uuid_to_mod_updated(
     else:
         metadata = get_mod_metadata(uuid)
 
-    return metadata.get("internal_time_updated") if metadata else 0
+    return metadata.get("internal_time_updated", 0) if metadata else 0
 
 
 def get_dir_size(path: str) -> int:

--- a/app/sort/mod_sorting.py
+++ b/app/sort/mod_sorting.py
@@ -266,6 +266,30 @@ def uuid_to_mod_tags(
     return ", ".join(sorted(tag.lower() for tag in tags))
 
 
+def uuid_to_mod_updated(
+    uuid: str,
+    cached_metadata: Optional[dict[str, Any]] = None,
+) -> int:
+    """
+    Get time a mod was updated on the Steam Workshop for inactive mods list sorting.
+
+    Returns the update timestamp as int if available, otherwise 0.
+
+    Args:
+        uuid: The UUID of the mod
+        cached_metadata: Optional pre-cached metadata dict to avoid repeated lookups
+
+    Returns:
+        Update timestamp as int, or 0 if not available
+    """
+    if cached_metadata is not None:
+        metadata = cached_metadata.get(uuid)
+    else:
+        metadata = get_mod_metadata(uuid)
+
+    return metadata.get("internal_time_updated") if metadata else None
+
+
 def get_dir_size(path: str) -> int:
     total = 0
     stack = [path]
@@ -398,6 +422,8 @@ def _build_sort_key_map(
             sort_key_map[uuid] = uuid_to_mod_tags(
                 uuid, cached_metadata, settings_controller
             )
+        elif key == ModsPanelSortKey.MOD_UPDATED:
+            sort_key_map[uuid] = uuid_to_mod_updated(uuid, cached_metadata)
         else:
             sort_key_map[uuid] = uuid
     return sort_key_map
@@ -417,6 +443,7 @@ class ModsPanelSortKey(Enum):
     VERSION = 6
     MOD_COLOR = 7
     MOD_TAGS = 8
+    MOD_UPDATED = 9
 
 
 # Lookup dictionary for default sort direction flags
@@ -431,6 +458,7 @@ DEFAULT_REVERSE_FLAGS = {
     ModsPanelSortKey.VERSION: False,
     ModsPanelSortKey.MOD_COLOR: False,
     ModsPanelSortKey.MOD_TAGS: False,
+    ModsPanelSortKey.MOD_UPDATED: False,
 }
 
 
@@ -453,7 +481,7 @@ def sort_uuids(
     Args:
         uuids: List of mod UUIDs to sort
         key: ModsPanelSortKey enum specifying the sort attribute
-             (MODNAME, FILESYSTEM_MODIFIED_TIME, AUTHOR, FOLDER_SIZE, PACKAGEID, VERSION, MOD_COLOR)
+             (MODNAME, FILESYSTEM_MODIFIED_TIME, AUTHOR, FOLDER_SIZE, PACKAGEID, VERSION, MOD_COLOR, MOD_UPDATED)
         descending: Optional bool to override default sort direction.
                    If None, uses DEFAULT_REVERSE_FLAGS. If True/False, sorts descending/ascending.
         cached_metadata: Optional pre-cached metadata dict to avoid repeated lookups.

--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -999,6 +999,7 @@ class ModListWidget(QListWidget):
         "PackageId": ModsPanelSortKey.PACKAGEID,
         "Color": ModsPanelSortKey.MOD_COLOR,
         "Tags": ModsPanelSortKey.MOD_TAGS,
+        "Mod Updated": ModsPanelSortKey.MOD_UPDATED,
     }
 
     @staticmethod
@@ -3854,6 +3855,7 @@ class ModsPanel(QWidget):
         "PackageId": ModsPanelSortKey.PACKAGEID,
         "Color": ModsPanelSortKey.MOD_COLOR,
         "Tags": ModsPanelSortKey.MOD_TAGS,
+        "Mod Updated": ModsPanelSortKey.MOD_UPDATED,
     }
 
     # Note: combobox items store their corresponding `ModsPanelSortKey` in
@@ -4230,6 +4232,9 @@ class ModsPanel(QWidget):
         )
         self.inactive_mods_sort_combobox.addItem(
             self.tr("Tags"), ModsPanelSortKey.MOD_TAGS
+        )
+        self.inactive_mods_sort_combobox.addItem(
+            self.tr("Mod Updated"), ModsPanelSortKey.MOD_UPDATED
         )
         # Set initial combo box selection based on loaded settings by matching
         # the stored enum name to the item userData. Fall back to

--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -999,7 +999,7 @@ class ModListWidget(QListWidget):
         "PackageId": ModsPanelSortKey.PACKAGEID,
         "Color": ModsPanelSortKey.MOD_COLOR,
         "Tags": ModsPanelSortKey.MOD_TAGS,
-        "Mod Updated": ModsPanelSortKey.MOD_UPDATED,
+        "Workshop Updated": ModsPanelSortKey.MOD_UPDATED,
     }
 
     @staticmethod
@@ -3855,7 +3855,7 @@ class ModsPanel(QWidget):
         "PackageId": ModsPanelSortKey.PACKAGEID,
         "Color": ModsPanelSortKey.MOD_COLOR,
         "Tags": ModsPanelSortKey.MOD_TAGS,
-        "Mod Updated": ModsPanelSortKey.MOD_UPDATED,
+        "Workshop Updated": ModsPanelSortKey.MOD_UPDATED,
     }
 
     # Note: combobox items store their corresponding `ModsPanelSortKey` in
@@ -4234,7 +4234,7 @@ class ModsPanel(QWidget):
             self.tr("Tags"), ModsPanelSortKey.MOD_TAGS
         )
         self.inactive_mods_sort_combobox.addItem(
-            self.tr("Mod Updated"), ModsPanelSortKey.MOD_UPDATED
+            self.tr("Workshop Updated"), ModsPanelSortKey.MOD_UPDATED
         )
         # Set initial combo box selection based on loaded settings by matching
         # the stored enum name to the item userData. Fall back to


### PR DESCRIPTION
Add ability to sort inactive mods by the date they were updated on the Steam Workshop

Closes #2153 