### PR TITLE
fix: eliminate duplicated create_instance by inlining wrapper

### DIFF
--- a/app/controllers/instance_controller.py
+++ b/app/controllers/instance_controller.py
@@ -126,8 +126,8 @@ class InstanceController(QObject):
             return None
         return Path(instance.config_folder)
 
+    @staticmethod
     def create_instance(
-        self,
         instance_name: str,
         game_folder: str = "",
         config_folder: str = "",

--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -255,35 +255,6 @@ class SettingsController(QObject):
             self.settings_dialog.switch_to_tab(tab_name)
         self.settings_dialog.show()
 
-    def create_instance(
-        self,
-        instance_name: str,
-        game_folder: str = "",
-        config_folder: str = "",
-        local_folder: str = "",
-        workshop_folder: str = "",
-        run_args: str = "",
-        steamcmd_install_path: str = "",
-        steam_client_integration: bool = False,
-        instance_folder_override: str = "",
-    ) -> None:
-        """
-        Create and set the instance.
-        """
-        instance = Instance(
-            name=instance_name,
-            game_folder=game_folder,
-            config_folder=config_folder,
-            local_folder=local_folder,
-            workshop_folder=workshop_folder,
-            run_args=run_args,
-            steamcmd_install_path=steamcmd_install_path,
-            steam_client_integration=steam_client_integration,
-            instance_folder_override=instance_folder_override,
-        )
-
-        self.set_instance(instance)
-
     def set_instance(self, instance: Instance) -> None:
         """
         Set the instance with the provided instance.

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -1049,7 +1049,7 @@ class MainWindow(QMainWindow):
                 if existing_args:
                     run_args = f"{run_args} {existing_args}".strip()
             # Add new instance to Settings
-            self.settings_controller.create_instance(
+            instance = InstanceController.create_instance(
                 instance_name=instance_name,
                 game_folder=instance_data.get("game_folder", ""),
                 local_folder=instance_data.get("local_folder", ""),
@@ -1062,6 +1062,7 @@ class MainWindow(QMainWindow):
                 ),
                 instance_folder_override=instance_folder_override,
             )
+            self.settings_controller.set_instance(instance)
 
             # Save settings
             self.settings_controller.settings.save()


### PR DESCRIPTION
Removed SettingsController.create_instance which was a thin wrapper duplicating InstanceController.create_instance's parameter list and Instance(...) construction.
- Made InstanceController.create_instance a @staticmethod
- Caller in MainWindow now uses InstanceController.create_instance + settings_controller.set_instance directly
- Resolves jscpd clone detection