### PR TITLE
refactor: centralize steam integration UI state in signal handlers

### DIFF
--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -23,7 +23,6 @@ from app.controllers.settings_tabs import (
 )
 from app.controllers.theme_controller import ThemeController
 from app.models.settings import Instance, Settings
-from app.utils.acf_utils import validate_acf_file_exists
 from app.utils.app_info import AppInfo
 from app.utils.constants import DEFAULT_INSTANCE_NAME
 from app.utils.event_bus import EventBus
@@ -254,6 +253,7 @@ class SettingsController(QObject):
         if tab_name:
             self.settings_dialog.switch_to_tab(tab_name)
         self.settings_dialog.show()
+        self._show_steam_integration_warnings()
 
     def set_instance(self, instance: Instance) -> None:
         """
@@ -267,6 +267,11 @@ class SettingsController(QObject):
         Get the active instance.
         """
         return self.settings.instances[self.settings.current_instance]
+
+    def _show_steam_integration_warnings(self) -> None:
+        for msg in self.settings._steam_integration_warnings:
+            QMessageBox.warning(self.settings_dialog, self.tr("Steam Integration"), msg)
+        self.settings._steam_integration_warnings.clear()
 
     def _update_view_from_model(self) -> None:
         """
@@ -431,108 +436,6 @@ class SettingsController(QObject):
             return False
         return True
 
-    def _check_steam_integration_validity(
-        self, steam_client_integration: bool, steam_mods_location: str
-    ) -> bool:
-        """
-        Check if Steam client integration and Steam mods location are valid.
-
-        Validation rules:
-        - If both disabled: valid
-        - If steam_client_integration enabled but steam_mods_location empty: invalid
-        - If steam_mods_location set: must have valid ACF file
-        - If steam_mods_location set but ACF missing: invalid
-
-        :param steam_client_integration: Whether Steam client integration is enabled.
-        :param steam_mods_location: Path to the Steam mods folder.
-        :return: True if valid configuration, False if invalid.
-        """
-        # If integration disabled, no location validation needed
-        if not steam_client_integration and not steam_mods_location:
-            return True
-
-        # If integration enabled but no location, invalid
-        if steam_client_integration and not steam_mods_location:
-            return False
-
-        # If location set (with or without integration), check ACF file
-        if steam_mods_location:
-            return validate_acf_file_exists(steam_mods_location)
-
-        return True
-
-    def _disable_steam_integration_ui(self) -> None:
-        """
-        Clear all Steam integration dependent UI settings.
-        Disables Steam client integration, clears workshop folder, and disables Steam protocol launch.
-        """
-        self.settings_dialog.steam_client_integration_checkbox.setChecked(False)
-        self.settings_dialog.steam_mods_folder_location.setText("")
-        self.settings_dialog.launch_via_steam_protocol_checkbox.setChecked(False)
-
-    def _validate_steam_integration(self) -> bool:
-        """
-        Validate Steam client integration and Steam mods location configuration.
-        Shows appropriate warnings if validation fails and prevents saving.
-
-        Ensures that Steam protocol launch is only enabled when Steam integration is enabled.
-
-        :return: True if valid configuration, False if invalid.
-        """
-        steam_client_integration = (
-            self.settings_dialog.steam_client_integration_checkbox.isChecked()
-        )
-        steam_mods_location = (
-            self.settings_dialog.steam_mods_folder_location.text().strip()
-        )
-
-        # Handle user explicitly disabling Steam integration
-        if not steam_client_integration:
-            QMessageBox.warning(
-                self.settings_dialog,
-                self.tr("Steam Client Integration Disabled"),
-                self.tr(
-                    "Steam client integration is disabled. Steam mods location and Steam protocol launch will be cleared."
-                ),
-            )
-            # Clear dependent settings when integration is disabled
-            self.settings_dialog.steam_mods_folder_location.setText("")
-            self.settings_dialog.launch_via_steam_protocol_checkbox.setChecked(False)
-
-        # Validate Steam integration configuration
-        is_valid = self._check_steam_integration_validity(
-            steam_client_integration, steam_mods_location
-        )
-
-        if not is_valid:
-            # Disable all Steam integration settings if validation fails
-            self._disable_steam_integration_ui()
-
-            # Determine which validation failed for appropriate error message
-            if steam_client_integration and not steam_mods_location:
-                QMessageBox.warning(
-                    self.settings_dialog,
-                    self.tr("Steam Mods Location Required"),
-                    self.tr(
-                        "Steam client integration requires a Steam mods location to be configured. "
-                        "Steam client integration, Steam mods location, and Steam protocol launch have been disabled."
-                    ),
-                )
-            elif steam_mods_location and not validate_acf_file_exists(
-                steam_mods_location
-            ):
-                QMessageBox.warning(
-                    self.settings_dialog,
-                    self.tr("Steam Workshop File Not Found"),
-                    self.tr(
-                        "The Steam Workshop file 'appworkshop_294100.acf' was not found at the expected location. "
-                        "Steam client integration, Steam mods location, and Steam protocol launch have been disabled. "
-                        "Please ensure Steam is properly installed and has downloaded RimWorld Workshop data."
-                    ),
-                )
-
-        return is_valid
-
     @Slot()
     def _on_global_ok_button_clicked(self) -> None:
         """
@@ -562,10 +465,11 @@ class SettingsController(QObject):
         ):
             return
 
-        # Validate Steam integration if enabled
-        if self.settings_dialog.steam_client_integration_checkbox.isChecked():
-            if not self._validate_steam_integration():
-                return
+        # Model-level Steam integration validation (silently fixes & logs)
+        if self.settings._validate_steam_integration_config():
+            self._show_steam_integration_warnings()
+            self._locations_tab.update_view_from_model()
+            return
 
         # If all validations pass, save settings and close dialog
         self.settings.save()
@@ -666,7 +570,7 @@ class SettingsController(QObject):
             ),
         ]
 
-        for group in path_groups:
+        for i, group in enumerate(path_groups):
             if group.folder.exists():
                 logger.info(
                     f"Auto-detected {group.name} folder path exists: {group.folder}"
@@ -676,6 +580,13 @@ class SettingsController(QObject):
                         f"No value set currently for {group.name} folder. Overwriting with auto-detected path"
                     )
                     group.settings_line.setText(str(group.folder))
+                    if i == 2:
+                        self.settings_dialog.steam_client_integration_checkbox.setChecked(
+                            True
+                        )
+                        self.settings_dialog.launch_via_steam_protocol_checkbox.setChecked(
+                            True
+                        )
                 else:
                     logger.info(f"Value already set for {group.name} folder. Passing")
             else:

--- a/app/controllers/settings_tabs/locations_tab_controller.py
+++ b/app/controllers/settings_tabs/locations_tab_controller.py
@@ -99,6 +99,7 @@ class LocationsTabController(BaseTabController):
             FolderPathGroup(
                 prefix="steam_mods_folder",
                 choose_callback=self._on_steam_mods_choose,
+                clear_callback=self._on_steam_mods_clear,
             ),
             FolderPathGroup(
                 prefix="local_mods_folder",
@@ -129,19 +130,17 @@ class LocationsTabController(BaseTabController):
     def update_view_from_model(self) -> None:
         instance = self.settings.instances[self.settings.current_instance]
 
+        self.dialog.steam_client_integration_checkbox.setChecked(
+            instance.steam_client_integration
+        )
+        # Explicitly sync UI enable states so the handler runs even when the
+        # checkbox state hasn't changed (e.g. default unchecked + model unchecked).
+        self.dialog._on_steam_integration_toggled()
+
         self._groups[0].update_view(self.dialog, str(instance.game_folder))
         self._groups[1].update_view(self.dialog, str(instance.config_folder))
         self._groups[2].update_view(self.dialog, str(instance.workshop_folder))
         self._groups[3].update_view(self.dialog, str(instance.local_folder))
-
-        self.dialog.steam_client_integration_checkbox.setChecked(
-            instance.steam_client_integration
-        )
-        checked = self.dialog.steam_client_integration_checkbox.isChecked()
-        self.dialog.steam_mods_folder_location.setEnabled(checked)
-        self.dialog.steam_mods_folder_location_open_button.setEnabled(checked)
-        self.dialog.steam_mods_folder_location_choose_button.setEnabled(checked)
-        self.dialog.steam_mods_folder_location_clear_button.setEnabled(checked)
 
         is_default = self.settings.current_instance == DEFAULT_INSTANCE_NAME
         self.dialog.instance_folder_location.setText(instance.instance_folder_override)
@@ -216,6 +215,11 @@ class LocationsTabController(BaseTabController):
         self._path_selected_callback(str(Path(steam_mods_folder).parent))
         return steam_mods_folder
 
+    @staticmethod
+    def _on_steam_mods_clear(dialog: SettingsDialog) -> None:
+        dialog.steam_client_integration_checkbox.setChecked(False)
+        dialog.launch_via_steam_protocol_checkbox.setChecked(False)
+
     def _on_local_mods_choose(self, dialog: SettingsDialog) -> str | None:
         local_mods_folder = show_dialogue_file(
             mode="open_dir",
@@ -246,3 +250,5 @@ class LocationsTabController(BaseTabController):
         self.dialog.config_folder_location.setText("")
         self.dialog.steam_mods_folder_location.setText("")
         self.dialog.local_mods_folder_location.setText("")
+        self.dialog.steam_client_integration_checkbox.setChecked(False)
+        self.dialog.launch_via_steam_protocol_checkbox.setChecked(False)

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -14,7 +14,10 @@ from PySide6.QtWidgets import QApplication
 
 from app.controllers.instance_controller import InstanceController
 from app.models.instance import Instance
-from app.utils.acf_utils import validate_acf_file_exists
+from app.utils.acf_utils import (
+    is_rimworld_workshop_folder,
+    validate_acf_file_exists,
+)
 from app.utils.app_info import AppInfo
 from app.utils.constants import (
     DEFAULT_INSTANCE_NAME,
@@ -233,6 +236,10 @@ class Settings(QObject):
         # Active mod list dividers: list of {uuid, name, collapsed, index}
         self.active_mods_dividers: list[dict[str, Any]] = []
 
+        # Accumulates human-readable warnings from the last model-level
+        # steam integration validation so the UI can show them on dialog open.
+        self._steam_integration_warnings: list[str] = []
+
     @property
     def aux_db_path(self) -> Path:
         """
@@ -418,6 +425,8 @@ class Settings(QObject):
         else:
             self._debug_file.unlink(missing_ok=True)
 
+        self._validate_steam_integration_config()
+
         with open(str(self._settings_file), "w") as file:
             json.dump(self._to_dict(), file, indent=4)
 
@@ -587,55 +596,73 @@ class Settings(QObject):
 
     def _validate_steam_integration_config(self) -> bool:
         """
-        Validate and fix Steam client integration configuration.
+        Validate and fix Steam client integration configuration on load.
 
-        Ensures that Steam client integration settings are valid:
-        - If steam_client_integration is enabled but workshop_folder is not set, disable it.
-        - If workshop_folder is set but the appworkshop_294100.acf file is missing,
-          disable steam_client_integration and clear workshop_folder.
-        - If launch_via_steam_protocol is enabled but steam_client_integration is disabled, disable it.
+        Ensures that Steam client integration settings are consistent:
+        - If ``steam_client_integration`` is enabled but ``workshop_folder`` is
+          empty or does not pass validation (path must end with ``294100`` and
+          ``appworkshop_294100.acf`` must exist), disable integration and
+          clear the workshop folder.
+        - If ``launch_via_steam_protocol`` is enabled without
+          ``steam_client_integration``, disable it.
 
         Invalid configurations are silently fixed without user interaction.
+        Validation does **not** depend on ``launch_via_steam_protocol``.
 
         :return: True if configuration was fixed, False if no changes were made.
         """
-        active_instance = self.instances[self.current_instance]
-        steam_client_integration = active_instance.steam_client_integration
-        workshop_folder = active_instance.workshop_folder
-        launch_via_steam_protocol = active_instance.launch_via_steam_protocol
+        instance = self.instances[self.current_instance]
+        fixed = False
 
-        # If neither is enabled, no validation needed
-        if (
-            not steam_client_integration
-            and not workshop_folder
-            and not launch_via_steam_protocol
-        ):
-            return False
-
-        # If launch_via_steam_protocol is enabled but steam_client_integration is not, disable it
-        if launch_via_steam_protocol and not steam_client_integration:
+        # Fix: steam protocol requires steam client integration
+        if instance.launch_via_steam_protocol and not instance.steam_client_integration:
             logger.warning(
                 "Steam protocol launch is enabled but Steam client integration is disabled. Disabling..."
             )
-            active_instance.launch_via_steam_protocol = False
-            return True
+            instance.launch_via_steam_protocol = False
+            fixed = True
 
-        # If steam_client_integration is enabled but workshop_folder is not set, disable it
-        if steam_client_integration and not workshop_folder:
+        # Validate steam_client_integration prerequisites
+        if instance.steam_client_integration:
+            if not instance.workshop_folder:
+                logger.warning(
+                    "Steam client integration is enabled but workshop folder is not configured. Disabling..."
+                )
+                instance.steam_client_integration = False
+                instance.launch_via_steam_protocol = False
+                fixed = True
+                self._steam_integration_warnings.append(
+                    "Steam client integration requires a Steam mods location to be configured.<br><br>"
+                    "Steam client integration, Steam mods location, and Steam protocol launch have been disabled."
+                )
+            elif not (
+                is_rimworld_workshop_folder(instance.workshop_folder)
+                and validate_acf_file_exists(instance.workshop_folder)
+            ):
+                logger.warning(
+                    f"Workshop folder validation failed for: {instance.workshop_folder}. "
+                    "Disabling Steam client integration and clearing workshop folder..."
+                )
+                instance.steam_client_integration = False
+                instance.launch_via_steam_protocol = False
+                instance.workshop_folder = ""
+                fixed = True
+                self._steam_integration_warnings.append(
+                    "Steam client integration has been disabled because the configured Steam mods "
+                    "location is not a valid RimWorld Steam Workshop folder.<br><br>"
+                    "Steam mods location and Steam protocol launch have been cleared."
+                )
+
+        # Clear orphaned workshop folder when integration is disabled
+        if not instance.steam_client_integration and instance.workshop_folder:
             logger.warning(
-                "Steam client integration is enabled but workshop folder is not configured. Disabling..."
+                "Steam client integration is disabled. Clearing workshop folder..."
             )
-            active_instance.steam_client_integration = False
-            return True
-
-        # If workshop_folder is set, validate that the ACF file exists
-        if workshop_folder and not validate_acf_file_exists(workshop_folder):
-            logger.warning(
-                f"ACF file not found for workshop folder: {workshop_folder}. "
-                "Disabling Steam client integration and clearing workshop folder..."
+            instance.workshop_folder = ""
+            fixed = True
+            self._steam_integration_warnings.append(
+                "Steam client integration is disabled.<br><br>"
+                "The Steam mods location has been cleared."
             )
-            active_instance.steam_client_integration = False
-            active_instance.workshop_folder = ""
-            return True
 
-        return False
+        return fixed

--- a/app/utils/acf_utils.py
+++ b/app/utils/acf_utils.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 
+from app.utils.constants import RIMWORLD_STEAM_APP_ID
 from app.utils.steam.steamfiles.wrapper import acf_to_dict, dict_to_acf
 
 if TYPE_CHECKING:
@@ -465,6 +466,19 @@ def steamcmd_purge_mods(
                 manifest_path.unlink()
             except Exception as e:
                 logger.error(f"Failed to remove manifest file {manifest_path}: {e}")
+
+
+def is_rimworld_workshop_folder(path: str) -> bool:
+    """
+    Check if a path points to a RimWorld Steam Workshop content folder.
+
+    Validation checks that the path ends with ``294100``, which is the Steam app ID
+    for RimWorld.
+
+    :param path: Path to check, typically a workshop content folder.
+    :return: True if the path ends with ``294100``.
+    """
+    return Path(path).name == RIMWORLD_STEAM_APP_ID
 
 
 def validate_acf_file_exists(steam_mods_location: str) -> bool:

--- a/app/utils/constants.py
+++ b/app/utils/constants.py
@@ -7,6 +7,9 @@ INSTANCE_FOLDER_NAME = "instances"
 STEAMCMD_FOLDER_NAME = "steamcmd"
 STEAM_FOLDER_NAME = "steam"
 
+# Steam App ID for RimWorld
+RIMWORLD_STEAM_APP_ID = "294100"
+
 # Default packageId for mods with missing or invalid packageId
 DEFAULT_MISSING_PACKAGEID = "missing.packageid"
 

--- a/app/utils/metadata.py
+++ b/app/utils/metadata.py
@@ -457,8 +457,11 @@ class MetadataManager(QObject):
             self.parser_threadpool.clear()
             return
 
-        # Process Steam Workshop mods
-        process_data_source_folder("workshop", settings_instance.workshop_folder)
+        # Process Steam Workshop mods (only when Steam client integration is enabled)
+        if settings_instance.steam_client_integration:
+            process_data_source_folder("workshop", settings_instance.workshop_folder)
+        elif settings_instance.workshop_folder:
+            logger.info("Steam client integration is disabled; skipping workshop mods")
 
         if self._abort_requested:
             self.parser_threadpool.clear()

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -1182,6 +1182,10 @@ This basically preserves your mod coloring, user notes etc. for this many second
         self.steam_mods_folder_location_open_button.setEnabled(checked)
         self.steam_mods_folder_location_choose_button.setEnabled(checked)
         self.steam_mods_folder_location_clear_button.setEnabled(checked)
+        self.launch_via_steam_protocol_checkbox.setEnabled(checked)
+        if not checked:
+            self.steam_mods_folder_location.clear()
+            self.launch_via_steam_protocol_checkbox.setChecked(False)
 
     def _on_steam_protocol_toggled(self) -> None:
         # Disable run_args group when Steam protocol launch is enabled


### PR DESCRIPTION
- _on_steam_integration_toggled now fully governs protocol checkbox enable/disable, workshop folder clearing, and protocol uncheck when integration is unchecked
- Removed redundant setEnabled/setChecked calls from locations_tab_controller (now covered by the signal handler)
- Extracted _show_steam_integration_warnings to eliminate duplicated warning display across dialog show and OK-click validation
- Moved steam integration validation from UI controller layer to model layer (settings._validate_steam_integration_config) with accumulated warnings shown on dialog open
- Autodetect explicitly checks both steam integration and protocol checkboxes when a workshop path is detected
- Added clear_callback for steam mods folder path group
- Added is_rimworld_workshop_folder helper and RIMWORLD_STEAM_APP_ID constant
- Skip processing workshop mods in metadata when steam integration is disabled