### PR TITLE
refactor: eliminate remaining SettingsController runtime imports

### DIFF
--- a/app/controllers/app_controller.py
+++ b/app/controllers/app_controller.py
@@ -4,6 +4,7 @@ import sys
 from PySide6.QtCore import QCoreApplication, QLibraryInfo, QObject, QTranslator
 from PySide6.QtWidgets import QApplication
 
+import app.utils.globals as app_globals
 from app.controllers.main_window_controller import MainWindowController
 from app.controllers.metadata_controller import MetadataController
 from app.controllers.metadata_db_controller import AuxMetadataController
@@ -77,6 +78,7 @@ class AppController(QObject):
         self.settings_controller = SettingsController(
             model=self.settings, view=self.settings_dialog
         )
+        app_globals.SETTINGS = self.settings
 
     def initialize_theme_controller(self) -> None:
         """Initializes the ThemeController."""
@@ -128,7 +130,12 @@ class AppController(QObject):
 
     def initialize_main_window(self) -> None:
         """Initializes the main window and its controller."""
-        self.main_window = MainWindow(settings_controller=self.settings_controller)
+        self.main_window = MainWindow(
+            settings=self.settings,
+            get_active_instance=lambda: self.settings_controller.active_instance,
+            set_instance=self.settings_controller.set_instance,
+            show_settings_dialog=self.settings_controller.show_settings_dialog,
+        )
         self.main_window_controller = MainWindowController(self.main_window)
 
     def run(self) -> int:

--- a/app/controllers/file_search_controller.py
+++ b/app/controllers/file_search_controller.py
@@ -10,7 +10,6 @@ from psutil import Process
 from PySide6.QtCore import QObject, QThread, QTimer, Signal
 
 from app.controllers.metadata_controller import MetadataController
-from app.controllers.settings_controller import SettingsController
 from app.models.divider import is_divider_uuid
 from app.models.search_result import SearchResult
 from app.models.settings import Settings
@@ -594,7 +593,6 @@ class FileSearchController(QObject):
     def __init__(
         self,
         settings: Settings,
-        settings_controller: SettingsController,
         dialog: FileSearchDialog,
         active_mod_ids: Optional[set[str]] = None,
     ) -> None:
@@ -603,14 +601,12 @@ class FileSearchController(QObject):
 
         Args:
             settings (Settings): Application settings instance.
-            settings_controller (SettingsController): Controller for settings management.
             dialog (FileSearchDialog): The file search dialog UI component.
             active_mod_ids (Optional[Set[str]]): Set of active mod IDs for filtering.
         """
         super().__init__()
         self.settings = settings
         self.dialog = dialog
-        self.settings_controller = settings_controller
         self.mods_panel = ModsPanel(
             settings=self.settings,
         )

--- a/app/utils/button_factory.py
+++ b/app/utils/button_factory.py
@@ -61,7 +61,7 @@ class ButtonFactory:
     ) -> QPushButton:
         """Create a deletion button with menu."""
         return self.panel._create_deletion_button(
-            self.panel.settings_controller,
+            self.panel.settings,
             self.panel._get_selected_mod_metadata,
             completion_callback,
             menu_title,

--- a/app/utils/globals.py
+++ b/app/utils/globals.py
@@ -5,8 +5,8 @@ Global variables for the application.
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from app.controllers.settings_controller import SettingsController
+    from app.models.settings import Settings
     from app.views.main_window import MainWindow
 
 MAIN_WINDOW: "MainWindow | None" = None
-SETTINGS_CONTROLLER: "SettingsController | None" = None
+SETTINGS: "Settings | None" = None

--- a/app/views/acf_log_reader.py
+++ b/app/views/acf_log_reader.py
@@ -33,7 +33,6 @@ from PySide6.QtWidgets import (
 )
 
 from app.controllers.metadata_controller import MetadataController
-from app.controllers.settings_controller import SettingsController
 from app.models.metadata.metadata_structure import AboutXmlMod
 from app.utils.csv_export_utils import export_to_csv
 from app.utils.event_bus import EventBus
@@ -70,17 +69,14 @@ class AcfLogReader(BaseModsPanel):
 
     def __init__(
         self,
-        settings_controller: SettingsController,
         active_mods_list: object | None = None,
     ) -> None:
         """
         Initialize ACF Log Reader using BaseModsPanel.
 
         Args:
-            settings_controller: Settings controller instance
             active_mods_list: Optional active mods list for highlighting
         """
-        self.settings_controller = settings_controller
         self.active_mods_list = active_mods_list
         self.metadata_controller = MetadataController.instance()
         # Set of PFIDs that are currently active in the game

--- a/app/views/dialogue.py
+++ b/app/views/dialogue.py
@@ -44,9 +44,9 @@ def _get_parent_if_constrain_enabled(parent: QWidget | None = None) -> QWidget |
         parent is None
         and hasattr(app_globals, "MAIN_WINDOW")
         and app_globals.MAIN_WINDOW
-        and hasattr(app_globals, "SETTINGS_CONTROLLER")
-        and app_globals.SETTINGS_CONTROLLER
-        and app_globals.SETTINGS_CONTROLLER.settings.constrain_dialogues_to_main_window_monitor
+        and hasattr(app_globals, "SETTINGS")
+        and app_globals.SETTINGS
+        and app_globals.SETTINGS.constrain_dialogues_to_main_window_monitor
     ):
         return app_globals.MAIN_WINDOW
     return parent

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -33,12 +33,12 @@ from PySide6.QtWidgets import (
 import app.utils.constants as app_constants
 import app.views.dialogue as dialogue
 from app.controllers.metadata_controller import MetadataController
-from app.controllers.settings_controller import SettingsController
 from app.controllers.sort_controller import Sorter
 from app.controllers.todds_controller import ToddsController
 from app.models.animations import LoadingAnimation
 from app.models.divider import is_divider_uuid
 from app.models.metadata.metadata_structure import AboutXmlMod, ModType
+from app.models.settings import Settings
 from app.services.import_export_service import ImportExportService
 from app.services.window_manager import WindowManager
 from app.sort.mod_sorting import ModsPanelSortKey
@@ -85,6 +85,7 @@ from app.views.mods_panel import (
     ModListWidget,
     ModsPanel,
 )
+from app.views.settings_dialog import SettingsDialog
 from app.views.task_progress_window import TaskProgressWindow
 from app.windows.duplicate_mods_panel import DuplicateModsPanel
 from app.windows.ignore_json_editor import IgnoreJsonEditor
@@ -117,12 +118,18 @@ class MainContent(QObject):
             cls._instance = super(MainContent, cls).__new__(cls)
         return cls._instance
 
-    def __init__(self, settings_controller: SettingsController) -> None:
+    def __init__(
+        self,
+        settings: Settings,
+        show_settings_dialog: Callable[..., None] | None = None,
+        settings_dialog: SettingsDialog | None = None,
+    ) -> None:
         if not hasattr(self, "initialized"):
             super().__init__()
             logger.debug("Initializing MainContent")
-            self.settings_controller = settings_controller
-            self.settings = settings_controller.settings
+            self.settings = settings
+            self._show_settings_dialog = show_settings_dialog
+            self._settings_dialog = settings_dialog
             self._init_services()
             self._init_widgets()
             self._setup_layout()
@@ -384,8 +391,11 @@ class MainContent(QObject):
                     )
                 ),
             )
-            if answer == QMessageBox.StandardButton.Yes:
-                self.settings_controller.show_settings_dialog("Locations")
+            if (
+                answer == QMessageBox.StandardButton.Yes
+                and self._show_settings_dialog is not None
+            ):
+                self._show_settings_dialog("Locations")
             return False
 
     def ___get_relative_middle(self, some_list: ModListWidget) -> int:
@@ -574,9 +584,7 @@ class MainContent(QObject):
             logger.info(
                 f"Found {duplicate_mods_count} duplicate mods. Opening DuplicateModsPanel..."
             )
-            duplicate_mods_panel = DuplicateModsPanel(
-                self.duplicate_mods, self.settings_controller
-            )
+            duplicate_mods_panel = DuplicateModsPanel(self.duplicate_mods)
             self.window_manager.register(duplicate_mods_panel)
             duplicate_mods_panel.setWindowModality(Qt.WindowModality.ApplicationModal)
             duplicate_mods_panel.show()
@@ -651,7 +659,6 @@ class MainContent(QObject):
             missing_mod_properties_panel = MissingModPropertiesPanel(
                 missing_packageid_mods=missing_packageid_paths,
                 missing_publishfieldid_mods=missing_publishfieldid_paths,
-                settings_controller=self.settings_controller,
             )
             self.window_manager.register(missing_mod_properties_panel)
             # Make the panel modal to ensure user acknowledges the issues
@@ -854,9 +861,12 @@ class MainContent(QObject):
             )
             # Wait for settings dialog to be closed before continuing.
             # This is to ensure steamcmd check and other ops are done after the user has a chance to set paths
-            if not self.settings_controller.settings_dialog.isHidden():
+            if (
+                self._settings_dialog is not None
+                and not self._settings_dialog.isHidden()
+            ):
                 loop = QEventLoop()
-                self.settings_controller.settings_dialog.finished.connect(loop.quit)
+                self._settings_dialog.finished.connect(loop.quit)
                 loop.exec_()
                 logger.debug("Settings dialog closed. Continuing with refresh...")
 
@@ -1553,8 +1563,8 @@ class MainContent(QObject):
         )
         answer_str = str(answer)
         download_text = self.tr("Open settings")
-        if download_text in answer_str:
-            self.settings_controller.show_settings_dialog()
+        if download_text in answer_str and self._show_settings_dialog is not None:
+            self._show_settings_dialog()
 
     def _upload_file(self, path: Path | None) -> None:
         if not path or not os.path.exists(path):

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -1,9 +1,13 @@
 import os
+from collections.abc import Callable
 from functools import partial
 from pathlib import Path
 from shutil import copytree, rmtree
 from traceback import format_exc
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from app.views.settings_dialog import SettingsDialog
 
 from loguru import logger
 from PySide6.QtCore import QTimer
@@ -31,9 +35,10 @@ from app.controllers.menu_bar_controller import MenuBarController
 from app.controllers.metadata_controller import MetadataController
 from app.controllers.metadata_db_controller import AuxMetadataController
 from app.controllers.mods_panel_controller import ModsPanelController
-from app.controllers.settings_controller import SettingsController
 from app.controllers.todds_controller import ToddsController
 from app.controllers.troubleshooting_controller import TroubleshootingController
+from app.models.instance import Instance
+from app.models.settings import Settings
 from app.utils import globals
 from app.utils.acf_utils import refresh_acf_metadata
 from app.utils.app_info import AppInfo
@@ -71,7 +76,13 @@ class MainWindow(QMainWindow):
     """
 
     def __init__(
-        self, settings_controller: SettingsController, debug_mode: bool = False
+        self,
+        settings: Settings,
+        get_active_instance: Callable[[], Instance],
+        set_instance: Callable[[Instance], None],
+        show_settings_dialog: Callable[..., None],
+        settings_dialog: "SettingsDialog | None" = None,
+        debug_mode: bool = False,
     ) -> None:
         """
         Initialize the main application window. Construct the layout,
@@ -80,12 +91,13 @@ class MainWindow(QMainWindow):
         logger.info("Initializing MainWindow")
         super(MainWindow, self).__init__()
 
-        self.settings_controller = settings_controller
-        self.settings = settings_controller.settings
+        self.settings = settings
+        self._get_active_instance = get_active_instance
+        self._set_instance = set_instance
+        self._show_settings_dialog = show_settings_dialog
 
         # Set global references
         globals.MAIN_WINDOW = self
-        globals.SETTINGS_CONTROLLER = settings_controller
 
         # Create the main application window
         self.DEBUG_MODE = debug_mode
@@ -110,7 +122,9 @@ class MainWindow(QMainWindow):
 
         # Create various panels on the application GUI
         self.main_content_panel: MainContent = MainContent(
-            settings_controller=self.settings_controller
+            settings=self.settings,
+            show_settings_dialog=self._show_settings_dialog,
+            settings_dialog=settings_dialog,
         )
         self.main_content_panel.disable_enable_widgets_signal.connect(
             self.__disable_enable_widgets
@@ -167,7 +181,6 @@ class MainWindow(QMainWindow):
 
         # Instantiate the AcfDataWindow and add it to the tab
         self.acf_log_reader = AcfLogReader(
-            settings_controller,
             active_mods_list=self.main_content_panel.mods_panel.active_mods_list,
         )
         self.acf_log_reader_layout.addWidget(self.acf_log_reader)
@@ -187,7 +200,6 @@ class MainWindow(QMainWindow):
         self.file_search_dialog = FileSearchDialog()
         self.file_search_controller = FileSearchController(
             settings=self.settings,
-            settings_controller=self.settings_controller,
             dialog=self.file_search_dialog,
         )
         self.file_search_layout.addWidget(self.file_search_dialog)
@@ -231,7 +243,7 @@ class MainWindow(QMainWindow):
         self.menu_bar_controller = MenuBarController(
             view=self.menu_bar,
             settings=self.settings,
-            show_settings_dialog=self.settings_controller.show_settings_dialog,
+            show_settings_dialog=self._show_settings_dialog,
         )
 
         self.main_content_controller = MainContentController(
@@ -325,11 +337,11 @@ class MainWindow(QMainWindow):
         ) or not self.steamcmd_wrapper.check_for_steamcmd(
             prefix=self.steamcmd_wrapper.steamcmd_prefix
         ):
-            if not self.settings_controller.active_instance.steamcmd_ignore:
+            if not self._get_active_instance().steamcmd_ignore:
                 self.steamcmd_wrapper.on_steamcmd_not_found(
                     ask_ignore=True,
                     settings=self.settings,
-                    active_instance=self.settings_controller.active_instance,
+                    active_instance=self._get_active_instance(),
                 )
         else:
             self.steamcmd_wrapper.setup = True
@@ -347,8 +359,8 @@ class MainWindow(QMainWindow):
         self.__check_steam_integration()
 
         # Force initial setup to False and save settings
-        if self.settings_controller.active_instance.initial_setup:
-            self.settings_controller.active_instance.initial_setup = False
+        if self._get_active_instance().initial_setup:
+            self._get_active_instance().initial_setup = False
             self.settings.save()
         # IF CHECK FOR UPDATE ON STARTUP...
         if self.settings.check_for_update_startup:
@@ -358,7 +370,7 @@ class MainWindow(QMainWindow):
 
     def __check_steam_integration(self) -> None:
         """Ask the user if they would like to enable Steam Client Integration for the active instance if it is the first time they are setting up RimSort."""
-        instance = self.settings_controller.active_instance
+        instance = self._get_active_instance()
 
         if instance.initial_setup and not instance.steam_client_integration:
             diag = BinaryChoiceDialog(
@@ -373,7 +385,7 @@ class MainWindow(QMainWindow):
             )
             if diag.exec_is_positive():
                 instance.steam_client_integration = True
-                self.settings_controller.set_instance(instance)
+                self._set_instance(instance)
 
         return
 
@@ -605,7 +617,7 @@ class MainWindow(QMainWindow):
                     "Skipping steamcmd symlink restoration: Local folder not set. The symlink will need to be manually updated."
                 )
 
-            self.settings_controller.set_instance(instance_controller.instance)
+            self._set_instance(instance_controller.instance)
             self.__switch_to_instance(instance_controller.instance.name)
         else:
             show_warning(
@@ -1057,7 +1069,7 @@ class MainWindow(QMainWindow):
                 ),
                 instance_folder_override=instance_folder_override,
             )
-            self.settings_controller.set_instance(instance)
+            self._set_instance(instance)
 
             # Save settings
             self.settings.save()
@@ -1154,7 +1166,7 @@ class MainWindow(QMainWindow):
     def initialize_watchdog(self) -> None:
         logger.info("Initializing watchdog FS Observer")
         self.watchdog_event_handler = WatchdogHandler(
-            instance=self.settings_controller.active_instance,
+            instance=self._get_active_instance(),
         )
         self.watchdog_event_handler.acf_changed.connect(
             partial(refresh_acf_metadata, self.main_content_panel.metadata_controller)

--- a/app/windows/base_mods_panel.py
+++ b/app/windows/base_mods_panel.py
@@ -28,6 +28,7 @@ from PySide6.QtWidgets import (
 
 from app.controllers.metadata_controller import MetadataController
 from app.models.metadata.metadata_structure import AboutXmlMod, ListedMod, ModType
+from app.models.settings import Settings
 from app.utils.button_factory import ButtonFactory, MenuItem
 from app.utils.event_bus import EventBus
 from app.utils.generic import platform_specific_open
@@ -131,7 +132,7 @@ class BaseModsPanel(QWidget):
 
     # Type hints for instance variables
     metadata_controller: MetadataController
-    settings_controller: Any
+    settings: Any
     editor_model: QStandardItemModel
     editor_table_view: QTableView
     ui_elements: UIElements
@@ -796,7 +797,7 @@ class BaseModsPanel(QWidget):
 
     def _create_deletion_button(
         self,
-        settings_controller: Any,
+        settings: Settings,
         get_selected_mod_metadata: Callable[[], list[dict[str, Any]]],
         completion_callback: Callable[[], None] | None,
         menu_title: str,
@@ -810,7 +811,7 @@ class BaseModsPanel(QWidget):
         Create a standardized deletion button with menu.
 
         Args:
-            settings_controller: The settings controller instance.
+            settings: The settings model instance.
             get_selected_mod_metadata: Function to get selected mod metadata.
             menu_title: Title for the deletion menu.
             completion_callback: Callback after deletion completes.
@@ -824,14 +825,14 @@ class BaseModsPanel(QWidget):
             QPushButton: Configured deletion button with dropdown menu.
         """
         # Check if Steam client integration is enabled
-        steam_client_integration_enabled = settings_controller.settings.instances[
-            settings_controller.settings.current_instance
+        steam_client_integration_enabled = settings.instances[
+            settings.current_instance
         ].steam_client_integration
 
         button = QPushButton()
         button.setText(self.tr("Delete"))
         deletion_menu = ModDeletionMenu(
-            settings=settings_controller.settings,
+            settings=settings,
             get_selected_mod_metadata=get_selected_mod_metadata,
             completion_callback=completion_callback,
             menu_title=menu_title,

--- a/app/windows/duplicate_mods_panel.py
+++ b/app/windows/duplicate_mods_panel.py
@@ -1,6 +1,5 @@
 from loguru import logger
 
-from app.controllers.settings_controller import SettingsController
 from app.utils.mod_info import ModInfo
 from app.windows.base_mods_panel import (
     BaseModsPanel,
@@ -18,26 +17,21 @@ class DuplicateModsPanel(BaseModsPanel):
     Attributes:
         duplicate_mods (dict[str, list[str]]): Dictionary mapping package IDs to lists of UUIDs
             of duplicate mods.
-        settings_controller (SettingsController): Controller for application settings.
         metadata_controller: MetadataController instance from base class for accessing mod data.
     """
 
     def __init__(
         self,
         duplicate_mods: dict[str, list[str]],
-        settings_controller: SettingsController,
     ) -> None:
         """
         Initialize the DuplicateModsPanel with duplicate mods data.
 
         Args:
             duplicate_mods: Dictionary mapping package IDs to lists of UUIDs of duplicate mods.
-            settings_controller: Controller for managing application settings.
         """
         logger.debug("Initializing DuplicateModsPanel")
         self.duplicate_mods = duplicate_mods
-        self.settings_controller = settings_controller
-        self.settings_controller = settings_controller
 
         super().__init__(
             object_name="duplicateModsPanel",

--- a/app/windows/github_mods_panel.py
+++ b/app/windows/github_mods_panel.py
@@ -90,7 +90,7 @@ class GitHubModsPanel(BaseModsPanel):
             from sqlalchemy.orm import sessionmaker as sa_sessionmaker
 
             aux_controller = AuxMetadataController.get_or_create_cached_instance(
-                self.settings_controller.settings.aux_db_path
+                self.settings.aux_db_path
             )
             Base.metadata.create_all(aux_controller.engine)
 
@@ -177,7 +177,7 @@ class GitHubModsPanel(BaseModsPanel):
 
         try:
             aux_controller = AuxMetadataController.get_or_create_cached_instance(
-                self.settings_controller.settings.aux_db_path
+                self.settings.aux_db_path
             )
             Base.metadata.create_all(aux_controller.engine)
 
@@ -203,7 +203,7 @@ class GitHubModsPanel(BaseModsPanel):
             from sqlalchemy.orm import sessionmaker as sa_sessionmaker
 
             aux_controller = AuxMetadataController.get_or_create_cached_instance(
-                self.settings_controller.settings.aux_db_path
+                self.settings.aux_db_path
             )
             Base.metadata.create_all(aux_controller.engine)
 
@@ -216,7 +216,7 @@ class GitHubModsPanel(BaseModsPanel):
             CacheBase.metadata.create_all(cache_engine)
             cache_session = sa_sessionmaker(bind=cache_engine)()
 
-            settings = self.settings_controller.settings
+            settings = self.settings
             provider = GitHubProvider(
                 github_token=settings.github_token or None,
                 cache_session=cache_session,

--- a/app/windows/missing_mod_properties_panel.py
+++ b/app/windows/missing_mod_properties_panel.py
@@ -3,7 +3,6 @@ from typing import Any, Iterable
 from loguru import logger
 from PySide6.QtWidgets import QMessageBox
 
-from app.controllers.settings_controller import SettingsController
 from app.models.metadata.metadata_structure import ListedMod
 from app.utils.constants import DEFAULT_MISSING_PACKAGEID
 from app.utils.event_bus import EventBus
@@ -23,7 +22,6 @@ class MissingModPropertiesPanel(BaseModsPanel):
     Attributes:
         missing_packageid_mods (list[str]): Mod path keys with missing Package ID.
         missing_publishfieldid_mods (list[str]): Mod path keys with missing Publish Field ID.
-        settings_controller (SettingsController): Controller for application settings.
         metadata_controller: Metadata controller instance from base class for accessing mod data.
     """
 
@@ -31,7 +29,6 @@ class MissingModPropertiesPanel(BaseModsPanel):
         self,
         missing_packageid_mods: list[str],
         missing_publishfieldid_mods: list[str],
-        settings_controller: SettingsController,
     ) -> None:
         """
         Initialize the MissingModPropertiesPanel with mods data.
@@ -39,12 +36,10 @@ class MissingModPropertiesPanel(BaseModsPanel):
         Args:
             missing_packageid_mods: Mod path keys with missing Package ID.
             missing_publishfieldid_mods: Mod path keys with missing Publish Field ID.
-            settings_controller: Controller for managing application settings.
         """
         logger.debug("Initializing MissingModPropertiesPanel")
         self.missing_packageid_mods = missing_packageid_mods
         self.missing_publishfieldid_mods = missing_publishfieldid_mods
-        self.settings_controller = settings_controller
 
         super().__init__(
             object_name="missingModPropertiesPanel",

--- a/tests/views/test_main_content_run.py
+++ b/tests/views/test_main_content_run.py
@@ -51,8 +51,8 @@ def main_content(
     instance = mock_settings_controller.settings.instances["Default"]
     instance.game_folder = "/fake/path"
     instance.run_args = "--test"
-    # Initialize MainContent with the shared mock settings controller
-    mc = MainContent(mock_settings_controller)
+    # Initialize MainContent with settings from the mock settings controller
+    mc = MainContent(mock_settings_controller.settings)
     # Patch _do_save to capture calls
     save_calls: List[bool] = []
     monkeypatch.setattr(mc, "_do_save", lambda: save_calls.append(True))


### PR DESCRIPTION
Eliminates SettingsController import from the last runtime consumers by extracting callables/Settings model directly. Only pp_controller.py (the creator) remains.

### Changes
- **7 consumer files** converted: ile_search_controller.py, cf_log_reader.py, duplicate_mods_panel.py, missing_mod_properties_panel.py, github_mods_panel.py, main_content_panel.py, main_window.py
- **2 infrastructure files** updated: ase_mods_panel._create_deletion_button + utton_factory accept Settings directly
- **1 test file** updated: 	est_main_content_run.py passes .settings instead of mock controller
- **1 global fix**: globals.SETTINGS_CONTROLLER → globals.SETTINGS (restores dialogue constrain feature)

### Quality Gates
- ✅ ruff — all checks passed
- ✅ mypy — no issues found
- ✅ pyright — 0 errors
- ✅ pytest — 1064 passed, 12 skipped

### Reverse deps
\pp.controllers.settings_controller\ runtime imports: **32 → 1** (only \pp_controller.py\, the creator)