### PR TITLE
refactor: convert remaining Group E/F files from SettingsController to Settings model

### DIFF
--- a/app/controllers/app_controller.py
+++ b/app/controllers/app_controller.py
@@ -121,7 +121,8 @@ class AppController(QObject):
             self.settings_controller.settings.aux_db_path
         )
         self.metadata_controller = MetadataController.instance(
-            settings_controller=self.settings_controller,
+            settings=self.settings_controller.settings,
+            get_active_instance=lambda: self.settings_controller.active_instance,
             metadata_db_controller=aux_db_controller,
         )
 

--- a/app/controllers/main_window_controller.py
+++ b/app/controllers/main_window_controller.py
@@ -124,7 +124,7 @@ class MainWindowController(QObject):
             if isinstance(mod, AboutXmlMod):
                 all_local_package_ids.add(str(mod.package_id))
 
-        consider_alternatives = self.metadata_controller.settings_controller.settings.use_alternative_package_ids_as_satisfying_dependencies
+        consider_alternatives = self.metadata_controller.settings.use_alternative_package_ids_as_satisfying_dependencies
 
         # Check each active mod's dependencies
         for path in active_mods:
@@ -229,7 +229,7 @@ class MainWindowController(QObject):
 
                                 prefer_versioned = False
                                 try:
-                                    prefer_versioned = self.metadata_controller.settings_controller.settings.prefer_versioned_about_tags
+                                    prefer_versioned = self.metadata_controller.settings.prefer_versioned_about_tags
                                 except Exception:
                                     prefer_versioned = False
 

--- a/app/controllers/menu_bar_controller.py
+++ b/app/controllers/menu_bar_controller.py
@@ -1,10 +1,11 @@
+from collections.abc import Callable
 from functools import partial
 
 from PySide6.QtCore import QObject, Slot
 from PySide6.QtGui import QAction
 from PySide6.QtWidgets import QApplication, QLineEdit, QPlainTextEdit, QTextEdit
 
-from app.controllers.settings_controller import SettingsController
+from app.models.settings import Settings
 from app.utils.event_bus import EventBus
 from app.utils.generic import open_url_browser
 from app.views.menu_bar import MenuBar
@@ -14,12 +15,14 @@ class MenuBarController(QObject):
     def __init__(
         self,
         view: MenuBar,
-        settings_controller: SettingsController,
+        settings: Settings,
+        show_settings_dialog: Callable[[], None],
     ) -> None:
         super().__init__()
 
         self.menu_bar = view
-        self.settings_controller = settings_controller
+        self.settings = settings
+        self._show_settings_dialog = show_settings_dialog
 
         # Application menu
         instance = QApplication.instance()
@@ -37,13 +40,11 @@ class MenuBarController(QObject):
                 self._on_menu_bar_check_for_updates_on_startup_triggered
             )
             self.menu_bar.check_for_updates_on_startup_action.setChecked(
-                self.settings_controller.settings.check_for_update_startup
+                self.settings.check_for_update_startup
             )
 
         # Settings menu
-        self.menu_bar.settings_action.triggered.connect(
-            self.settings_controller.show_settings_dialog
-        )
+        self.menu_bar.settings_action.triggered.connect(self._show_settings_dialog)
 
         # File menu
         self.menu_bar.open_mod_list_action.triggered.connect(
@@ -188,14 +189,10 @@ class MenuBarController(QObject):
         EventBus().refresh_finished.connect(self._on_refresh_finished)
 
     def _on_do_backup_current_instance(self) -> None:
-        EventBus().do_backup_existing_instance.emit(
-            self.settings_controller.settings.current_instance
-        )
+        EventBus().do_backup_existing_instance.emit(self.settings.current_instance)
 
     def _on_do_clone_current_instance(self) -> None:
-        EventBus().do_clone_existing_instance.emit(
-            self.settings_controller.settings.current_instance
-        )
+        EventBus().do_clone_existing_instance.emit(self.settings.current_instance)
 
     def _on_instances_submenu_population(self, instance_names: list[str]) -> None:
         self.menu_bar.instances_submenu.clear()
@@ -241,8 +238,8 @@ class MenuBarController(QObject):
         if self.menu_bar.check_for_updates_on_startup_action is None:
             return
         is_checked = self.menu_bar.check_for_updates_on_startup_action.isChecked()
-        self.settings_controller.settings.check_for_update_startup = is_checked
-        self.settings_controller.settings.save()
+        self.settings.check_for_update_startup = is_checked
+        self.settings.save()
 
     @Slot()
     def _on_menu_bar_cut_triggered(self) -> None:

--- a/app/controllers/metadata_controller.py
+++ b/app/controllers/metadata_controller.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import time
+from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -11,7 +12,6 @@ from natsort import natsorted
 from PySide6.QtCore import QMutex, QObject, Signal, Slot
 
 from app.controllers.metadata_db_controller import AuxMetadataController
-from app.controllers.settings_controller import SettingsController
 from app.models.metadata.metadata_mediator import MetadataMediator
 from app.models.metadata.metadata_structure import (
     AboutXmlMod,
@@ -22,6 +22,7 @@ from app.models.metadata.metadata_structure import (
     SteamDbEntry,
     SteamDbEntryBlacklist,
 )
+from app.models.settings import Instance, Settings
 from app.utils.acf_utils import load_acf_from_path
 from app.utils.app_info import AppInfo
 from app.utils.schema import generate_rimworld_mods_list, validate_rimworld_mods_list
@@ -50,12 +51,14 @@ class MetadataController(QObject):
 
     def __init__(
         self,
-        settings_controller: SettingsController,
+        settings: Settings,
+        get_active_instance: Callable[[], Instance],
         metadata_db_controller: AuxMetadataController,
     ) -> None:
         super().__init__()
 
-        self.settings_controller = settings_controller
+        self.settings = settings
+        self._get_active_instance = get_active_instance
 
         self.metadata_mediator = MetadataMediator(
             user_rules_path=AppInfo().user_rules_file,
@@ -79,29 +82,35 @@ class MetadataController(QObject):
     @classmethod
     def instance(
         cls,
-        settings_controller: SettingsController | None = None,
+        settings: Settings | None = None,
+        get_active_instance: Callable[[], Instance] | None = None,
         metadata_db_controller: AuxMetadataController | None = None,
     ) -> MetadataController:
         """Get or create the singleton instance.
 
-        :param settings_controller: Required on first call
+        :param settings: Required on first call
+        :param get_active_instance: Required on first call
         :param metadata_db_controller: Required on first call
         :return: The singleton instance
         :raises RuntimeError: If called before initialization
         """
         if cls._instance is None:
-            if settings_controller is None or metadata_db_controller is None:
+            if (
+                settings is None
+                or get_active_instance is None
+                or metadata_db_controller is None
+            ):
                 raise RuntimeError(
                     "MetadataController.instance() called before initialization"
                 )
-            cls._instance = cls(settings_controller, metadata_db_controller)
+            cls._instance = cls(settings, get_active_instance, metadata_db_controller)
         return cls._instance
 
     @Slot()
     def refresh_metadata(self) -> None:
         """Refresh the metadata."""
         self.reset_paths()
-        prefer_versioned = self.settings_controller.settings.prefer_versioned_about_tags
+        prefer_versioned = self.settings.prefer_versioned_about_tags
         self.metadata_mediator.refresh_metadata(prefer_versioned=prefer_versioned)
 
         with self.metadata_db_controller.Session() as session:
@@ -145,8 +154,8 @@ class MetadataController(QObject):
         def _get_path(path_str: str) -> Path | None:
             return Path(path_str) if path_str else None
 
-        active_instance = self.settings_controller.active_instance
-        active_settings = self.settings_controller.settings
+        active_instance = self._get_active_instance()
+        active_settings = self.settings
 
         cr_path = self._resolve_db_path(
             active_settings.external_community_rules_metadata_source,
@@ -605,7 +614,7 @@ class MetadataController(QObject):
         if self.metadata_mediator._mods_metadata is None:
             return False
 
-        prefer_versioned = self.settings_controller.settings.prefer_versioned_about_tags
+        prefer_versioned = self.settings.prefer_versioned_about_tags
         worker = self.metadata_mediator._ParserWorker(
             [path],
             self.metadata_mediator.game_version,
@@ -734,9 +743,7 @@ class MetadataController(QObject):
         if steam_db is None or steam_db_path is None:
             return False
 
-        steam_db.version = int(
-            time.time() + self.settings_controller.settings.database_expiry
-        )
+        steam_db.version = int(time.time() + self.settings.database_expiry)
         encoded = msgspec.json.encode(steam_db)
         formatted = msgspec.json.format(encoded, indent=4)
         steam_db_path.write_bytes(formatted)

--- a/app/utils/steam/steamcmd/wrapper.py
+++ b/app/utils/steam/steamcmd/wrapper.py
@@ -14,7 +14,7 @@ from PySide6.QtCore import QCoreApplication
 from PySide6.QtWidgets import QMessageBox
 
 import app.utils.symlink as symlink
-from app.controllers.settings_controller import SettingsController
+from app.models.settings import Instance, Settings
 from app.utils import http
 from app.utils.event_bus import EventBus
 from app.utils.generic import handle_remove_read_only
@@ -389,7 +389,8 @@ class SteamcmdInterface:
         self,
         runner: RunnerPanel | None = None,
         ask_ignore: bool = False,
-        settings_controller: SettingsController | None = None,
+        settings: Settings | None = None,
+        active_instance: Instance | None = None,
     ) -> bool:
         """Asks if the user wants to setup SteamCMD. If the user chooses to ignore the dialogue, set the steamcmd ignore flag in the settings.
 
@@ -397,8 +398,10 @@ class SteamcmdInterface:
         :type runner: RunnerPanel | None, optional
         :param ask_ignore: Whether to ask the user to ignore the dialogue, defaults to False
         :type ask_ignore: bool, optional
-        :param settings_controller: The settings controller used to set steamcmd ignore flag, defaults to None
-        :type settings_controller: SettingsController | None, optional
+        :param settings: The settings model used to save steamcmd ignore flag, defaults to None
+        :type settings: Settings | None, optional
+        :param active_instance: The active instance used to set steamcmd ignore flag, defaults to None
+        :type active_instance: Instance | None, optional
         :return: Whenever or not the user chose to ignore the dialogue
         :rtype: bool
         """
@@ -430,9 +433,9 @@ class SteamcmdInterface:
             runner.close()
 
         if ask_ignore and answer == dont_ask_text:
-            if settings_controller is not None:
-                settings_controller.active_instance.steamcmd_ignore = True
-                settings_controller.settings.save()
+            if settings is not None and active_instance is not None:
+                active_instance.steamcmd_ignore = True
+                settings.save()
 
             return True
         return False

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -122,6 +122,7 @@ class MainContent(QObject):
             super().__init__()
             logger.debug("Initializing MainContent")
             self.settings_controller = settings_controller
+            self.settings = settings_controller.settings
             self._init_services()
             self._init_widgets()
             self._setup_layout()
@@ -131,13 +132,13 @@ class MainContent(QObject):
             self.initialized = True
 
     def _init_services(self) -> None:
-        self.db_builder = DatabaseBuilder(self.settings_controller.settings)
+        self.db_builder = DatabaseBuilder(self.settings)
         self.steam_browser: SteamBrowser | None = None
         self.steamcmd_runner: RunnerPanel | None = None
         self.steamcmd_wrapper = SteamcmdInterface.instance()
         self.metadata_controller = MetadataController.instance()
         self._import_export_service = ImportExportService(
-            self.metadata_controller, self.settings_controller.settings
+            self.metadata_controller, self.settings
         )
         self.query_runner: RunnerPanel | None = None
         self.steamworks_in_use = False
@@ -146,10 +147,10 @@ class MainContent(QObject):
 
     def _init_widgets(self) -> None:
         self.mod_info_panel = ModInfoPanel(
-            settings_controller=self.settings_controller,
+            settings=self.settings,
         )
         self.mods_panel = ModsPanel(
-            settings=self.settings_controller.settings,
+            settings=self.settings,
         )
         self.mod_info_container = QWidget()
         self.mod_info_container.setLayout(self.mod_info_panel.panel)
@@ -349,16 +350,10 @@ class MainContent(QObject):
         not throw a fatal error trying to load mods until the
         user has had a chance to set paths.
         """
-        current_instance = self.settings_controller.settings.current_instance
-        game_folder_path = self.settings_controller.settings.instances[
-            current_instance
-        ].game_folder
-        config_folder_path = self.settings_controller.settings.instances[
-            current_instance
-        ].config_folder
-        local_mods_folder_path = self.settings_controller.settings.instances[
-            current_instance
-        ].local_folder
+        current_instance = self.settings.current_instance
+        game_folder_path = self.settings.instances[current_instance].game_folder
+        config_folder_path = self.settings.instances[current_instance].config_folder
+        local_mods_folder_path = self.settings.instances[current_instance].local_folder
         logger.info(f"Game folder: {game_folder_path}")
         logger.info(f"Config folder: {config_folder_path}")
         logger.info(f"Local mods folder: {local_mods_folder_path}")
@@ -532,8 +527,8 @@ class MainContent(QObject):
         # Snapshot live divider state before the list is cleared
         live_dividers = self.mods_panel.active_mods_list.get_dividers_data()
         if live_dividers:
-            self.settings_controller.settings.active_mods_dividers = live_dividers
-        saved_dividers = self.settings_controller.settings.active_mods_dividers
+            self.settings.active_mods_dividers = live_dividers
+        saved_dividers = self.settings.active_mods_dividers
         self.mods_panel.active_mods_list.recreate_mod_list(
             list_type="active", uuids=active_mods_uuids
         )
@@ -541,7 +536,7 @@ class MainContent(QObject):
         if saved_dividers:
             self.mods_panel.active_mods_list.restore_dividers(saved_dividers)
         # Determine sort key and descending for inactive mods
-        if self.settings_controller.settings.inactive_mods_sorting:
+        if self.settings.inactive_mods_sorting:
             # Use current UI state from the combobox and button
             sort_key = ModsPanelSortKey[self.mods_panel.inactive_mods_sort_key]
             descending = self.mods_panel.inactive_sort_descending
@@ -565,13 +560,13 @@ class MainContent(QObject):
         """
         Opens the DuplicateModsPanel to allow user to resolve duplicate mods.
         """
-        if not self.settings_controller.settings.duplicate_mods_warning:
+        if not self.settings.duplicate_mods_warning:
             logger.warning(
                 "User preference is not configured to display duplicate mods. Skipping..."
             )
             return
         elif (
-            self.settings_controller.settings.duplicate_mods_warning
+            self.settings.duplicate_mods_warning
             and self.duplicate_mods
             and len(self.duplicate_mods) > 0
         ):
@@ -590,13 +585,13 @@ class MainContent(QObject):
 
     def __missing_mods_prompt(self) -> None:
         """Open the MissingModsPrompt to allow user to download missing mods."""
-        if not self.settings_controller.settings.try_download_missing_mods:
+        if not self.settings.try_download_missing_mods:
             logger.warning(
                 "User preference is not configured to attempt downloading missing mods. Skipping..."
             )
             return
         elif (
-            self.settings_controller.settings.try_download_missing_mods
+            self.settings.try_download_missing_mods
             and self.missing_mods
             and len(self.missing_mods) > 0
         ):
@@ -684,7 +679,7 @@ class MainContent(QObject):
         """
         self.mod_info_panel.display_mod_info(
             uuid=uuid,
-            render_unity_rt=self.settings_controller.settings.render_unity_rich_text,
+            render_unity_rt=self.settings.render_unity_rich_text,
         )
         self.mod_info_panel.show_user_mod_notes(item)
 
@@ -706,8 +701,8 @@ class MainContent(QObject):
             mod_list=str(
                 (
                     Path(
-                        self.settings_controller.settings.instances[
-                            self.settings_controller.settings.current_instance
+                        self.settings.instances[
+                            self.settings.current_instance
                         ].config_folder
                     )
                     / "ModsConfig.xml"
@@ -726,9 +721,7 @@ class MainContent(QObject):
         """
         Check for RimSort updates using UpdateManager.
         """
-        update_manager = UpdateManager(
-            self.settings_controller.settings, self, self.mod_info_panel
-        )
+        update_manager = UpdateManager(self.settings, self, self.mod_info_panel)
         update_manager.do_check_for_update()
 
     def __do_get_github_release_info(self) -> dict[str, Any]:
@@ -847,7 +840,7 @@ class MainContent(QObject):
             self.__check_and_warn_missing_mod_properties()
 
             # Check Workshop mods for updates if configured
-            if self.settings_controller.settings.steam_mods_update_check:
+            if self.settings.steam_mods_update_check:
                 logger.info("Checking Workshop mods for updates...")
                 self._do_check_for_workshop_updates()
             else:
@@ -890,7 +883,7 @@ class MainContent(QObject):
             app_constants.RIMWORLD_DLC_METADATA["3022790"]["packageid"],
         ]
         # If user wants Clear to also move DLC, only keep the base game in Active
-        if self.settings_controller.settings.clear_moves_dlc and package_id_order:
+        if self.settings.clear_moves_dlc and package_id_order:
             package_ids_to_keep_active = [package_id_order[0]]  # Base game only
         else:
             package_ids_to_keep_active = package_id_order
@@ -918,8 +911,8 @@ class MainContent(QObject):
             if uuid not in active_mods_uuids
         )
         # Clear dividers on list clear
-        self.settings_controller.settings.active_mods_dividers = []
-        self.settings_controller.settings.save()
+        self.settings.active_mods_dividers = []
+        self.settings.save()
         # Disable widgets while inserting
         self.disable_enable_widgets_signal.emit(False)
         # Insert data into lists
@@ -947,7 +940,7 @@ class MainContent(QObject):
         self.metadata_controller.compile()
 
         # Check for missing dependencies if enabled in settings and check_deps is True
-        if check_deps and self.settings_controller.settings.check_dependencies_on_sort:
+        if check_deps and self.settings.check_dependencies_on_sort:
             missing_deps = self.metadata_controller.get_missing_dependencies(
                 active_mods
             )
@@ -985,8 +978,8 @@ class MainContent(QObject):
         # Compile dependency data from MetadataController
         try:
             compiled_data = self.metadata_controller.compile(
-                use_moddependencies_as_loadTheseBefore=self.settings_controller.settings.use_moddependencies_as_loadTheseBefore,
-                use_alternative_package_ids=self.settings_controller.settings.use_alternative_package_ids_as_satisfying_dependencies,
+                use_moddependencies_as_loadTheseBefore=self.settings.use_moddependencies_as_loadTheseBefore,
+                use_alternative_package_ids=self.settings.use_alternative_package_ids_as_satisfying_dependencies,
             )
         except ValueError:
             dialogue.show_warning(
@@ -1008,7 +1001,7 @@ class MainContent(QObject):
         current_order = active_mods
         try:
             sorter = Sorter(
-                self.settings_controller.settings.sorting_algorithm,
+                self.settings.sorting_algorithm,
                 compiled_data=compiled_data,
                 mods_metadata=self.metadata_controller.mods_metadata,
                 active_mod_paths=active_mod_paths,
@@ -1055,8 +1048,8 @@ class MainContent(QObject):
             for i, div in enumerate(saved_dividers):
                 div["index"] = bottom + i
                 div["collapsed"] = False
-            self.settings_controller.settings.active_mods_dividers = saved_dividers
-            self.settings_controller.settings.save()
+            self.settings.active_mods_dividers = saved_dividers
+            self.settings.save()
             # Disable widgets while inserting
             self.disable_enable_widgets_signal.emit(False)
             # Insert data into lists
@@ -1159,7 +1152,7 @@ class MainContent(QObject):
         - If Prompts the user about duplicate or missing mods.
         """
         # Create an instance of RentryImport
-        rentry_import = RentryImport(self.settings_controller.settings)
+        rentry_import = RentryImport(self.settings)
         # Exit if user cancels or no package IDs
         if not rentry_import.package_ids:
             logger.debug("USER ACTION: pressed cancel or no package IDs, passing")
@@ -1215,8 +1208,8 @@ class MainContent(QObject):
                     notify_user()
 
             def dowmload_using_steam() -> None:
-                current_instance = self.settings_controller.settings.current_instance
-                steam_client_integration = self.settings_controller.settings.instances[
+                current_instance = self.settings.current_instance
+                steam_client_integration = self.settings.instances[
                     current_instance
                 ].steam_client_integration
 
@@ -1450,9 +1443,7 @@ class MainContent(QObject):
         # Default to the instance's Saves directory (sibling of Config)
         saves_dir = str(
             Path(
-                self.settings_controller.settings.instances[
-                    self.settings_controller.settings.current_instance
-                ].config_folder
+                self.settings.instances[self.settings.current_instance].config_folder
             ).parent
             / "Saves"
         )
@@ -1538,9 +1529,9 @@ class MainContent(QObject):
         self._open_directory("Steam mods", "workshop_folder")
 
     def _open_directory(self, directory_name: str, attribute: str) -> None:
-        current_instance = self.settings_controller.settings.current_instance
+        current_instance = self.settings.current_instance
         directory = getattr(
-            self.settings_controller.settings.instances[current_instance],
+            self.settings.instances[current_instance],
             attribute,
             None,
         )
@@ -1603,9 +1594,8 @@ class MainContent(QObject):
         if path and path.exists():
             logger.info(f"Opening file in default editor: {path}")
             launch_process(
-                self.settings_controller.settings.text_editor_location,
-                self.settings_controller.settings.text_editor_folder_arg.split(" ")
-                + [str(path)],
+                self.settings.text_editor_location,
+                self.settings.text_editor_folder_arg.split(" ") + [str(path)],
                 str(AppInfo().application_folder),
             )
         else:
@@ -1622,10 +1612,10 @@ class MainContent(QObject):
         """
         logger.info("Saving current active mods to ModsConfig.xml")
         # Persist divider data before saving
-        self.settings_controller.settings.active_mods_dividers = (
+        self.settings.active_mods_dividers = (
             self.mods_panel.active_mods_list.get_dividers_data()
         )
-        self.settings_controller.settings.save()
+        self.settings.save()
 
         data = self._import_export_service.collect_active_mods(
             self.mods_panel.active_mods_list.paths, self.duplicate_mods
@@ -1683,7 +1673,7 @@ class MainContent(QObject):
     # TODDS ACTIONS
     def _create_todds_runner(self, is_pre_launch: bool) -> RunnerPanel:
         runner = RunnerPanel(
-            todds_dry_run_support=self.settings_controller.settings.todds_dry_run,
+            todds_dry_run_support=self.settings.todds_dry_run,
             auto_close_on_complete=is_pre_launch,
         )
 
@@ -1907,7 +1897,7 @@ class MainContent(QObject):
         self.steam_browser = SteamBrowser(
             "https://steamcommunity.com/app/294100/workshop/",
             self.metadata_controller,
-            self.settings_controller.settings,
+            self.settings,
         )
         self.window_manager.register_attr(self, "steam_browser")
 
@@ -1972,8 +1962,8 @@ class MainContent(QObject):
     def do_steam_verify_game_files(self) -> None:
         """Verify RimWorld game files through Steam."""
         # Retrieve settings for the current RimWorld instance
-        steam_client_integration_enabled = self.settings_controller.settings.instances[
-            self.settings_controller.settings.current_instance
+        steam_client_integration_enabled = self.settings.instances[
+            self.settings.current_instance
         ].steam_client_integration
 
         # Check if Steam Client Integration is enabled
@@ -2015,8 +2005,8 @@ class MainContent(QObject):
                 + self.steamcmd_runner.process.program(),
             )
             return
-        local_mods_path = self.settings_controller.settings.instances[
-            self.settings_controller.settings.current_instance
+        local_mods_path = self.settings.instances[
+            self.settings.current_instance
         ].local_folder
         if local_mods_path and os.path.exists(local_mods_path):
             self.steamcmd_runner = RunnerPanel()
@@ -2097,8 +2087,8 @@ class MainContent(QObject):
             self.steamcmd_wrapper.download_mods(
                 publishedfileids=publishedfileids,
                 runner=self.steamcmd_runner,
-                clear_cache=self.settings_controller.settings.instances[
-                    self.settings_controller.settings.current_instance
+                clear_cache=self.settings.instances[
+                    self.settings.current_instance
                 ].steamcmd_auto_clear_depot_cache,
             )
         else:
@@ -2401,9 +2391,7 @@ class MainContent(QObject):
             return
 
         base_path = str(
-            self.settings_controller.settings.instances[
-                self.settings_controller.settings.current_instance
-            ].local_folder
+            self.settings.instances[self.settings.current_instance].local_folder
         )
 
         try:
@@ -2599,10 +2587,8 @@ class MainContent(QObject):
         )
         logger.info(f"Selected path: {input_path}")
         if input_path and os.path.exists(input_path):
-            self.settings_controller.settings.external_steam_metadata_file_path = (
-                input_path
-            )
-            self.settings_controller.settings.save()
+            self.settings.external_steam_metadata_file_path = input_path
+            self.settings.save()
         else:
             logger.debug("USER ACTION: cancelled selection!")
             return
@@ -2618,10 +2604,8 @@ class MainContent(QObject):
         )
         logger.info(f"Selected path: {input_path}")
         if input_path and os.path.exists(input_path):
-            self.settings_controller.settings.external_community_rules_file_path = (
-                input_path
-            )
-            self.settings_controller.settings.save()
+            self.settings.external_community_rules_file_path = input_path
+            self.settings.save()
         else:
             logger.debug("USER ACTION: cancelled selection!")
             return
@@ -2635,11 +2619,11 @@ class MainContent(QObject):
             None,
             self.tr("Edit Steam DB repo"),
             self.tr("Enter URL (https://github.com/AccountName/RepositoryName):"),
-            text=self.settings_controller.settings.external_steam_metadata_repo,
+            text=self.settings.external_steam_metadata_repo,
         )
         if ok:
-            self.settings_controller.settings.external_steam_metadata_repo = args
-            self.settings_controller.settings.save()
+            self.settings.external_steam_metadata_repo = args
+            self.settings.save()
 
     def _do_configure_community_rules_db_repo(self) -> None:
         """
@@ -2650,11 +2634,11 @@ class MainContent(QObject):
             None,
             self.tr("Edit Community Rules DB repo"),
             self.tr("Enter URL (https://github.com/AccountName/RepositoryName):"),
-            text=self.settings_controller.settings.external_community_rules_repo,
+            text=self.settings.external_community_rules_repo,
         )
         if ok:
-            self.settings_controller.settings.external_community_rules_repo = args
-            self.settings_controller.settings.save()
+            self.settings.external_community_rules_repo = args
+            self.settings.save()
 
     def _do_blacklist_action_steamdb(self, instruction: list[Any]) -> None:
         logger.info(f"Updating SteamDB blacklist status for item: {instruction}")
@@ -2686,11 +2670,11 @@ class MainContent(QObject):
             None,
             self.tr("Edit Steam WebAPI key"),
             self.tr("Enter your personal 32 character Steam WebAPI key here:"),
-            text=self.settings_controller.settings.steam_apikey,
+            text=self.settings.steam_apikey,
         )
         if ok:
-            self.settings_controller.settings.steam_apikey = args
-            self.settings_controller.settings.save()
+            self.settings.steam_apikey = args
+            self.settings.save()
 
     def _do_update_rules_database(self, instruction: list[Any]) -> None:
         rules_source = instruction[0]
@@ -2761,12 +2745,12 @@ class MainContent(QObject):
             self.tr(
                 "Enter your preferred expiry duration in seconds (default 1 week/604800 sec):"
             ),
-            text=str(self.settings_controller.settings.database_expiry),
+            text=str(self.settings.database_expiry),
         )
         if ok:
             try:
-                self.settings_controller.settings.database_expiry = int(args)
-                self.settings_controller.settings.save()
+                self.settings.database_expiry = int(args)
+                self.settings.save()
             except ValueError:
                 dialogue.show_warning(
                     self.tr(
@@ -2779,12 +2763,10 @@ class MainContent(QObject):
 
     @Slot()
     def _on_settings_have_changed(self) -> None:
-        instance = self.settings_controller.settings.instances.get(
-            self.settings_controller.settings.current_instance
-        )
+        instance = self.settings.instances.get(self.settings.current_instance)
         if not instance:
             logger.warning(
-                f"Tried to access instance {self.settings_controller.settings.current_instance} that does not exist!"
+                f"Tried to access instance {self.settings.current_instance} that does not exist!"
             )
             return None
 
@@ -2793,10 +2775,10 @@ class MainContent(QObject):
         if steamcmd_prefix:
             self.steamcmd_wrapper.initialize_prefix(
                 steamcmd_prefix=str(steamcmd_prefix),
-                validate=self.settings_controller.settings.steamcmd_validate_downloads,
+                validate=self.settings.steamcmd_validate_downloads,
             )
         self.steamcmd_wrapper.validate_downloads = (
-            self.settings_controller.settings.steamcmd_validate_downloads
+            self.settings.steamcmd_validate_downloads
         )
 
     @Slot()
@@ -2823,7 +2805,7 @@ class MainContent(QObject):
         if not self.check_if_essential_paths_are_set(prompt=True):
             return
 
-        create_backup_in_thread(self.settings_controller.settings)
+        create_backup_in_thread(self.settings)
 
         # Check for unsaved mod list changes and prompt user
         current_mod_uuids = [
@@ -2850,7 +2832,7 @@ class MainContent(QObject):
                 return
 
         # Run todds before launch if auto-run is enabled
-        if self.settings_controller.settings.auto_run_todds_before_launch:
+        if self.settings.auto_run_todds_before_launch:
             success, exit_code = self._do_optimize_textures(block_until_complete=True)
 
             # Show error message if todds failed, but continue to launch game
@@ -2867,20 +2849,16 @@ class MainContent(QObject):
                 )
 
         # Retrieve instance configuration
-        current_instance = self.settings_controller.settings.current_instance
-        game_install_path = Path(
-            self.settings_controller.settings.instances[current_instance].game_folder
-        )
-        run_args = self.settings_controller.settings.instances[
-            current_instance
-        ].run_args
+        current_instance = self.settings.current_instance
+        game_install_path = Path(self.settings.instances[current_instance].game_folder)
+        run_args = self.settings.instances[current_instance].run_args
 
         # Retrieve Steam-related settings for this instance
-        steam_client_integration = self.settings_controller.settings.instances[
+        steam_client_integration = self.settings.instances[
             current_instance
         ].steam_client_integration
 
-        launch_via_steam_protocol = self.settings_controller.settings.instances[
+        launch_via_steam_protocol = self.settings.instances[
             current_instance
         ].launch_via_steam_protocol
 
@@ -2936,10 +2914,7 @@ class MainContent(QObject):
         """
         When clicked, opens the Use This Instead panel.
         """
-        if (
-            self.settings_controller.settings.external_use_this_instead_metadata_source
-            == "None"
-        ):
+        if self.settings.external_use_this_instead_metadata_source == "None":
             dialogue.show_warning(
                 title=self.tr("Use This Instead"),
                 text=self.tr(

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -81,6 +81,7 @@ class MainWindow(QMainWindow):
         super(MainWindow, self).__init__()
 
         self.settings_controller = settings_controller
+        self.settings = settings_controller.settings
 
         # Set global references
         globals.MAIN_WINDOW = self
@@ -95,7 +96,7 @@ class MainWindow(QMainWindow):
         # Watchdog
         self.watchdog_event_handler: WatchdogHandler | None = None
         # Set up the window
-        current_instance = self.settings_controller.settings.current_instance
+        current_instance = self.settings.current_instance
         self.__set_window_title(current_instance)
 
         # Create the window layout
@@ -174,7 +175,7 @@ class MainWindow(QMainWindow):
         self.tab_widget.addTab(self.acf_log_reader_tab, self.tr("ACF Log Reader"))
 
         # Create and add the Player Log tab
-        self.player_log_widget = PlayerLogTab(self.settings_controller.settings)
+        self.player_log_widget = PlayerLogTab(self.settings)
         self.tab_widget.addTab(self.player_log_widget, self.tr("Player Log"))
 
         # Create and add the Search tab
@@ -185,7 +186,7 @@ class MainWindow(QMainWindow):
         # Instantiate the SearchWindow and add it to the tab
         self.file_search_dialog = FileSearchDialog()
         self.file_search_controller = FileSearchController(
-            settings=self.settings_controller.settings,
+            settings=self.settings,
             settings_controller=self.settings_controller,
             dialog=self.file_search_dialog,
         )
@@ -201,7 +202,7 @@ class MainWindow(QMainWindow):
         # Instantiate the TroubleshootingDialog and add it to the tab
         self.troubleshooting_dialog = TroubleshootingDialog()
         self.troubleshooting_controller = TroubleshootingController(
-            settings=self.settings_controller.settings,
+            settings=self.settings,
             dialog=self.troubleshooting_dialog,
         )
         self.troubleshooting_layout.addWidget(self.troubleshooting_dialog)
@@ -223,24 +224,23 @@ class MainWindow(QMainWindow):
 
         self.mods_panel_controller = ModsPanelController(
             view=self.main_content_panel.mods_panel,
-            settings=self.settings_controller.settings,
+            settings=self.settings,
         )
 
-        self.menu_bar = MenuBar(
-            menu_bar=self.menuBar(), settings=self.settings_controller.settings
-        )
+        self.menu_bar = MenuBar(menu_bar=self.menuBar(), settings=self.settings)
         self.menu_bar_controller = MenuBarController(
             view=self.menu_bar,
-            settings_controller=self.settings_controller,
+            settings=self.settings,
+            show_settings_dialog=self.settings_controller.show_settings_dialog,
         )
 
         self.main_content_controller = MainContentController(
             view=self.main_content_panel,
-            settings=self.settings_controller.settings,
+            settings=self.settings,
         )
 
         self.todds_controller = ToddsController(
-            settings=self.settings_controller.settings,
+            settings=self.settings,
             metadata_controller=self.main_content_panel.metadata_controller,
         )
         self.main_content_panel.todds_controller = self.todds_controller
@@ -261,11 +261,9 @@ class MainWindow(QMainWindow):
 
     def _launch_main_window(self) -> None:
         """Apply main window launch state from settings"""
-        main_window_launch_state = (
-            self.settings_controller.settings.main_window_launch_state
-        )
-        custom_width = self.settings_controller.settings.main_window_custom_width
-        custom_height = self.settings_controller.settings.main_window_custom_height
+        main_window_launch_state = self.settings.main_window_launch_state
+        custom_width = self.settings.main_window_custom_width
+        custom_height = self.settings.main_window_custom_height
 
         apply_window_launch_state(
             self, main_window_launch_state, custom_width, custom_height
@@ -311,10 +309,10 @@ class MainWindow(QMainWindow):
         EventBus().do_set_all_entries_in_aux_db_as_outdated.emit()
         # POPULATE INSTANCES SUBMENU
         self.menu_bar_controller._on_instances_submenu_population(
-            instance_names=list(self.settings_controller.settings.instances.keys())
+            instance_names=list(self.settings.instances.keys())
         )
         self.menu_bar_controller._on_set_current_instance(
-            self.settings_controller.settings.current_instance
+            self.settings.current_instance
         )
         # REFRESH CONFIGURED METADATA
         self.main_content_panel._do_refresh(is_initial=is_initial)
@@ -329,7 +327,9 @@ class MainWindow(QMainWindow):
         ):
             if not self.settings_controller.active_instance.steamcmd_ignore:
                 self.steamcmd_wrapper.on_steamcmd_not_found(
-                    ask_ignore=True, settings_controller=self.settings_controller
+                    ask_ignore=True,
+                    settings=self.settings,
+                    active_instance=self.settings_controller.active_instance,
                 )
         else:
             self.steamcmd_wrapper.setup = True
@@ -340,7 +340,7 @@ class MainWindow(QMainWindow):
             self.main_content_controller._update_databases_on_startup_if_enabled_silent()
 
         # CHECK USER PREFERENCE FOR WATCHDOG
-        if self.settings_controller.settings.watchdog_toggle:
+        if self.settings.watchdog_toggle:
             # Setup watchdog
             self.initialize_watchdog()
 
@@ -349,9 +349,9 @@ class MainWindow(QMainWindow):
         # Force initial setup to False and save settings
         if self.settings_controller.active_instance.initial_setup:
             self.settings_controller.active_instance.initial_setup = False
-            self.settings_controller.settings.save()
+            self.settings.save()
         # IF CHECK FOR UPDATE ON STARTUP...
-        if self.settings_controller.settings.check_for_update_startup:
+        if self.settings.check_for_update_startup:
             EventBus().do_check_for_application_update.emit()
         # Delete outdated entries in aux DB
         EventBus().do_delete_outdated_entries_in_aux_db.emit()
@@ -435,7 +435,7 @@ class MainWindow(QMainWindow):
     def __backup_existing_instance(self, instance_name: str) -> None:
         """Backup an instance to a ZIP archive."""
         # Get instance data from Settings
-        instance = self.settings_controller.settings.instances.get(instance_name)
+        instance = self.settings.instances.get(instance_name)
 
         # If the instance_name is "Default", prompt the user for a new instance name.
         if instance_name == DEFAULT_INSTANCE_NAME:
@@ -747,10 +747,8 @@ class MainWindow(QMainWindow):
         if not self.main_content_panel.check_if_essential_paths_are_set(prompt=True):
             return
         # Get instance data from Settings
-        current_instances = list(self.settings_controller.settings.instances.keys())
-        existing_instance = self.settings_controller.settings.instances[
-            existing_instance_name
-        ]
+        current_instances = list(self.settings.instances.keys())
+        existing_instance = self.settings.instances[existing_instance_name]
 
         existing_instance_game_folder = existing_instance.game_folder
         game_folder_name = os.path.split(existing_instance_game_folder)[1]
@@ -988,7 +986,7 @@ class MainWindow(QMainWindow):
                 logger.info("User cancelled operation")
                 return
             instance_name = new_instance_name
-        current_instances = list(self.settings_controller.settings.instances.keys())
+        current_instances = list(self.settings.instances.keys())
         if (
             instance_name
             and instance_name != DEFAULT_INSTANCE_NAME
@@ -1000,8 +998,8 @@ class MainWindow(QMainWindow):
             # If not provided in instance_data, check the current instance's override
             # This allows new instances to use the custom folder set in settings
             if not instance_folder_override:
-                current_instance = self.settings_controller.settings.instances[
-                    self.settings_controller.settings.current_instance
+                current_instance = self.settings.instances[
+                    self.settings.current_instance
                 ]
                 instance_folder_override = current_instance.instance_folder_override
             # Create new instance folder if it does not exist
@@ -1011,9 +1009,7 @@ class MainWindow(QMainWindow):
             if not instance_path.exists():
                 instance_path.mkdir(parents=True, exist_ok=True)
             # Fall back to current instance's folders if missing or empty (e.g., Create Instance)
-            current_inst = self.settings_controller.settings.instances[
-                self.settings_controller.settings.current_instance
-            ]
+            current_inst = self.settings.instances[self.settings.current_instance]
             if not instance_data.get("game_folder"):
                 instance_data["game_folder"] = current_inst.game_folder
             if not instance_data.get("config_folder"):
@@ -1064,7 +1060,7 @@ class MainWindow(QMainWindow):
             self.settings_controller.set_instance(instance)
 
             # Save settings
-            self.settings_controller.settings.save()
+            self.settings.save()
             # Switch to new instance and initialize content
             self.__switch_to_instance(instance_name)
         else:
@@ -1078,22 +1074,20 @@ class MainWindow(QMainWindow):
 
     def __delete_current_instance(self) -> None:
         """Delete the current instance and all its data."""
-        if self.settings_controller.settings.current_instance == DEFAULT_INSTANCE_NAME:
+        if self.settings.current_instance == DEFAULT_INSTANCE_NAME:
             show_warning(
                 title=self.tr("Problem deleting instance"),
                 text=self.tr("Unable to delete instance {current_instance}.").format(
-                    current_instance=self.settings_controller.settings.current_instance
+                    current_instance=self.settings.current_instance
                 ),
                 information=self.tr("The default instance cannot be deleted."),
             )
             return
-        elif not self.settings_controller.settings.instances.get(
-            self.settings_controller.settings.current_instance
-        ):
+        elif not self.settings.instances.get(self.settings.current_instance):
             show_fatal_error(
                 title=self.tr("Error deleting instance"),
                 text=self.tr("Unable to delete instance {current_instance}.").format(
-                    current_instance=self.settings_controller.settings.current_instance
+                    current_instance=self.settings.current_instance
                 ),
                 information=self.tr("The selected instance does not exist."),
             )
@@ -1101,7 +1095,7 @@ class MainWindow(QMainWindow):
         else:
             answer = BinaryChoiceDialog(
                 title=self.tr("Delete instance {current_instance}").format(
-                    current_instance=self.settings_controller.settings.current_instance
+                    current_instance=self.settings.current_instance
                 ),
                 text=self.tr(
                     "Are you sure you want to delete the selected instance and all of its data?"
@@ -1111,7 +1105,7 @@ class MainWindow(QMainWindow):
             if answer.exec_is_positive():
                 aux_metadata_controller = (
                     AuxMetadataController.get_or_create_cached_instance(
-                        self.settings_controller.settings.aux_db_path
+                        self.settings.aux_db_path
                     )
                 )
                 aux_metadata_controller.engine.dispose()
@@ -1121,7 +1115,7 @@ class MainWindow(QMainWindow):
                             Path(
                                 AppInfo().app_storage_folder
                                 / INSTANCE_FOLDER_NAME
-                                / self.settings_controller.settings.current_instance
+                                / self.settings.current_instance
                             )
                         ),
                         ignore_errors=False,
@@ -1130,22 +1124,20 @@ class MainWindow(QMainWindow):
                 except Exception as e:
                     logger.error(f"Error deleting instance: {e}")
                 # Remove instance from settings and reset to Default
-                self.settings_controller.settings.instances.pop(
-                    self.settings_controller.settings.current_instance
-                )
+                self.settings.instances.pop(self.settings.current_instance)
                 self.__switch_to_instance(DEFAULT_INSTANCE_NAME)
 
     def __switch_to_instance(self, instance: str) -> None:
         """Switch to a different instance."""
         self.shutdown_watchdog()
         # Set current instance
-        self.settings_controller.settings.current_instance = instance
+        self.settings.current_instance = instance
         instance_path = str(InstanceController.get_instance_folder_path(instance))
-        self.settings_controller.settings.current_instance_path = instance_path
+        self.settings.current_instance_path = instance_path
         # Update window title with current instance
         self.__set_window_title(instance)
         # Save settings
-        self.settings_controller.settings.save()
+        self.settings.save()
         # Clear mod lists
         self.main_content_panel._insert_data_into_lists([], [])
         # Initialize content

--- a/app/views/mod_info_panel.py
+++ b/app/views/mod_info_panel.py
@@ -20,10 +20,10 @@ from PySide6.QtWidgets import (
 
 from app.controllers.metadata_controller import MetadataController
 from app.controllers.metadata_db_controller import AuxMetadataController
-from app.controllers.settings_controller import SettingsController
 from app.models.image_label import ImageLabel
 from app.models.metadata.metadata_db import Base
 from app.models.metadata.metadata_structure import AboutXmlMod, ListedMod, ScenarioMod
+from app.models.settings import Settings
 from app.sort.mod_sorting import path_to_folder_size
 from app.utils.app_info import AppInfo
 from app.utils.aux_db_utils import auxdb_get_mod_tags
@@ -110,7 +110,7 @@ class ModInfoPanel:
     mod information panel on the GUI.
     """
 
-    def __init__(self, settings_controller: SettingsController) -> None:
+    def __init__(self, settings: Settings) -> None:
         """
         Initialize the class.
         """
@@ -118,7 +118,7 @@ class ModInfoPanel:
 
         # Cache MetadataController instance
         self.metadata_controller = MetadataController.instance()
-        self.settings_controller = settings_controller
+        self.settings = settings
 
         # Used to keep track of which mod items notes we are viewing/editing
         # This is set when a mod is clicked on
@@ -528,7 +528,7 @@ class ModInfoPanel:
 
         try:
             aux_controller = AuxMetadataController.get_or_create_cached_instance(
-                self.settings_controller.settings.aux_db_path
+                self.settings.aux_db_path
             )
             Base.metadata.create_all(aux_controller.engine)
 
@@ -685,7 +685,7 @@ class ModInfoPanel:
     def _set_mod_tags_info(self, uuid: str) -> None:
         """Set user-defined tags information."""
         try:
-            tags = auxdb_get_mod_tags(self.settings_controller.settings, uuid)
+            tags = auxdb_get_mod_tags(self.settings, uuid)
         except Exception as e:
             logger.debug(f"Failed to load tags for mod info panel UUID {uuid}: {e}")
             tags = []
@@ -701,7 +701,7 @@ class ModInfoPanel:
     def _set_folder_size_info(self, uuid: str) -> None:
         """Set folder size information using optimized calculation."""
         try:
-            if self.settings_controller.settings.inactive_mods_sorting:
+            if self.settings.inactive_mods_sorting:
                 size_bytes = path_to_folder_size(uuid)
                 self.mod_info_folder_size_value.setText(format_file_size(size_bytes))
             else:
@@ -728,7 +728,7 @@ class ModInfoPanel:
     def _set_filesystem_time_info(self, mod_path: str | None) -> None:
         """Set filesystem modification time information."""
         if (
-            self.settings_controller.settings.inactive_mods_sorting
+            self.settings.inactive_mods_sorting
             and mod_path
             and os.path.exists(mod_path)
         ):

--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -3166,7 +3166,7 @@ class ModListWidget(QListWidget):
         alternative_deps: set[str] = set()
         if not isinstance(mod_data, AboutXmlMod):
             return missing_deps, alternative_deps
-        consider_alternatives = self.metadata_controller.settings_controller.settings.use_alternative_package_ids_as_satisfying_dependencies
+        consider_alternatives = self.metadata_controller.settings.use_alternative_package_ids_as_satisfying_dependencies
         for dep_id, dep_mod in mod_data.overall_rules.dependencies.items():
             alt_ids: set[str] = {str(a) for a in dep_mod.alternative_package_ids}
 
@@ -3400,7 +3400,7 @@ class ModListWidget(QListWidget):
                     self.tr("\nIncompatible (per other mod's rules):"),
                 ),
             ]
-            if self.metadata_controller.settings_controller.settings.use_alternative_package_ids_as_satisfying_dependencies:
+            if self.metadata_controller.settings.use_alternative_package_ids_as_satisfying_dependencies:
                 tooltip_sections.insert(
                     1,
                     (

--- a/app/windows/base_mods_panel.py
+++ b/app/windows/base_mods_panel.py
@@ -152,7 +152,7 @@ class BaseModsPanel(QWidget):
     def _setup_metadata(self) -> None:
         """Set up metadata controller and settings controller."""
         self.metadata_controller = MetadataController.instance()
-        self.settings_controller = self.metadata_controller.settings_controller
+        self.settings = self.metadata_controller.settings
 
     def _get_steam_client_integration_enabled(self) -> bool:
         """
@@ -161,8 +161,8 @@ class BaseModsPanel(QWidget):
         Returns:
             True if Steam client integration is enabled, False otherwise.
         """
-        return self.settings_controller.settings.instances[
-            self.settings_controller.settings.current_instance
+        return self.settings.instances[
+            self.settings.current_instance
         ].steam_client_integration
 
     def _setup_ui_elements(
@@ -600,9 +600,7 @@ class BaseModsPanel(QWidget):
     def _delete_selected_mods(
         self, pfid_column: int, mode: OperationMode | str | int
     ) -> None:
-        delete_before_update_state = (
-            self.settings_controller.settings.steamcmd_delete_before_update
-        )
+        delete_before_update_state = self.settings.steamcmd_delete_before_update
         if delete_before_update_state:
             pfid_fn = self._get_selected_text_by_column(pfid_column)
             get_mode = self._resolve_mode_getter(mode)

--- a/tests/controllers/test_metadata_controller.py
+++ b/tests/controllers/test_metadata_controller.py
@@ -9,7 +9,7 @@ import pytest
 
 from app.controllers.metadata_controller import MetadataController
 from app.controllers.metadata_db_controller import AuxMetadataController
-from app.controllers.settings_controller import SettingsController
+from app.models.instance import Instance
 from app.models.metadata.metadata_structure import (
     AboutXmlMod,
     CaseInsensitiveStr,
@@ -53,15 +53,13 @@ def mock_settings_dialog() -> MagicMock:
     return MagicMock(spec=SettingsDialog)
 
 
-@pytest.fixture
-def settings_controller(
-    mock_settings: Settings,
-) -> SettingsController:
-    mock_sc = MagicMock(spec=SettingsController)
-    mock_sc._update_view_from_model.return_value = None
-    mock_sc.settings = mock_settings
-
-    return mock_sc
+@pytest.fixture()
+def mock_active_instance() -> MagicMock:
+    instance = MagicMock(spec=Instance)
+    instance.game_folder = ""
+    instance.local_folder = ""
+    instance.workshop_folder = ""
+    return instance
 
 
 @pytest.fixture()
@@ -73,7 +71,8 @@ def temp_db(tmp_path: Path) -> Generator[AuxMetadataController, None, None]:
 
 @pytest.fixture()
 def metadata_controller(
-    settings_controller: SettingsController,
+    mock_settings: Settings,
+    mock_active_instance: MagicMock,
     temp_db: AuxMetadataController,
 ) -> MetadataController:
     with (
@@ -89,7 +88,7 @@ def metadata_controller(
                 / "appworkshop_294100.acf"
             )
         )
-        return MetadataController(settings_controller, temp_db)
+        return MetadataController(mock_settings, lambda: mock_active_instance, temp_db)
 
 
 def test_metadata_controller_creation(metadata_controller: MetadataController) -> None:
@@ -101,17 +100,14 @@ def test_metadata_controller_creation(metadata_controller: MetadataController) -
 @pytest.fixture
 def metadata_controller_p(
     metadata_controller: MetadataController,
+    mock_active_instance: MagicMock,
 ) -> MetadataController:
-    metadata_controller.settings_controller.settings.external_steam_metadata_file_path = "tests/data/dbs/steamDB.json"
-    metadata_controller.settings_controller.active_instance.game_folder = (
-        "tests/data/mod_examples/RimWorld"
+    metadata_controller.settings.external_steam_metadata_file_path = (
+        "tests/data/dbs/steamDB.json"
     )
-    metadata_controller.settings_controller.active_instance.local_folder = (
-        "tests/data/mod_examples/Local"
-    )
-    metadata_controller.settings_controller.active_instance.workshop_folder = (
-        "tests/data/mod_examples/Steam"
-    )
+    mock_active_instance.game_folder = "tests/data/mod_examples/RimWorld"
+    mock_active_instance.local_folder = "tests/data/mod_examples/Local"
+    mock_active_instance.workshop_folder = "tests/data/mod_examples/Steam"
 
     metadata_controller.reset_paths()
     return metadata_controller
@@ -167,7 +163,9 @@ def metadata_controller_with_steamdb(
     metadata_controller_p: MetadataController,
 ) -> MetadataController:
     """metadata_controller_p with Steam DB source enabled."""
-    metadata_controller_p.settings_controller.settings.external_steam_metadata_source = "Configured file path"
+    metadata_controller_p.settings.external_steam_metadata_source = (
+        "Configured file path"
+    )
     metadata_controller_p.reset_paths()
     return metadata_controller_p
 
@@ -283,7 +281,7 @@ def test_workshop_acf_path_when_no_workshop(
     metadata_controller: MetadataController,
 ) -> None:
     """Verify workshop_acf_path returns None when workshop is not configured."""
-    metadata_controller.settings_controller.active_instance.workshop_folder = ""
+    metadata_controller._get_active_instance().workshop_folder = ""
     metadata_controller.reset_paths()
     acf_path = metadata_controller.workshop_acf_path
     assert acf_path is None
@@ -437,8 +435,12 @@ def test_community_rules_path_when_configured(
     metadata_controller_p: MetadataController,
 ) -> None:
     """Verify community_rules_path returns a Path when community rules are configured."""
-    metadata_controller_p.settings_controller.settings.external_community_rules_metadata_source = "Configured file path"
-    metadata_controller_p.settings_controller.settings.external_community_rules_file_path = "tests/data/dbs/communityRules.json"
+    metadata_controller_p.settings.external_community_rules_metadata_source = (
+        "Configured file path"
+    )
+    metadata_controller_p.settings.external_community_rules_file_path = (
+        "tests/data/dbs/communityRules.json"
+    )
     metadata_controller_p.reset_paths()
     result = metadata_controller_p.community_rules_path
     assert result is not None
@@ -909,10 +911,10 @@ def test_reset_paths_derives_local_mods_from_game_when_empty(
     metadata_controller: MetadataController,
 ) -> None:
     """When local_folder is empty but game_folder is set, local_mods_path is derived as game_path / 'Mods'."""
-    metadata_controller.settings_controller.active_instance.game_folder = (
+    metadata_controller._get_active_instance().game_folder = (
         "tests/data/mod_examples/RimWorld"
     )
-    metadata_controller.settings_controller.active_instance.local_folder = ""
+    metadata_controller._get_active_instance().local_folder = ""
 
     metadata_controller.reset_paths()
 
@@ -925,10 +927,10 @@ def test_reset_paths_preserves_explicit_local_folder(
     metadata_controller: MetadataController,
 ) -> None:
     """An explicitly set local_folder is NOT overwritten by derivation."""
-    metadata_controller.settings_controller.active_instance.game_folder = (
+    metadata_controller._get_active_instance().game_folder = (
         "tests/data/mod_examples/RimWorld"
     )
-    metadata_controller.settings_controller.active_instance.local_folder = (
+    metadata_controller._get_active_instance().local_folder = (
         "tests/data/mod_examples/Local"
     )
 
@@ -943,8 +945,8 @@ def test_reset_paths_leaves_local_mods_none_when_no_game(
     metadata_controller: MetadataController,
 ) -> None:
     """When both game_folder and local_folder are empty, local_mods_path stays None."""
-    metadata_controller.settings_controller.active_instance.game_folder = ""
-    metadata_controller.settings_controller.active_instance.local_folder = ""
+    metadata_controller._get_active_instance().game_folder = ""
+    metadata_controller._get_active_instance().local_folder = ""
 
     metadata_controller.reset_paths()
 

--- a/tests/views/test_menu_bar.py
+++ b/tests/views/test_menu_bar.py
@@ -91,7 +91,9 @@ class TestMenuBarControllerWithDisabledUpdater:
 
             # This should not raise an exception even though actions are None
             with patch("app.controllers.menu_bar_controller.EventBus"):
-                controller = MenuBarController(menu_bar, mock_settings_controller)
+                controller = MenuBarController(
+                    menu_bar, mock_settings_controller.settings, lambda: None
+                )
 
             # Verify the controller was created successfully
             assert controller is not None
@@ -112,7 +114,9 @@ class TestMenuBarControllerWithDisabledUpdater:
 
             # This should not raise an exception
             with patch("app.controllers.menu_bar_controller.EventBus"):
-                controller = MenuBarController(menu_bar, mock_settings_controller)
+                controller = MenuBarController(
+                    menu_bar, mock_settings_controller.settings, lambda: None
+                )
 
             # Verify the controller was created successfully
             assert controller is not None


### PR DESCRIPTION
Converts the last batch of files from depending on SettingsController to accepting the Settings model directly:

- \mod_info_panel.py\ — Category 1 (\.settings.X\ only) → \Settings\
- \menu_bar_controller.py\ — \Settings\ + \show_settings_dialog: Callable\
- \metadata_controller.py\ — \Settings\ + \get_active_instance: Callable\
- \main_content_panel.py\ — all \.settings_controller.settings\ → \.settings\
- \main_window.py\ — \self.settings = settings_controller.settings\, all body refs updated
- \steamcmd/wrapper.py\ — \on_steamcmd_not_found\ signature updated
- Callers and tests updated accordingly

After this PR, SettingsController reverse deps drop from 10 → 5.