### PR TITLE
refactor(settings): extract platform path autodetect to service

### DIFF
--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -23,13 +23,12 @@ from app.controllers.settings_tabs import (
 )
 from app.controllers.theme_controller import ThemeController
 from app.models.settings import Instance, Settings
+from app.services.path_autodetect_service import PathAutodetectService
 from app.utils.app_info import AppInfo
 from app.utils.constants import DEFAULT_INSTANCE_NAME
 from app.utils.event_bus import EventBus
 from app.utils.generic import (
     extract_git_dir_name,
-    find_steam_rimworld,
-    get_path_up_to_string,
     validate_game_executable,
 )
 from app.utils.http_downloader import (
@@ -90,8 +89,6 @@ class SettingsController(QObject):
         self.app_instance = QApplication.instance()
 
         self._http_download_worker: HttpDownloadWorker | None = None
-
-        self._detected_steam_root: Path | None = None
 
         # Initialize per-tab controllers (registry pattern)
         self._tab_controllers: dict[str, BaseTabController] = {
@@ -414,32 +411,6 @@ class SettingsController(QObject):
         # Do a full refresh after updating the settings
         EventBus().do_refresh_mods_lists.emit()
 
-    @staticmethod
-    def _find_steam_root(candidates: list[Path]) -> Path | None:
-        """
-        Find the Steam installation root from a prioritized list of candidate paths.
-
-        A candidate is valid if it exists as a directory and contains either
-        a ``steamapps/`` directory or ``config/libraryfolders.vdf``.
-
-        :param candidates: Ordered list of candidate Steam root paths
-        :return: First valid Steam root, or None if no candidate matches
-        """
-        for candidate in candidates:
-            if not candidate.is_dir():
-                logger.debug(f"Steam root candidate does not exist: {candidate}")
-                continue
-            has_steamapps = (candidate / "steamapps").is_dir()
-            has_vdf = (candidate / "config" / "libraryfolders.vdf").is_file()
-            if has_steamapps or has_vdf:
-                logger.info(f"Found Steam root: {candidate}")
-                return candidate
-            logger.debug(
-                f"Steam root candidate exists but has no steamapps/ or config/libraryfolders.vdf: {candidate}"
-            )
-        logger.warning("No valid Steam root found from any candidate path")
-        return None
-
     @Slot()
     def _on_locations_autodetect_button_clicked(self) -> None:
         """
@@ -448,16 +419,18 @@ class SettingsController(QObject):
         """
         logger.info("USER ACTION: starting autodetect paths")
 
-        os_paths: tuple[Path, Path, Path]  # Initialize os_paths
+        autodetect = PathAutodetectService()
+
+        os_paths: tuple[Path, Path, Path]
         if SystemInfo().operating_system == SystemInfo.OperatingSystem.MACOS:
-            os_paths = self.__get_darwin_paths()
+            os_paths = autodetect.get_darwin_paths()
             logger.info(f"Running on MacOS with the following paths: {os_paths}")
         elif SystemInfo().operating_system == SystemInfo.OperatingSystem.LINUX:
-            os_paths = self.__get_linux_paths()
+            os_paths = autodetect.get_linux_paths()
             logger.info(f"Running on Linux with the following paths: {os_paths}")
             if (
-                self._detected_steam_root is not None
-                and "snap" in self._detected_steam_root.parts
+                autodetect.detected_steam_root is not None
+                and "snap" in autodetect.detected_steam_root.parts
             ):
                 show_warning(
                     title="Unsupported Steam installation",
@@ -470,7 +443,7 @@ class SettingsController(QObject):
                     ),
                 )
         elif sys.platform == "win32":
-            os_paths = self.__get_windows_paths()
+            os_paths = autodetect.get_windows_paths()
             logger.info(f"Running on Windows with the following paths: {os_paths}")
         else:
             logger.error("Attempting to autodetect paths on an unknown system")
@@ -522,229 +495,6 @@ class SettingsController(QObject):
                 logger.warning(
                     f"Auto-detected {group.name} folder path does not exist: {group.folder}"
                 )
-
-    def __get_darwin_paths(self) -> tuple[Path, Path, Path]:
-        """
-        Get paths for macOS. Uses VDF parsing to locate RimWorld in non-default
-        Steam library folders, with hardcoded fallback.
-
-        :return: (game_folder, config_folder, steam_mods_folder)
-        """
-        user_home = Path.home()
-        candidates = [
-            user_home / "Library" / "Application Support" / "Steam",
-        ]
-
-        steam_root = self._find_steam_root(candidates)
-        self._detected_steam_root = steam_root
-
-        if steam_root:
-            game_folder_str = find_steam_rimworld(steam_root)
-            if game_folder_str:
-                game_folder = self._find_mac_app_bundle(Path(game_folder_str))
-                logger.debug(f"VDF parsing found RimWorld at: {game_folder}")
-            else:
-                fallback_game_folder = steam_root / "steamapps" / "common" / "RimWorld"
-                game_folder = self._find_mac_app_bundle(fallback_game_folder)
-                logger.debug(
-                    f"VDF parsing did not find RimWorld, using fallback_game_folder: {game_folder}"
-                )
-
-            steam_mods_folder_str = get_path_up_to_string(
-                game_folder.parent, "common", exclude=True
-            )
-            if steam_mods_folder_str == "":
-                steam_mods_folder: Path = (
-                    steam_root / "steamapps" / "workshop" / "content" / "294100"
-                )
-            else:
-                steam_mods_folder = (
-                    Path(steam_mods_folder_str) / "workshop" / "content" / "294100"
-                )
-        else:
-            fallback_game_folder = (
-                user_home
-                / "Library"
-                / "Application Support"
-                / "Steam"
-                / "steamapps"
-                / "common"
-                / "RimWorld"
-            )
-            game_folder = self._find_mac_app_bundle(fallback_game_folder)
-            steam_mods_folder = (
-                user_home
-                / "Library"
-                / "Application Support"
-                / "Steam"
-                / "steamapps"
-                / "workshop"
-                / "content"
-                / "294100"
-            )
-
-        config_folder = (
-            user_home / "Library" / "Application Support" / "Rimworld" / "Config"
-        )
-
-        return game_folder, config_folder, steam_mods_folder
-
-    @staticmethod
-    def _find_mac_app_bundle(rimworld_dir: Path) -> Path:
-        """Find the .app bundle in a RimWorld directory.
-
-        Discovers the actual filesystem-cased name instead of hardcoding it,
-        since macOS is case-insensitive but path comparisons are case-sensitive.
-        """
-        if rimworld_dir.is_dir():
-            apps = list(rimworld_dir.glob("*.app"))
-            if apps:
-                return apps[0]
-        return rimworld_dir / "RimWorldMac.app"
-
-    def __get_linux_paths(self) -> tuple[Path, Path, Path]:
-        """
-        Get paths for Linux by discovering the Steam root across distribution methods.
-
-        Checks Debian, native, Flatpak, and Snap Steam installations in priority
-        order. Uses VDF parsing to locate RimWorld in non-default library folders.
-        Detects Proton prefix for config folder.
-
-        :return: (game_folder, config_folder, steam_mods_folder)
-        """
-        user_home = Path.home()
-        candidates = [
-            user_home / ".steam" / "debian-installation",
-            user_home / ".steam" / "steam",
-            user_home / ".local" / "share" / "Steam",
-            user_home
-            / ".var"
-            / "app"
-            / "com.valvesoftware.Steam"
-            / ".local"
-            / "share"
-            / "Steam",
-            user_home / "snap" / "steam" / "common" / ".local" / "share" / "Steam",
-        ]
-
-        steam_root = self._find_steam_root(candidates)
-        self._detected_steam_root = steam_root
-
-        if steam_root:
-            game_folder_str = find_steam_rimworld(steam_root)
-            if game_folder_str:
-                game_folder = Path(game_folder_str)
-                logger.debug(f"VDF parsing found RimWorld at: {game_folder}")
-            else:
-                game_folder = steam_root / "steamapps" / "common" / "RimWorld"
-                logger.debug(
-                    f"VDF parsing did not find RimWorld, using fallback: {game_folder}"
-                )
-
-            steam_mods_folder_str = get_path_up_to_string(
-                game_folder, "common", exclude=True
-            )
-            if steam_mods_folder_str == "":
-                steam_mods_folder = (
-                    steam_root / "steamapps" / "workshop" / "content" / "294100"
-                )
-            else:
-                steam_mods_folder = (
-                    Path(steam_mods_folder_str) / "workshop" / "content" / "294100"
-                )
-        else:
-            game_folder = (
-                user_home / ".steam" / "steam" / "steamapps" / "common" / "RimWorld"
-            )
-            steam_mods_folder = (
-                user_home
-                / ".steam"
-                / "steam"
-                / "steamapps"
-                / "workshop"
-                / "content"
-                / "294100"
-            )
-
-        # Config folder: check Proton prefix first, then native
-        native_config = (
-            user_home
-            / ".config"
-            / "unity3d"
-            / "Ludeon Studios"
-            / "RimWorld by Ludeon Studios"
-            / "Config"
-        )
-        if steam_root:
-            proton_config = (
-                steam_root
-                / "steamapps"
-                / "compatdata"
-                / "294100"
-                / "pfx"
-                / "drive_c"
-                / "users"
-                / "steamuser"
-                / "AppData"
-                / "LocalLow"
-                / "Ludeon Studios"
-                / "RimWorld by Ludeon Studios"
-                / "Config"
-            )
-            if proton_config.exists():
-                logger.info(f"Proton prefix detected for config: {proton_config}")
-                config_folder = proton_config
-            else:
-                config_folder = native_config
-        else:
-            config_folder = native_config
-
-        return game_folder, config_folder, steam_mods_folder
-
-    def __get_windows_paths(self) -> tuple[Path, Path, Path]:
-        """
-        Get the default paths for Windows.
-
-        Returns:
-            tuple[Path, Path, Path]: game_folder, config_folder, steam_mods_folder
-        """
-        if sys.platform == "win32":
-            user_home = Path.home()
-            from app.utils.win_find_steam import find_steam_folder
-
-            steam_folder, found = find_steam_folder()
-
-            if not found:
-                logger.error(
-                    "[win32] Could not find Steam folder. Using fallback assumptions"
-                )
-                steam_folder = "C:/Program Files (x86)/Steam"
-
-            game_folder: str | Path = find_steam_rimworld(steam_folder)
-
-            # Fallback game folder
-            if game_folder == "":
-                game_folder = f"{steam_folder}/steamapps/common/RimWorld"
-            game_folder = Path(game_folder)
-
-            config_folder = Path(
-                f"{user_home}/AppData/LocalLow/Ludeon Studios/RimWorld by Ludeon Studios/Config"
-            )
-
-            steam_mods_folder = get_path_up_to_string(
-                game_folder, "common", exclude=True
-            )
-            if steam_mods_folder == "":
-                # Fallback steam mods path
-                steam_mods_folder = Path(
-                    f"{steam_folder}/steamapps/workshop/content/294100"
-                )
-            else:
-                steam_mods_folder = Path(steam_mods_folder) / "workshop/content/294100"
-
-            return game_folder, config_folder, steam_mods_folder
-        else:
-            raise ValueError("This function should only be called on Windows")
 
     @Slot(bool)
     def _do_http_download_from_dialog(

--- a/app/services/path_autodetect_service.py
+++ b/app/services/path_autodetect_service.py
@@ -1,0 +1,255 @@
+"""Service for auto-detecting RimWorld installation paths per platform."""
+
+from pathlib import Path
+
+from loguru import logger
+
+from app.utils.generic import find_steam_rimworld, get_path_up_to_string
+from app.utils.win_find_steam import find_steam_folder
+
+
+class PathAutodetectService:
+    """Detects RimWorld game, config, and workshop folder paths per platform."""
+
+    def __init__(self) -> None:
+        self._detected_steam_root: Path | None = None
+
+    @property
+    def detected_steam_root(self) -> Path | None:
+        return self._detected_steam_root
+
+    def get_darwin_paths(self) -> tuple[Path, Path, Path]:
+        """Get paths for macOS.
+
+        Uses VDF parsing to locate RimWorld in non-default Steam library
+        folders, with hardcoded fallback.
+
+        :return: (game_folder, config_folder, steam_mods_folder)
+        """
+        user_home = Path.home()
+        candidates = [
+            user_home / "Library" / "Application Support" / "Steam",
+        ]
+
+        steam_root = self._find_steam_root(candidates)
+        self._detected_steam_root = steam_root
+
+        if steam_root:
+            game_folder_str = find_steam_rimworld(steam_root)
+            if game_folder_str:
+                game_folder = self._find_mac_app_bundle(Path(game_folder_str))
+                logger.debug(f"VDF parsing found RimWorld at: {game_folder}")
+            else:
+                fallback_game_folder = steam_root / "steamapps" / "common" / "RimWorld"
+                game_folder = self._find_mac_app_bundle(fallback_game_folder)
+                logger.debug(
+                    f"VDF parsing did not find RimWorld, using fallback_game_folder: {game_folder}"
+                )
+
+            steam_mods_folder_str = get_path_up_to_string(
+                game_folder.parent, "common", exclude=True
+            )
+            if steam_mods_folder_str == "":
+                steam_mods_folder: Path = (
+                    steam_root / "steamapps" / "workshop" / "content" / "294100"
+                )
+            else:
+                steam_mods_folder = (
+                    Path(steam_mods_folder_str) / "workshop" / "content" / "294100"
+                )
+        else:
+            fallback_game_folder = (
+                user_home
+                / "Library"
+                / "Application Support"
+                / "Steam"
+                / "steamapps"
+                / "common"
+                / "RimWorld"
+            )
+            game_folder = self._find_mac_app_bundle(fallback_game_folder)
+            steam_mods_folder = (
+                user_home
+                / "Library"
+                / "Application Support"
+                / "Steam"
+                / "steamapps"
+                / "workshop"
+                / "content"
+                / "294100"
+            )
+
+        config_folder = (
+            user_home / "Library" / "Application Support" / "Rimworld" / "Config"
+        )
+
+        return game_folder, config_folder, steam_mods_folder
+
+    def get_linux_paths(self) -> tuple[Path, Path, Path]:
+        """Get paths for Linux.
+
+        Checks Debian, native, Flatpak, and Snap Steam installations in priority
+        order. Uses VDF parsing to locate RimWorld in non-default library folders.
+        Detects Proton prefix for config folder.
+
+        :return: (game_folder, config_folder, steam_mods_folder)
+        """
+        user_home = Path.home()
+        candidates = [
+            user_home / ".steam" / "debian-installation",
+            user_home / ".steam" / "steam",
+            user_home / ".local" / "share" / "Steam",
+            user_home
+            / ".var"
+            / "app"
+            / "com.valvesoftware.Steam"
+            / ".local"
+            / "share"
+            / "Steam",
+            user_home / "snap" / "steam" / "common" / ".local" / "share" / "Steam",
+        ]
+
+        steam_root = self._find_steam_root(candidates)
+        self._detected_steam_root = steam_root
+
+        if steam_root:
+            game_folder_str = find_steam_rimworld(steam_root)
+            if game_folder_str:
+                game_folder = Path(game_folder_str)
+                logger.debug(f"VDF parsing found RimWorld at: {game_folder}")
+            else:
+                game_folder = steam_root / "steamapps" / "common" / "RimWorld"
+                logger.debug(
+                    f"VDF parsing did not find RimWorld, using fallback: {game_folder}"
+                )
+
+            steam_mods_folder_str = get_path_up_to_string(
+                game_folder, "common", exclude=True
+            )
+            if steam_mods_folder_str == "":
+                steam_mods_folder = (
+                    steam_root / "steamapps" / "workshop" / "content" / "294100"
+                )
+            else:
+                steam_mods_folder = (
+                    Path(steam_mods_folder_str) / "workshop" / "content" / "294100"
+                )
+        else:
+            game_folder = (
+                user_home / ".steam" / "steam" / "steamapps" / "common" / "RimWorld"
+            )
+            steam_mods_folder = (
+                user_home
+                / ".steam"
+                / "steam"
+                / "steamapps"
+                / "workshop"
+                / "content"
+                / "294100"
+            )
+
+        native_config = (
+            user_home
+            / ".config"
+            / "unity3d"
+            / "Ludeon Studios"
+            / "RimWorld by Ludeon Studios"
+            / "Config"
+        )
+        if steam_root:
+            proton_config = (
+                steam_root
+                / "steamapps"
+                / "compatdata"
+                / "294100"
+                / "pfx"
+                / "drive_c"
+                / "users"
+                / "steamuser"
+                / "AppData"
+                / "LocalLow"
+                / "Ludeon Studios"
+                / "RimWorld by Ludeon Studios"
+                / "Config"
+            )
+            if proton_config.exists():
+                logger.info(f"Proton prefix detected for config: {proton_config}")
+                config_folder = proton_config
+            else:
+                config_folder = native_config
+        else:
+            config_folder = native_config
+
+        return game_folder, config_folder, steam_mods_folder
+
+    def get_windows_paths(self) -> tuple[Path, Path, Path]:
+        """Get the default paths for Windows.
+
+        :return: (game_folder, config_folder, steam_mods_folder)
+        """
+        user_home = Path.home()
+
+        steam_folder, found = find_steam_folder()
+
+        if not found:
+            logger.error(
+                "[win32] Could not find Steam folder. Using fallback assumptions"
+            )
+            steam_folder = "C:/Program Files (x86)/Steam"
+
+        game_folder: str | Path = find_steam_rimworld(steam_folder)
+
+        if game_folder == "":
+            game_folder = f"{steam_folder}/steamapps/common/RimWorld"
+        game_folder = Path(game_folder)
+
+        config_folder = Path(
+            f"{user_home}/AppData/LocalLow/Ludeon Studios/RimWorld by Ludeon Studios/Config"
+        )
+
+        steam_mods_folder = get_path_up_to_string(game_folder, "common", exclude=True)
+        if steam_mods_folder == "":
+            steam_mods_folder = Path(
+                f"{steam_folder}/steamapps/workshop/content/294100"
+            )
+        else:
+            steam_mods_folder = Path(steam_mods_folder) / "workshop/content/294100"
+
+        return game_folder, config_folder, steam_mods_folder
+
+    def _find_steam_root(self, candidates: list[Path]) -> Path | None:
+        """Find the Steam installation root from a prioritized list of paths.
+
+        A candidate is valid if it exists as a directory and contains either
+        a ``steamapps/`` directory or ``config/libraryfolders.vdf``.
+
+        :param candidates: Ordered list of candidate Steam root paths
+        :return: First valid Steam root, or None if no candidate matches
+        """
+        for candidate in candidates:
+            if not candidate.is_dir():
+                logger.debug(f"Steam root candidate does not exist: {candidate}")
+                continue
+            has_steamapps = (candidate / "steamapps").is_dir()
+            has_vdf = (candidate / "config" / "libraryfolders.vdf").is_file()
+            if has_steamapps or has_vdf:
+                logger.info(f"Found Steam root: {candidate}")
+                return candidate
+            logger.debug(
+                f"Steam root candidate exists but has no steamapps/ or config/libraryfolders.vdf: {candidate}"
+            )
+        logger.warning("No valid Steam root found from any candidate path")
+        return None
+
+    @staticmethod
+    def _find_mac_app_bundle(rimworld_dir: Path) -> Path:
+        """Find the .app bundle in a RimWorld directory.
+
+        Discovers the actual filesystem-cased name instead of hardcoding it,
+        since macOS is case-insensitive but path comparisons are case-sensitive.
+        """
+        if rimworld_dir.is_dir():
+            apps = list(rimworld_dir.glob("*.app"))
+            if apps:
+                return apps[0]
+        return rimworld_dir / "RimWorldMac.app"

--- a/app/services/path_autodetect_service.py
+++ b/app/services/path_autodetect_service.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from loguru import logger
 
 from app.utils.generic import find_steam_rimworld, get_path_up_to_string
-from app.utils.win_find_steam import find_steam_folder
 
 
 class PathAutodetectService:
@@ -187,6 +186,8 @@ class PathAutodetectService:
 
         :return: (game_folder, config_folder, steam_mods_folder)
         """
+        from app.utils.win_find_steam import find_steam_folder
+
         user_home = Path.home()
 
         steam_folder, found = find_steam_folder()

--- a/app/services/path_autodetect_service.py
+++ b/app/services/path_autodetect_service.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from loguru import logger
 
 from app.utils.generic import find_steam_rimworld, get_path_up_to_string
+from app.utils.win_find_steam import find_steam_folder
 
 
 class PathAutodetectService:
@@ -186,8 +187,6 @@ class PathAutodetectService:
 
         :return: (game_folder, config_folder, steam_mods_folder)
         """
-        from app.utils.win_find_steam import find_steam_folder
-
         user_home = Path.home()
 
         steam_folder, found = find_steam_folder()

--- a/app/utils/win_find_steam.py
+++ b/app/utils/win_find_steam.py
@@ -2,41 +2,43 @@
 
 import os
 import sys
-import winreg
 
 from loguru import logger
 
-if sys.platform == "win32":
 
-    def find_steam_folder() -> tuple[str, bool]:
-        """Windows only function to find the steam folder by checking the registry.
-        The function will check the registry for the steam install path and return the path to the steam folder
-        and a boolean indicating if the path was found or not.
+def find_steam_folder() -> tuple[str, bool]:
+    """Find the Steam installation folder by checking the Windows registry.
 
-        Validates the path by checking if the steam executable is present in the path.
+    Validates the path by checking if the steam executable is present.
 
-        Returns:
-            tuple[str, bool]: The path to the steam folder and a boolean indicating if the path was found
-        """
-        candidate_reg_keys = [
-            r"SOFTWARE\Wow6432Node\Valve\Steam",
-            r"SOFTWARE\Valve\Steam",
-        ]
-
-        for reg_key in candidate_reg_keys:
-            try:
-                with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, reg_key) as key:
-                    value = winreg.QueryValueEx(key, "InstallPath")
-                    candidate_path = os.path.join(value[0], "steam.exe")
-
-                    if os.path.isfile(candidate_path):
-                        return value[0], True
-
-                    logger.warning(
-                        f"Steam executable not found at path defined by registry: {candidate_path}"
-                    )
-            except FileNotFoundError:
-                # Registry key not found. Continue to the next candidate key
-                continue
-
+    Returns:
+        tuple[str, bool]: The path to the steam folder and a boolean indicating
+            if the path was found.  On non-Windows platforms always returns
+            ``("", False)``.
+    """
+    if sys.platform != "win32":
         return "", False
+
+    import winreg
+
+    candidate_reg_keys = [
+        r"SOFTWARE\Wow6432Node\Valve\Steam",
+        r"SOFTWARE\Valve\Steam",
+    ]
+
+    for reg_key in candidate_reg_keys:
+        try:
+            with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, reg_key) as key:
+                value = winreg.QueryValueEx(key, "InstallPath")
+                candidate_path = os.path.join(value[0], "steam.exe")
+
+                if os.path.isfile(candidate_path):
+                    return value[0], True
+
+                logger.warning(
+                    f"Steam executable not found at path defined by registry: {candidate_path}"
+                )
+        except FileNotFoundError:
+            continue
+
+    return "", False

--- a/tests/controllers/test_path_autodetection.py
+++ b/tests/controllers/test_path_autodetection.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from unittest.mock import patch
 
-from app.controllers.settings_controller import SettingsController
+from app.services.path_autodetect_service import PathAutodetectService
 
 
 def _vdf_escape(path: Path) -> str:
@@ -18,24 +18,20 @@ def _setup_steam_root(tmp_path: Path, subdir: str) -> Path:
     return steam_root
 
 
-def _make_controller() -> SettingsController:
-    """Create a SettingsController without __init__ (which requires Qt widgets).
-
-    Safe because the path detection methods only use Path.home(), static
-    methods, and module-level utility functions — no instance attributes.
-    """
-    return SettingsController.__new__(SettingsController)
+def _make_service() -> PathAutodetectService:
+    """Create a PathAutodetectService (no __init__ setup needed)."""
+    return PathAutodetectService()
 
 
 class TestFindSteamRoot:
-    """Tests for SettingsController._find_steam_root()."""
+    """Tests for PathAutodetectService._find_steam_root()."""
 
     def test_returns_first_valid_candidate_with_steamapps(self, tmp_path: Path) -> None:
         candidate = tmp_path / ".steam" / "steam"
         candidate.mkdir(parents=True)
         (candidate / "steamapps").mkdir()
 
-        result = SettingsController._find_steam_root([candidate])
+        result = _make_service()._find_steam_root([candidate])
         assert result == candidate
 
     def test_returns_first_valid_candidate_with_vdf(self, tmp_path: Path) -> None:
@@ -43,7 +39,7 @@ class TestFindSteamRoot:
         (candidate / "config").mkdir(parents=True)
         (candidate / "config" / "libraryfolders.vdf").touch()
 
-        result = SettingsController._find_steam_root([candidate])
+        result = _make_service()._find_steam_root([candidate])
         assert result == candidate
 
     def test_skips_nonexistent_candidates(self, tmp_path: Path) -> None:
@@ -52,18 +48,18 @@ class TestFindSteamRoot:
         valid.mkdir()
         (valid / "steamapps").mkdir()
 
-        result = SettingsController._find_steam_root([nonexistent, valid])
+        result = _make_service()._find_steam_root([nonexistent, valid])
         assert result == valid
 
     def test_skips_candidates_without_steamapps_or_vdf(self, tmp_path: Path) -> None:
         empty_dir = tmp_path / "empty"
         empty_dir.mkdir()
 
-        result = SettingsController._find_steam_root([empty_dir])
+        result = _make_service()._find_steam_root([empty_dir])
         assert result is None
 
     def test_returns_none_when_no_candidates_match(self, tmp_path: Path) -> None:
-        result = SettingsController._find_steam_root([tmp_path / "a", tmp_path / "b"])
+        result = _make_service()._find_steam_root([tmp_path / "a", tmp_path / "b"])
         assert result is None
 
     def test_respects_priority_order(self, tmp_path: Path) -> None:
@@ -75,25 +71,25 @@ class TestFindSteamRoot:
         second.mkdir()
         (second / "steamapps").mkdir()
 
-        result = SettingsController._find_steam_root([first, second])
+        result = _make_service()._find_steam_root([first, second])
         assert result == first
 
     def test_returns_none_for_empty_list(self) -> None:
-        result = SettingsController._find_steam_root([])
+        result = _make_service()._find_steam_root([])
         assert result is None
 
 
 class TestGetLinuxPaths:
-    """Tests for SettingsController.__get_linux_paths() via the name-mangled accessor."""
+    """Tests for PathAutodetectService.get_linux_paths()."""
 
-    def _call(self, controller: SettingsController) -> tuple[Path, Path, Path]:
-        return controller._SettingsController__get_linux_paths()  # type: ignore[attr-defined]
+    def _call(self) -> tuple[Path, Path, Path]:
+        return _make_service().get_linux_paths()
 
     def test_debian_installation_path(self, tmp_path: Path) -> None:
         steam_root = _setup_steam_root(tmp_path, ".steam/debian-installation")
 
         with patch("pathlib.Path.home", return_value=tmp_path):
-            result = self._call(_make_controller())
+            result = self._call()
 
         assert result[0] == steam_root / "steamapps" / "common" / "RimWorld"
         assert result[2] == steam_root / "steamapps" / "workshop" / "content" / "294100"
@@ -102,7 +98,7 @@ class TestGetLinuxPaths:
         steam_root = _setup_steam_root(tmp_path, ".steam/steam")
 
         with patch("pathlib.Path.home", return_value=tmp_path):
-            result = self._call(_make_controller())
+            result = self._call()
 
         assert result[0] == steam_root / "steamapps" / "common" / "RimWorld"
 
@@ -110,7 +106,7 @@ class TestGetLinuxPaths:
         steam_root = _setup_steam_root(tmp_path, ".local/share/Steam")
 
         with patch("pathlib.Path.home", return_value=tmp_path):
-            result = self._call(_make_controller())
+            result = self._call()
 
         assert result[0] == steam_root / "steamapps" / "common" / "RimWorld"
 
@@ -121,7 +117,7 @@ class TestGetLinuxPaths:
         )
 
         with patch("pathlib.Path.home", return_value=tmp_path):
-            result = self._call(_make_controller())
+            result = self._call()
 
         assert result[0] == steam_root / "steamapps" / "common" / "RimWorld"
 
@@ -129,7 +125,7 @@ class TestGetLinuxPaths:
         steam_root = _setup_steam_root(tmp_path, "snap/steam/common/.local/share/Steam")
 
         with patch("pathlib.Path.home", return_value=tmp_path):
-            result = self._call(_make_controller())
+            result = self._call()
 
         assert result[0] == steam_root / "steamapps" / "common" / "RimWorld"
 
@@ -150,7 +146,7 @@ class TestGetLinuxPaths:
         (vdf_dir / "libraryfolders.vdf").write_text(vdf_content)
 
         with patch("pathlib.Path.home", return_value=tmp_path):
-            result = self._call(_make_controller())
+            result = self._call()
 
         assert result[0] == secondary_lib / "steamapps" / "common" / "RimWorld"
         assert (
@@ -177,7 +173,7 @@ class TestGetLinuxPaths:
         proton_config.mkdir(parents=True)
 
         with patch("pathlib.Path.home", return_value=tmp_path):
-            result = self._call(_make_controller())
+            result = self._call()
 
         assert result[1] == proton_config
 
@@ -193,13 +189,13 @@ class TestGetLinuxPaths:
         )
 
         with patch("pathlib.Path.home", return_value=tmp_path):
-            result = self._call(_make_controller())
+            result = self._call()
 
         assert result[1] == native_config
 
     def test_no_steam_root_returns_fallback_paths(self, tmp_path: Path) -> None:
         with patch("pathlib.Path.home", return_value=tmp_path):
-            result = self._call(_make_controller())
+            result = self._call()
 
         assert "steamapps" in str(result[0])
         assert "Config" in str(result[1])
@@ -210,13 +206,13 @@ class TestGetLinuxPaths:
         _setup_steam_root(tmp_path, ".steam/steam")
 
         with patch("pathlib.Path.home", return_value=tmp_path):
-            result = self._call(_make_controller())
+            result = self._call()
 
         assert result[0] == debian_root / "steamapps" / "common" / "RimWorld"
 
 
 class TestGetDarwinPaths:
-    """Tests for SettingsController.__get_darwin_paths().
+    """Tests for PathAutodetectService.get_darwin_paths().
 
     Note: macOS uses "Rimworld" (lowercase w) in hardcoded fallback paths,
     while VDF parsing returns "RimWorld" (capital W). This is fine because
@@ -224,8 +220,8 @@ class TestGetDarwinPaths:
     exact casing each code path produces.
     """
 
-    def _call(self, controller: SettingsController) -> tuple[Path, Path, Path]:
-        return controller._SettingsController__get_darwin_paths()  # type: ignore[attr-defined]
+    def _call(self) -> tuple[Path, Path, Path]:
+        return _make_service().get_darwin_paths()
 
     @staticmethod
     def _make_darwin_steam_root(tmp_path: Path) -> Path:
@@ -249,7 +245,7 @@ class TestGetDarwinPaths:
         (vdf_dir / "libraryfolders.vdf").write_text(vdf_content)
 
         with patch("pathlib.Path.home", return_value=tmp_path):
-            result = self._call(_make_controller())
+            result = self._call()
 
         # VDF returns "RimWorld" (capital W)
         assert (
@@ -261,7 +257,7 @@ class TestGetDarwinPaths:
         steam_root = self._make_darwin_steam_root(tmp_path)
 
         with patch("pathlib.Path.home", return_value=tmp_path):
-            result = self._call(_make_controller())
+            result = self._call()
 
         # Fallback uses canonical "RimWorld" casing when no .app bundle found on disk
         expected_game = (
@@ -273,7 +269,7 @@ class TestGetDarwinPaths:
         self._make_darwin_steam_root(tmp_path)
 
         with patch("pathlib.Path.home", return_value=tmp_path):
-            result = self._call(_make_controller())
+            result = self._call()
 
         expected_config = (
             tmp_path / "Library" / "Application Support" / "Rimworld" / "Config"
@@ -284,13 +280,13 @@ class TestGetDarwinPaths:
         self._make_darwin_steam_root(tmp_path)
 
         with patch("pathlib.Path.home", return_value=tmp_path):
-            result = self._call(_make_controller())
+            result = self._call()
 
         assert result[2].parts[-3:] == ("workshop", "content", "294100")
 
     def test_no_steam_root_returns_hardcoded_paths(self, tmp_path: Path) -> None:
         with patch("pathlib.Path.home", return_value=tmp_path):
-            result = self._call(_make_controller())
+            result = self._call()
 
         assert "RimWorldMac.app" in str(result[0])
         assert "Config" in str(result[1])
@@ -298,42 +294,42 @@ class TestGetDarwinPaths:
 
 
 class TestSnapWarning:
-    """Tests for Snap detection via _detected_steam_root."""
+    """Tests for Snap detection via PathAutodetectService.detected_steam_root."""
 
     def test_snap_steam_root_detected(self, tmp_path: Path) -> None:
         _setup_steam_root(tmp_path, "snap/steam/common/.local/share/Steam")
-        controller = _make_controller()
+        service = _make_service()
 
         with patch("pathlib.Path.home", return_value=tmp_path):
-            controller._SettingsController__get_linux_paths()  # type: ignore[attr-defined]
+            service.get_linux_paths()
 
-        assert controller._detected_steam_root is not None
-        assert "snap" in controller._detected_steam_root.parts
+        assert service.detected_steam_root is not None
+        assert "snap" in service.detected_steam_root.parts
 
     def test_native_steam_root_not_flagged(self, tmp_path: Path) -> None:
         _setup_steam_root(tmp_path, ".steam/steam")
-        controller = _make_controller()
+        service = _make_service()
 
         with patch("pathlib.Path.home", return_value=tmp_path):
-            controller._SettingsController__get_linux_paths()  # type: ignore[attr-defined]
+            service.get_linux_paths()
 
-        assert controller._detected_steam_root is not None
-        assert "snap" not in controller._detected_steam_root.parts
+        assert service.detected_steam_root is not None
+        assert "snap" not in service.detected_steam_root.parts
 
     def test_no_steam_root_not_flagged(self, tmp_path: Path) -> None:
-        controller = _make_controller()
+        service = _make_service()
 
         with patch("pathlib.Path.home", return_value=tmp_path):
-            controller._SettingsController__get_linux_paths()  # type: ignore[attr-defined]
+            service.get_linux_paths()
 
-        assert controller._detected_steam_root is None
+        assert service.detected_steam_root is None
 
 
 class TestVdfEdgeCases:
     """Tests for VDF parsing edge cases in path autodetection."""
 
-    def _call_linux(self, controller: SettingsController) -> tuple[Path, Path, Path]:
-        return controller._SettingsController__get_linux_paths()  # type: ignore[attr-defined]
+    def _call_linux(self) -> tuple[Path, Path, Path]:
+        return _make_service().get_linux_paths()
 
     def test_malformed_vdf_falls_back_to_default(self, tmp_path: Path) -> None:
         steam_root = tmp_path / ".steam" / "steam"
@@ -344,7 +340,7 @@ class TestVdfEdgeCases:
         (vdf_dir / "libraryfolders.vdf").write_text("this is not valid vdf {{{")
 
         with patch("pathlib.Path.home", return_value=tmp_path):
-            result = self._call_linux(_make_controller())
+            result = self._call_linux()
 
         assert result[0] == steam_root / "steamapps" / "common" / "RimWorld"
         assert result[2] == steam_root / "steamapps" / "workshop" / "content" / "294100"
@@ -371,6 +367,6 @@ class TestVdfEdgeCases:
         (vdf_dir / "libraryfolders.vdf").write_text(vdf_content)
 
         with patch("pathlib.Path.home", return_value=tmp_path):
-            result = self._call_linux(_make_controller())
+            result = self._call_linux()
 
         assert result[0] == steam_root / "steamapps" / "common" / "RimWorld"


### PR DESCRIPTION
Extract \__get_darwin_paths\, \__get_linux_paths\, \__get_windows_paths\, \_find_steam_root\, and \_find_mac_app_bundle\ from \SettingsController\ into a new \PathAutodetectService\ class in \pp/services/\.