### PR TITLE
refactor: convert Group A files from SettingsController to Settings model

### DIFF
--- a/app/controllers/app_controller.py
+++ b/app/controllers/app_controller.py
@@ -112,7 +112,7 @@ class AppController(QObject):
     def do_dds_cleanup(self) -> None:
         """Performs cleanup of orphaned DDS files if the setting is enabled."""
         if self.settings.auto_delete_orphaned_dds:
-            dds_utility = DDSUtility(self.settings_controller)
+            dds_utility = DDSUtility(self.settings_controller.settings)
             dds_utility.delete_dds_files_without_png()
 
     def initialize_metadata_controller(self) -> None:

--- a/app/services/import_export_service.py
+++ b/app/services/import_export_service.py
@@ -8,9 +8,9 @@ from urllib.parse import urlparse
 from loguru import logger
 
 from app.controllers.metadata_controller import MetadataController
-from app.controllers.settings_controller import SettingsController
 from app.models.divider import is_divider_uuid
 from app.models.metadata.metadata_structure import AboutXmlMod, ModType
+from app.models.settings import Settings
 from app.utils.app_info import AppInfo
 from app.utils.rentry.wrapper import RentryUpload
 from app.utils.schema import generate_rimworld_mods_list
@@ -42,10 +42,10 @@ class ImportExportService:
     def __init__(
         self,
         metadata_controller: MetadataController,
-        settings_controller: SettingsController,
+        settings: Settings,
     ) -> None:
         self.metadata_controller = metadata_controller
-        self.settings_controller = settings_controller
+        self.settings = settings
 
     def collect_active_mods(
         self,
@@ -289,10 +289,8 @@ class ImportExportService:
         :return: the path to the saved file
         :raises Exception: on write failure
         """
-        current_instance = self.settings_controller.settings.current_instance
-        config_folder = self.settings_controller.settings.instances[
-            current_instance
-        ].config_folder
+        current_instance = self.settings.current_instance
+        config_folder = self.settings.instances[current_instance].config_folder
         mods_config_path = str(Path(config_folder) / "ModsConfig.xml")
 
         mods_config_data = generate_rimworld_mods_list(

--- a/app/sort/mod_sorting.py
+++ b/app/sort/mod_sorting.py
@@ -1,7 +1,6 @@
 import os
 import time
 from enum import Enum
-from typing import Any
 
 from loguru import logger
 from PySide6.QtCore import QObject, Signal, Slot
@@ -9,6 +8,7 @@ from PySide6.QtCore import QObject, Signal, Slot
 from app.controllers.metadata_controller import MetadataController
 from app.controllers.metadata_db_controller import AuxMetadataController
 from app.models.metadata.metadata_structure import AboutXmlMod, ListedMod
+from app.models.settings import Settings
 from app.utils.aux_db_utils import auxdb_get_mod_tags
 from app.utils.generic import scanpath
 
@@ -185,7 +185,7 @@ def path_to_mod_color(path: str, path_to_color: dict[str, str] | None = None) ->
 def path_to_mod_tags(
     path: str,
     cached_metadata: dict[str, ListedMod | None] | None = None,
-    settings_controller: Any | None = None,
+    settings: Settings | None = None,
 ) -> str:
     """
     Get user tags for inactive mods list sorting.
@@ -193,11 +193,11 @@ def path_to_mod_tags(
     Mods without tags sort first by an empty string. Tagged mods are sorted by
     their comma-separated, normalized tag list.
     """
-    if settings_controller is None:
+    if settings is None:
         return ""
 
     try:
-        tags = auxdb_get_mod_tags(settings_controller, path)
+        tags = auxdb_get_mod_tags(settings, path)
     except Exception as e:
         logger.debug(f"Failed to retrieve tags for sorting path {path}: {e}")
         return ""
@@ -269,18 +269,18 @@ def get_cached_metadata_for_batch(
 
 def _get_path_to_color_map(
     paths: list[str],
-    settings_controller: Any,
+    settings: Settings,
 ) -> dict[str, str]:
     """Build a path→color_hex mapping from the aux DB for color-based sorting.
 
     :param paths: List of mod paths to fetch colors for
-    :param settings_controller: SettingsController instance
+    :param settings: Settings instance
     :return: Dictionary mapping path -> color_hex string (only includes mods with colors)
     """
     path_to_color: dict[str, str] = {}
     try:
         aux_controller = AuxMetadataController.get_or_create_cached_instance(
-            settings_controller.settings.aux_db_path
+            settings.aux_db_path
         )
         with aux_controller.Session() as aux_session:
             for path in paths:
@@ -294,18 +294,18 @@ def _get_path_to_color_map(
 
 def _get_path_to_updated_map(
     paths: list[str],
-    settings_controller: Any,
+    settings: Settings,
 ) -> dict[str, int]:
     """Build a path→acf_time_updated mapping from the aux DB for update-time sorting.
 
     :param paths: List of mod paths to fetch update times for
-    :param settings_controller: SettingsController instance
+    :param settings: Settings instance
     :return: Dictionary mapping path -> update timestamp (only includes mods with valid timestamps)
     """
     path_to_updated: dict[str, int] = {}
     try:
         aux_controller = AuxMetadataController.get_or_create_cached_instance(
-            settings_controller.settings.aux_db_path
+            settings.aux_db_path
         )
         with aux_controller.Session() as aux_session:
             for path in paths:
@@ -321,7 +321,7 @@ def _build_sort_key_map(
     paths: list[str],
     key: "ModsPanelSortKey",
     cached_metadata: dict[str, ListedMod | None] | None = None,
-    settings_controller: Any | None = None,
+    settings: Settings | None = None,
     path_to_color: dict[str, str] | None = None,
     path_to_updated: dict[str, int] | None = None,
 ) -> dict[str, str | int]:
@@ -331,7 +331,7 @@ def _build_sort_key_map(
     :param paths: List of mod paths to compute keys for
     :param key: The ModsPanelSortKey enum indicating which attribute to extract
     :param cached_metadata: Optional pre-cached metadata dict
-    :param settings_controller: Optional SettingsController for tag sorting
+    :param settings: Optional Settings for tag sorting
     :param path_to_color: Optional pre-built path→color mapping for color sorting
     :param path_to_updated: Optional pre-built path→timestamp mapping for update-time sorting
     :return: Dictionary mapping path -> computed sort key value (str or int).
@@ -353,9 +353,7 @@ def _build_sort_key_map(
         elif key == ModsPanelSortKey.MOD_COLOR:
             sort_key_map[path] = path_to_mod_color(path, path_to_color)
         elif key == ModsPanelSortKey.MOD_TAGS:
-            sort_key_map[path] = path_to_mod_tags(
-                path, cached_metadata, settings_controller
-            )
+            sort_key_map[path] = path_to_mod_tags(path, cached_metadata, settings)
         elif key == ModsPanelSortKey.MOD_UPDATED:
             sort_key_map[path] = path_to_mod_updated(path, path_to_updated)
         else:
@@ -401,7 +399,7 @@ def sort_paths(
     key: ModsPanelSortKey,
     descending: bool | None = None,
     cached_metadata: dict[str, ListedMod | None] | None = None,
-    settings_controller: Any | None = None,
+    settings: Settings | None = None,
 ) -> list[str]:
     """
     Sort mod paths by the specified attribute.
@@ -413,7 +411,7 @@ def sort_paths(
     :param key: ModsPanelSortKey enum specifying the sort attribute
     :param descending: Optional bool to override default sort direction.
     :param cached_metadata: Optional pre-cached metadata dict.
-    :param settings_controller: Optional SettingsController for fetching auxiliary metadata.
+    :param settings: Optional Settings for fetching auxiliary metadata.
     :return: Sorted list of paths in the specified order.
     """
     # Performance instrumentation - track sort timing
@@ -421,20 +419,20 @@ def sort_paths(
 
     # Build color map if sorting by color
     path_to_color: dict[str, str] | None = None
-    if key == ModsPanelSortKey.MOD_COLOR and settings_controller is not None:
-        path_to_color = _get_path_to_color_map(paths, settings_controller)
+    if key == ModsPanelSortKey.MOD_COLOR and settings is not None:
+        path_to_color = _get_path_to_color_map(paths, settings)
 
     # Build update-time map if sorting by update time
     path_to_updated: dict[str, int] | None = None
-    if key == ModsPanelSortKey.MOD_UPDATED and settings_controller is not None:
-        path_to_updated = _get_path_to_updated_map(paths, settings_controller)
+    if key == ModsPanelSortKey.MOD_UPDATED and settings is not None:
+        path_to_updated = _get_path_to_updated_map(paths, settings)
 
     # Pre-compute sort keys to avoid repeated function calls during sort
     sort_key_map = _build_sort_key_map(
         paths,
         key,
         cached_metadata,
-        settings_controller=settings_controller,
+        settings=settings,
         path_to_color=path_to_color,
         path_to_updated=path_to_updated,
     )

--- a/app/utils/aux_db_utils.py
+++ b/app/utils/aux_db_utils.py
@@ -4,12 +4,12 @@ from PySide6.QtGui import QColor
 from sqlalchemy.orm.session import Session
 
 from app.controllers.metadata_db_controller import AuxMetadataController
-from app.controllers.settings_controller import SettingsController
 from app.models.metadata.metadata_db import AuxMetadataEntry, TagsEntry
+from app.models.settings import Settings
 
 
 def auxdb_get_aux_db_entry(
-    settings_controller: SettingsController,
+    settings: Settings,
     path: str,
     aux_db_controller: AuxMetadataController | None = None,
     session: Session | None = None,
@@ -17,7 +17,7 @@ def auxdb_get_aux_db_entry(
     """
     Get the AuxMetadataEntry for a given mod path from the Aux Metadata DB.
 
-    :param settings_controller: SettingsController, settings controller instance
+    :param settings: Settings, settings controller instance
     :param path: str, the filesystem path of the mod
     :param aux_db_controller: AuxMetadataController | None, optional aux metadata controller instance
     :param session: Session | None, optional SQLAlchemy session to use for the query; if None, a new session will be created and closed within this function
@@ -25,9 +25,7 @@ def auxdb_get_aux_db_entry(
     """
     local_controller = (
         aux_db_controller
-        or AuxMetadataController.get_or_create_cached_instance(
-            settings_controller.settings.aux_db_path
-        )
+        or AuxMetadataController.get_or_create_cached_instance(settings.aux_db_path)
     )
     local_session = session or local_controller.Session()
     try:
@@ -42,7 +40,7 @@ def auxdb_get_aux_db_entry(
 
 
 def auxdb_get_mod_color(
-    settings_controller: SettingsController,
+    settings: Settings,
     path: str,
     aux_db_controller: AuxMetadataController | None = None,
     session: Session | None = None,
@@ -50,15 +48,13 @@ def auxdb_get_mod_color(
     """
     Get the mod color from Aux Metadata DB.
 
-    :param settings_controller: SettingsController, settings controller instance
+    :param settings: Settings, settings controller instance
     :param path: str, the filesystem path of the mod
     :param aux_db_controller: AuxMetadataController | None, optional aux metadata controller instance
     :param session: Session | None, optional SQLAlchemy session to use for the query; if None, a new session will be created and closed within this function
     :return: QColor | None, Color of the mod, or None if no color
     """
-    entry = auxdb_get_aux_db_entry(
-        settings_controller, path, aux_db_controller, session
-    )
+    entry = auxdb_get_aux_db_entry(settings, path, aux_db_controller, session)
     mod_color = None
     if entry:
         color_text = entry.color_hex
@@ -69,7 +65,7 @@ def auxdb_get_mod_color(
 
 
 def auxdb_get_mod_user_notes(
-    settings_controller: SettingsController,
+    settings: Settings,
     path: str,
     aux_db_controller: AuxMetadataController | None = None,
     session: Session | None = None,
@@ -77,15 +73,13 @@ def auxdb_get_mod_user_notes(
     """
     Get the user notes for a mod from Aux Metadata DB.
 
-    :param settings_controller: SettingsController, settings controller instance
+    :param settings: Settings, settings controller instance
     :param path: str, the filesystem path of the mod
     :param aux_db_controller: AuxMetadataController | None, optional aux metadata controller instance
     :param session: Session | None, optional SQLAlchemy session to use for the query; if None, a new session will be created and closed within this function
     :return: str, User notes for the mod, or empty string if no notes
     """
-    entry = auxdb_get_aux_db_entry(
-        settings_controller, path, aux_db_controller, session
-    )
+    entry = auxdb_get_aux_db_entry(settings, path, aux_db_controller, session)
     user_notes = ""
     if entry:
         user_notes = entry.user_notes
@@ -94,7 +88,7 @@ def auxdb_get_mod_user_notes(
 
 
 def auxdb_get_mod_warning_toggled(
-    settings_controller: SettingsController,
+    settings: Settings,
     path: str,
     aux_db_controller: AuxMetadataController | None = None,
     session: Session | None = None,
@@ -102,15 +96,13 @@ def auxdb_get_mod_warning_toggled(
     """
     Get the warning_toggled status for a mod from Aux Metadata DB.
 
-    :param settings_controller: SettingsController, settings controller instance
+    :param settings: Settings, settings controller instance
     :param path: str, the filesystem path of the mod
     :param aux_db_controller: AuxMetadataController | None, optional aux metadata controller instance
     :param session: Session | None, optional SQLAlchemy session to use for the query; if None, a new session will be created and closed within this function
     :return: bool, Warning toggled status for the mod
     """
-    entry = auxdb_get_aux_db_entry(
-        settings_controller, path, aux_db_controller, session
-    )
+    entry = auxdb_get_aux_db_entry(settings, path, aux_db_controller, session)
     warning_toggled = False
     if entry:
         warning_toggled = entry.ignore_warnings
@@ -119,7 +111,7 @@ def auxdb_get_mod_warning_toggled(
 
 
 def auxdb_update_mod_color(
-    settings_controller: SettingsController,
+    settings: Settings,
     path: str,
     color: QColor | None,
     aux_db_controller: AuxMetadataController | None = None,
@@ -128,7 +120,7 @@ def auxdb_update_mod_color(
     """
     Update the mod color in the Aux Metadata DB.
 
-    :param settings_controller: SettingsController, settings controller instance
+    :param settings: Settings, settings controller instance
     :param path: str, the filesystem path of the mod
     :param color: QColor | None, the new color to set for the mod, or None to clear the color
     :param aux_db_controller: AuxMetadataController, the aux metadata controller instance to use for the update
@@ -136,9 +128,7 @@ def auxdb_update_mod_color(
     """
     local_controller = (
         aux_db_controller
-        or AuxMetadataController.get_or_create_cached_instance(
-            settings_controller.settings.aux_db_path
-        )
+        or AuxMetadataController.get_or_create_cached_instance(settings.aux_db_path)
     )
 
     local_session = session or local_controller.Session()
@@ -154,7 +144,7 @@ def auxdb_update_mod_color(
 
 
 def auxdb_update_all_mod_colors(
-    settings_controller: SettingsController,
+    settings: Settings,
     path_color_mapping: dict[str, QColor | None],
     aux_db_controller: AuxMetadataController | None = None,
     session: Session | None = None,
@@ -162,16 +152,14 @@ def auxdb_update_all_mod_colors(
     """
     Update the mod colors in the Aux Metadata DB for multiple mods.
 
-    :param settings_controller: SettingsController, settings controller instance
+    :param settings: Settings, settings controller instance
     :param path_color_mapping: dict[str, QColor | None], a mapping of mod paths to their new colors (or None to clear the color)
     :param aux_db_controller: AuxMetadataController, the aux metadata controller instance to use for the update
     :param session: Session | None, optional SQLAlchemy session to use for the update; if None, a new session will be created and closed within this function
     """
     local_controller = (
         aux_db_controller
-        or AuxMetadataController.get_or_create_cached_instance(
-            settings_controller.settings.aux_db_path
-        )
+        or AuxMetadataController.get_or_create_cached_instance(settings.aux_db_path)
     )
 
     local_session = session or local_controller.Session()
@@ -191,7 +179,7 @@ def auxdb_update_all_mod_colors(
 
 
 def auxdb_get_mod_tags(
-    settings_controller: SettingsController,
+    settings: Settings,
     path: str,
     aux_db_controller: AuxMetadataController | None = None,
     session: Session | None = None,
@@ -201,9 +189,7 @@ def auxdb_get_mod_tags(
     """
     local_controller = (
         aux_db_controller
-        or AuxMetadataController.get_or_create_cached_instance(
-            settings_controller.settings.aux_db_path
-        )
+        or AuxMetadataController.get_or_create_cached_instance(settings.aux_db_path)
     )
     local_session = session or local_controller.Session()
     try:
@@ -218,23 +204,19 @@ def auxdb_get_mod_tags(
 
 
 def auxdb_get_all_tags(
-    settings_controller: SettingsController,
+    settings: Settings,
     aux_db_controller: AuxMetadataController | None = None,
     session: Session | None = None,
 ) -> list[str]:
     """
     Get all user-defined mod tags from Aux Metadata DB.
     """
-    if aux_db_controller is None and not hasattr(
-        settings_controller.settings, "aux_db_path"
-    ):
+    if aux_db_controller is None and not hasattr(settings, "aux_db_path"):
         return []
 
     local_controller = (
         aux_db_controller
-        or AuxMetadataController.get_or_create_cached_instance(
-            settings_controller.settings.aux_db_path
-        )
+        or AuxMetadataController.get_or_create_cached_instance(settings.aux_db_path)
     )
     local_session = session or local_controller.Session()
     try:
@@ -250,11 +232,11 @@ def _normalize_tags(tags: list[str]) -> list[str]:
 
 
 def _get_aux_controller(
-    settings_controller: SettingsController,
+    settings: Settings,
     aux_db_controller: AuxMetadataController | None = None,
 ) -> AuxMetadataController:
     return aux_db_controller or AuxMetadataController.get_or_create_cached_instance(
-        settings_controller.settings.aux_db_path
+        settings.aux_db_path
     )
 
 
@@ -268,14 +250,14 @@ def _get_or_create_tag_entry(session: Session, tag_text: str) -> TagsEntry:
 
 
 def _update_mod_tags(
-    settings_controller: SettingsController,
+    settings: Settings,
     path: str,
     tags: list[str] | None,
     mode: Literal["add", "replace", "remove"],
     aux_db_controller: AuxMetadataController | None = None,
     session: Session | None = None,
 ) -> None:
-    local_controller = _get_aux_controller(settings_controller, aux_db_controller)
+    local_controller = _get_aux_controller(settings, aux_db_controller)
     local_session = session or local_controller.Session()
 
     try:
@@ -301,7 +283,7 @@ def _update_mod_tags(
 
 
 def auxdb_add_mod_tags(
-    settings_controller: SettingsController,
+    settings: Settings,
     path: str,
     tags: list[str],
     aux_db_controller: AuxMetadataController | None = None,
@@ -311,7 +293,7 @@ def auxdb_add_mod_tags(
     Add tags to a mod without removing existing tags.
     """
     _update_mod_tags(
-        settings_controller=settings_controller,
+        settings=settings,
         path=path,
         tags=tags,
         mode="add",
@@ -321,7 +303,7 @@ def auxdb_add_mod_tags(
 
 
 def auxdb_replace_mod_tags(
-    settings_controller: SettingsController,
+    settings: Settings,
     path: str,
     tags: list[str],
     aux_db_controller: AuxMetadataController | None = None,
@@ -331,7 +313,7 @@ def auxdb_replace_mod_tags(
     Replace all tags for a mod.
     """
     _update_mod_tags(
-        settings_controller=settings_controller,
+        settings=settings,
         path=path,
         tags=tags,
         mode="replace",
@@ -341,7 +323,7 @@ def auxdb_replace_mod_tags(
 
 
 def auxdb_remove_mod_tags(
-    settings_controller: SettingsController,
+    settings: Settings,
     path: str,
     aux_db_controller: AuxMetadataController | None = None,
     session: Session | None = None,
@@ -350,7 +332,7 @@ def auxdb_remove_mod_tags(
     Remove all tags from a mod.
     """
     _update_mod_tags(
-        settings_controller=settings_controller,
+        settings=settings,
         path=path,
         tags=None,
         mode="remove",
@@ -360,7 +342,7 @@ def auxdb_remove_mod_tags(
 
 
 def auxdb_update_all_mod_tags(
-    settings_controller: SettingsController,
+    settings: Settings,
     paths: list[str],
     tags: list[str],
     replace: bool,
@@ -369,13 +351,13 @@ def auxdb_update_all_mod_tags(
     Update tags for multiple mods.
     """
     aux_db_controller = AuxMetadataController.get_or_create_cached_instance(
-        settings_controller.settings.aux_db_path
+        settings.aux_db_path
     )
     with aux_db_controller.Session() as aux_metadata_session:
         for path in paths:
             if replace:
                 auxdb_replace_mod_tags(
-                    settings_controller,
+                    settings,
                     path,
                     tags,
                     aux_db_controller,
@@ -383,7 +365,7 @@ def auxdb_update_all_mod_tags(
                 )
             else:
                 auxdb_add_mod_tags(
-                    settings_controller,
+                    settings,
                     path,
                     tags,
                     aux_db_controller,
@@ -392,14 +374,14 @@ def auxdb_update_all_mod_tags(
 
 
 def auxdb_cleanup_unused_tags(
-    settings_controller: SettingsController,
+    settings: Settings,
     aux_db_controller: AuxMetadataController | None = None,
     session: Session | None = None,
 ) -> None:
     """
     Delete tags that are no longer assigned to any mod.
     """
-    local_controller = _get_aux_controller(settings_controller, aux_db_controller)
+    local_controller = _get_aux_controller(settings, aux_db_controller)
     local_session = session or local_controller.Session()
 
     try:

--- a/app/utils/custom_list_widget_item_metadata.py
+++ b/app/utils/custom_list_widget_item_metadata.py
@@ -6,8 +6,8 @@ from sqlalchemy.orm.session import Session
 
 from app.controllers.metadata_controller import MetadataController
 from app.controllers.metadata_db_controller import AuxMetadataController
-from app.controllers.settings_controller import SettingsController
 from app.models.metadata.metadata_structure import AboutXmlMod
+from app.models.settings import Settings
 from app.utils.aux_db_utils import (
     auxdb_get_mod_color,
     auxdb_get_mod_tags,
@@ -24,7 +24,7 @@ class CustomListWidgetItemMetadata:
     def __init__(
         self,
         path: str,
-        settings_controller: SettingsController,
+        settings: Settings,
         errors_warnings: str = "",
         errors: str = "",
         warnings: str = "",
@@ -47,7 +47,7 @@ class CustomListWidgetItemMetadata:
         Unless explicitly provided, invalid and mismatch are automatically set based on the path using metadata controller.
 
         :param path: str, the path of the mod which corresponds to a mod's metadata key
-        :param settings_controller: SettingsController, instance of settings controller
+        :param settings: Settings, settings model instance
         :param errors_warnings: a string of errors and warnings
         :param errors: a string of errors for the notification tooltip
         :param warnings: a string of warnings for the notification tooltip
@@ -74,7 +74,7 @@ class CustomListWidgetItemMetadata:
         self.hidden_by_filter = hidden_by_filter
         if not warning_toggled:
             self.warning_toggled = auxdb_get_mod_warning_toggled(
-                settings_controller, path, aux_metadata_controller, aux_metadata_session
+                settings, path, aux_metadata_controller, aux_metadata_session
             )
         else:
             self.warning_toggled = warning_toggled
@@ -86,7 +86,7 @@ class CustomListWidgetItemMetadata:
         )
         if mod_color is None:
             self.mod_color = auxdb_get_mod_color(
-                settings_controller, path, aux_metadata_controller, aux_metadata_session
+                settings, path, aux_metadata_controller, aux_metadata_session
             )
         else:
             self.mod_color = mod_color
@@ -97,7 +97,7 @@ class CustomListWidgetItemMetadata:
         )
         self.mod_tags = (
             auxdb_get_mod_tags(
-                settings_controller, path, aux_metadata_controller, aux_metadata_session
+                settings, path, aux_metadata_controller, aux_metadata_session
             )
             if mod_tags is None
             else mod_tags
@@ -110,7 +110,7 @@ class CustomListWidgetItemMetadata:
         )
         if user_notes == "":
             self.user_notes = auxdb_get_mod_user_notes(
-                settings_controller, path, aux_metadata_controller, aux_metadata_session
+                settings, path, aux_metadata_controller, aux_metadata_session
             )
         else:
             self.user_notes = user_notes

--- a/app/utils/db_builder.py
+++ b/app/utils/db_builder.py
@@ -10,8 +10,8 @@ from PySide6.QtWidgets import QMessageBox
 import app.utils.constants as app_constants
 import app.views.dialogue as dialogue
 from app.controllers.metadata_controller import MetadataController
-from app.controllers.settings_controller import SettingsController
 from app.models.metadata.metadata_structure import ModType
+from app.models.settings import Settings
 from app.utils.app_info import AppInfo
 from app.utils.dict_utils import recursively_update_dict
 from app.utils.event_bus import EventBus
@@ -41,18 +41,18 @@ class DatabaseBuilder(QObject):
             cls._instance = super(DatabaseBuilder, cls).__new__(cls)
         return cls._instance
 
-    def __init__(self, settings_controller: SettingsController) -> None:
+    def __init__(self, settings: Settings) -> None:
         """
         Initialize the Database Builder singleton.
 
         Args:
-            settings_controller: The settings controller for the application.
+            settings: The settings model for the application.
         """
         if not hasattr(self, "initialized"):
             super(DatabaseBuilder, self).__init__()
             logger.info("Initializing DatabaseBuilder")
 
-            self.settings_controller = settings_controller
+            self.settings = settings
             self.metadata_controller = MetadataController.instance()
             self.query_runner: RunnerPanel | None = None
 
@@ -123,13 +123,13 @@ class DatabaseBuilder(QObject):
             - MODE_ALL_MODS: Includes locally available mod metadata with packageids.
         """
         base_kwargs: dict[str, Any] = {
-            "apikey": self.settings_controller.settings.steam_apikey,
+            "apikey": self.settings.steam_apikey,
             "appid": self.RIMWORLD_APPID,
-            "database_expiry": self.settings_controller.settings.database_expiry,
+            "database_expiry": self.settings.database_expiry,
             "mode": mode,
             "output_database_path": output_path,
-            "get_appid_deps": self.settings_controller.settings.build_steam_database_dlc_data,
-            "update": self.settings_controller.settings.build_steam_database_update_toggle,
+            "get_appid_deps": self.settings.build_steam_database_dlc_data,
+            "update": self.settings.build_steam_database_update_toggle,
         }
 
         if mode == self.MODE_ALL_MODS:
@@ -166,7 +166,7 @@ class DatabaseBuilder(QObject):
             logger.debug("USER ACTION: cancelled selection")
             return
 
-        mode = self.settings_controller.settings.db_builder_include
+        mode = self.settings.db_builder_include
         self.db_builder = self._create_database_builder(mode, output_path)
         self._setup_query_runner(f"RimSort - DB Builder ({mode})")
         self.db_builder.start()
@@ -212,9 +212,9 @@ class DatabaseBuilder(QObject):
             filters out existing mods, and emits appropriate download signals.
         """
         self.db_builder = SteamDatabaseBuilder(
-            apikey=self.settings_controller.settings.steam_apikey,
+            apikey=self.settings.steam_apikey,
             appid=self.RIMWORLD_APPID,
-            database_expiry=self.settings_controller.settings.database_expiry,
+            database_expiry=self.settings.database_expiry,
             mode=self.MODE_PFIDS_BY_APPID,
         )
 

--- a/app/utils/dds_utility.py
+++ b/app/utils/dds_utility.py
@@ -3,7 +3,7 @@ from glob import glob
 
 from loguru import logger
 
-from app.controllers.settings_controller import SettingsController
+from app.models.settings import Settings
 
 
 class DDSUtility:
@@ -11,8 +11,8 @@ class DDSUtility:
     Utility class for handling DDS files in the application.
     """
 
-    def __init__(self, settings_controller: SettingsController) -> None:
-        self.settings_controller = settings_controller
+    def __init__(self, settings: Settings) -> None:
+        self.settings = settings
         logger.info("DDSUtility initialized.")
 
     def delete_dds_files_without_png(self) -> None:
@@ -20,11 +20,11 @@ class DDSUtility:
         logger.info(
             "Running checks for deleting DDS files without corresponding PNG files..."
         )
-        local_mods_target = self.settings_controller.settings.instances[
-            self.settings_controller.settings.current_instance
+        local_mods_target = self.settings.instances[
+            self.settings.current_instance
         ].local_folder
-        workshop_mods_target = self.settings_controller.settings.instances[
-            self.settings_controller.settings.current_instance
+        workshop_mods_target = self.settings.instances[
+            self.settings.current_instance
         ].workshop_folder
 
         # Combine both paths to search for DDS files

--- a/app/utils/rentry/wrapper.py
+++ b/app/utils/rentry/wrapper.py
@@ -9,7 +9,7 @@ from loguru import logger
 from PySide6.QtCore import QCoreApplication
 from PySide6.QtWidgets import QInputDialog, QMessageBox
 
-from app.controllers.settings_controller import SettingsController
+from app.models.settings import Settings
 from app.utils import http
 from app.utils.http import DEFAULT_TIMEOUT
 from app.views.dialogue import (
@@ -164,9 +164,7 @@ class RentryUpload:
 class RentryImport:
     """Class to handle importing Rentry.co links and extracting package IDs."""
 
-    def __init__(
-        self, settings_controller: SettingsController, rentry_auth_code: bool = False
-    ) -> None:
+    def __init__(self, settings: Settings, rentry_auth_code: bool = False) -> None:
         """Initialize the Rentry Import instance and prompt for a link."""
         self.package_ids: list[
             str
@@ -174,19 +172,17 @@ class RentryImport:
         self.publishedfileids: list[
             str
         ] = []  # Initialize an empty list for publishedfileids
-        self.settings_controller = settings_controller
+        self.settings = settings
         self.rentry_auth_code = rentry_auth_code
 
         # If user does not have an auth code, show a warning
-        if settings_controller.settings.rentry_auth_code == "":
+        if settings.rentry_auth_code == "":
             self.rentry_auth_code = False
             RentryError().show_missing_rentry_auth_warning()
             self.input_dialog()  # Call the input_dialog method to set up the UI
         else:
             # Retrieve auth code from user settings
-            _HEADERS.update(
-                {"rentry-auth": settings_controller.settings.rentry_auth_code}
-            )
+            _HEADERS.update({"rentry-auth": settings.rentry_auth_code})
             self.rentry_auth_code = True
             self.input_dialog()  # Call the input_dialog method to set up the UI
 

--- a/app/utils/steam/steambrowser/browser.py
+++ b/app/utils/steam/steambrowser/browser.py
@@ -38,8 +38,8 @@ from PySide6.QtWidgets import (
 from PySide6.QtWidgets import QDialogButtonBox as ButtonBox
 
 from app.controllers.metadata_controller import MetadataController
-from app.controllers.settings_controller import SettingsController
 from app.models.image_label import ImageLabel
+from app.models.settings import Settings
 from app.utils.app_info import AppInfo
 from app.utils.event_bus import EventBus
 from app.utils.generic import extract_page_title_steam_browser
@@ -68,21 +68,21 @@ class SteamBrowser(QWidget):
     web_view: QWebEngineView | None
     web_profile: QWebEngineProfile | None
     metadata_controller: MetadataController | None
-    settings_controller: SettingsController | None
+    settings: Settings | None
     js_bridge: JavaScriptBridge | None
 
     def __init__(
         self,
         startpage: str,
         metadata_controller: MetadataController,
-        settongs_controller: SettingsController,
+        settings: Settings,
     ):
         super().__init__()
         logger.debug("Initializing SteamBrowser")
 
         # store metadata controller reference so we can use it to check if mods are installed
         self.metadata_controller = metadata_controller
-        self.settings_controller = settongs_controller
+        self.settings = settings
 
         # This is used to fix issue described here on non-Windows platform:
         # https://doc.qt.io/qt-6/qtwebengine-platform-notes.html#sandboxing-support
@@ -291,12 +291,10 @@ class SteamBrowser(QWidget):
 
     def _launch_browser_window(self) -> None:
         """Apply browser window launch state from settings"""
-        assert self.settings_controller is not None
-        browser_window_launch_state = (
-            self.settings_controller.settings.browser_window_launch_state
-        )
-        custom_width = self.settings_controller.settings.browser_window_custom_width
-        custom_height = self.settings_controller.settings.browser_window_custom_height
+        assert self.settings is not None
+        browser_window_launch_state = self.settings.browser_window_launch_state
+        custom_width = self.settings.browser_window_custom_width
+        custom_height = self.settings.browser_window_custom_height
 
         apply_window_launch_state(
             self, browser_window_launch_state, custom_width, custom_height
@@ -887,7 +885,7 @@ class SteamBrowser(QWidget):
 
         # Clear all references
         self.metadata_controller = None
-        self.settings_controller = None
+        self.settings = None
         self.js_bridge = None
         self.downloader_list_mods_tracking.clear()
         self.downloader_list_dupe_tracking.clear()

--- a/app/utils/update_utils.py
+++ b/app/utils/update_utils.py
@@ -97,7 +97,7 @@ ERR_RETRIEVE_RELEASE_TITLE = "Unable to retrieve latest release information"
 ERR_RETRIEVE_RELEASE_TEXT = "Please check your internet connection and try again, You can also check 'https://github.com/RimSort/RimSort/releases' directly."
 
 if TYPE_CHECKING:
-    from app.controllers.settings_controller import SettingsController
+    from app.models.settings import Settings
 
 
 class UpdateError(Exception):
@@ -461,12 +461,12 @@ class UpdateManager(QObject):
 
     def __init__(
         self,
-        settings_controller: "SettingsController",
+        settings: "Settings",
         main_content: Any,
         mod_info_panel: Optional[Any] = None,
     ) -> None:
         super().__init__()
-        self.settings_controller = settings_controller
+        self.settings = settings
         self.main_content = main_content
         self.mod_info_panel = mod_info_panel
         self._update_content: bytes | None = None
@@ -1219,10 +1219,7 @@ class UpdateManager(QObject):
                 return
 
             # AppImage updates use .bak rename as the backup — skip ZIP backup
-            if (
-                not is_appimage
-                and self.settings_controller.settings.enable_backup_before_update
-            ):
+            if not is_appimage and self.settings.enable_backup_before_update:
                 # Create backup of current installation with progress window
                 self._create_backup_with_progress()
                 # Clean up old backups after successful backup creation
@@ -2605,7 +2602,7 @@ class UpdateManager(QObject):
         Clean up old backups, keeping only the most recent ones based on max_backups setting.
         """
         app_backup_folder = AppInfo().application_backups_folder
-        max_backups = self.settings_controller.settings.max_backups
+        max_backups = self.settings.max_backups
 
         try:
             # Get all backup files

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -131,13 +131,13 @@ class MainContent(QObject):
             self.initialized = True
 
     def _init_services(self) -> None:
-        self.db_builder = DatabaseBuilder(self.settings_controller)
+        self.db_builder = DatabaseBuilder(self.settings_controller.settings)
         self.steam_browser: SteamBrowser | None = None
         self.steamcmd_runner: RunnerPanel | None = None
         self.steamcmd_wrapper = SteamcmdInterface.instance()
         self.metadata_controller = MetadataController.instance()
         self._import_export_service = ImportExportService(
-            self.metadata_controller, self.settings_controller
+            self.metadata_controller, self.settings_controller.settings
         )
         self.query_runner: RunnerPanel | None = None
         self.steamworks_in_use = False
@@ -727,7 +727,7 @@ class MainContent(QObject):
         Check for RimSort updates using UpdateManager.
         """
         update_manager = UpdateManager(
-            self.settings_controller, self, self.mod_info_panel
+            self.settings_controller.settings, self, self.mod_info_panel
         )
         update_manager.do_check_for_update()
 
@@ -1159,7 +1159,7 @@ class MainContent(QObject):
         - If Prompts the user about duplicate or missing mods.
         """
         # Create an instance of RentryImport
-        rentry_import = RentryImport(self.settings_controller)
+        rentry_import = RentryImport(self.settings_controller.settings)
         # Exit if user cancels or no package IDs
         if not rentry_import.package_ids:
             logger.debug("USER ACTION: pressed cancel or no package IDs, passing")
@@ -1907,7 +1907,7 @@ class MainContent(QObject):
         self.steam_browser = SteamBrowser(
             "https://steamcommunity.com/app/294100/workshop/",
             self.metadata_controller,
-            self.settings_controller,
+            self.settings_controller.settings,
         )
         self.window_manager.register_attr(self, "steam_browser")
 

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -174,7 +174,7 @@ class MainWindow(QMainWindow):
         self.tab_widget.addTab(self.acf_log_reader_tab, self.tr("ACF Log Reader"))
 
         # Create and add the Player Log tab
-        self.player_log_widget = PlayerLogTab(self.settings_controller)
+        self.player_log_widget = PlayerLogTab(self.settings_controller.settings)
         self.tab_widget.addTab(self.player_log_widget, self.tr("Player Log"))
 
         # Create and add the Search tab
@@ -227,7 +227,7 @@ class MainWindow(QMainWindow):
         )
 
         self.menu_bar = MenuBar(
-            menu_bar=self.menuBar(), settings_controller=self.settings_controller
+            menu_bar=self.menuBar(), settings=self.settings_controller.settings
         )
         self.menu_bar_controller = MenuBarController(
             view=self.menu_bar,

--- a/app/views/menu_bar.py
+++ b/app/views/menu_bar.py
@@ -7,15 +7,13 @@ from PySide6.QtCore import QObject
 from PySide6.QtGui import QAction, QKeySequence
 from PySide6.QtWidgets import QMenu, QMenuBar
 
-from app.controllers.settings_controller import SettingsController
+from app.models.settings import Settings
 from app.utils.app_info import AppInfo
 from app.utils.system_info import SystemInfo
 
 
 class MenuBar(QObject):
-    def __init__(
-        self, menu_bar: QMenuBar, settings_controller: SettingsController
-    ) -> None:
+    def __init__(self, menu_bar: QMenuBar, settings: Settings) -> None:
         """
         Initialize the MenuBar object.
 
@@ -25,7 +23,7 @@ class MenuBar(QObject):
         super().__init__()
 
         self.menu_bar: QMenuBar = menu_bar
-        self.settings_controller: SettingsController = settings_controller
+        self.settings: Settings = settings
 
         # Declare actions and submenus as class variables
         # to be used by menu_bar_controller
@@ -159,7 +157,7 @@ class MenuBar(QObject):
         )
         file_menu.addMenu(self.upload_submenu)
 
-        if self.settings_controller.settings.text_editor_location:
+        if self.settings.text_editor_location:
             file_menu.addSeparator()
 
             self.default_open_logs_submenu = self._create_logfile_submenu(
@@ -224,8 +222,8 @@ class MenuBar(QObject):
             return action
 
         def rimworld_log_path(suffix: str) -> Path | None:
-            config_str = self.settings_controller.settings.instances[
-                self.settings_controller.settings.current_instance
+            config_str = self.settings.instances[
+                self.settings.current_instance
             ].config_folder
             if config_str:
                 return Path(config_str).parent / suffix

--- a/app/views/mod_info_panel.py
+++ b/app/views/mod_info_panel.py
@@ -685,7 +685,7 @@ class ModInfoPanel:
     def _set_mod_tags_info(self, uuid: str) -> None:
         """Set user-defined tags information."""
         try:
-            tags = auxdb_get_mod_tags(self.settings_controller, uuid)
+            tags = auxdb_get_mod_tags(self.settings_controller.settings, uuid)
         except Exception as e:
             logger.debug(f"Failed to load tags for mod info panel UUID {uuid}: {e}")
             tags = []

--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -452,7 +452,7 @@ class ModListItemInner(QWidget):
 
         name_line = f"Mod: {mod.name if mod is not None else 'Not specified'}\n"
 
-        tags = auxdb_get_mod_tags(self.settings_controller, self.path)
+        tags = auxdb_get_mod_tags(self.settings_controller.settings, self.path)
         tags_line = f"Tags: {', '.join(tags) if tags else 'None'}\n"
 
         if isinstance(mod, AboutXmlMod) and mod.authors:
@@ -731,7 +731,7 @@ class ModListItemInner(QWidget):
 
     def update_tags_label(self, tags: list[str] | None = None) -> None:
         if tags is None:
-            tags = auxdb_get_mod_tags(self.settings_controller, self.path)
+            tags = auxdb_get_mod_tags(self.settings_controller.settings, self.path)
 
         if not self.show_tags or not tags:
             self.mod_tags_label.setText("")
@@ -818,7 +818,7 @@ class TagEditDialog(QDialog):
 
     def populate_tags(self) -> None:
         try:
-            tags = auxdb_get_all_tags(self.settings_controller)
+            tags = auxdb_get_all_tags(self.settings_controller.settings)
         except Exception as e:
             logger.debug(f"Unable to load existing tags: {e}")
             tags = []
@@ -2353,17 +2353,21 @@ class ModListWidget(QListWidget):
                         for selected_uuid in selected_uuids:
                             if action == replace_mod_tags_action:
                                 auxdb_replace_mod_tags(
-                                    self.settings_controller, selected_uuid, tags
+                                    self.settings_controller.settings,
+                                    selected_uuid,
+                                    tags,
                                 )
                             else:
                                 auxdb_add_mod_tags(
-                                    self.settings_controller, selected_uuid, tags
+                                    self.settings_controller.settings,
+                                    selected_uuid,
+                                    tags,
                                 )
 
                             self.refresh_mod_tags_for_uuid(selected_uuid)
 
                         if action == replace_mod_tags_action:
-                            auxdb_cleanup_unused_tags(self.settings_controller)
+                            auxdb_cleanup_unused_tags(self.settings_controller.settings)
 
                         self.tags_changed_signal.emit()
                         return True
@@ -2372,9 +2376,11 @@ class ModListWidget(QListWidget):
                 if action == remove_mod_tags_action:
                     selected_uuids = list(all_selected_paths.values())
                     for selected_uuid in selected_uuids:
-                        auxdb_remove_mod_tags(self.settings_controller, selected_uuid)
+                        auxdb_remove_mod_tags(
+                            self.settings_controller.settings, selected_uuid
+                        )
                         self.refresh_mod_tags_for_uuid(selected_uuid)
-                    auxdb_cleanup_unused_tags(self.settings_controller)
+                    auxdb_cleanup_unused_tags(self.settings_controller.settings)
                     self.tags_changed_signal.emit()
                     return True
                 # If user is changing mod color, display color picker once no matter how many mods are selected
@@ -2635,7 +2641,7 @@ class ModListWidget(QListWidget):
                 list_type=self.list_type,
                 aux_metadata_controller=aux_metadata_controller,
                 aux_metadata_session=aux_metadata_session,
-                settings_controller=self.settings_controller,
+                settings=self.settings_controller.settings,
             )
             data.__dict__["show_tags"] = self.show_tags
         # Create item without a parent first so we can set data before adding to the list.
@@ -3617,7 +3623,7 @@ class ModListWidget(QListWidget):
                 uuids,
                 key=key,
                 descending=descending,
-                settings_controller=self.settings_controller,
+                settings=self.settings_controller.settings,
             )
             self.recreate_mod_list(list_type, sorted_uuids, filtering=filtering)
         else:
@@ -3651,7 +3657,7 @@ class ModListWidget(QListWidget):
                     uuids,
                     key=sort_key,
                     descending=descending,
-                    settings_controller=self.settings_controller,
+                    settings=self.settings_controller.settings,
                 )
             else:
                 if list_type == "Inactive":
@@ -3659,7 +3665,7 @@ class ModListWidget(QListWidget):
                         uuids,
                         key=ModsPanelSortKey.FILESYSTEM_MODIFIED_TIME,
                         descending=True,
-                        settings_controller=self.settings_controller,
+                        settings=self.settings_controller.settings,
                     )
         # Disable updates and disconnect model signals during rebuild
         self.setUpdatesEnabled(False)
@@ -3699,7 +3705,7 @@ class ModListWidget(QListWidget):
                         list_type=self.list_type,
                         aux_metadata_controller=aux_metadata_controller,
                         aux_metadata_session=aux_metadata_session,
-                        settings_controller=self.settings_controller,
+                        settings=self.settings_controller.settings,
                     )
                     data.__dict__["show_tags"] = self.show_tags
                 list_item.setData(Qt.ItemDataRole.UserRole, data)
@@ -3770,7 +3776,7 @@ class ModListWidget(QListWidget):
         item_data = item.data(Qt.ItemDataRole.UserRole)
         item_data["mod_color"] = new_color
         item.setData(Qt.ItemDataRole.UserRole, item_data)
-        auxdb_update_mod_color(self.settings_controller, uuid, new_color)
+        auxdb_update_mod_color(self.settings_controller.settings, uuid, new_color)
 
     def change_all_mod_colors(self, uuids: list[str], new_color: QColor) -> None:
         uuid_to_color: dict[str, QColor | None] = {}
@@ -3781,7 +3787,7 @@ class ModListWidget(QListWidget):
             item_data["mod_color"] = new_color
             item.setData(Qt.ItemDataRole.UserRole, item_data)
             uuid_to_color[uuid] = new_color
-        auxdb_update_all_mod_colors(self.settings_controller, uuid_to_color)
+        auxdb_update_all_mod_colors(self.settings_controller.settings, uuid_to_color)
 
     def reset_mod_color(self, uuid: str) -> None:
         current_mod_index = self.paths.index(uuid)
@@ -3789,7 +3795,7 @@ class ModListWidget(QListWidget):
         item_data = item.data(Qt.ItemDataRole.UserRole)
         item_data["mod_color"] = None
         item.setData(Qt.ItemDataRole.UserRole, item_data)
-        auxdb_update_mod_color(self.settings_controller, uuid, None)
+        auxdb_update_mod_color(self.settings_controller.settings, uuid, None)
 
     def reset_all_mod_colors(self, uuids: list[str]) -> None:
         uuid_to_color: dict[str, QColor | None] = {}
@@ -3800,13 +3806,13 @@ class ModListWidget(QListWidget):
             item_data["mod_color"] = None
             item.setData(Qt.ItemDataRole.UserRole, item_data)
             uuid_to_color[uuid] = None
-        auxdb_update_all_mod_colors(self.settings_controller, uuid_to_color)
+        auxdb_update_all_mod_colors(self.settings_controller.settings, uuid_to_color)
 
     def get_common_selected_tags(self, uuids: list[str]) -> set[str]:
         common_tags: set[str] | None = None
 
         for uuid in uuids:
-            tags = set(auxdb_get_mod_tags(self.settings_controller, uuid))
+            tags = set(auxdb_get_mod_tags(self.settings_controller.settings, uuid))
             if common_tags is None:
                 common_tags = tags
             else:
@@ -3821,7 +3827,9 @@ class ModListWidget(QListWidget):
         current_mod_index = self.paths.index(uuid)
         item = self.item(current_mod_index)
         item_data = item.data(Qt.ItemDataRole.UserRole)
-        item_data["mod_tags"] = auxdb_get_mod_tags(self.settings_controller, uuid)
+        item_data["mod_tags"] = auxdb_get_mod_tags(
+            self.settings_controller.settings, uuid
+        )
         item_data.__dict__["show_tags"] = bool(
             item_data.__dict__.get("show_tags", False)
         )
@@ -4462,7 +4470,7 @@ class ModsPanel(QWidget):
                     data = CustomListWidgetItemMetadata(
                         path=uuid_key,
                         list_type=lw.list_type,
-                        settings_controller=self.settings_controller,
+                        settings=self.settings_controller.settings,
                         aux_metadata_controller=aux_metadata_controller,
                         aux_metadata_session=aux_metadata_session,
                     )
@@ -4675,7 +4683,7 @@ class ModsPanel(QWidget):
     def refresh_all_tag_filter_selectors(self) -> None:
         """Refresh the available tags in both filter panels from the aux DB."""
         try:
-            tags = auxdb_get_all_tags(self.settings_controller)
+            tags = auxdb_get_all_tags(self.settings_controller.settings)
         except Exception as e:
             logger.debug(f"Unable to load tag filter list: {e}")
             tags = []

--- a/app/views/player_log_tab.py
+++ b/app/views/player_log_tab.py
@@ -38,7 +38,7 @@ from PySide6.QtWidgets import (
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 
-from app.controllers.settings_controller import SettingsController
+from app.models.settings import Settings
 from app.utils import http
 from app.utils.app_info import AppInfo
 from app.utils.generic import launch_process
@@ -316,9 +316,9 @@ class PlayerLogTab(QWidget):
     _error_pattern = re.compile(r"\b(error|failed|fatal)\b|\[E\]", re.IGNORECASE)
     _exception_pattern = re.compile(r"exception", re.IGNORECASE)
 
-    def __init__(self, settings_controller: SettingsController) -> None:
+    def __init__(self, settings: Settings) -> None:
         super().__init__()
-        self.settings_controller = settings_controller
+        self.settings = settings
         self.player_log_path: Optional[Path] = None
         self.log_storage = LogContentStorage()  # Use new memory-efficient storage
         self.current_log_content: str = ""
@@ -382,14 +382,14 @@ class PlayerLogTab(QWidget):
         return collapsed_lines
 
     def _delayed_load_log(self) -> None:
-        if self.settings_controller.settings.auto_load_player_log_on_startup:
+        if self.settings.auto_load_player_log_on_startup:
             self.player_log_path = self._get_player_log_path()
             if self.player_log_path is not None:
                 self.load_log()
 
     def _on_auto_load_player_log_on_startup_toggled(self, checked: bool) -> None:
-        self.settings_controller.settings.auto_load_player_log_on_startup = checked
-        self.settings_controller.settings.save()
+        self.settings.auto_load_player_log_on_startup = checked
+        self.settings.save()
 
     def set_highlight_color(self, color: QColor) -> None:
         self.highlighter.set_highlight_color(color)
@@ -429,10 +429,8 @@ class PlayerLogTab(QWidget):
 
     def _get_player_log_path(self) -> Optional[Path]:
         try:
-            current_instance: str = self.settings_controller.settings.current_instance
-            config_folder: str = self.settings_controller.settings.instances[
-                current_instance
-            ].config_folder
+            current_instance: str = self.settings.current_instance
+            config_folder: str = self.settings.instances[current_instance].config_folder
             player_log_path: Path = Path(config_folder).parent / "Player.log"
             if player_log_path.exists():
                 return player_log_path
@@ -627,7 +625,7 @@ class PlayerLogTab(QWidget):
         )
         controls_layout.addWidget(self.auto_load_player_log_on_startup_checkbox)
         self.auto_load_player_log_on_startup_checkbox.setChecked(
-            self.settings_controller.settings.auto_load_player_log_on_startup
+            self.settings.auto_load_player_log_on_startup
         )
         self.auto_load_player_log_on_startup_checkbox.toggled.connect(
             self._on_auto_load_player_log_on_startup_toggled
@@ -1394,11 +1392,10 @@ class PlayerLogTab(QWidget):
         menu.exec(self.log_display.mapToGlobal(pos))
 
     def open_file(self, file_path: str) -> None:
-        if self.settings_controller.settings.text_editor_location:
+        if self.settings.text_editor_location:
             launch_process(
-                self.settings_controller.settings.text_editor_location,
-                self.settings_controller.settings.text_editor_file_arg.split(" ")
-                + [file_path],
+                self.settings.text_editor_location,
+                self.settings.text_editor_file_arg.split(" ") + [file_path],
                 str(AppInfo().application_folder),
             )
 

--- a/app/windows/duplicate_mods_panel.py
+++ b/app/windows/duplicate_mods_panel.py
@@ -37,6 +37,7 @@ class DuplicateModsPanel(BaseModsPanel):
         logger.debug("Initializing DuplicateModsPanel")
         self.duplicate_mods = duplicate_mods
         self.settings_controller = settings_controller
+        self.settings_controller = settings_controller
 
         super().__init__(
             object_name="duplicateModsPanel",

--- a/tests/sort/test_mod_sorting.py
+++ b/tests/sort/test_mod_sorting.py
@@ -394,8 +394,8 @@ class TestGetDirSize:
 
 
 class TestPathToModTags:
-    def test_no_settings_controller(self) -> None:
-        assert path_to_mod_tags("/mods/mod1", settings_controller=None) == ""
+    def test_no_settings(self) -> None:
+        assert path_to_mod_tags("/mods/mod1", settings=None) == ""
 
     def test_normal_tags(self) -> None:
         mock_sc = MagicMock()
@@ -403,13 +403,13 @@ class TestPathToModTags:
             "app.sort.mod_sorting.auxdb_get_mod_tags",
             return_value=["Zebra", "Alpha", "Beta"],
         ):
-            result = path_to_mod_tags("/mods/mod1", settings_controller=mock_sc)
+            result = path_to_mod_tags("/mods/mod1", settings=mock_sc)
         assert result == "alpha, beta, zebra"
 
     def test_empty_tags(self) -> None:
         mock_sc = MagicMock()
         with patch("app.sort.mod_sorting.auxdb_get_mod_tags", return_value=[]):
-            result = path_to_mod_tags("/mods/mod1", settings_controller=mock_sc)
+            result = path_to_mod_tags("/mods/mod1", settings=mock_sc)
         assert result == ""
 
     def test_exception_returns_empty(self) -> None:
@@ -418,13 +418,13 @@ class TestPathToModTags:
             "app.sort.mod_sorting.auxdb_get_mod_tags",
             side_effect=RuntimeError("db error"),
         ):
-            result = path_to_mod_tags("/mods/mod1", settings_controller=mock_sc)
+            result = path_to_mod_tags("/mods/mod1", settings=mock_sc)
         assert result == ""
 
     def test_single_tag(self) -> None:
         mock_sc = MagicMock()
         with patch("app.sort.mod_sorting.auxdb_get_mod_tags", return_value=["OnlyTag"]):
-            result = path_to_mod_tags("/mods/mod1", settings_controller=mock_sc)
+            result = path_to_mod_tags("/mods/mod1", settings=mock_sc)
         assert result == "onlytag"
 
 
@@ -564,7 +564,7 @@ class TestBuildSortKeyMap:
                 ["/mods/m"],
                 ModsPanelSortKey.MOD_TAGS,
                 cached,
-                settings_controller=mock_sc,
+                settings=mock_sc,
             )
         assert result["/mods/m"] == "tag1, tag2"
 

--- a/tests/views/test_menu_bar.py
+++ b/tests/views/test_menu_bar.py
@@ -20,7 +20,7 @@ def menu_bar_instance(
         mock_settings_controller.settings, "check_for_update_startup", False
     )
     qt_menu_bar = QMenuBar()
-    menu_bar = MenuBar(qt_menu_bar, mock_settings_controller)
+    menu_bar = MenuBar(qt_menu_bar, mock_settings_controller.settings)
     return menu_bar
 
 
@@ -39,7 +39,7 @@ class TestMenuBarUpdateMenuCreation:
                 del os.environ["RIMSORT_DISABLE_UPDATER"]
 
             qt_menu_bar = QMenuBar()
-            menu_bar = MenuBar(qt_menu_bar, mock_settings_controller)
+            menu_bar = MenuBar(qt_menu_bar, mock_settings_controller.settings)
 
             # Verify that update actions were created
             assert menu_bar.check_for_updates_action is not None
@@ -61,7 +61,7 @@ class TestMenuBarUpdateMenuCreation:
         # Set the environment variable
         with patch.dict(os.environ, {"RIMSORT_DISABLE_UPDATER": "1"}):
             qt_menu_bar = QMenuBar()
-            menu_bar = MenuBar(qt_menu_bar, mock_settings_controller)
+            menu_bar = MenuBar(qt_menu_bar, mock_settings_controller.settings)
 
             # Verify that update actions were not created (should be None)
             assert menu_bar.check_for_updates_action is None
@@ -87,7 +87,7 @@ class TestMenuBarControllerWithDisabledUpdater:
         # Set the environment variable
         with patch.dict(os.environ, {"RIMSORT_DISABLE_UPDATER": "1"}):
             qt_menu_bar = QMenuBar()
-            menu_bar = MenuBar(qt_menu_bar, mock_settings_controller)
+            menu_bar = MenuBar(qt_menu_bar, mock_settings_controller.settings)
 
             # This should not raise an exception even though actions are None
             with patch("app.controllers.menu_bar_controller.EventBus"):
@@ -108,7 +108,7 @@ class TestMenuBarControllerWithDisabledUpdater:
                 del os.environ["RIMSORT_DISABLE_UPDATER"]
 
             qt_menu_bar = QMenuBar()
-            menu_bar = MenuBar(qt_menu_bar, mock_settings_controller)
+            menu_bar = MenuBar(qt_menu_bar, mock_settings_controller.settings)
 
             # This should not raise an exception
             with patch("app.controllers.menu_bar_controller.EventBus"):

--- a/tests/views/test_mods_panel.py
+++ b/tests/views/test_mods_panel.py
@@ -25,7 +25,9 @@ class TestTagEditDialog:
         ):
             dialog = TagEditDialog(
                 title="Test Dialog",
-                settings_controller=MagicMock(spec=SettingsController),
+                settings_controller=MagicMock(
+                    spec=SettingsController, settings=MagicMock()
+                ),
                 existing_selected_tags={"a", "aa", "b", "bb"},
             )
             qtbot.addWidget(dialog)


### PR DESCRIPTION
## Summary

Switch 11 .settings-only consumers to accept the Settings model directly instead of the full SettingsController, reducing runtime reverse deps from 32 to 16.

## Changes

### Group A files converted (SettingsController → Settings param)
| File | Key change |
|------|-----------|
| utils/aux_db_utils.py | 12 functions — central hub for aux DB lookups |
| utils/custom_list_widget_item_metadata.py | Constructor + 4 internal auxdb calls |
| sort/mod_sorting.py | 5 functions — Any → Settings typing |
| services/import_export_service.py | Constructor + 2 accesses |
| utils/db_builder.py | Constructor + 7 accesses |
| utils/dds_utility.py | Constructor + 4 accesses |
| utils/rentry/wrapper.py | Constructor + 2 accesses |
| utils/steam/steambrowser/browser.py | Constructor (fixed typo settongs_controller) + 3 accesses |
| utils/update_utils.py | TYPE_CHECKING import changed, constructor + 2 accesses |
| iews/menu_bar.py | Constructor + 3 accesses |
| iews/player_log_tab.py | Constructor + 7 accesses |

### Callers updated
- main_content_panel.py — 5 sites
- main_window.py — 2 sites
- pp_controller.py — 1 site
- mods_panel.py — 18 auxdb calls + 3 sort_paths + 3 CustomListWidgetItemMetadata
- mod_info_panel.py — 1 auxdb call

### Tests updated
- 	est_menu_bar.py — 5 instantiations
- 	est_mod_sorting.py — 6 keyword args
- 	est_mods_panel.py — 1 mock fix (missing .settings attr)

### Excluded (inherit BaseModsPanel, need full SettingsController)
- duplicate_mods_panel.py, missing_mod_properties_panel.py, cf_log_reader.py

## Quality Gates
- ✅ ruff — all clear
- ✅ mypy — no new errors
- ✅ pyright — pre-existing import warnings only
- ✅ check_deferred_imports — OK
- ✅ jscpd — no duplicates
- ✅ pytest — 1059 passed, 1 skipped (pre-existing Windows symlink privilege issue)