### PR TITLE
Add local mods validation and improve path checks

### DIFF
--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -112,6 +112,7 @@ class SettingsController(QObject):
             self.settings_dialog,
             validate_game_location=self._validate_game_location,
             validate_config_folder_location=self._validate_config_folder_location,
+            validate_local_mods_location=self._validate_local_mods_location,
             on_path_selected=self._on_locations_path_selected,
             on_autodetect=self._on_locations_autodetect_button_clicked,
             on_instance_folder_choose=self._on_instance_folder_location_choose_button_clicked,
@@ -389,19 +390,24 @@ class SettingsController(QObject):
         """Update the last selected path for file dialog default directories."""
         self._last_file_dialog_path = path
 
-    def _validate_game_location(self, game_location: str) -> bool:
+    def _validate_game_location(self, game_folder: str) -> bool:
         """
         Validate the game location and show a warning if invalid.
 
-        :param game_location: Path to the game folder as a string.
+        :param game_folder: Path to the game folder as a string.
         :return: True if valid, False otherwise.
         """
-        if not validate_game_executable(game_location):
+        if not validate_game_executable(game_folder):
             QMessageBox.information(
                 self.settings_dialog,
                 self.tr("Invalid Game Location"),
                 self.tr(
-                    "The selected game folder does not contain a valid RimWorld executable. Please select a valid game location."
+                    "The selected game folder does not contain a valid RimWorld executable.<br><br>"
+                    "Please select a valid game location.<br><br>"
+                    "Windows: RimWorldWin64.exe or RimWorldWin.exe<br><br>"
+                    "Mac: RimworldMac.app<br><br>"
+                    "Linux: RimWorldLinux<br><br>"
+                    "RimWorldWin64.exe or RimWorldWin.exe if you using windows version of the game on Linux"
                 ),
             )
             return False
@@ -419,7 +425,36 @@ class SettingsController(QObject):
                 self.settings_dialog,
                 self.tr("Invalid Config Folder"),
                 self.tr(
-                    "The selected config folder does not contain ModsConfig.xml. Please select a valid config folder."
+                    "The selected config folder does not contain ModsConfig.xml.<br><br>"
+                    "Please select a valid config folder.<br><br>"
+                    "If you have not launched the game before,<br><br>"
+                    "Please launch the game at least once to generate the necessary config files."
+                ),
+            )
+            return False
+        return True
+
+    def _validate_local_mods_location(self, local_folder: str) -> bool:
+        """
+        Validate the local mods folder location and show a warning if invalid.
+        The local mods folder is valid if it is a directory.
+
+        :param local_folder: Path to the local mods folder as a string.
+        :return: True if valid, False otherwise.
+        """
+        game_folder = self.settings.instances[
+            self.settings.current_instance
+        ].game_folder
+        if not (Path(local_folder).is_dir()) or local_folder != str(
+            Path(game_folder) / "Mods"
+        ):
+            QMessageBox.warning(
+                self.settings_dialog,
+                self.tr("Invalid Local Mods Folder"),
+                self.tr(
+                    "The selected local mods folder location is not a valid directory.<br><br>"
+                    "Please select a valid folder for local mods.<br><br>"
+                    "The local mods folder should be a 'Mods' subfolder within the game folder."
                 ),
             )
             return False
@@ -532,6 +567,9 @@ class SettingsController(QObject):
         """
         Close the settings dialog, update the model from the view, and save the settings.
         """
+        # Update the model from the view before saving to ensure validation checks have the latest data
+        self._update_model_from_view()
+
         # Validate game folder if set
         game_folder_text = self.settings_dialog.game_location.text().strip()
         if game_folder_text and not self._validate_game_location(game_folder_text):
@@ -544,14 +582,23 @@ class SettingsController(QObject):
         ):
             return
 
+        # Validate local mods folder if set
+        local_mods_folder_text = (
+            self.settings_dialog.local_mods_folder_location.text().strip()
+        )
+        if local_mods_folder_text and not self._validate_local_mods_location(
+            local_mods_folder_text
+        ):
+            return
+
         # Validate Steam integration if enabled
         if self.settings_dialog.steam_client_integration_checkbox.isChecked():
             if not self._validate_steam_integration():
                 return
 
-        self.settings_dialog.close()
-        self._update_model_from_view()
+        # If all validations pass, save settings and close dialog
         self.settings.save()
+        self.settings_dialog.close()
         self.theme_controller.set_font(
             self.settings.font_family,
             self.settings.font_size,

--- a/app/controllers/settings_tabs/locations_tab_controller.py
+++ b/app/controllers/settings_tabs/locations_tab_controller.py
@@ -71,6 +71,7 @@ class LocationsTabController(BaseTabController):
         dialog: SettingsDialog,
         validate_game_location: Callable[[str], bool],
         validate_config_folder_location: Callable[[str], bool],
+        validate_local_mods_location: Callable[[str], bool],
         on_path_selected: Callable[[str], None],
         on_autodetect: Callable[[], None],
         on_instance_folder_choose: Callable[[], None],
@@ -79,6 +80,7 @@ class LocationsTabController(BaseTabController):
         super().__init__(settings, dialog)
         self._validate_game_location = validate_game_location
         self._validate_config_folder_location = validate_config_folder_location
+        self._validate_local_mods_location = validate_local_mods_location
         self._path_selected_callback = on_path_selected
         self._on_autodetect_callback = on_autodetect
         self._on_instance_folder_choose_callback = on_instance_folder_choose
@@ -210,6 +212,7 @@ class LocationsTabController(BaseTabController):
         )
         if not steam_mods_folder:
             return None
+
         self._path_selected_callback(str(Path(steam_mods_folder).parent))
         return steam_mods_folder
 
@@ -220,6 +223,10 @@ class LocationsTabController(BaseTabController):
         )
         if not local_mods_folder:
             return None
+
+        if not self._validate_local_mods_location(local_mods_folder):
+            return None
+
         self._path_selected_callback(str(Path(local_mods_folder).parent))
         return local_mods_folder
 

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -346,13 +346,19 @@ class MainContent(QObject):
         config_folder_path = self.settings_controller.settings.instances[
             current_instance
         ].config_folder
-        logger.debug(f"Game folder: {game_folder_path}")
-        logger.debug(f"Config folder: {config_folder_path}")
+        local_mods_folder_path = self.settings_controller.settings.instances[
+            current_instance
+        ].local_folder
+        logger.info(f"Game folder: {game_folder_path}")
+        logger.info(f"Config folder: {config_folder_path}")
+        logger.info(f"Local mods folder: {local_mods_folder_path}")
         if (
             game_folder_path
             and config_folder_path
+            and local_mods_folder_path
             and os.path.exists(game_folder_path)
             and os.path.exists(config_folder_path)
+            and os.path.exists(local_mods_folder_path)
         ):
             logger.info("Essential paths set!")
             return True
@@ -360,13 +366,16 @@ class MainContent(QObject):
             logger.warning("Essential path(s) are invalid or not set!")
             answer = dialogue.show_dialogue_conditional(
                 title=self.tr("Essential path(s)"),
-                text=self.tr("Essential path(s) are invalid or not set!\n"),
+                text=self.tr("Essential path(s) are invalid or not set!"),
                 information=(
                     self.tr(
-                        "RimSort requires, at the minimum, for the game install folder and the "
-                        "config folder paths to be set, and that the paths both exist. Please set "
-                        "both of these manually or by using the autodetect functionality.\n\n"
-                        "Would you like to configure them now?"
+                        "RimSort requires the below paths to be set.<br/><br/>"
+                        "1) Game folder (Folder where RimWorld is installed).<br/><br/>"
+                        "2) Config folder (Folder where ModsConfig.xml is located)<br/><br/>"
+                        "3) Local mods folder (Mods folder inside the RimWorld installation).<br/><br/>"
+                        "4) Steam mods folder (Only set if you use Steam user also enable Steam Client Integration)<br/><br/>"
+                        "Try Using the autodetect functionality to set all paths automatically.<br/><br/>"
+                        "Would you like to open the settings to configure them now?"
                     )
                 ),
             )


### PR DESCRIPTION
Introduce validation for the local mods folder and wire it into the settings UI and autodetect flows.

1. Added _validate_local_mods_location to SettingsController and passed it into LocationsTabController so selected local mods paths are checked and rejected if invalid.
2. Improve validation UX by updating the model from the view before running validations, refining the game/config validation messages with more detailed guidance, and requiring the local mods folder to exist.
3. MainContent now logs and verifies the local mods path and the settings warning text was expanded to list required paths and recommend using autodetect.
4. Also adjusted save/close ordering to ensure settings are saved only after successful validation.