### PR TITLE
Update VSCode settings: set default formatter null

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -64,15 +64,20 @@
     "virtualenv",
     "webapi"
   ],
-  "cSpell.ignorePaths": ["**test**"],
-  "isort.args": ["--profile", "black"],
+  "cSpell.ignorePaths": [
+    "**test**"
+  ],
+  "isort.args": [
+    "--profile",
+    "black"
+  ],
   "[python]": {
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
       "source.fixAll": "explicit",
       "source.organizeImports": "explicit"
     },
-    "editor.defaultFormatter": "charliermarsh.ruff"
+    "editor.defaultFormatter": null
   },
   "languageToolLinter.languageTool.ignoredWordsInWorkspace": [
     " macport",
@@ -97,10 +102,12 @@
   "yaml.schemas": {
     "https://json.schemastore.org/github-issue-config.json": "file:///c%3A/Code%20Repos/RimSort/.github/ISSUE_TEMPLATE/config.yml"
   },
-  "python.testing.pytestArgs": ["."],
+  "python.testing.pytestArgs": [
+    "."
+  ],
   "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true,
-  "editor.defaultFormatter": "charliermarsh.ruff",
+  "editor.defaultFormatter": null,
   "[yaml]": {
     "editor.defaultFormatter": "redhat.vscode-yaml"
   },


### PR DESCRIPTION
Remove charliermarsh.ruff as the default formatter (set editor.defaultFormatter to null globally and for Python) and reformat several JSON arrays for readability (cSpell.ignorePaths, isort.args, python.testing.pytestArgs). These changes avoid enforcing a specific formatter in the workspace and tidy up the settings file formatting.