### PR TITLE
Replace \n with <br> in dialogue strings for RichText rendering

### DIFF
--- a/app/controllers/file_search_controller.py
+++ b/app/controllers/file_search_controller.py
@@ -1037,7 +1037,7 @@ class FileSearchController(QObject):
                     "There was an error with your regular expression pattern."
                 ),
                 information=self.tr(
-                    "{error_msg}\n\nTry simplifying your pattern or check for syntax errors."
+                    "{error_msg}<br><br>Try simplifying your pattern or check for syntax errors."
                 ).format(error_msg=error_msg),
             )
         elif "permission" in error_msg.lower() or "access" in error_msg.lower():
@@ -1045,7 +1045,7 @@ class FileSearchController(QObject):
                 title=self.tr("File Access Error"),
                 text=self.tr("RimSort doesn't have permission to access some files."),
                 information=self.tr(
-                    "{error_msg}\n\nTry running RimSort with administrator privileges or check folder permissions."
+                    "{error_msg}<br><br>Try running RimSort with administrator privileges or check folder permissions."
                 ).format(error_msg=error_msg),
             )
         elif "memory" in error_msg.lower():
@@ -1053,7 +1053,7 @@ class FileSearchController(QObject):
                 title=self.tr("Memory Error"),
                 text=self.tr("RimSort ran out of memory while searching."),
                 information=self.tr(
-                    "{error_msg}\n\nTry searching in smaller batches or use the 'streaming search' method for very large files."
+                    "{error_msg}<br><br>Try searching in smaller batches or use the 'streaming search' method for very large files."
                 ).format(error_msg=error_msg),
             )
         else:
@@ -1061,7 +1061,7 @@ class FileSearchController(QObject):
                 title=self.tr("Search Error"),
                 text=self.tr("An error occurred during the search."),
                 information=self.tr(
-                    "{error_msg}\n\nPlease check your settings and try again."
+                    "{error_msg}<br><br>Please check your settings and try again."
                 ).format(error_msg=error_msg),
             )
 

--- a/app/controllers/main_content_controller.py
+++ b/app/controllers/main_content_controller.py
@@ -297,10 +297,10 @@ class MainContentController(QObject):
         refresh_now = show_dialogue_conditional(
             title=self.tr("GitHub Auto-Update Complete"),
             text=self.tr(
-                "{count} mod(s) were auto-updated.\n\n{summary}\n\n"
+                "{count} mod(s) were auto-updated.<br><br>{summary}<br><br>"
                 "The updated versions won't appear until you refresh. "
                 "Refresh now?"
-            ).format(count=len(succeeded), summary="\n".join(summary_parts)),
+            ).format(count=len(succeeded), summary="<br>".join(summary_parts)),
         )
         if refresh_now:
             EventBus().do_refresh_mods_lists.emit()
@@ -410,12 +410,12 @@ class MainContentController(QObject):
         logger.debug(f"Found {len(updates)} repositories with updates.")
 
         if results.errors:
-            msg = "\n".join(f"{path}: {err}" for path, err in results.errors.items())
+            msg = "<br>".join(f"{path}: {err}" for path, err in results.errors.items())
             InformationBox(
                 title=self.tr("Errors during update check"),
                 text=self.tr("Some repositories encountered errors."),
                 information=self.tr(
-                    "Errors occurred while checking for updates:\n{errors}"
+                    "Errors occurred while checking for updates:<br>{errors}"
                 ).format(errors=msg),
             ).exec()
             return
@@ -431,9 +431,9 @@ class MainContentController(QObject):
         # Build details for user
         details_msg = ""
         for repo_path, messages in updates.items():
-            details_msg += f"{repo_path}\n"
+            details_msg += f"{repo_path}<br>"
             for msg in messages:
-                details_msg += f"\t{msg}\n"
+                details_msg += f"\t{msg}<br>"
 
         binary_diag = BinaryChoiceDialog(
             title=self.tr("Git Updates Found"),
@@ -499,7 +499,7 @@ class MainContentController(QObject):
                 commit_info = getattr(results, "commit_info", {}).get(
                     str(repo_path), "No commit info"
                 )
-                details_msg += f"✓ {repo_name}\n  └─ {commit_info}\n\n"
+                details_msg += f"✓ {repo_name}<br>  └─ {commit_info}<br><br>"
 
             InformationBox(
                 title=self.tr("Updates Completed"),
@@ -512,7 +512,7 @@ class MainContentController(QObject):
         elif not successful:
             details_msg = ""
             for repo_path, err in failed:
-                details_msg += f"{Path(repo_path).name}: {err}\n"
+                details_msg += f"{Path(repo_path).name}: {err}<br>"
 
             InformationBox(
                 title=self.tr("Failed to update repo!"),
@@ -523,17 +523,17 @@ class MainContentController(QObject):
                 details=details_msg,
             ).exec()
         else:
-            details_msg = self.tr("Successful updates:\n")
+            details_msg = self.tr("Successful updates:<br>")
             for repo_path in successful:
                 repo_name = Path(repo_path).name
                 commit_info = getattr(results, "commit_info", {}).get(
                     str(repo_path), "No commit info"
                 )
-                details_msg += f"  ✓ {repo_name}\n    └─ {commit_info}\n"
+                details_msg += f"  ✓ {repo_name}<br>    └─ {commit_info}<br>"
 
-            details_msg += f"\n{self.tr('Failed updates:')}\n"
+            details_msg += f"<br>{self.tr('Failed updates:')}<br>"
             for repo_path, err in failed:
-                details_msg += f"  ✗ {Path(repo_path).name}: {err}\n"
+                details_msg += f"  ✗ {Path(repo_path).name}: {err}<br>"
 
             InformationBox(
                 title=self.tr("Partial Updates Completed"),
@@ -563,7 +563,7 @@ class MainContentController(QObject):
             information=self.tr(
                 "This will push local commits to the remote repositories."
             ),
-            details="\n".join([str(p) for p in repos_paths]),
+            details="<br>".join([str(p) for p in repos_paths]),
             positive_text=self.tr("Push"),
             negative_text=self.tr("Cancel"),
         )
@@ -621,12 +621,12 @@ class MainContentController(QObject):
                 information=self.tr("{count} repositories were pushed.").format(
                     count=len(successful)
                 ),
-                details="\n".join([Path(p).name for p in successful]),
+                details="<br>".join([Path(p).name for p in successful]),
             ).exec()
         elif not successful:
             details_msg = ""
             for repo_path, err in failed:
-                details_msg += f"{Path(repo_path).name}: {err}\n"
+                details_msg += f"{Path(repo_path).name}: {err}<br>"
 
             InformationBox(
                 title=self.tr("Push Failed"),
@@ -637,12 +637,12 @@ class MainContentController(QObject):
                 details=details_msg,
             ).exec()
         else:
-            details_msg = self.tr("Successful pushes:\n")
+            details_msg = self.tr("Successful pushes:<br>")
             for p in successful:
-                details_msg += f"  ✓ {Path(p).name}\n"
-            details_msg += f"\n{self.tr('Failed pushes:')}\n"
+                details_msg += f"  ✓ {Path(p).name}<br>"
+            details_msg += f"<br>{self.tr('Failed pushes:')}<br>"
             for repo_path, err in failed:
-                details_msg += f"  ✗ {Path(repo_path).name}: {err}\n"
+                details_msg += f"  ✗ {Path(repo_path).name}: {err}<br>"
 
             InformationBox(
                 title=self.tr("Partial Push Completed"),
@@ -673,7 +673,7 @@ class MainContentController(QObject):
         binary_diag = BinaryChoiceDialog(
             title=self.tr("Clone Repository"),
             text=self.tr("Do you want to clone this repository?"),
-            information=self.tr("Repository: {repo_url}\nDestination: {dest}").format(
+            information=self.tr("Repository: {repo_url}<br>Destination: {dest}").format(
                 repo_url=repo_url, dest=str(full_repo_path)
             ),
             positive_text=self.tr("Clone"),
@@ -999,8 +999,8 @@ class MainContentController(QObject):
         InformationBox(
             title=self.tr("Failed to clone repo!"),
             text=self.tr(
-                "The configured repo failed to clone/initialize! "
-                + "Are you connected to the Internet? "
+                "The configured repo failed to clone/initialize!<br><br>"
+                + "Are you connected to the Internet?<br><br>"
                 + "Is your configured repo valid?"
             ),
             information=error_message,
@@ -1396,7 +1396,7 @@ class MainContentController(QObject):
                 title=self.tr("Invalid repository"),
                 text=self.tr("An invalid repository was detected!"),
                 information=self.tr(
-                    "Please reconfigure a repository in settings!\n"
+                    "Please reconfigure a repository in settings!<br>"
                     + 'A valid repository is a repository URL which is not empty and is prefixed with "http://" or "https://"'
                 ),
             ).exec()
@@ -1411,7 +1411,7 @@ class MainContentController(QObject):
             InformationBox(
                 title=self.tr("Invalid repository URL"),
                 text=self.tr("Failed to parse repository information from URL."),
-                information=self.tr("URL: {repo_url}\nError: {error}").format(
+                information=self.tr("URL: {repo_url}<br>Error: {error}").format(
                     repo_url=repo_url, error=str(e)
                 ),
             ).exec()
@@ -1459,7 +1459,7 @@ class MainContentController(QObject):
                     "Please ensure the file exists and then try to upload again!"
                 ),
                 information=self.tr(
-                    "File not found:\n{file_full_path}\nRepository:\n{repo_url}"
+                    "File not found:<br>{file_full_path}<br>Repository:<br>{repo_url}"
                 ).format(file_full_path=file_full_path, repo_url=repo_url),
             ).exec()
             return
@@ -1534,7 +1534,7 @@ class MainContentController(QObject):
                     title=self.tr("Fork created"),
                     text=self.tr("Created fork of repository."),
                     information=self.tr(
-                        "Fork: {fork_name}\nPlease wait a moment for GitHub to set up the fork."
+                        "Fork: {fork_name}<br>Please wait a moment for GitHub to set up the fork."
                     ).format(fork_name=fork_repo.full_name),
                 ).exec()
             except Exception as e:
@@ -2030,7 +2030,7 @@ class MainContentController(QObject):
                 title=self.tr("Pull request created"),
                 text=self.tr("Successfully created pull request!"),
                 information=self.tr(
-                    "Pull request created successfully.\nDo you want to open it in your web browser?\n\nURL: {url}"
+                    "Pull request created successfully.<br>Do you want to open it in your web browser?<br><br>URL: {url}"
                 ).format(url=pull_request.html_url),
             )
 
@@ -2049,8 +2049,8 @@ class MainContentController(QObject):
                 title=self.tr("Pull request failed"),
                 text=self.tr("Failed to create pull request."),
                 information=self.tr(
-                    "The changes were pushed to your fork successfully, but the pull request creation failed.\n\n"
-                    + "You can manually create a pull request on GitHub.\n\nError: {error}"
+                    "The changes were pushed to your fork successfully, but the pull request creation failed.<br><br>"
+                    + "You can manually create a pull request on GitHub.<br><br>Error: {error}"
                 ).format(error=str(e)),
             ).exec()
 

--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -661,7 +661,7 @@ class SettingsController(QObject):
                     information=(
                         "Steam installed via Snap is not officially supported and may cause issues. "
                         "We recommend installing Steam via your distribution's native package manager "
-                        "or Flatpak instead.\n\n"
+                        "or Flatpak instead.<br><br>"
                         "Autodetection will continue, but some paths may not work correctly."
                     ),
                 )

--- a/app/controllers/troubleshooting_controller.py
+++ b/app/controllers/troubleshooting_controller.py
@@ -151,7 +151,7 @@ class TroubleshootingController:
                 ),
                 text=self.translate(
                     "TroubleshootingController",
-                    "Could not automatically start game installation through Steam.\n\nPlease manually verify/install the game through Steam.",
+                    "Could not automatically start game installation through Steam.<br><br>Please manually verify/install the game through Steam.",
                 ),
                 icon="warning",
             )
@@ -184,7 +184,7 @@ class TroubleshootingController:
             title=self.translate("TroubleshootingController", "Process complete"),
             text=self.translate(
                 "TroubleshootingController",
-                "Deleted all files in the Steam mods directory.\n\n Trying to restart Steam to trigger automatic redownload of subscribed mods.",
+                "Deleted all files in the Steam mods directory.<br><br> Trying to restart Steam to trigger automatic redownload of subscribed mods.",
             ),
         )
 
@@ -207,7 +207,7 @@ class TroubleshootingController:
                 ),
                 text=self.translate(
                     "TroubleshootingController",
-                    "Mods have been deleted. Please restart Steam to trigger automatic redownload of subscribed mods.\n\nIf mods don't download automatically, try:\n1. Restart Steam\n2. Verify game files in Steam\n3. Visit the Workshop page of each mod",
+                    "Mods have been deleted. Please restart Steam to trigger automatic redownload of subscribed mods.<br><br>If mods don't download automatically, try:<br>1. Restart Steam<br>2. Verify game files in Steam<br>3. Visit the Workshop page of each mod",
                 ),
                 icon="warning",
             )
@@ -337,7 +337,7 @@ class TroubleshootingController:
             title=self.translate("TroubleshootingController", "Confirm Clear"),
             text=self.translate(
                 "TroubleshootingController",
-                "Are you sure you want to delete all mods?\n\nWARNING: This will permanently delete all mods in your Mods folder and reset to vanilla state.",
+                "Are you sure you want to delete all mods?<br><br>WARNING: This will permanently delete all mods in your Mods folder and reset to vanilla state.",
             ),
             icon="warning",
         ):
@@ -581,7 +581,7 @@ class TroubleshootingController:
                 ),
                 self.translate(
                     "TroubleshootingController",
-                    "The selected file is not a valid mod list file.\nDetails: {e}",
+                    "The selected file is not a valid mod list file.<br>Details: {e}",
                 ).format(e=str(e)),
             )
 
@@ -650,7 +650,7 @@ class TroubleshootingController:
                     title=self.translate("TroubleshootingController", "Cache Cleared"),
                     text=self.translate(
                         "TroubleshootingController",
-                        "Successfully deleted Steam's downloading folder.\nRestart Steam for the changes to take effect.",
+                        "Successfully deleted Steam's downloading folder.<br>Restart Steam for the changes to take effect.",
                     ),
                     icon="info",
                 )
@@ -671,7 +671,7 @@ class TroubleshootingController:
                 title=self.translate("TroubleshootingController", "Cache Clear Failed"),
                 text=self.translate(
                     "TroubleshootingController",
-                    "Could not delete Steam's downloading folder.\nPlease delete it manually: Steam/steamapps/downloading\nDetails: {e}",
+                    "Could not delete Steam's downloading folder.<br>Please delete it manually: Steam/steamapps/downloading<br>Details: {e}",
                 ).format(e=str(e)),
                 icon="warning",
                 buttons=["Ok"],
@@ -698,7 +698,7 @@ class TroubleshootingController:
                     title=self.translate("TroubleshootingController", "No Games Found"),
                     text=self.translate(
                         "TroubleshootingController",
-                        "No installed games found in this Steam library folder.\nYou may have games installed in a different Steam library folder or drive.",
+                        "No installed games found in this Steam library folder.<br>You may have games installed in a different Steam library folder or drive.",
                     ),
                     icon="warning",
                     buttons=["Ok"],
@@ -712,7 +712,7 @@ class TroubleshootingController:
                 ),
                 text=self.translate(
                     "TroubleshootingController",
-                    "This will verify all {len} games in your Steam library.\nThis may take a while. Continue?",
+                    "This will verify all {len} games in your Steam library.<br>This may take a while. Continue?",
                 ).format(len=len(app_ids)),
             ):
                 return
@@ -727,7 +727,7 @@ class TroubleshootingController:
                 ),
                 text=self.translate(
                     "TroubleshootingController",
-                    "Steam will now verify {len} games.\nYou can monitor progress in the Steam client.",
+                    "Steam will now verify {len} games.<br>You can monitor progress in the Steam client.",
                 ).format(len=len(app_ids)),
                 icon="info",
             )
@@ -740,7 +740,7 @@ class TroubleshootingController:
                 ),
                 text=self.translate(
                     "TroubleshootingController",
-                    "Could not repair Steam library.\nPlease verify your games manually through Steam.\nDetails: {e}",
+                    "Could not repair Steam library.<br>Please verify your games manually through Steam.<br>Details: {e}",
                 ).format(e=str(e)),
                 icon="warning",
             )
@@ -759,7 +759,7 @@ class TroubleshootingController:
                 title=self.translate("TroubleshootingController", "ACF File Not Found"),
                 text=self.translate(
                     "TroubleshootingController",
-                    "Could not find the Steam Workshop ACF file at:\n{acf_path}",
+                    "Could not find the Steam Workshop ACF file at:<br>{acf_path}",
                 ).format(acf_path=acf_path),
             )
             return
@@ -770,7 +770,7 @@ class TroubleshootingController:
             ),
             text=self.translate(
                 "TroubleshootingController",
-                "This will remove stale workshop entries from the ACF metadata file for mods that no longer exist on disk.\n\nA backup will be created before any changes are made.\n\nContinue?",
+                "This will remove stale workshop entries from the ACF metadata file for mods that no longer exist on disk.<br><br>A backup will be created before any changes are made.<br><br>Continue?",
             ),
             icon="warning",
         ):
@@ -782,7 +782,8 @@ class TroubleshootingController:
             if removed_pfids:
                 backup_path = str(acf_path) + ".backup"
                 details = (
-                    "\n".join(removed_pfids) + f"\n\nBackup saved to: {backup_path}"
+                    "<br>".join(removed_pfids)
+                    + f"<br><br>Backup saved to: {backup_path}"
                 )
                 show_information(
                     title=self.translate(

--- a/app/sort/topo_sort.py
+++ b/app/sort/topo_sort.py
@@ -91,5 +91,5 @@ def find_circular_dependencies(dependency_graph: dict[str, set[str]]) -> None:
             "find_circular_dependencies",
             "RimSort found circular dependencies in your mods list. Please see the details for dependency loops.",
         ),
-        details="\n\n".join(cycle_strings),
+        details="<br><br>".join(cycle_strings),
     )

--- a/app/utils/db_builder.py
+++ b/app/utils/db_builder.py
@@ -230,7 +230,7 @@ class DatabaseBuilder(QObject):
                 text=self.tr("DB Builder query did not return any PublishedFileIDs!"),
                 information=self.tr(
                     "This is typically caused by invalid/missing Steam WebAPI key, "
-                    "or a connectivity issue to the Steam WebAPI.\n"
+                    "or a connectivity issue to the Steam WebAPI.<br>"
                     "PublishedFileIDs are needed to retrieve mods from Steam!"
                 ),
             )
@@ -397,10 +397,10 @@ class DatabaseBuilder(QObject):
                 "This operation will compare 2 databases, A & B, by checking dependencies from A with dependencies from B."
             ),
             information=self.tr(
-                "- This will produce an accurate comparison of dependency data between 2 Steam DBs.\n"
-                "A report of discrepancies is generated. You will be prompted for these paths in order:\n"
-                "\n\t1) Select input A"
-                "\n\t2) Select input B"
+                "- This will produce an accurate comparison of dependency data between 2 Steam DBs.<br>"
+                "A report of discrepancies is generated. You will be prompted for these paths in order:<br>"
+                "<br>\t1) Select input A"
+                "<br>\t2) Select input B"
             ),
         )
 
@@ -461,14 +461,14 @@ class DatabaseBuilder(QObject):
                 "This operation will merge 2 databases, A & B, by recursively updating A with B, barring exceptions."
             ),
             information=self.tr(
-                "- This will effectively recursively overwrite A's key/value with B's key/value to the resultant database.\n"
-                "- Exceptions will not be recursively updated. Instead, they will be overwritten with B's key entirely.\n"
-                "- The following exceptions will be made:\n"
-                "\n\t{DB_BUILDER_RECURSE_EXCEPTIONS}\n\n"
-                "The resultant database, C, is saved to a user-specified path. You will be prompted for these paths in order:\n"
-                "\n\t1) Select input A (db to-be-updated)"
-                "\n\t2) Select input B (update source)"
-                "\n\t3) Select output C (resultant db)"
+                "- This will effectively recursively overwrite A's key/value with B's key/value to the resultant database.<br>"
+                "- Exceptions will not be recursively updated. Instead, they will be overwritten with B's key entirely.<br>"
+                "- The following exceptions will be made:<br>"
+                "<br>\t{DB_BUILDER_RECURSE_EXCEPTIONS}<br><br>"
+                "The resultant database, C, is saved to a user-specified path. You will be prompted for these paths in order:<br>"
+                "<br>\t1) Select input A (db to-be-updated)"
+                "<br>\t2) Select input B (update source)"
+                "<br>\t3) Select output C (resultant db)"
             ).format(
                 DB_BUILDER_RECURSE_EXCEPTIONS=app_constants.DB_BUILDER_RECURSE_EXCEPTIONS
             ),

--- a/app/utils/generic.py
+++ b/app/utils/generic.py
@@ -502,7 +502,7 @@ def platform_specific_open(path: str | Path) -> None:
                     dialogue.show_warning(
                         title="Failed to open file",
                         text="Could not open the file",
-                        information=f"No default application is associated with this file type: {p.suffix}\n\nPlease manually associate an application with {p.suffix} files or open the file manually.",
+                        information=f"No default application is associated with this file type: {p.suffix}<br><br>Please manually associate an application with {p.suffix} files or open the file manually.",
                         details=str(e),
                     )
             else:
@@ -830,9 +830,9 @@ def show_no_steam_warning() -> None:
         text=translate("SteamworksInterface", "Steam Integration Unavailable"),
         information=translate(
             "SteamworksInterface",
-            "RimSort could not detect Steam client or it may be unresponsive. "
-            "Please make sure Steam is installed and running. "
-            "If you are a Steam user, please check that Steam is running and that you are logged in. "
+            "RimSort could not detect Steam client or it may be unresponsive.<br><br>"
+            "Please make sure Steam is installed and running.<br><br>"
+            "If you are a Steam user, please check that Steam is running and that you are logged in.<br><br>"
             "Try restarting Steam.",
         ),
         details=translate(

--- a/app/utils/metadata.py
+++ b/app/utils/metadata.py
@@ -2751,7 +2751,7 @@ def check_if_pfids_blacklisted(
         blacklisted_mods_report = ""
         for publishedfileid in blacklisted_mods:
             blacklisted_mods_report += (
-                f"{blacklisted_mods[publishedfileid]['name']} ({publishedfileid})\n"
+                f"{blacklisted_mods[publishedfileid]['name']} ({publishedfileid})<br>"
             )
             blacklisted_mods_report += f"Reason for blacklisting: {blacklisted_mods[publishedfileid]['comment']}"
         answer = show_dialogue_conditional(

--- a/app/utils/steam/steambrowser/browser.py
+++ b/app/utils/steam/steambrowser/browser.py
@@ -379,14 +379,14 @@ class SteamBrowser(QWidget):
                         "Empty list of mods returned, unable to add collection to list!"
                     ),
                     information=self.tr(
-                        "Please reach out to us on Github Issues page or\n#rimsort-testing on the Rocketman/CAI discord"
+                        "Please reach out to us on Github Issues page or<br>#rimsort-testing on the Rocketman/CAI discord"
                     ),
                 )
         if len(self.downloader_list_dupe_tracking.keys()) > 0:
             # Build a report from our dict
             dupe_report = ""
             for pfid, name in self.downloader_list_dupe_tracking.items():
-                dupe_report = dupe_report + f"{name} | {pfid}\n"
+                dupe_report = dupe_report + f"{name} | {pfid}<br>"
             # Notify the user
             show_warning(
                 title=self.tr("SteamCMD downloader"),

--- a/app/utils/steam/steamcmd/wrapper.py
+++ b/app/utils/steam/steamcmd/wrapper.py
@@ -415,9 +415,9 @@ class SteamcmdInterface:
             title=self.translate("SteamcmdInterface", "RimSort - SteamCMD setup"),
             text=self.translate(
                 "SteamcmdInterface",
-                "RimSort was unable to find SteamCMD installed in the configured prefix:\n",
+                "RimSort was unable to find SteamCMD installed in the configured prefix:<br>",
             ),
-            information=f"{self.steamcmd_prefix if self.steamcmd_prefix else '<None>'}\n\n"
+            information=f"{self.steamcmd_prefix if self.steamcmd_prefix else '<None>'}<br><br>"
             + self.translate("SteamcmdInterface", "Do you want to setup SteamCMD?"),
             button_text_override=translated_btn_text,
         )
@@ -535,7 +535,7 @@ class SteamcmdInterface:
                 show_fatal_error(
                     "SteamcmdInterface",
                     f"Failed to download steamcmd for {self.system}",
-                    "Did the file/url change?\nDoes your environment have access to the internet?",
+                    "Did the file/url change?<br>Does your environment have access to the internet?",
                     details=f"Error: {type(e).__name__}: {str(e)}",
                 )
         else:
@@ -582,7 +582,7 @@ class SteamcmdInterface:
                     ),
                     self.translate(
                         "SteamcmdInterface",
-                        "Existing symlink: {symlink_destination_path}\n\nNew symlink:\n[{symlink_source_path}] -> ",
+                        "Existing symlink: {symlink_destination_path}<br><br>New symlink:<br>[{symlink_source_path}] -> ",
                     ).format(
                         symlink_source_path=symlink_source_path,
                         symlink_destination_path=symlink_destination_path,
@@ -613,7 +613,7 @@ class SteamcmdInterface:
                     ),
                     self.translate(
                         "SteamcmdInterface",
-                        "Existing destination: {symlink_destination_path}\n\nNew symlink:\n[{symlink_source_path}] -> ",
+                        "Existing destination: {symlink_destination_path}<br><br>New symlink:<br>[{symlink_source_path}] -> ",
                     ).format(
                         symlink_source_path=symlink_source_path,
                         symlink_destination_path=symlink_destination_path,
@@ -638,7 +638,8 @@ class SteamcmdInterface:
                         + " and is required for SteamCMD mod downloads to work correctly.",
                     ),
                     self.translate(
-                        "SteamcmdInterface", "New symlink:\n[{symlink_source_path}] -> "
+                        "SteamcmdInterface",
+                        "New symlink:<br>[{symlink_source_path}] -> ",
                     ).format(
                         symlink_source_path=symlink_source_path,
                     )

--- a/app/utils/steam/webapi/wrapper.py
+++ b/app/utils/steam/webapi/wrapper.py
@@ -164,10 +164,10 @@ class CollectionImport:
                         text=self.translate(
                             "CollectionImport",
                             f"{len(failed_mods)} mods could not be imported due to missing package ids. "
-                            "This may happen if you don't have all the mods downloaded.\n\n"
+                            "This may happen if you don't have all the mods downloaded.<br><br>"
                             "Try subscribing to the collection first",
                         ),
-                        details="\n".join(failed_mods),
+                        details="<br>".join(failed_mods),
                     )
         except Exception as e:
             logger.error(

--- a/app/utils/update_utils.py
+++ b/app/utils/update_utils.py
@@ -760,7 +760,7 @@ class UpdateManager(QObject):
                 "An update to RimSort has been released: {latest_tag_name}"
             ).format(latest_tag_name=latest_tag_name),
             information=self.tr(
-                "You are running RimSort {current_version}\nDo you want to update now?"
+                "You are running RimSort {current_version}<br>Do you want to update now?"
             ).format(current_version=current_version),
         )
         return answer == QMessageBox.StandardButton.Yes
@@ -1198,7 +1198,7 @@ class UpdateManager(QObject):
                 title=self.tr("Update downloaded"),
                 text=self.tr("Do you want to proceed with the update?"),
                 information=self.tr(
-                    f"\nSuccessfully retrieved latest release.\nThe update will be installed from: {update_source_path}"
+                    f"<br>Successfully retrieved latest release.<br>The update will be installed from: {update_source_path}"
                 ),
             )
 
@@ -1243,7 +1243,7 @@ class UpdateManager(QObject):
             dialogue.show_warning(
                 title=self.tr(ERR_DOWNLOAD_FAILED_TITLE),
                 text=self.tr(ERR_DOWNLOAD_FAILED_TEXT),
-                information=f"Error: {str(e)}\nURL: {download_url}",
+                information=f"Error: {str(e)}<br>URL: {download_url}",
             )
         except UpdateExtractionError as e:
             logger.error(f"Update extraction failed: {e}")
@@ -1264,7 +1264,7 @@ class UpdateManager(QObject):
             dialogue.show_warning(
                 title=self.tr(ERR_UPDATE_FAILED_TITLE),
                 text=self.tr(ERR_UPDATE_FAILED_TEXT),
-                information=f"Error: {str(e)}\nURL: {download_url}",
+                information=f"Error: {str(e)}<br>URL: {download_url}",
                 details=traceback.format_exc(),
             )
         finally:

--- a/app/views/deletion_menu.py
+++ b/app/views/deletion_menu.py
@@ -588,7 +588,7 @@ class ModDeletionMenu(QMenu):
                 f"You have selected {selected_count} mod(s) for complete deletion."
             ),
             confirmation_info=self.tr(
-                "\nThis operation will permanently delete the selected mod directories from the filesystem.\n\nDo you want to proceed?"
+                "<br>This operation will permanently delete the selected mod directories from the filesystem.<br><br>Do you want to proceed?"
             ),
             deletion_fn=self._delete_mod_directory,
         )
@@ -602,7 +602,7 @@ class ModDeletionMenu(QMenu):
                 f"You have selected {selected_count} mod(s) for DDS texture deletion."
             ),
             confirmation_info=self.tr(
-                "\nThis operation will only delete optimized textures (.dds files) from the selected mods.\n\nDo you want to proceed?"
+                "<br>This operation will only delete optimized textures (.dds files) from the selected mods.<br><br>Do you want to proceed?"
             ),
             deletion_fn=self._delete_dds_from_mod,
             update_db=False,
@@ -627,7 +627,7 @@ class ModDeletionMenu(QMenu):
                 f"You have selected {selected_count} mod(s) for selective deletion."
             ),
             confirmation_info=self.tr(
-                "\nThis operation will delete all mod files except for .dds texture files.\nThe .dds files will be preserved.\n\nDo you want to proceed?"
+                "<br>This operation will delete all mod files except for .dds texture files.<br>The .dds files will be preserved.<br><br>Do you want to proceed?"
             ),
             deletion_fn=self._delete_except_dds,
         )
@@ -701,7 +701,7 @@ class ModDeletionMenu(QMenu):
                     action=self.tr(action).capitalize()
                 ),
                 text=self.tr(
-                    "Successfully initiated {action} from {len} Steam Workshop mod(s).\n"
+                    "Successfully initiated {action} from {len} Steam Workshop mod(s).<br>"
                     "The process may take a few moments to complete."
                 ).format(
                     action=self.tr(action).capitalize(),
@@ -763,10 +763,10 @@ class ModDeletionMenu(QMenu):
         if self._confirm_deletion(
             self.tr(f"Confirm Deletion and {action_capitalized}"),
             self.tr(
-                f"You have selected {selected_count} mod(s) for deletion.\n{steam_count} of these are Steam Workshop mods that will also be {action_past}."
+                f"You have selected {selected_count} mod(s) for deletion.<br>{steam_count} of these are Steam Workshop mods that will also be {action_past}."
             ),
             self.tr(
-                f"\nThis operation will:\n• Delete the selected mod directories from your filesystem\n• {action_capitalized} Steam Workshop mods from your Steam account\n\nDo you want to proceed?"
+                f"<br>This operation will:<br>• Delete the selected mod directories from your filesystem<br>• {action_capitalized} Steam Workshop mods from your Steam account<br><br>Do you want to proceed?"
             ),
         ):
             # Synchronize remove_from_uuids with current selected mods before deletion

--- a/app/views/dialogue.py
+++ b/app/views/dialogue.py
@@ -295,16 +295,16 @@ def show_internet_connection_error(
         title="No Internet Connection",
         text="RimSort requires an active internet connection to perform this operation.",
         information=(
-            f"{failed_urls_str}\n\n"
-            "If you are connected but still see this message, your firewall or security software may be blocking RimSort. \n"
-            "To resolve this issue: \n\n"
-            "Add RimSort to your firewall's allowed applications. \n"
+            f"{failed_urls_str}<br><br>"
+            "If you are connected but still see this message, your firewall or security software may be blocking RimSort. <br>"
+            "To resolve this issue: <br><br>"
+            "Add RimSort to your firewall's allowed applications. <br>"
             "You may need to add RimSort to your firewall's allowed list."
         ),
         details=(
-            "On Windows: Open Windows Security > Firewall & network protection > Allow an app through firewall. \n"
-            "Find RimSort or add it manually if needed. \n"
-            "On other systems, check your firewall or security software settings. \n"
+            "On Windows: Open Windows Security > Firewall & network protection > Allow an app through firewall. <br>"
+            "Find RimSort or add it manually if needed. <br>"
+            "On other systems, check your firewall or security software settings. <br>"
             "If you need more help, Please reach out to us on Github Issues page or Discord server."
         ),
         parent=parent,
@@ -603,10 +603,12 @@ class FatalErrorDialog(_BaseDialogue):
 
         txt = QLabel(self.text)
         txt.setWordWrap(True)
-        r_layout.addWidget(QLabel(self.text))
+        txt.setTextFormat(Qt.TextFormat.RichText)
+        r_layout.addWidget(txt)
 
         info = QLabel(self.information)
         info.setWordWrap(True)
+        info.setTextFormat(Qt.TextFormat.RichText)
         r_layout.addWidget(info)
 
         r_layout.addLayout(btn_layout)

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -1006,9 +1006,10 @@ class MainContent(QObject):
                 text=self.tr("The selected sorting algorithm is not implemented"),
                 information=(
                     self.tr(
-                        "This may be caused by malformed settings or improper migration between versions or different mod manager. "
+                        "This may be caused by malformed settings or improper migration between versions or different mod manager.<br><br>"
                         "Try resetting your settings, selecting a different sorting algorithm, or "
-                        "deleting your settings file. If the issue persists, please report it the developers."
+                        "deleting your settings file.<br><br>"
+                        "If the issue persists, please report it to the developers."
                     )
                 ),
                 details=str(e),
@@ -1176,8 +1177,8 @@ class MainContent(QObject):
                 dialogue.show_information(
                     title=self.tr("Important"),
                     text=self.tr(
-                        "You will need to redo Rentry import again after downloads complete. "
-                        "If there missing mods after download completes, they will be shown inside the missing mods panel. "
+                        "You will need to redo Rentry import again after downloads complete.<br><br>"
+                        "If there missing mods after download completes, they will be shown inside the missing mods panel.<br><br>"
                         "If RimSort is still not able to download some mods, "
                         "It's due to the mod data not being available in both Rentry link and steam database."
                     ),
@@ -1409,7 +1410,7 @@ class MainContent(QObject):
             dialogue.show_information(
                 title=self.tr("Uploaded active mod list"),
                 text=self.tr(
-                    "Uploaded active mod list report to Rentry.co! The URL has been copied to your clipboard:\n\n{url}"
+                    "Uploaded active mod list report to Rentry.co! The URL has been copied to your clipboard:<br><br>{url}"
                 ).format(url=url),
                 information=self.tr('Click "Show Details" to see the full report!'),
                 details=report,
@@ -1569,7 +1570,7 @@ class MainContent(QObject):
                     path=path
                 ),
                 information=self.tr(
-                    "The URL has been copied to your clipboard:\n\n{ret}"
+                    "The URL has been copied to your clipboard:<br><br>{ret}"
                 ).format(ret=ret),
             )
             webbrowser.open(ret)
@@ -1753,7 +1754,7 @@ class MainContent(QObject):
             title=self.tr("No valid paths for todds"),
             text=self.tr("todds could not find any valid mod folders to process."),
             information=self.tr(
-                "None of the configured mod folder paths exist on disk. "
+                "None of the configured mod folder paths exist on disk.<br><br>"
                 "Please verify your Local Mods and Workshop folders are correctly "
                 "set in Settings, then try again."
             ),
@@ -1922,7 +1923,7 @@ class MainContent(QObject):
                 text=self.tr(
                     "RimSort was unable to check your Workshop mods for updates."
                 ),
-                details="\n".join(result.errors) if result.errors else None,
+                details="<br>".join(result.errors) if result.errors else None,
             )
             return
 
@@ -1935,7 +1936,7 @@ class MainContent(QObject):
                     failed=len(result.failed_pfids),
                     total=result.mods_checked,
                 ),
-                details="\n".join(result.errors) if result.errors else None,
+                details="<br>".join(result.errors) if result.errors else None,
             )
 
         # For both "success" and "partial", show the updater panel
@@ -1965,7 +1966,7 @@ class MainContent(QObject):
             dialogue.show_warning(
                 title=self.tr("Steam Client Integration is disabled"),
                 text=self.tr(
-                    "This feature requires Steam Client Integration to be enabled in Settings. "
+                    "This feature requires Steam Client Integration to be enabled in Settings.<br><br>"
                     "Please enable Steam Client Integration if you own the game on Steam."
                 ),
             )
@@ -2346,7 +2347,7 @@ class MainContent(QObject):
                     dialogue.show_warning(
                         title=self.tr("Failed to download zip file"),
                         text=self.tr("The zip file could not be downloaded."),
-                        information=self.tr("File: {file_path}\nError: {e}").format(
+                        information=self.tr("File: {file_path}<br>Error: {e}").format(
                             file_path=temp_path, e=e
                         ),
                     )
@@ -2397,7 +2398,7 @@ class MainContent(QObject):
                 text=self.tr(
                     "This ZIP file uses a compression method that is not supported by this version."
                 ),
-                information=self.tr("File: {file_path}\nError: {e}").format(
+                information=self.tr("File: {file_path}<br>Error: {e}").format(
                     file_path=file_path, e=e
                 ),
             )
@@ -2406,7 +2407,7 @@ class MainContent(QObject):
             dialogue.show_warning(
                 title=self.tr("Failed to extract zip file"),
                 text=self.tr("The zip file could not be extracted."),
-                information=self.tr("File: {file_path}\nError: {e}").format(
+                information=self.tr("File: {file_path}<br>Error: {e}").format(
                     file_path=file_path, e=e
                 ),
             )
@@ -2443,8 +2444,8 @@ class MainContent(QObject):
                     "All files in the archive already exist in the target path."
                 ),
                 information=self.tr(
-                    "How would you like to proceed?\n\n"
-                    "1) Overwrite All — Replace all existing files and directories.\n"
+                    "How would you like to proceed?<br><br>"
+                    "1) Overwrite All — Replace all existing files and directories.<br>"
                     "2) Cancel — Abort the operation."
                 ),
                 button_text_override=["Overwrite All"],
@@ -2459,10 +2460,10 @@ class MainContent(QObject):
                     "The following files or directories already exist in the target path:"
                 ),
                 information=self.tr(
-                    "{conflicts_list}\n\n"
-                    "How would you like to proceed?\n\n"
-                    "1) Overwrite All — Replace all existing files and directories.\n"
-                    "2) Skip Existing — Extract only new files and leave existing ones untouched.\n"
+                    "{conflicts_list}<br><br>"
+                    "How would you like to proceed?<br><br>"
+                    "1) Overwrite All — Replace all existing files and directories.<br>"
+                    "2) Skip Existing — Extract only new files and leave existing ones untouched.<br>"
                     "3) Cancel — Abort the extraction."
                 ).format(
                     conflicts_list="<br/>".join(conflicts[:5])
@@ -2540,7 +2541,7 @@ class MainContent(QObject):
             text=self.tr("git executable was not found in $PATH!"),
             information=(
                 self.tr(
-                    "Git integration will not work without Git installed! Do you want to open download page for Git?\n\n"
+                    "Git integration will not work without Git installed! Do you want to open download page for Git?<br><br>"
                     "If you just installed Git, please restart RimSort for the PATH changes to take effect."
                 )
             ),
@@ -2754,7 +2755,7 @@ class MainContent(QObject):
             title=self.tr("RimSort - DB Builder"),
             text=self.tr("Do you want to continue?"),
             information=self.tr(
-                "This operation will overwrite the {rules_source} database located at the following path:\n\n{path}"
+                "This operation will overwrite the {rules_source} database located at the following path:<br><br>{path}"
             ).format(rules_source=rules_source, path=path),
         )
         if answer == QMessageBox.StandardButton.Yes:
@@ -2876,7 +2877,7 @@ class MainContent(QObject):
                         "todds texture optimization failed (exit code: {exit_code}), but the game will launch anyway."
                     ).format(exit_code=exit_code),
                     information=self.tr(
-                        "You may experience longer loading times or higher memory usage. "
+                        "You may experience longer loading times or higher memory usage.<br><br>"
                         "Check the todds output window for details."
                     ),
                 )

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -414,11 +414,11 @@ class MainWindow(QMainWindow):
             ),
             information=(
                 self.tr(
-                    "Workshop folder: {existing_instance_workshop_folder}\n\n"
-                    + "Option 1: Convert to SteamCMD\n"
-                    + "RimSort will copy all Workshop mods to the new instance's local mods folder, converting them to SteamCMD mods that you can manage inside the new instance. The Workshop folder will be ignored for this instance to prevent duplicate mods.\n\n"
-                    + "Option 2: Keep Workshop Folder\n"
-                    + "The new instance will use the same Workshop folder as the original instance. You can change this later in the settings if needed.\n\n"
+                    "Workshop folder: {existing_instance_workshop_folder}<br><br>"
+                    + "Option 1: Convert to SteamCMD<br>"
+                    + "RimSort will copy all Workshop mods to the new instance's local mods folder, converting them to SteamCMD mods that you can manage inside the new instance. The Workshop folder will be ignored for this instance to prevent duplicate mods.<br><br>"
+                    + "Option 2: Keep Workshop Folder<br>"
+                    + "The new instance will use the same Workshop folder as the original instance. You can change this later in the settings if needed.<br><br>"
                     + "How would you like to proceed?"
                 ).format(
                     existing_instance_workshop_folder=existing_instance_workshop_folder
@@ -782,16 +782,16 @@ class MainWindow(QMainWindow):
             # Prompt user with the existing instance configuration and confirm that they would like to clone it
             answer = BinaryChoiceDialog(
                 title=f"Clone instance [{existing_instance_name}]",
-                text=f"Would you like to clone instance [{existing_instance_name}] to create new instance [{new_instance_name}]?\n"
-                + "\nThis will clone the instance's game, mod, and configuration data. This operation may take a long time depending on the amount of data being cloned.\n"
-                + "\nThe following folders will be cloned:",
-                information=f"Game folder:\n{existing_instance_game_folder if existing_instance_game_folder else '<None>'}\n"
-                + f"\nConfiguration folder:\n{existing_instance_config_folder if existing_instance_config_folder else '<None>'}\n"
-                + f"\nLocal mods folder:\n{existing_instance_local_folder if existing_instance_local_folder else '<None>'}\n"
-                + f"\nWorkshop mods folder:\n{existing_instance_workshop_folder if existing_instance_workshop_folder else '<None>'}\n"
-                + "\nSteamCMD install path (steamcmd + steam folders will be cloned):"
-                + f"\n{existing_instance_steamcmd_install_path if existing_instance_steamcmd_install_path else '<None>'}\n"
-                + f"\nRun arguments:\n{existing_instance_run_args if existing_instance_run_args else '<None>'}\n",
+                text=f"Would you like to clone instance [{existing_instance_name}] to create new instance [{new_instance_name}]?<br>"
+                + "<br>This will clone the instance's game, mod, and configuration data. This operation may take a long time depending on the amount of data being cloned.<br>"
+                + "<br>The following folders will be cloned:",
+                information=f"Game folder:<br>{existing_instance_game_folder if existing_instance_game_folder else '&lt;None&gt;'}<br>"
+                + f"<br>Configuration folder:<br>{existing_instance_config_folder if existing_instance_config_folder else '&lt;None&gt;'}<br>"
+                + f"<br>Local mods folder:<br>{existing_instance_local_folder if existing_instance_local_folder else '&lt;None&gt;'}<br>"
+                + f"<br>Workshop mods folder:<br>{existing_instance_workshop_folder if existing_instance_workshop_folder else '&lt;None&gt;'}<br>"
+                + "<br>SteamCMD install path (steamcmd + steam folders will be cloned):"
+                + f"<br>{existing_instance_steamcmd_install_path if existing_instance_steamcmd_install_path else '&lt;None&gt;'}<br>"
+                + f"<br>Run arguments:<br>{existing_instance_run_args if existing_instance_run_args else '&lt;None&gt;'}<br>",
             )
             if answer.exec_is_positive():
                 # Clone the RimWorld game_folder to the new instance
@@ -1033,8 +1033,8 @@ class MainWindow(QMainWindow):
                         "Would you like to automatically generate run args for the new instance?"
                     ),
                     information=self.tr(
-                        "This will try to generate run args for the new instance based on the configured Game/Config folders.\n\n"
-                        + "Generated run arguments preview:\n{preview}"
+                        "This will try to generate run args for the new instance based on the configured Game/Config folders.<br><br>"
+                        + "Generated run arguments preview:<br>{preview}"
                     ).format(preview=preview_text),
                 )
                 if answer == QMessageBox.StandardButton.Yes:

--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -2084,7 +2084,7 @@ class ModListWidget(QListWidget):
                             "You have selected {len} mods for deletion + re-download."
                         ).format(len=len(steamcmd_publishedfileid_to_redownload)),
                         information=self.tr(
-                            "\nThis operation will recursively delete all mod files, except for .dds textures found, "
+                            "<br>This operation will recursively delete all mod files, except for .dds textures found, "
                             + "and attempt to re-download the mods via SteamCMD. Do you want to proceed?"
                         ),
                     )
@@ -2184,7 +2184,7 @@ class ModListWidget(QListWidget):
                             "You have selected {len} mods for resubscribe:(unsubscribe + subscribe)."
                         ).format(len=len(publishedfileids)),
                         information=self.tr(
-                            "\nThis operation will potentially delete .dds textures leftover. Steam is unreliable for this. Do you want to proceed?"
+                            "<br>This operation will potentially delete .dds textures leftover. Steam is unreliable for this. Do you want to proceed?"
                         ),
                     )
                     if answer == QMessageBox.StandardButton.Yes:
@@ -2213,7 +2213,7 @@ class ModListWidget(QListWidget):
                         text=self.tr(
                             "You have selected {len} mods for unsubscribe."
                         ).format(len=len(publishedfileids)),
-                        information=self.tr("\nDo you want to proceed?"),
+                        information=self.tr("<br>Do you want to proceed?"),
                     )
                     if answer == QMessageBox.StandardButton.Yes:
                         logger.debug(
@@ -2287,7 +2287,7 @@ class ModListWidget(QListWidget):
                         text=self.tr("This will remove the selected mod, ")
                         + f"{self.metadata_manager.external_steam_metadata.get(steamdb_remove_blacklist, {}).get('steamName', steamdb_remove_blacklist)}, "
                         + "from your configured Steam DB blacklist."
-                        + "\nDo you want to proceed?",
+                        + "<br>Do you want to proceed?",
                     )
                     if answer == QMessageBox.StandardButton.Yes:
                         self.steamdb_blacklist_signal.emit(

--- a/app/windows/missing_mod_properties_panel.py
+++ b/app/windows/missing_mod_properties_panel.py
@@ -225,10 +225,10 @@ class MissingModPropertiesPanel(BaseModsPanel):
             skipped_mods: List of mod names that were skipped
         """
         if skipped_mods:
-            skipped_list = "\n".join([f"• {m}" for m in skipped_mods])
+            skipped_list = "<br>".join([f"• {m}" for m in skipped_mods])
             message = (
-                "Cannot add mods with missing Package IDs to the ignore list.\n"
-                "These mods need valid Package IDs first:\n" + skipped_list
+                "Cannot add mods with missing Package IDs to the ignore list.<br>"
+                "These mods need valid Package IDs first:<br>" + skipped_list
             )
             self._show_message("Cannot Add", message, "warning")
         else:

--- a/app/windows/runner_panel.py
+++ b/app/windows/runner_panel.py
@@ -589,7 +589,7 @@ class RunnerPanel(QWidget):
         pfids_to_name = self._resolve_mod_names()
 
         # Compile details of failed mods for the report
-        details = "\n".join(
+        details = "<br>".join(
             f"{pfids_to_name.get(pfid, f'Mod name not found (ID: {pfid})')}"
             for pfid in self.steamcmd_download_tracking
         )
@@ -597,7 +597,7 @@ class RunnerPanel(QWidget):
         answer = show_dialogue_conditional(
             title=self.tr("SteamCMD downloader"),
             text=self.tr(
-                "SteamCMD failed to download mod(s)! Would you like to retry download of the mods that failed?\n\n"
+                "SteamCMD failed to download mod(s)! Would you like to retry download of the mods that failed?<br><br>"
                 "Click 'Show Details' to see a list of mods that failed."
             ),
             details=details,


### PR DESCRIPTION
All dialogue functions (show_information, show_warning, show_dialogue_conditional, show_fatal_error, InformationBox, BinaryChoiceDialog) already use Qt.TextFormat.RichText, but raw \n doesn't create line breaks in HTML mode.

Converted all \n/\n\n to <br>/<br><br> across 19 files in dialogue text/information/details parameters. This ensures proper line break rendering in all dialog boxes.

Also fixed:
- Duplicate QLabel bug in FatalErrorDialog (created txt variable but added separate QLabel)
- Missing line breaks in multi-line concatenated strings without any \n
- Typo: 'report it the developers' -> 'report it to the developers'
- HTML-escaped '<None>' to '&lt;None&gt;' in RichText context in main_window.py