### PR TITLE
fix: restore shell=True for Windows game launch (#2166)

### DIFF
--- a/app/utils/generic.py
+++ b/app/utils/generic.py
@@ -444,6 +444,7 @@ def launch_process(
             p = subprocess.Popen(
                 popen_args,
                 creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,
+                shell=True,
                 cwd=cwd,
                 env=env,
             )


### PR DESCRIPTION
## Summary

- Restores `shell=True` on the Windows `subprocess.Popen` call in `launch_process()`, reverting the game-launch portion of PR #1839

## Root Cause

PR #1839 removed `shell=True` to harden against command injection. However, all inputs to `launch_process()` (executable path, args, wrapper commands) are user-configured local settings — there is no untrusted external input, so the injection risk doesn't apply.

The removal broke game launch for Windows users whose RimWorld executable requires UAC elevation: `CreateProcessW` (used without `shell=True`) cannot trigger elevation and fails with `WinError 740`. With `shell=True`, `cmd.exe` delegates to `ShellExecuteEx` which handles UAC prompts transparently.

The other two changes from PR #1839 (MSI installer list args, tempfile hardening) were legitimate and are not affected.

## Test plan

- [x] All 1054 existing tests pass
- [x] Lint (`just ruff-fix`) clean
- [ ] Verify game launch works on Windows without elevation requirement
- [ ] Verify game launch works on Windows with elevation requirement (user from #2166)

Closes #2166

🤖 Generated with [Claude Code](https://claude.com/claude-code)