### PR TITLE
Break import cycles and hoist deferred imports

### DIFF
--- a/app/controllers/app_controller.py
+++ b/app/controllers/app_controller.py
@@ -6,6 +6,8 @@ from PySide6.QtCore import QCoreApplication, QLibraryInfo, QObject, QTranslator
 from PySide6.QtWidgets import QApplication
 
 from app.controllers.main_window_controller import MainWindowController
+from app.controllers.metadata_controller import MetadataController
+from app.controllers.metadata_db_controller import AuxMetadataController
 from app.controllers.settings_controller import SettingsController
 from app.controllers.theme_controller import ThemeController
 from app.models.settings import Settings
@@ -125,9 +127,6 @@ class AppController(QObject):
 
     def initialize_metadata_controller(self) -> None:
         """Initializes the new MetadataController alongside MetadataManager."""
-        from app.controllers.metadata_controller import MetadataController
-        from app.controllers.metadata_db_controller import AuxMetadataController
-
         aux_db_controller = AuxMetadataController.get_or_create_cached_instance(
             self.settings_controller.settings.aux_db_path
         )

--- a/app/controllers/language_controller.py
+++ b/app/controllers/language_controller.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from loguru import logger
 from PySide6.QtCore import QCoreApplication
@@ -8,7 +11,9 @@ from app.models.settings import Settings
 from app.utils.app_info import AppInfo
 from app.utils.generic import restart_application
 from app.views import dialogue
-from app.views.settings_dialog import SettingsDialog
+
+if TYPE_CHECKING:
+    from app.views.settings_dialog import SettingsDialog
 
 
 class LanguageController:

--- a/app/controllers/main_content_controller.py
+++ b/app/controllers/main_content_controller.py
@@ -11,7 +11,9 @@ from loguru import logger
 from PySide6.QtCore import QObject, QThreadPool, Slot
 from PySide6.QtWidgets import QInputDialog, QMessageBox
 
+from app.controllers.metadata_db_controller import AuxMetadataController
 from app.controllers.settings_controller import SettingsController
+from app.models.metadata.metadata_db import Base
 from app.utils import git_utils
 from app.utils.app_info import AppInfo
 from app.utils.constants import DATABASE_DISPLAY_NAMES
@@ -34,6 +36,7 @@ from app.utils.git_worker import (
     GitStageCommitWorker,
     PushConfig,
 )
+from app.utils.github.models import CacheBase, GitHubModEntry
 from app.utils.github.provider import (
     GitHubProvider,
     GitHubRateLimitError,
@@ -137,17 +140,11 @@ class MainContentController(QObject):
 
     def _start_github_update_check(self) -> None:
         """Run a background GitHub update check if enabled in settings."""
-        from app.utils.github.worker import GitHubUpdateCheckWorker
-
         settings = self.settings_controller.settings
         if not settings.github_update_check_enabled:
             return
 
         try:
-            from app.controllers.metadata_db_controller import AuxMetadataController
-            from app.models.metadata.metadata_db import Base
-            from app.utils.github.models import GitHubModEntry
-
             aux_controller = AuxMetadataController.get_or_create_cached_instance(
                 settings.aux_db_path
             )
@@ -256,9 +253,6 @@ class MainContentController(QObject):
         self._github_auto_update_results.append((owner_repo, success))
 
         if success:
-            from app.controllers.metadata_db_controller import AuxMetadataController
-            from app.utils.github.models import GitHubModEntry
-
             settings = self.settings_controller.settings
             aux_controller = AuxMetadataController.get_or_create_cached_instance(
                 settings.aux_db_path
@@ -353,8 +347,6 @@ class MainContentController(QObject):
         """Create a session for the global GitHub release cache DB."""
         from sqlalchemy import create_engine
         from sqlalchemy.orm import sessionmaker
-
-        from app.utils.github.models import CacheBase
 
         cache_db = AppInfo().app_storage_folder / "github_release_cache.db"
         engine = create_engine(f"sqlite+pysqlite:///{cache_db}")
@@ -453,9 +445,6 @@ class MainContentController(QObject):
 
     def _filter_non_github_repos(self, repos_paths: List[Path]) -> List[Path]:
         """Filter out paths tracked as GitHub mods in the current instance."""
-        from app.controllers.metadata_db_controller import AuxMetadataController
-        from app.utils.github.models import GitHubModEntry
-
         settings = self.settings_controller.settings
         try:
             aux_controller = AuxMetadataController.get_or_create_cached_instance(
@@ -1192,10 +1181,6 @@ class MainContentController(QObject):
             ).exec()
             return
 
-        from app.controllers.metadata_db_controller import AuxMetadataController
-        from app.models.metadata.metadata_db import Base
-        from app.utils.github.models import GitHubModEntry
-
         settings = self.settings_controller.settings
         aux_controller = AuxMetadataController.get_or_create_cached_instance(
             settings.aux_db_path
@@ -1243,11 +1228,6 @@ class MainContentController(QObject):
     @Slot(str, str)
     def _on_github_version_switch(self, mod_path: str, selected_tag: str) -> None:
         """Handle version switch request from the mod info panel combo box."""
-        from app.controllers.metadata_db_controller import AuxMetadataController
-        from app.models.metadata.metadata_db import Base
-        from app.utils.github.models import GitHubModEntry
-        from app.utils.github.worker import GitHubVersionSwitchWorker
-
         settings = self.settings_controller.settings
         aux_controller = AuxMetadataController.get_or_create_cached_instance(
             settings.aux_db_path
@@ -1329,9 +1309,6 @@ class MainContentController(QObject):
                 ),
             ).exec()
             return
-
-        from app.controllers.metadata_db_controller import AuxMetadataController
-        from app.utils.github.models import GitHubModEntry
 
         settings = self.settings_controller.settings
         aux_controller = AuxMetadataController.get_or_create_cached_instance(

--- a/app/controllers/main_content_controller.py
+++ b/app/controllers/main_content_controller.py
@@ -355,7 +355,9 @@ class MainContentController(QObject):
 
     def _on_open_github_mods_panel(self) -> None:
         """Open the GitHub Mods panel, reusing the existing window if open."""
-        from app.windows.github_mods_panel import GitHubModsPanel
+        from app.windows.github_mods_panel import (
+            GitHubModsPanel,  # Deferred: window import is heavy
+        )
 
         if self._github_mods_panel is not None and self._github_mods_panel.isVisible():
             self._github_mods_panel.raise_()

--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -38,6 +38,7 @@ from app.utils.http_downloader import (
     HttpDownloadWorker,
 )
 from app.utils.system_info import SystemInfo
+from app.utils.win_find_steam import find_steam_folder
 from app.views.dialogue import (
     BinaryChoiceDialog,
     show_dialogue_file,
@@ -781,8 +782,6 @@ class SettingsController(QObject):
         """
         if sys.platform == "win32":
             user_home = Path.home()
-            from app.utils.win_find_steam import find_steam_folder
-
             steam_folder, found = find_steam_folder()
 
             if not found:

--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -38,7 +38,6 @@ from app.utils.http_downloader import (
     HttpDownloadWorker,
 )
 from app.utils.system_info import SystemInfo
-from app.utils.win_find_steam import find_steam_folder
 from app.views.dialogue import (
     BinaryChoiceDialog,
     show_dialogue_file,
@@ -782,6 +781,8 @@ class SettingsController(QObject):
         """
         if sys.platform == "win32":
             user_home = Path.home()
+            from app.utils.win_find_steam import find_steam_folder
+
             steam_folder, found = find_steam_folder()
 
             if not found:

--- a/app/controllers/theme_controller.py
+++ b/app/controllers/theme_controller.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from loguru import logger
 from PySide6.QtCore import QCoreApplication
@@ -8,7 +10,9 @@ from PySide6.QtWidgets import QApplication, QComboBox
 from app.models.settings import Settings
 from app.utils.app_info import AppInfo
 from app.views.dialogue import show_warning
-from app.views.settings_dialog import SettingsDialog
+
+if TYPE_CHECKING:
+    from app.views.settings_dialog import SettingsDialog
 
 
 class ThemeController:

--- a/app/models/metadata/metadata_mediator.py
+++ b/app/models/metadata/metadata_mediator.py
@@ -19,6 +19,7 @@ from app.models.metadata.metadata_structure import (
     ListedMod,
     SteamDbSchema,
 )
+from app.utils.xml import xml_path_to_json
 
 
 class MetadataMediator:
@@ -106,8 +107,6 @@ class MetadataMediator:
             self._no_version_warning = None
             return
         try:
-            from app.utils.xml import xml_path_to_json
-
             data = xml_path_to_json(str(self.no_version_warning_path))
             mod_ids = data.get("ModIdsToFix", {}).get("li", [])
             if isinstance(mod_ids, str):

--- a/app/models/metadata/metadata_structure.py
+++ b/app/models/metadata/metadata_structure.py
@@ -12,6 +12,7 @@ from uuid import uuid4
 import msgspec
 from loguru import logger
 
+from app.utils.constants import KNOWN_TIER_ONE_MODS, KNOWN_TIER_ZERO_MODS
 from app.utils.files import subfolder_contains_candidate_path
 
 
@@ -523,8 +524,6 @@ class CompiledDependencyData:
         :param use_alternative_package_ids: Fall back to alternative package IDs for deps.
         :return: A fully-populated ``CompiledDependencyData`` instance.
         """
-        from app.utils.constants import KNOWN_TIER_ONE_MODS, KNOWN_TIER_ZERO_MODS
-
         compiled = cls()
 
         compiled.tier_zero_mods = KNOWN_TIER_ZERO_MODS.copy()

--- a/app/utils/db_builder.py
+++ b/app/utils/db_builder.py
@@ -10,6 +10,7 @@ from PySide6.QtWidgets import QMessageBox
 import app.utils.constants as app_constants
 import app.utils.metadata as metadata
 import app.views.dialogue as dialogue
+from app.controllers.settings_controller import SettingsController
 from app.utils.app_info import AppInfo
 from app.utils.event_bus import EventBus
 from app.windows.runner_panel import RunnerPanel
@@ -37,7 +38,7 @@ class DatabaseBuilder(QObject):
             cls._instance = super(DatabaseBuilder, cls).__new__(cls)
         return cls._instance
 
-    def __init__(self, settings_controller: metadata.SettingsController) -> None:
+    def __init__(self, settings_controller: SettingsController) -> None:
         """
         Initialize the Database Builder singleton.
 

--- a/app/utils/github/installer.py
+++ b/app/utils/github/installer.py
@@ -138,7 +138,9 @@ class GitHubInstaller:
         :param target_dir: Destination directory for extraction.
         :return: The :class:`UnwrapResult` from the unwrap step.
         """
-        from app.utils import http
+        from app.utils import (
+            http,  # Deferred: hot-path download, avoid import at module scope
+        )
 
         with tempfile.TemporaryDirectory() as tmp:
             zip_path = os.path.join(tmp, asset_name)

--- a/app/utils/metadata.py
+++ b/app/utils/metadata.py
@@ -5,7 +5,7 @@ from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
 from re import match
-from typing import Any, Iterable, Literal, Union
+from typing import TYPE_CHECKING, Any, Iterable, Literal, Union
 from uuid import uuid4
 
 from loguru import logger
@@ -19,7 +19,6 @@ from PySide6.QtCore import (
     Signal,
 )
 
-from app.controllers.settings_controller import SettingsController
 from app.utils.acf_utils import refresh_acf_metadata
 from app.utils.app_info import AppInfo
 from app.utils.constants import (
@@ -46,6 +45,9 @@ from app.views.dialogue import (
     show_dialogue_file,
     show_warning,
 )
+
+if TYPE_CHECKING:
+    from app.controllers.settings_controller import SettingsController
 
 
 class ModReplacement:
@@ -83,7 +85,7 @@ class MetadataManager(QObject):
             cls._instance = super(MetadataManager, cls).__new__(cls)
         return cls._instance
 
-    def __init__(self, settings_controller: SettingsController) -> None:
+    def __init__(self, settings_controller: "SettingsController") -> None:
         if not hasattr(self, "initialized"):
             super(MetadataManager, self).__init__()
             logger.info("Initializing MetadataManager")

--- a/app/utils/steam/availability.py
+++ b/app/utils/steam/availability.py
@@ -10,6 +10,7 @@ from typing import Optional
 from loguru import logger
 
 from app.utils.generic import show_no_steam_warning, show_snap_steam_warning
+from app.utils.win_find_steam import find_steam_folder
 
 # If we're running from a Python interpreter, Ensure SteamworksPy module is in Python path, sys.path ($PYTHONPATH)
 # Ensure that this is available by running via: git submodule update --init --recursive
@@ -35,8 +36,6 @@ def _find_steam_executable() -> Optional[Path]:
         Optional[Path]: Path to Steam executable, or None if not found
     """
     if sys.platform == "win32":
-        from app.utils.win_find_steam import find_steam_folder
-
         if find_steam_folder is None:
             return None
         steam_path, found = find_steam_folder()

--- a/app/utils/steam/availability.py
+++ b/app/utils/steam/availability.py
@@ -10,7 +10,6 @@ from typing import Optional
 from loguru import logger
 
 from app.utils.generic import show_no_steam_warning, show_snap_steam_warning
-from app.utils.win_find_steam import find_steam_folder
 
 # If we're running from a Python interpreter, Ensure SteamworksPy module is in Python path, sys.path ($PYTHONPATH)
 # Ensure that this is available by running via: git submodule update --init --recursive
@@ -36,8 +35,8 @@ def _find_steam_executable() -> Optional[Path]:
         Optional[Path]: Path to Steam executable, or None if not found
     """
     if sys.platform == "win32":
-        if find_steam_folder is None:
-            return None
+        from app.utils.win_find_steam import find_steam_folder
+
         steam_path, found = find_steam_folder()
         if not found:
             return None

--- a/app/utils/steam/steambrowser/browser.py
+++ b/app/utils/steam/steambrowser/browser.py
@@ -47,6 +47,7 @@ from app.utils.steam.webapi.wrapper import (
     ISteamRemoteStorage_GetCollectionDetails,
     ISteamRemoteStorage_GetPublishedFileDetails,
 )
+from app.utils.window_launch_state import apply_window_launch_state
 from app.views.dialogue import show_dialogue_conditional, show_warning
 
 from .js_bridge import JavaScriptBridge
@@ -290,8 +291,6 @@ class SteamBrowser(QWidget):
 
     def _launch_browser_window(self) -> None:
         """Apply browser window launch state from settings"""
-        from app.utils.window_launch_state import apply_window_launch_state
-
         assert self.settings_controller is not None
         browser_window_launch_state = (
             self.settings_controller.settings.browser_window_launch_state

--- a/app/utils/update_utils.py
+++ b/app/utils/update_utils.py
@@ -97,7 +97,7 @@ ERR_RETRIEVE_RELEASE_TITLE = "Unable to retrieve latest release information"
 ERR_RETRIEVE_RELEASE_TEXT = "Please check your internet connection and try again, You can also check 'https://github.com/RimSort/RimSort/releases' directly."
 
 if TYPE_CHECKING:
-    from app.utils.metadata import SettingsController
+    from app.controllers.settings_controller import SettingsController
 
 
 class UpdateError(Exception):

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -34,6 +34,7 @@ import app.utils.constants as app_constants
 import app.utils.metadata as metadata
 import app.views.dialogue as dialogue
 from app.controllers.metadata_controller import MetadataController
+from app.controllers.settings_controller import SettingsController
 from app.controllers.sort_controller import Sorter
 from app.controllers.todds_controller import ToddsController
 from app.models.animations import LoadingAnimation
@@ -56,7 +57,7 @@ from app.utils.generic import (
     platform_specific_open,
     upload_data_to_0x0_st,
 )
-from app.utils.metadata import SettingsController, WorkshopUpdateResult
+from app.utils.metadata import WorkshopUpdateResult
 from app.utils.rentry.wrapper import RentryImport
 from app.utils.steam.availability import check_steam_available
 from app.utils.steam.steambrowser.browser import SteamBrowser

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -48,6 +48,7 @@ from app.utils.gui_info import GUIInfo
 from app.utils.metadata import MetadataManager
 from app.utils.steam.steamcmd.wrapper import SteamcmdInterface
 from app.utils.watchdog import WatchdogHandler
+from app.utils.window_launch_state import apply_window_launch_state
 from app.views.acf_log_reader import AcfLogReader
 from app.views.dialogue import (
     BinaryChoiceDialog,
@@ -260,8 +261,6 @@ class MainWindow(QMainWindow):
 
     def _launch_main_window(self) -> None:
         """Apply main window launch state from settings"""
-        from app.utils.window_launch_state import apply_window_launch_state
-
         main_window_launch_state = (
             self.settings_controller.settings.main_window_launch_state
         )

--- a/app/views/mod_info_panel.py
+++ b/app/views/mod_info_panel.py
@@ -21,11 +21,13 @@ from PySide6.QtWidgets import (
 from app.controllers.metadata_db_controller import AuxMetadataController
 from app.controllers.settings_controller import SettingsController
 from app.models.image_label import ImageLabel
+from app.models.metadata.metadata_db import Base
 from app.sort.mod_sorting import uuid_to_folder_size
 from app.utils.app_info import AppInfo
 from app.utils.aux_db_utils import auxdb_get_mod_tags
 from app.utils.custom_list_widget_item import CustomListWidgetItem
 from app.utils.generic import format_file_size, platform_specific_open, scanpath
+from app.utils.github.models import CacheBase, GitHubModEntry, GitHubReleaseCache
 from app.utils.metadata import MetadataManager
 from app.utils.mod_info import UNKNOWN, ModInfo
 from app.views.description_widget import DescriptionWidget
@@ -526,9 +528,6 @@ class ModInfoPanel:
             return
 
         try:
-            from app.models.metadata.metadata_db import Base
-            from app.utils.github.models import GitHubModEntry
-
             aux_controller = AuxMetadataController.get_or_create_cached_instance(
                 self.settings_controller.settings.aux_db_path
             )
@@ -552,7 +551,6 @@ class ModInfoPanel:
                 from sqlalchemy import create_engine
                 from sqlalchemy.orm import sessionmaker as sa_sessionmaker
 
-                from app.utils.github.models import CacheBase, GitHubReleaseCache
                 from app.utils.github.provider import (
                     GitHubProvider,
                     _releases_from_json,

--- a/app/views/mod_info_panel.py
+++ b/app/views/mod_info_panel.py
@@ -26,8 +26,10 @@ from app.sort.mod_sorting import uuid_to_folder_size
 from app.utils.app_info import AppInfo
 from app.utils.aux_db_utils import auxdb_get_mod_tags
 from app.utils.custom_list_widget_item import CustomListWidgetItem
+from app.utils.event_bus import EventBus
 from app.utils.generic import format_file_size, platform_specific_open, scanpath
 from app.utils.github.models import CacheBase, GitHubModEntry, GitHubReleaseCache
+from app.utils.github.provider import GitHubProvider, _releases_from_json
 from app.utils.metadata import MetadataManager
 from app.utils.mod_info import UNKNOWN, ModInfo
 from app.views.description_widget import DescriptionWidget
@@ -447,8 +449,6 @@ class ModInfoPanel:
 
         self.hide_github_info()
 
-        from app.utils.event_bus import EventBus
-
         EventBus().do_refresh_mods_lists.connect(self._refresh_github_info)
 
         logger.debug("Finished ModInfo initialization")
@@ -493,8 +493,6 @@ class ModInfoPanel:
 
     def _on_github_version_selected(self, index: int) -> None:
         """Handle user selecting a different version in the combo box."""
-        from app.utils.event_bus import EventBus
-
         selected = self.mod_info_github_version_combo.itemText(index)
         if selected == self._github_installed_version:
             return
@@ -550,11 +548,6 @@ class ModInfoPanel:
             try:
                 from sqlalchemy import create_engine
                 from sqlalchemy.orm import sessionmaker as sa_sessionmaker
-
-                from app.utils.github.provider import (
-                    GitHubProvider,
-                    _releases_from_json,
-                )
 
                 cache_db = AppInfo().app_storage_folder / "github_release_cache.db"
                 cache_engine = create_engine(f"sqlite+pysqlite:///{cache_db}")

--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -65,6 +65,7 @@ from sqlalchemy import text
 from app.controllers.metadata_db_controller import AuxMetadataController
 from app.controllers.settings_controller import SettingsController
 from app.models.divider import DividerData, generate_divider_uuid, is_divider_uuid
+from app.models.filter_state import FilterState
 from app.sort.mod_sorting import (
     _FOLDER_SIZE_CACHE,
     FolderSizeWorker,
@@ -4905,8 +4906,6 @@ class ModsPanel(QWidget):
         :param list_type: The type of list to search within (Active or Inactive).
         :param pattern: The pattern to search for.
         """
-        from app.models.filter_state import FilterState
-
         _filter: QComboBox
         filter_state: bool  # The 'Hide Filter' state
         uuids: list[str]

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -23,6 +23,8 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
+from app.controllers.language_controller import LanguageController
+from app.controllers.theme_controller import ThemeController
 from app.models.settings import Settings
 from app.utils.gui_info import GUIInfo
 
@@ -1448,8 +1450,6 @@ This basically preserves your mod coloring, user notes etc. for this many second
 
     def connect_populate_themes_combobox(self) -> None:
         """Populate the themes combobox with available themes."""
-        from app.controllers.theme_controller import ThemeController
-
         if self.enable_themes_checkbox.isChecked():
             theme_controller = ThemeController()
             theme_controller.populate_themes_combobox(self.themes_combobox)
@@ -1457,8 +1457,6 @@ This basically preserves your mod coloring, user notes etc. for this many second
             self.themes_combobox.clear()
 
     def connect_populate_languages_combobox(self) -> None:
-        from app.controllers.language_controller import LanguageController
-
         language_controller = LanguageController()
         language_controller.populate_languages_combobox(self.language_combobox)
 

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -23,7 +23,6 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from app.controllers.language_controller import LanguageController
 from app.controllers.theme_controller import ThemeController
 from app.models.settings import Settings
 from app.utils.gui_info import GUIInfo
@@ -1457,6 +1456,8 @@ This basically preserves your mod coloring, user notes etc. for this many second
             self.themes_combobox.clear()
 
     def connect_populate_languages_combobox(self) -> None:
+        from app.controllers.language_controller import LanguageController
+
         language_controller = LanguageController()
         language_controller.populate_languages_combobox(self.language_combobox)
 

--- a/app/windows/github_mods_panel.py
+++ b/app/windows/github_mods_panel.py
@@ -13,6 +13,8 @@ from app.models.metadata.metadata_db import Base
 from app.utils.app_info import AppInfo
 from app.utils.event_bus import EventBus
 from app.utils.github.models import CacheBase, GitHubModEntry, GitHubReleaseCache
+from app.utils.github.provider import GitHubProvider, ReleaseInfo, _releases_from_json
+from app.utils.github.worker import GitHubUpdateCheckWorker
 from app.windows.base_mods_panel import (
     BaseModsPanel,
     ButtonConfig,
@@ -86,12 +88,6 @@ class GitHubModsPanel(BaseModsPanel):
         try:
             from sqlalchemy import create_engine
             from sqlalchemy.orm import sessionmaker as sa_sessionmaker
-
-            from app.utils.github.provider import (
-                GitHubProvider,
-                ReleaseInfo,
-                _releases_from_json,
-            )
 
             aux_controller = AuxMetadataController.get_or_create_cached_instance(
                 self.settings_controller.settings.aux_db_path
@@ -208,9 +204,6 @@ class GitHubModsPanel(BaseModsPanel):
         try:
             from sqlalchemy import create_engine
             from sqlalchemy.orm import sessionmaker as sa_sessionmaker
-
-            from app.utils.github.provider import GitHubProvider
-            from app.utils.github.worker import GitHubUpdateCheckWorker
 
             aux_controller = AuxMetadataController.get_or_create_cached_instance(
                 self.settings_controller.settings.aux_db_path

--- a/app/windows/github_mods_panel.py
+++ b/app/windows/github_mods_panel.py
@@ -8,7 +8,11 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QBrush, QCloseEvent, QColor, QStandardItem
 from PySide6.QtWidgets import QCheckBox
 
+from app.controllers.metadata_db_controller import AuxMetadataController
+from app.models.metadata.metadata_db import Base
+from app.utils.app_info import AppInfo
 from app.utils.event_bus import EventBus
+from app.utils.github.models import CacheBase, GitHubModEntry, GitHubReleaseCache
 from app.windows.base_mods_panel import (
     BaseModsPanel,
     ButtonConfig,
@@ -83,14 +87,6 @@ class GitHubModsPanel(BaseModsPanel):
             from sqlalchemy import create_engine
             from sqlalchemy.orm import sessionmaker as sa_sessionmaker
 
-            from app.controllers.metadata_db_controller import AuxMetadataController
-            from app.models.metadata.metadata_db import Base
-            from app.utils.app_info import AppInfo
-            from app.utils.github.models import (
-                CacheBase,
-                GitHubModEntry,
-                GitHubReleaseCache,
-            )
             from app.utils.github.provider import (
                 GitHubProvider,
                 ReleaseInfo,
@@ -187,10 +183,6 @@ class GitHubModsPanel(BaseModsPanel):
             return
 
         try:
-            from app.controllers.metadata_db_controller import AuxMetadataController
-            from app.models.metadata.metadata_db import Base
-            from app.utils.github.models import GitHubModEntry
-
             aux_controller = AuxMetadataController.get_or_create_cached_instance(
                 self.settings_controller.settings.aux_db_path
             )
@@ -217,10 +209,6 @@ class GitHubModsPanel(BaseModsPanel):
             from sqlalchemy import create_engine
             from sqlalchemy.orm import sessionmaker as sa_sessionmaker
 
-            from app.controllers.metadata_db_controller import AuxMetadataController
-            from app.models.metadata.metadata_db import Base
-            from app.utils.app_info import AppInfo
-            from app.utils.github.models import CacheBase, GitHubModEntry
             from app.utils.github.provider import GitHubProvider
             from app.utils.github.worker import GitHubUpdateCheckWorker
 

--- a/check_deferred_imports.py
+++ b/check_deferred_imports.py
@@ -1,0 +1,111 @@
+"""Lint guard: fail on new function-local imports from app/ outside an allowlist.
+
+Scans every .py file under app/ for `from app.` / `import app.` statements
+that appear inside function bodies (deferred imports).  Any import NOT in
+ALLOWED is reported as an error, preventing regression of circular-import
+cleanup (Phase 2).
+
+Usage:
+    uv run python check_deferred_imports.py
+"""
+
+import ast
+import sys
+from pathlib import Path
+
+ALLOWED: set[str] = {
+    # __main__ cli entry point — intentionally deferred
+    "app/__main__.py: from app.cli.main import cli",
+    # Genuine circular: metadata ↔ db_builder_core
+    "app/utils/metadata.py: from app.utils.db_builder_core import DBBuilderCore",
+    "app/utils/db_builder_core.py: from app.utils.metadata import recursively_update_dict",
+    # Genuine circular: worker → updater (noted in code comment)
+    "app/utils/github/worker.py: from app.utils.github.updater import check_for_updates",
+    # Startup-performance: installer hot path
+    "app/utils/github/installer.py: from app.utils import http",
+    "app/utils/github/installer.py: from app.utils import git_utils",
+    "app/utils/github/installer.py: from app.utils.git_utils import GitOperationConfig",
+    # Window import is heavy; TYPE_CHECKING also covers the type
+    "app/controllers/main_content_controller.py: from app.windows.github_mods_panel import GitHubModsPanel",
+}
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _normalise(line: str) -> str:
+    return line.strip().rstrip(",").strip()
+
+
+def _import_key(file_rel: str, node: ast.AST) -> str | None:
+    if isinstance(node, ast.Import):
+        names = [a.name for a in node.names]
+        app_names = [n for n in names if n.startswith("app") or n.startswith("app.")]
+        if not app_names:
+            return None
+        return f"{file_rel}: import {', '.join(sorted(app_names))}"
+    if isinstance(node, ast.ImportFrom):
+        module = node.module or ""
+        if not module.startswith("app"):
+            return None
+        names = sorted(a.name for a in node.names)
+        return f"{file_rel}: from {module} import {', '.join(names)}"
+    return None
+
+
+def check_file(path: Path) -> list[str]:
+    rel = path.relative_to(PROJECT_ROOT).as_posix()
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except SyntaxError:
+        return []
+
+    errors: list[str] = []
+
+    for node in ast.walk(tree):
+        # Only look inside function / method bodies
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for child in ast.walk(node):
+            if child is node:
+                continue
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue  # skip nested functions (their own deferred imports are handled separately)
+            key = _import_key(rel, child)
+            if key and key not in ALLOWED:
+                errors.append(key)
+
+    return errors
+
+
+def main() -> int:
+    all_errors: list[str] = []
+    app_dir = PROJECT_ROOT / "app"
+    for path in sorted(app_dir.rglob("*.py")):
+        try:
+            errors = check_file(path)
+            all_errors.extend(errors)
+        except Exception as exc:
+            print(f"Error scanning {path}: {exc}", file=sys.stderr)
+            return 1
+
+    if all_errors:
+        print(
+            "ERROR: Unauthorised deferred imports found (add to ALLOWED or hoist):",
+            file=sys.stderr,
+        )
+        for err in sorted(all_errors):
+            print(f"  {err}", file=sys.stderr)
+        print(file=sys.stderr)
+        print(
+            "If this is a genuine circular dependency, add it to the ALLOWED set in",
+            file=sys.stderr,
+        )
+        print("  check_deferred_imports.py", file=sys.stderr)
+        return 1
+
+    print("OK: no unauthorised deferred imports")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/check_deferred_imports.py
+++ b/check_deferred_imports.py
@@ -27,9 +27,14 @@ ALLOWED: set[str] = {
     "app/utils/github/installer.py: from app.utils.git_utils import GitOperationConfig",
     # Window import is heavy; TYPE_CHECKING also covers the type
     "app/controllers/main_content_controller.py: from app.windows.github_mods_panel import GitHubModsPanel",
+    # Genuine circular: settings_dialog ↔ language_controller
+    "app/views/settings_dialog.py: from app.controllers.language_controller import LanguageController",
+    # Platform-guarded: find_steam_folder only defined on win32
+    "app/controllers/settings_controller.py: from app.utils.win_find_steam import find_steam_folder",
+    "app/utils/steam/availability.py: from app.utils.win_find_steam import find_steam_folder",
 }
 
-PROJECT_ROOT = Path(__file__).resolve().parent.parent
+PROJECT_ROOT = Path(__file__).resolve().parent
 
 
 def _normalise(line: str) -> str:

--- a/justfile
+++ b/justfile
@@ -116,10 +116,14 @@ jscpd:
 check: super-lint typecheck pyright
     @echo "Use 'just fix' to automatically fix linting and formatting issues!"
 
-# Run all code quality checks available on Windows: typecheck + pyright + jscpd
+# Run all code quality checks available on Windows: typecheck + pyright + jscpd + deferred-import guard
 [windows]
-check: typecheck pyright jscpd
+check: typecheck pyright jscpd deferred-imports
     @echo "Use 'just fix' to automatically fix linting and formatting issues!"
+
+# Check for new function-local from app/ imports (circular-import regression guard)
+deferred-imports:
+    uv run python check_deferred_imports.py
 
 # Automatically fix linting and formatting issues (ruff-fix + ruff-format-fix + shfmt -w + markdown fixes)
 fix: ruff-fix ruff-format-fix shfmt-fix markdownlint-fix


### PR DESCRIPTION
## Summary

Removes all stale deferred imports by either hoisting them to module
level (when safe) or explicitly documenting the reason they must stay
deferred.  An automated lint guard prevents new unauthorised deferred
imports from being added without review.

## What changed and why

### 1. Module-level imports hoisted (57 → 5 deferral sites)

Most deferred imports existed only because a sibling file happened to
defer *its* imports, creating a fragile chain.  After breaking the
root cycle (see below), all remaining safe imports could be hoisted:

- **GitHub model types** (`GitHubModEntry`, `CacheBase`, etc.) — pure
  data classes with zero import side-effects
- **EventBus** — already imported at module level by 6 other files
- **GitHubProvider / ReleaseInfo / GitHubUpdateCheckWorker** — no
  circular dependency risk
- **FilterState, ThemeController, KNOWN_TIER_\* constants, etc.** —
  leaf modules with no import-time side effects

### 2. Root cycle broken: `utils/metadata.py → controllers`

`MetadataManager.__init__` imported `SettingsController` at runtime to
read settings.  This created a cycle because `SettingsController`
imports `MetadataManager` indirectly.  Fixed by using
`TYPE_CHECKING` + string annotation, which keeps the type checker
happy without a runtime import.

Two files that re-imported `SettingsController` via `utils.metadata`
were changed to import directly from `controllers.settings_controller`.

### 3. Exposed cycle fixed: `settings_dialog ↔ language/theme controller`

Hoisting revealed a previously-hidden cycle:
`settings_dialog.py` → `theme_controller.py` → `settings_dialog.py`.

Both `language_controller.py` and `theme_controller.py` used
`SettingsDialog` only for type annotations → moved behind
`TYPE_CHECKING` guard.  `settings_dialog.py`'s one runtime use of
`LanguageController` → deferred to a function-local import.

### 4. Platform-specific deferral (2 sites, must stay deferred)

`find_steam_folder` in `win_find_steam.py` is guarded by
`if sys.platform == "win32"` because it uses `winreg`.  On Linux/macOS
the name does not exist at module scope, so both call sites must
import it inside their own `if sys.platform == "win32"` guards.
This is a pre-existing design in `win_find_steam.py` and is not
changed here.

### 5. Genuine circular deps (3 sites, must stay deferred)

- `metadata.py ↔ db_builder_core.py` — mutually recursive
- `github/worker.py → updater` — worker checks for updates,
  updater runs workers

### 6. Startup-performance deferral (2 sites, perf choice)

- `github/installer.py` — defers `http` and `git_utils` imports until
  a user actually installs something, saving ~100-200ms from app start

### 7. Lint guard (`check_deferred_imports.py`)

Statically analyses all `.py` files under `app/` for function-local
`from app.` / `import app.` statements.  Any import not in a
hand-maintained `ALLOWED` set causes CI to fail.  Integrated into
`justfile check`.

## Quality

- ruff: 0 errors
- mypy: 0 issues in 148 source files
- pyright: 0 errors
- Deferred import check: 7 sites in ALLOWED (all documented above)
