### PR TITLE
fix: use path equivalence for local mods folder validation

### DIFF
--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -445,9 +445,7 @@ class SettingsController(QObject):
         """
         game_folder = (
             self.settings_dialog.game_location.text().strip()
-            or self.settings.instances[
-                self.settings.current_instance
-            ].game_folder
+            or self.settings.instances[self.settings.current_instance].game_folder
         )
         local_path = Path(local_folder)
         expected_path = Path(game_folder) / "Mods"

--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -437,17 +437,29 @@ class SettingsController(QObject):
     def _validate_local_mods_location(self, local_folder: str) -> bool:
         """
         Validate the local mods folder location and show a warning if invalid.
-        The local mods folder is valid if it is a directory.
+        The local mods folder is valid if it is a directory that is path-equivalent
+        to ``<game_folder>/Mods``.
 
         :param local_folder: Path to the local mods folder as a string.
         :return: True if valid, False otherwise.
         """
-        game_folder = self.settings.instances[
-            self.settings.current_instance
-        ].game_folder
-        if not (Path(local_folder).is_dir()) or local_folder != str(
-            Path(game_folder) / "Mods"
-        ):
+        game_folder = (
+            self.settings_dialog.game_location.text().strip()
+            or self.settings.instances[
+                self.settings.current_instance
+            ].game_folder
+        )
+        local_path = Path(local_folder)
+        expected_path = Path(game_folder) / "Mods"
+        try:
+            paths_match = (
+                local_path.is_dir()
+                and game_folder
+                and local_path.resolve() == expected_path.resolve()
+            )
+        except OSError:
+            paths_match = False
+        if not paths_match:
             QMessageBox.warning(
                 self.settings_dialog,
                 self.tr("Invalid Local Mods Folder"),


### PR DESCRIPTION
## Summary

- Fixes local mods folder validation rejecting valid paths on Windows due to string comparison of paths that differ textually but point to the same directory (e.g., different slash direction from VDF parsing vs user input, case differences)
- Fixes validation reading `game_folder` from the stale settings model instead of the current dialog text, causing first-time setup and unsaved changes to always fail validation

## Root Cause

`_validate_local_mods_location` used `local_folder != str(Path(game_folder) / "Mods")` — a raw string comparison. On Windows, paths from different sources (VDF parsing, file dialogs, manual input) often have different formatting (forward vs back slashes, casing, trailing separators) while pointing to the same directory.

Additionally, `game_folder` was read from the settings model rather than the current dialog text. On first-time setup, the model defaults to `""`, making `str(Path("") / "Mods")` = `"Mods"` — which never matches a full path.

## Changes

- Read `game_folder` from the dialog text first, falling back to the saved model value
- Replace string comparison with `Path.resolve()` equivalence check, which normalizes paths across platforms
- Wrap in `try/except OSError` for edge cases (broken symlinks, permission issues)

## Test plan

- [ ] On Windows: autodetect paths, click OK — local mods folder should be accepted
- [ ] On Windows: manually type `C:\Program Files (x86)\Steam\steamapps\common\RimWorld\Mods` — should be accepted when game folder matches
- [ ] On Windows: use "Choose" button for local mods folder before clicking OK — should validate against the current game folder text, not saved state
- [ ] Verify that an actually invalid path (non-existent directory, or a Mods folder not inside the game folder) is still rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)