### PR TITLE
refactor(settings): extract get_mod_paths/resolve_data_source to ModPathService

### DIFF
--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -24,6 +24,7 @@ from app.controllers.settings_tabs import (
 from app.controllers.theme_controller import ThemeController
 from app.models.settings import Instance, Settings
 from app.services.http_download_service import HttpDownloadService
+from app.services.mod_path_service import get_mod_paths, resolve_data_source
 from app.services.path_autodetect_service import PathAutodetectService
 from app.utils.constants import DEFAULT_INSTANCE_NAME
 from app.utils.event_bus import EventBus
@@ -158,56 +159,10 @@ class SettingsController(QObject):
             show_settings_error()
 
     def get_mod_paths(self) -> list[str]:
-        """
-        Get the mod paths for the current instance. Return the Default instance if the current instance is not found.
-        """
-        return [
-            str(
-                Path(
-                    self.settings.instances[self.settings.current_instance].game_folder
-                )
-                / "Data"
-            ),
-            str(
-                Path(
-                    self.settings.instances[self.settings.current_instance].local_folder
-                )
-            ),
-            str(
-                Path(
-                    self.settings.instances[
-                        self.settings.current_instance
-                    ].workshop_folder
-                )
-            ),
-        ]
+        return get_mod_paths(self.active_instance)
 
     def resolve_data_source(self, path: str) -> str | None:
-        """
-        Resolve the data source for the provided path string.
-        """
-        # Pathlib the provided path string
-        sanitized_path = Path(path)
-        # Grab paths from Settings
-        expansions_path = (
-            Path(self.settings.instances[self.settings.current_instance].game_folder)
-            / "Data"
-        )
-        local_path = Path(
-            self.settings.instances[self.settings.current_instance].local_folder
-        )
-        workshop_path = Path(
-            self.settings.instances[self.settings.current_instance].workshop_folder
-        )
-        # Validate data source, then emit if path is valid and not mapped
-        if sanitized_path.parent == expansions_path:
-            return "expansion"
-        elif sanitized_path.parent == local_path:
-            return "local"
-        elif sanitized_path.parent == workshop_path:
-            return "workshop"
-        else:
-            return None
+        return resolve_data_source(self.active_instance, path)
 
     def show_settings_dialog(self, tab_name: str = "") -> None:
         """

--- a/app/services/mod_path_service.py
+++ b/app/services/mod_path_service.py
@@ -1,0 +1,39 @@
+"""Service for resolving mod folder paths from an Instance model."""
+
+from pathlib import Path
+
+from app.models.instance import Instance
+
+
+def get_mod_paths(instance: Instance) -> list[str]:
+    """Get the mod paths for the given instance.
+
+    Returns the game Data folder, local folder, and workshop folder
+    as string paths.
+    """
+    return [
+        str(Path(instance.game_folder) / "Data"),
+        str(Path(instance.local_folder)),
+        str(Path(instance.workshop_folder)),
+    ]
+
+
+def resolve_data_source(instance: Instance, path: str) -> str | None:
+    """Resolve the data source for the provided path string.
+
+    :param instance: The active game instance
+    :param path: The file path to resolve
+    :return: ``"expansion"``, ``"local"``, ``"workshop"``, or ``None``
+    """
+    sanitized_path = Path(path)
+    game_data = Path(instance.game_folder) / "Data"
+    local = Path(instance.local_folder)
+    workshop = Path(instance.workshop_folder)
+
+    if sanitized_path.parent == game_data:
+        return "expansion"
+    elif sanitized_path.parent == local:
+        return "local"
+    elif sanitized_path.parent == workshop:
+        return "workshop"
+    return None

--- a/app/utils/watchdog.py
+++ b/app/utils/watchdog.py
@@ -12,7 +12,8 @@ from watchdog.observers.api import BaseObserver
 from watchdog.observers.polling import PollingObserver
 
 from app.controllers.metadata_controller import MetadataController
-from app.controllers.settings_controller import SettingsController
+from app.models.instance import Instance
+from app.services.mod_path_service import get_mod_paths, resolve_data_source
 
 
 class WatchdogHandler(FileSystemEventHandler, QObject):
@@ -21,13 +22,13 @@ class WatchdogHandler(FileSystemEventHandler, QObject):
     mod_deleted = Signal(str, str)
     mod_updated = Signal(str, str)
 
-    def __init__(self, settings_controller: SettingsController) -> None:
+    def __init__(self, instance: Instance) -> None:
         """Initialize the WatchdogHandler.
 
         The WatchdogHandler is a subclass of :class:`watchdog.events.FileSystemEventHandler`
         and :class:`PySide6.QtCore.QObject`. It is used to monitor relevant mod files for changes.
 
-        :param settings_controller: The settings controller for the application
+        :param instance: The active game instance
 
         :return: None
         """
@@ -39,7 +40,7 @@ class WatchdogHandler(FileSystemEventHandler, QObject):
             str(workshop_acf) if workshop_acf is not None else None
         )
         self.steamcmd_appworkshop_acf_path = self.metadata_controller.steamcmd_acf_path
-        self.settings_controller: SettingsController = settings_controller
+        self._instance = instance
         # Steam .acf file monitoring
         self.watchdog_acf_observer: BaseObserver | None
         self.watchdog_acf_observer = PollingObserver()
@@ -49,7 +50,7 @@ class WatchdogHandler(FileSystemEventHandler, QObject):
         # Keep track of cooldowns for each mod path
         self.cooldown_timers: dict[str, Any] = {}
         self.__add_acf_observers()
-        self.__add_mod_observers(self.settings_controller.get_mod_paths())
+        self.__add_mod_observers(get_mod_paths(self._instance))
 
     def start(self) -> None:
         """Start all configured observers.
@@ -217,7 +218,7 @@ class WatchdogHandler(FileSystemEventHandler, QObject):
         if self.__check_acf_file(event, Path(event_scr_path_str)):
             return
         # If we are still here, assume we need to try to resolve the mod's data source from the potential mod path
-        data_source = self.settings_controller.resolve_data_source(event_scr_path_str)
+        data_source = resolve_data_source(self._instance, event_scr_path_str)
         # Check if this is a new mod directory (not already tracked)
         is_new_mod_dir = (
             event.is_directory

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -1162,7 +1162,7 @@ class MainWindow(QMainWindow):
     def initialize_watchdog(self) -> None:
         logger.info("Initializing watchdog FS Observer")
         self.watchdog_event_handler = WatchdogHandler(
-            settings_controller=self.settings_controller,
+            instance=self.settings_controller.active_instance,
         )
         self.watchdog_event_handler.acf_changed.connect(
             partial(refresh_acf_metadata, self.main_content_panel.metadata_controller)


### PR DESCRIPTION
Extract two standalone methods from SettingsController into a dedicated mod_path_service: get_mod_paths() and resolve_data_source(). Both only operate on Instance data — no controller coupling needed.

- watchdog.py no longer imports SettingsController (uses Instance + mod_path_service directly)
- SettingsController methods slim to one-liner delegates
- SettingsController reverse deps: 28 -> 27