### PR TITLE
fix: validate SteamCMD content symlink before download

### DIFF
--- a/app/utils/steam/steamcmd/wrapper.py
+++ b/app/utils/steam/steamcmd/wrapper.py
@@ -52,6 +52,7 @@ class SteamcmdInterface:
         if not hasattr(self, "initialized"):
             self.initialized = True
             self.setup = False
+            self.symlink_source_path = ""
             self.steamcmd_prefix = steamcmd_prefix
             super(SteamcmdInterface, self).__init__()
             logger.debug("Initializing SteamcmdInterface")
@@ -395,6 +396,14 @@ class SteamcmdInterface:
             self.on_steamcmd_not_found(runner=runner)
             return
 
+        if self.symlink_source_path:
+            if not self.validate_content_symlink(self.symlink_source_path):
+                runner.message(
+                    "Download cancelled — SteamCMD content symlink could not be validated."
+                )
+                runner.close()
+                return
+
         total = len(publishedfileids)
         runner.message(
             f"Got it: {self.steamcmd}\n"
@@ -607,6 +616,7 @@ class SteamcmdInterface:
                 runner.message(f"Reinstalling SteamCMD: {self.steamcmd_install_path}")
                 self.setup_steamcmd(symlink_source_path, True, runner)
         if installed:
+            self.symlink_source_path = symlink_source_path
             if not os.path.exists(self.steamcmd_content_path):
                 os.makedirs(self.steamcmd_content_path)
                 runner.message(

--- a/app/utils/steam/steamcmd/wrapper.py
+++ b/app/utils/steam/steamcmd/wrapper.py
@@ -309,6 +309,60 @@ class SteamcmdInterface:
             fh.write("\n".join(script_lines))
         return script_path
 
+    def validate_content_symlink(self, symlink_source_path: str) -> bool:
+        """Check that the workshop content symlink exists and points to a valid target.
+
+        If the symlink is missing or dangling (e.g. after reinstalling the game),
+        prompt the user to re-create it.
+
+        :param symlink_source_path: The local mods directory the symlink should target.
+        :return: True if the symlink is healthy or was successfully re-created.
+        """
+        content_link = Path(self.steamcmd_content_path) / "294100"
+
+        if content_link.exists() and content_link.is_dir():
+            return True
+
+        is_dangling = symlink.is_junction_or_link(str(content_link))
+        if is_dangling:
+            problem = self.translate(
+                "SteamcmdInterface",
+                "The SteamCMD workshop content symlink exists but points to a "
+                "directory that no longer exists. This typically happens after "
+                "reinstalling the game.",
+            )
+        else:
+            problem = self.translate(
+                "SteamcmdInterface",
+                "The SteamCMD workshop content symlink is missing. "
+                "Downloads will fail without it.",
+            )
+
+        logger.warning(f"SteamCMD content symlink invalid: {content_link} (dangling={is_dangling})")
+
+        diag = BinaryChoiceDialog(
+            title=self.translate("SteamcmdInterface", "SteamCMD Symlink Issue"),
+            text=problem,
+            information=self.translate(
+                "SteamcmdInterface",
+                "Would you like RimSort to fix this by re-creating the symlink?",
+            ),
+            details=self.translate(
+                "SteamcmdInterface",
+                "Symlink: [{source}] -> {destination}",
+            ).format(source=symlink_source_path, destination=str(content_link)),
+            positive_text=self.translate("SteamcmdInterface", "Fix && Retry"),
+            negative_text=self.translate("SteamcmdInterface", "Cancel Download"),
+            icon=QMessageBox.Icon.Warning,
+        )
+
+        if not diag.exec_is_positive():
+            return False
+
+        return self.create_symlink(
+            symlink_source_path, str(content_link), force=True
+        )
+
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------

--- a/app/utils/symlink.py
+++ b/app/utils/symlink.py
@@ -53,6 +53,18 @@ def is_junction_or_link(path: str | Path) -> bool:
         return False
 
 
+def resolve_symlink_target(path: str | Path) -> str | None:
+    """Return the resolved target of a symlink/junction if it exists, else None."""
+    try:
+        target = os.readlink(path)
+    except OSError:
+        return None
+    resolved = Path(target) if os.path.isabs(target) else Path(os.path.dirname(str(path))) / target
+    if resolved.exists() and resolved.is_dir():
+        return str(resolved)
+    return None
+
+
 def create_symlink(
     src_path: str,
     dst_path: str,

--- a/tests/utils/steam/steamcmd/test_symlink_validation.py
+++ b/tests/utils/steam/steamcmd/test_symlink_validation.py
@@ -1,0 +1,36 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from app.utils.symlink import resolve_symlink_target
+
+
+class TestResolveSymlinkTarget:
+    def test_valid_symlink_returns_target(self, tmp_path: Path) -> None:
+        target = tmp_path / "target_dir"
+        target.mkdir()
+        link = tmp_path / "link"
+        os.symlink(str(target), str(link))
+
+        result = resolve_symlink_target(str(link))
+        assert result == str(target)
+
+    def test_dangling_symlink_returns_none(self, tmp_path: Path) -> None:
+        target = tmp_path / "nonexistent"
+        link = tmp_path / "link"
+        os.symlink(str(target), str(link))
+
+        result = resolve_symlink_target(str(link))
+        assert result is None
+
+    def test_not_a_symlink_returns_none(self, tmp_path: Path) -> None:
+        regular_dir = tmp_path / "regular"
+        regular_dir.mkdir()
+
+        result = resolve_symlink_target(str(regular_dir))
+        assert result is None
+
+    def test_nonexistent_path_returns_none(self, tmp_path: Path) -> None:
+        result = resolve_symlink_target(str(tmp_path / "nope"))
+        assert result is None

--- a/tests/utils/steam/steamcmd/test_symlink_validation.py
+++ b/tests/utils/steam/steamcmd/test_symlink_validation.py
@@ -1,8 +1,10 @@
 import os
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from app.utils.steam.steamcmd.wrapper import SteamcmdInterface
 from app.utils.symlink import resolve_symlink_target
 
 
@@ -34,3 +36,88 @@ class TestResolveSymlinkTarget:
     def test_nonexistent_path_returns_none(self, tmp_path: Path) -> None:
         result = resolve_symlink_target(str(tmp_path / "nope"))
         assert result is None
+
+
+@pytest.fixture
+def steamcmd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> SteamcmdInterface:
+    """Create a SteamcmdInterface with paths rooted in tmp_path, bypassing __init__."""
+    monkeypatch.setattr(SteamcmdInterface, "_instance", None)
+    instance = object.__new__(SteamcmdInterface)
+    instance.initialized = True
+    instance.setup = True
+    instance.steamcmd_prefix = str(tmp_path)
+    instance.steamcmd_steam_path = str(tmp_path / "steam")
+    instance.steamcmd_content_path = str(
+        tmp_path / "steam" / "steamapps" / "workshop" / "content"
+    )
+    instance.translate = lambda ctx, text: text
+    Path(instance.steamcmd_content_path).mkdir(parents=True, exist_ok=True)
+    return instance
+
+
+class TestValidateContentSymlink:
+    def test_healthy_symlink_returns_true(
+        self, steamcmd: SteamcmdInterface, tmp_path: Path
+    ) -> None:
+        target = tmp_path / "local_mods"
+        target.mkdir()
+        link = Path(steamcmd.steamcmd_content_path) / "294100"
+        os.symlink(str(target), str(link))
+
+        assert steamcmd.validate_content_symlink(str(target)) is True
+
+    def test_real_directory_returns_true(
+        self, steamcmd: SteamcmdInterface
+    ) -> None:
+        real_dir = Path(steamcmd.steamcmd_content_path) / "294100"
+        real_dir.mkdir()
+
+        assert steamcmd.validate_content_symlink(str(real_dir)) is True
+
+    def test_dangling_symlink_shows_dialog_and_returns_false_on_decline(
+        self, steamcmd: SteamcmdInterface, tmp_path: Path
+    ) -> None:
+        gone = tmp_path / "deleted_mods"
+        link = Path(steamcmd.steamcmd_content_path) / "294100"
+        os.symlink(str(gone), str(link))
+
+        with patch(
+            "app.utils.steam.steamcmd.wrapper.BinaryChoiceDialog"
+        ) as MockDialog:
+            MockDialog.return_value.exec_is_positive.return_value = False
+            result = steamcmd.validate_content_symlink(str(tmp_path / "new_mods"))
+            assert result is False
+            MockDialog.assert_called_once()
+
+    def test_dangling_symlink_recreates_on_accept(
+        self, steamcmd: SteamcmdInterface, tmp_path: Path
+    ) -> None:
+        gone = tmp_path / "deleted_mods"
+        new_target = tmp_path / "new_mods"
+        new_target.mkdir()
+        link = Path(steamcmd.steamcmd_content_path) / "294100"
+        os.symlink(str(gone), str(link))
+
+        with patch(
+            "app.utils.steam.steamcmd.wrapper.BinaryChoiceDialog"
+        ) as MockDialog:
+            MockDialog.return_value.exec_is_positive.return_value = True
+            steamcmd.create_symlink = MagicMock(return_value=True)
+            result = steamcmd.validate_content_symlink(str(new_target))
+            assert result is True
+            steamcmd.create_symlink.assert_called_once_with(
+                str(new_target), str(link), force=True
+            )
+
+    def test_missing_symlink_shows_dialog(
+        self, steamcmd: SteamcmdInterface, tmp_path: Path
+    ) -> None:
+        new_target = tmp_path / "mods"
+        new_target.mkdir()
+
+        with patch(
+            "app.utils.steam.steamcmd.wrapper.BinaryChoiceDialog"
+        ) as MockDialog:
+            MockDialog.return_value.exec_is_positive.return_value = False
+            result = steamcmd.validate_content_symlink(str(new_target))
+            assert result is False

--- a/tests/utils/steam/steamcmd/test_symlink_validation.py
+++ b/tests/utils/steam/steamcmd/test_symlink_validation.py
@@ -121,3 +121,53 @@ class TestValidateContentSymlink:
             MockDialog.return_value.exec_is_positive.return_value = False
             result = steamcmd.validate_content_symlink(str(new_target))
             assert result is False
+
+
+class TestDownloadModsValidation:
+    def test_download_mods_aborts_on_broken_symlink(
+        self, steamcmd: SteamcmdInterface, tmp_path: Path
+    ) -> None:
+        gone = tmp_path / "deleted_mods"
+        link = Path(steamcmd.steamcmd_content_path) / "294100"
+        os.symlink(str(gone), str(link))
+
+        steamcmd.symlink_source_path = str(tmp_path / "new_mods")
+        runner = MagicMock()
+
+        with patch(
+            "app.utils.steam.steamcmd.wrapper.BinaryChoiceDialog"
+        ) as MockDialog:
+            MockDialog.return_value.exec_is_positive.return_value = False
+            steamcmd.download_mods(["123456"], runner)
+
+        runner.execute.assert_not_called()
+
+    def test_download_mods_proceeds_on_healthy_symlink(
+        self, steamcmd: SteamcmdInterface, tmp_path: Path
+    ) -> None:
+        target = tmp_path / "local_mods"
+        target.mkdir()
+        link = Path(steamcmd.steamcmd_content_path) / "294100"
+        os.symlink(str(target), str(link))
+
+        steamcmd.symlink_source_path = str(target)
+        steamcmd.steamcmd = "/fake/steamcmd"
+        steamcmd.validate_downloads = False
+        runner = MagicMock()
+
+        steamcmd.download_mods(["123456"], runner)
+
+        runner.execute.assert_called_once()
+
+    def test_download_mods_skips_validation_when_no_source_path(
+        self, steamcmd: SteamcmdInterface, tmp_path: Path
+    ) -> None:
+        """If symlink_source_path was never set, skip validation gracefully."""
+        steamcmd.symlink_source_path = ""
+        steamcmd.steamcmd = "/fake/steamcmd"
+        steamcmd.validate_downloads = False
+        runner = MagicMock()
+
+        steamcmd.download_mods(["123456"], runner)
+
+        runner.execute.assert_called_once()


### PR DESCRIPTION
## Summary

- Validates the SteamCMD workshop content symlink (`content/294100`) before launching downloads, preventing the cryptic "I/O Operation Failed" from SteamCMD
- Detects both dangling symlinks (target directory removed, e.g. after reinstalling RimWorld) and missing symlinks
- Shows a clear dialog offering a one-click fix to re-create the symlink, instead of letting SteamCMD fail silently

## Changes

- `app/utils/symlink.py` — Added `resolve_symlink_target()` utility for checking symlink health
- `app/utils/steam/steamcmd/wrapper.py` — Added `validate_content_symlink()` method and wired it into `download_mods()` as a pre-flight check; stored `symlink_source_path` on the instance during `setup_steamcmd()`
- `tests/utils/steam/steamcmd/test_symlink_validation.py` — 12 tests covering the utility, validation logic, dialog interaction, and download integration

## Test plan

- [x] 12 new tests covering all validation paths (healthy, dangling, missing, dialog accept/decline, download integration)
- [x] Full test suite passes (1066 tests, 0 failures)
- [ ] Manual test: set up SteamCMD, delete the symlink target directory, attempt a mod download → should see the new dialog instead of "I/O Operation Failed"

Closes #2185

🤖 Generated with [Claude Code](https://claude.com/claude-code)