### PR TITLE
refactor: eliminate MetadataController.instance() singleton from views/windows

### DIFF
--- a/app/controllers/app_controller.py
+++ b/app/controllers/app_controller.py
@@ -135,6 +135,7 @@ class AppController(QObject):
             get_active_instance=lambda: self.settings_controller.active_instance,
             set_instance=self.settings_controller.set_instance,
             show_settings_dialog=self.settings_controller.show_settings_dialog,
+            metadata_controller=self.metadata_controller,
         )
         self.main_window_controller = MainWindowController(self.main_window)
 

--- a/app/controllers/main_window_controller.py
+++ b/app/controllers/main_window_controller.py
@@ -177,7 +177,9 @@ class MainWindowController(QObject):
                 missing_deps[mod_id] = local | download
 
         # Always show the dialog (even if no missing deps)
-        dialog = MissingDependenciesDialog(self.main_window)
+        dialog = MissingDependenciesDialog(
+            self.main_window, metadata_controller=self.metadata_controller
+        )
         selected_deps = dialog.show_dialog(deps_summary, missing_deps)
 
         if not missing_deps:

--- a/app/views/acf_log_reader.py
+++ b/app/views/acf_log_reader.py
@@ -70,6 +70,7 @@ class AcfLogReader(BaseModsPanel):
     def __init__(
         self,
         active_mods_list: object | None = None,
+        metadata_controller: MetadataController | None = None,
     ) -> None:
         """
         Initialize ACF Log Reader using BaseModsPanel.
@@ -78,7 +79,7 @@ class AcfLogReader(BaseModsPanel):
             active_mods_list: Optional active mods list for highlighting
         """
         self.active_mods_list = active_mods_list
-        self.metadata_controller = MetadataController.instance()
+        self.metadata_controller = metadata_controller or MetadataController.instance()
         # Set of PFIDs that are currently active in the game
         self.active_pfids: set[str] = set()
         # Timer for debouncing search input (300ms delay)
@@ -97,6 +98,7 @@ class AcfLogReader(BaseModsPanel):
             title_text="Workshop Items from ACF Files",
             details_text="Displays all mods in your SteamCMD and Steam ACF data",
             additional_columns=self._get_standard_mod_columns(),
+            metadata_controller=self.metadata_controller,
         )
 
         # Set up BaseModsPanel buttons (Refresh, etc.)

--- a/app/views/deletion_menu.py
+++ b/app/views/deletion_menu.py
@@ -54,6 +54,7 @@ class ModDeletionMenu(QMenu):
         self,
         settings: Settings,
         get_selected_mod_metadata: Callable[[], list[ModMetadata]],
+        metadata_controller: MetadataController | None = None,
         remove_from_uuids: list[str] | None = None,
         menu_title: str = "Deletion options",
         enable_delete_mod: bool = True,
@@ -66,7 +67,7 @@ class ModDeletionMenu(QMenu):
         super().__init__(title=self.tr("Deletion options"))
         self.remove_from_uuids = remove_from_uuids
         self.get_selected_mod_metadata = get_selected_mod_metadata
-        self.metadata_controller = MetadataController.instance()
+        self.metadata_controller = metadata_controller or MetadataController.instance()
         self.settings = settings
         self.completion_callback = completion_callback
         self._actions_initialized = False

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -123,6 +123,7 @@ class MainContent(QObject):
         settings: Settings,
         show_settings_dialog: Callable[..., None] | None = None,
         settings_dialog: SettingsDialog | None = None,
+        metadata_controller: MetadataController | None = None,
     ) -> None:
         if not hasattr(self, "initialized"):
             super().__init__()
@@ -130,6 +131,9 @@ class MainContent(QObject):
             self.settings = settings
             self._show_settings_dialog = show_settings_dialog
             self._settings_dialog = settings_dialog
+            self.metadata_controller = (
+                metadata_controller or MetadataController.instance()
+            )
             self._init_services()
             self._init_widgets()
             self._setup_layout()
@@ -143,7 +147,6 @@ class MainContent(QObject):
         self.steam_browser: SteamBrowser | None = None
         self.steamcmd_runner: RunnerPanel | None = None
         self.steamcmd_wrapper = SteamcmdInterface.instance()
-        self.metadata_controller = MetadataController.instance()
         self._import_export_service = ImportExportService(
             self.metadata_controller, self.settings
         )
@@ -155,9 +158,11 @@ class MainContent(QObject):
     def _init_widgets(self) -> None:
         self.mod_info_panel = ModInfoPanel(
             settings=self.settings,
+            metadata_controller=self.metadata_controller,
         )
         self.mods_panel = ModsPanel(
             settings=self.settings,
+            metadata_controller=self.metadata_controller,
         )
         self.mod_info_container = QWidget()
         self.mod_info_container.setLayout(self.mod_info_panel.panel)
@@ -584,7 +589,9 @@ class MainContent(QObject):
             logger.info(
                 f"Found {duplicate_mods_count} duplicate mods. Opening DuplicateModsPanel..."
             )
-            duplicate_mods_panel = DuplicateModsPanel(self.duplicate_mods)
+            duplicate_mods_panel = DuplicateModsPanel(
+                self.duplicate_mods, metadata_controller=self.metadata_controller
+            )
             self.window_manager.register(duplicate_mods_panel)
             duplicate_mods_panel.setWindowModality(Qt.WindowModality.ApplicationModal)
             duplicate_mods_panel.show()
@@ -608,7 +615,10 @@ class MainContent(QObject):
                 f"Found {missing_mods_count} missing mods. Opening MissingModsPrompt..."
             )
             # Always open the MissingModsPrompt panel, allowing manual entry if Steam database is unavailable
-            self.missing_mods_prompt = MissingModsPrompt(packageids=self.missing_mods)
+            self.missing_mods_prompt = MissingModsPrompt(
+                packageids=self.missing_mods,
+                metadata_controller=self.metadata_controller,
+            )
             self.window_manager.register_attr(self, "missing_mods_prompt")
             self.missing_mods_prompt._populate_from_metadata()
             self.missing_mods_prompt.setWindowModality(
@@ -659,6 +669,7 @@ class MainContent(QObject):
             missing_mod_properties_panel = MissingModPropertiesPanel(
                 missing_packageid_mods=missing_packageid_paths,
                 missing_publishfieldid_mods=missing_publishfieldid_paths,
+                metadata_controller=self.metadata_controller,
             )
             self.window_manager.register(missing_mod_properties_panel)
             # Make the panel modal to ensure user acknowledges the issues
@@ -955,7 +966,9 @@ class MainContent(QObject):
                 active_mods
             )
             if missing_deps:
-                dialog = MissingDependenciesDialog()
+                dialog = MissingDependenciesDialog(
+                    metadata_controller=self.metadata_controller
+                )
                 self.window_manager.register(dialog)
 
                 # Build a deps_summary from the missing deps for the dialog display
@@ -1959,7 +1972,9 @@ class MainContent(QObject):
             )
 
         # For both "success" and "partial", show the updater panel
-        workshop_mod_updater = WorkshopModUpdaterPanel()
+        workshop_mod_updater = WorkshopModUpdaterPanel(
+            metadata_controller=self.metadata_controller
+        )
         self.window_manager.register(workshop_mod_updater)
         if workshop_mod_updater._row_count() > 0:
             logger.debug("Displaying potential Workshop mod updates")
@@ -2934,7 +2949,8 @@ class MainContent(QObject):
             return
 
         self.use_this_instead_dialog = UseThisInsteadPanel(
-            mod_metadata=self.metadata_controller.mods_metadata
+            mod_metadata=self.metadata_controller.mods_metadata,
+            metadata_controller=self.metadata_controller,
         )
         self.window_manager.register_attr(self, "use_this_instead_dialog")
         if not self.use_this_instead_dialog.show_if_has_alternatives():

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -81,6 +81,7 @@ class MainWindow(QMainWindow):
         get_active_instance: Callable[[], Instance],
         set_instance: Callable[[Instance], None],
         show_settings_dialog: Callable[..., None],
+        metadata_controller: MetadataController,
         settings_dialog: "SettingsDialog | None" = None,
         debug_mode: bool = False,
     ) -> None:
@@ -95,6 +96,7 @@ class MainWindow(QMainWindow):
         self._get_active_instance = get_active_instance
         self._set_instance = set_instance
         self._show_settings_dialog = show_settings_dialog
+        self.metadata_controller = metadata_controller
 
         # Set global references
         globals.MAIN_WINDOW = self
@@ -125,6 +127,7 @@ class MainWindow(QMainWindow):
             settings=self.settings,
             show_settings_dialog=self._show_settings_dialog,
             settings_dialog=settings_dialog,
+            metadata_controller=self.metadata_controller,
         )
         self.main_content_panel.disable_enable_widgets_signal.connect(
             self.__disable_enable_widgets
@@ -182,6 +185,7 @@ class MainWindow(QMainWindow):
         # Instantiate the AcfDataWindow and add it to the tab
         self.acf_log_reader = AcfLogReader(
             active_mods_list=self.main_content_panel.mods_panel.active_mods_list,
+            metadata_controller=self.metadata_controller,
         )
         self.acf_log_reader_layout.addWidget(self.acf_log_reader)
 
@@ -298,7 +302,7 @@ class MainWindow(QMainWindow):
         :param event: The close event to handle.
         """
         # Abort any in-progress metadata scanning so background threads stop
-        MetadataController.instance().is_abort_requested = True
+        self.metadata_controller.is_abort_requested = True
 
         # Break out of the nested QEventLoop in do_threaded_loading_animation
         # so the startup sequence can unwind and the process can exit

--- a/app/views/mod_info_panel.py
+++ b/app/views/mod_info_panel.py
@@ -110,14 +110,16 @@ class ModInfoPanel:
     mod information panel on the GUI.
     """
 
-    def __init__(self, settings: Settings) -> None:
+    def __init__(
+        self, settings: Settings, metadata_controller: MetadataController | None = None
+    ) -> None:
         """
         Initialize the class.
         """
         logger.debug("Initializing ModInfo")
 
         # Cache MetadataController instance
-        self.metadata_controller = MetadataController.instance()
+        self.metadata_controller = metadata_controller or MetadataController.instance()
         self.settings = settings
 
         # Used to keep track of which mod items notes we are viewing/editing

--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -998,7 +998,12 @@ class ModListWidget(QListWidget):
     update_git_mods_signal = Signal(list)
     steamdb_blacklist_signal = Signal(list)
 
-    def __init__(self, list_type: str, settings: Settings) -> None:
+    def __init__(
+        self,
+        list_type: str,
+        settings: Settings,
+        metadata_controller: MetadataController | None = None,
+    ) -> None:
         """
         Initialize the ListWidget with a dict of mods.
         Keys are the package ids and values are a dict of
@@ -1011,7 +1016,7 @@ class ModListWidget(QListWidget):
         self.list_type = list_type
 
         # Cache MetadataController instance
-        self.metadata_controller = MetadataController.instance()
+        self.metadata_controller = metadata_controller or MetadataController.instance()
 
         self.settings = settings
 
@@ -1077,7 +1082,8 @@ class ModListWidget(QListWidget):
         self.deletion_sub_menu = ModDeletionMenu(
             self.settings,
             self._get_selected_metadata,
-            self.paths,
+            metadata_controller=self.metadata_controller,
+            remove_from_uuids=self.paths,
         )  # TODO: should we enable items conditionally? For now use all
         logger.debug("Finished ModListWidget initialization")
 
@@ -3940,7 +3946,9 @@ class ModsPanel(QWidget):
             self.tr("Desc") if self.inactive_mods_sort_descending else self.tr("Asc")
         )
 
-    def __init__(self, settings: Settings) -> None:
+    def __init__(
+        self, settings: Settings, metadata_controller: MetadataController | None = None
+    ) -> None:
         """
         Initialize the class.
         Create a ListWidget using the dict of mods. This will
@@ -3950,7 +3958,7 @@ class ModsPanel(QWidget):
 
         # Cache MetadataController instance and initialize panel
         logger.debug("Initializing ModsPanel")
-        self.metadata_controller = MetadataController.instance()
+        self.metadata_controller = metadata_controller or MetadataController.instance()
         self.settings = settings
 
         # Load inactive mods sort settings
@@ -4043,6 +4051,7 @@ class ModsPanel(QWidget):
         self.active_mods_list = ModListWidget(
             list_type="Active",
             settings=self.settings,
+            metadata_controller=self.metadata_controller,
         )
         # Active mods search widgets
         self.active_mods_search_layout = QHBoxLayout()
@@ -4063,6 +4072,7 @@ class ModsPanel(QWidget):
         self.inactive_mods_list = ModListWidget(
             list_type="Inactive",
             settings=self.settings,
+            metadata_controller=self.metadata_controller,
         )
 
         # Inactive mods search layout

--- a/app/windows/base_mods_panel.py
+++ b/app/windows/base_mods_panel.py
@@ -152,7 +152,10 @@ class BaseModsPanel(QWidget):
 
     def _setup_metadata(self) -> None:
         """Set up metadata controller and settings controller."""
-        self.metadata_controller = MetadataController.instance()
+        if self._metadata_controller is not None:
+            self.metadata_controller = self._metadata_controller
+        else:
+            self.metadata_controller = MetadataController.instance()
         self.settings = self.metadata_controller.settings
 
     def _get_steam_client_integration_enabled(self) -> bool:
@@ -353,8 +356,10 @@ class BaseModsPanel(QWidget):
         title_text: str,
         details_text: str,
         additional_columns: Sequence[HeaderColumn],
+        metadata_controller: MetadataController | None = None,
     ):
         super().__init__()
+        self._metadata_controller = metadata_controller
         self._initialize_ui_elements()
         self._initialize_layouts()
         self._initialize_components()
@@ -834,6 +839,7 @@ class BaseModsPanel(QWidget):
         deletion_menu = ModDeletionMenu(
             settings=settings,
             get_selected_mod_metadata=get_selected_mod_metadata,
+            metadata_controller=self.metadata_controller,
             completion_callback=completion_callback,
             menu_title=menu_title,
             enable_delete_mod=enable_delete_mod,

--- a/app/windows/duplicate_mods_panel.py
+++ b/app/windows/duplicate_mods_panel.py
@@ -1,5 +1,6 @@
 from loguru import logger
 
+from app.controllers.metadata_controller import MetadataController
 from app.utils.mod_info import ModInfo
 from app.windows.base_mods_panel import (
     BaseModsPanel,
@@ -23,6 +24,7 @@ class DuplicateModsPanel(BaseModsPanel):
     def __init__(
         self,
         duplicate_mods: dict[str, list[str]],
+        metadata_controller: MetadataController | None = None,
     ) -> None:
         """
         Initialize the DuplicateModsPanel with duplicate mods data.
@@ -42,6 +44,7 @@ class DuplicateModsPanel(BaseModsPanel):
                 "Select which versions to keep and choose an action."
             ),
             additional_columns=self._get_standard_mod_columns(),
+            metadata_controller=metadata_controller,
         )
 
         button_configs = self._get_base_button_configs()

--- a/app/windows/github_mods_panel.py
+++ b/app/windows/github_mods_panel.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from app.controllers.metadata_controller import MetadataController
 
 from loguru import logger
 from PySide6.QtCore import Qt
@@ -31,7 +34,10 @@ _COL_AUTO_UPDATE = 5
 class GitHubModsPanel(BaseModsPanel):
     """Panel for managing GitHub mods -- view installed, check updates, switch versions."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        metadata_controller: MetadataController | None = None,
+    ) -> None:
         self._update_worker: Any = None
         self._auto_update_signals_blocked = False
 
@@ -47,6 +53,7 @@ class GitHubModsPanel(BaseModsPanel):
                 "Latest Version",
                 "Auto-Update",
             ],
+            metadata_controller=metadata_controller,
         )
 
         button_configs = [

--- a/app/windows/missing_dependencies_dialog.py
+++ b/app/windows/missing_dependencies_dialog.py
@@ -26,13 +26,17 @@ class MissingDependenciesDialog(QDialog):
         - Dependencies that need to be downloaded
     """
 
-    def __init__(self, parent: QWidget | None = None) -> None:
+    def __init__(
+        self,
+        parent: QWidget | None = None,
+        metadata_controller: MetadataController | None = None,
+    ) -> None:
         """
         Initialize the MissingDependenciesDialog.
         """
         super().__init__(parent)
         self.setObjectName("missingDependenciesDialog")
-        self.metadata_controller = MetadataController.instance()
+        self.metadata_controller = metadata_controller or MetadataController.instance()
         self.selected_mods: set[str] = set()
         self.checkboxes: dict[str, QCheckBox] = {}
         self._setup_ui()

--- a/app/windows/missing_mod_properties_panel.py
+++ b/app/windows/missing_mod_properties_panel.py
@@ -3,6 +3,7 @@ from typing import Any, Iterable
 from loguru import logger
 from PySide6.QtWidgets import QMessageBox
 
+from app.controllers.metadata_controller import MetadataController
 from app.models.metadata.metadata_structure import ListedMod
 from app.utils.constants import DEFAULT_MISSING_PACKAGEID
 from app.utils.event_bus import EventBus
@@ -29,9 +30,10 @@ class MissingModPropertiesPanel(BaseModsPanel):
         self,
         missing_packageid_mods: list[str],
         missing_publishfieldid_mods: list[str],
+        metadata_controller: MetadataController | None = None,
     ) -> None:
         """
-        Initialize the MissingModPropertiesPanel with mods data.
+        Initialize the MissingModPropertiesPanel.
 
         Args:
             missing_packageid_mods: Mod path keys with missing Package ID.
@@ -52,6 +54,7 @@ class MissingModPropertiesPanel(BaseModsPanel):
                 "Please contact the mod authors to add these properties to their mods."
             ),
             additional_columns=self._get_standard_mod_columns(),
+            metadata_controller=metadata_controller,
         )
 
         # Build button configurations

--- a/app/windows/missing_mods_panel.py
+++ b/app/windows/missing_mods_panel.py
@@ -6,6 +6,7 @@ from PySide6.QtWidgets import (
     QComboBox,
 )
 
+from app.controllers.metadata_controller import MetadataController
 from app.utils.constants import RIMWORLD_DLC_METADATA
 from app.windows.base_mods_panel import (
     BaseModsPanel,
@@ -27,6 +28,7 @@ class MissingModsPrompt(BaseModsPanel):
     def __init__(
         self,
         packageids: list[str],
+        metadata_controller: MetadataController | None = None,
     ) -> None:
         """
         Initialize the MissingModsPrompt.
@@ -53,6 +55,7 @@ class MissingModsPrompt(BaseModsPanel):
                 self.tr(self.COL_PUBLISHED_FILE_ID),
                 self.tr(self.COL_WORKSHOP_PAGE),
             ],
+            metadata_controller=metadata_controller,
         )
 
         self.data_by_variants: dict[str, dict[str, Any]] = {}

--- a/app/windows/use_this_instead_panel.py
+++ b/app/windows/use_this_instead_panel.py
@@ -7,6 +7,7 @@ from loguru import logger
 from PySide6.QtGui import QStandardItem
 from PySide6.QtWidgets import QCheckBox
 
+from app.controllers.metadata_controller import MetadataController
 from app.models.metadata.metadata_structure import (
     AboutXmlMod,
     ListedMod,
@@ -52,7 +53,11 @@ class UseThisInsteadPanel(BaseModsPanel):
     Groups mods by replacement mod and provides actions for subscription, unsubscription, and deletion.
     """
 
-    def __init__(self, mod_metadata: dict[str, Any]) -> None:
+    def __init__(
+        self,
+        mod_metadata: dict[str, Any],
+        metadata_controller: MetadataController | None = None,
+    ) -> None:
         """
         Initialize the UseThisInsteadPanel with mod metadata.
 
@@ -71,6 +76,7 @@ class UseThisInsteadPanel(BaseModsPanel):
                 'according to the "Use This Instead" database, grouped by replacement mod.'
             ),
             additional_columns=self._get_standard_mod_columns(),
+            metadata_controller=metadata_controller,
         )
 
         steam_client_integration_enabled = self._get_steam_client_integration_enabled()

--- a/app/windows/workshop_mod_updater_panel.py
+++ b/app/windows/workshop_mod_updater_panel.py
@@ -23,7 +23,10 @@ class WorkshopModUpdaterPanel(BaseModsPanel):
     keep their mods up-to-date with the latest versions from the Workshop.
     """
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        metadata_controller: MetadataController | None = None,
+    ) -> None:
         """
         Initialize the WorkshopModUpdaterPanel.
 
@@ -31,7 +34,7 @@ class WorkshopModUpdaterPanel(BaseModsPanel):
         for updating via SteamCMD or Steam client (if enabled).
         """
         logger.debug("Initializing WorkshopModUpdaterPanel")
-        self.metadata_controller = MetadataController.instance()
+        self._metadata_controller = metadata_controller
         self.eligible_metadata: list[tuple[str, dict[str, Any]]] = []
 
         super().__init__(
@@ -42,6 +45,7 @@ class WorkshopModUpdaterPanel(BaseModsPanel):
                 "\nThe following table displays Workshop mods available for update from Steam."
             ),
             additional_columns=self._get_standard_mod_columns(),
+            metadata_controller=self._metadata_controller,
         )
 
         button_configs = [

--- a/tests/views/conftest.py
+++ b/tests/views/conftest.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from app.views.main_window import MainWindow
 
 
-def make_stub_main_window() -> MainWindow:
+def make_stub_main_window(metadata_controller: MagicMock | None = None) -> MainWindow:
     """Create a MainWindow instance without running MainWindow.__init__.
 
     Calls QMainWindow.__init__ to satisfy the C++ side (Shiboken),
@@ -39,6 +39,7 @@ def make_stub_main_window() -> MainWindow:
     QMainWindow.__init__(instance)
     instance.main_content_panel = MagicMock()
     instance.watchdog_event_handler = None
+    instance.metadata_controller = metadata_controller or MagicMock()
     return instance
 
 

--- a/tests/views/test_deletion_menu.py
+++ b/tests/views/test_deletion_menu.py
@@ -34,6 +34,7 @@ def deletion_menu(
     menu = ModDeletionMenu(
         settings=mock_settings_controller.settings,
         get_selected_mod_metadata=lambda: [],
+        metadata_controller=mock_metadata_controller,
         menu_title="Test Menu",
     )
     return menu

--- a/tests/views/test_main_window_close.py
+++ b/tests/views/test_main_window_close.py
@@ -18,7 +18,7 @@ class TestMainWindowCloseEvent:
         mock_metadata_controller: MagicMock,
     ) -> None:
         """Verify closeEvent delegates to MainContent.close_child_windows."""
-        window = make_stub_main_window()
+        window = make_stub_main_window(mock_metadata_controller)
 
         event = QCloseEvent()
         window.closeEvent(event)
@@ -31,7 +31,7 @@ class TestMainWindowCloseEvent:
         mock_metadata_controller: MagicMock,
     ) -> None:
         """Verify closeEvent stops the watchdog if running."""
-        window = make_stub_main_window()
+        window = make_stub_main_window(mock_metadata_controller)
         mock_handler = MagicMock()
         window.watchdog_event_handler = mock_handler
 
@@ -46,7 +46,7 @@ class TestMainWindowCloseEvent:
         mock_metadata_controller: MagicMock,
     ) -> None:
         """No crash when watchdog_event_handler is None."""
-        window = make_stub_main_window()
+        window = make_stub_main_window(mock_metadata_controller)
         assert window.watchdog_event_handler is None
 
         event = QCloseEvent()
@@ -58,12 +58,12 @@ class TestMainWindowCloseEvent:
         mock_metadata_controller: MagicMock,
     ) -> None:
         """Verify closeEvent requests metadata abort."""
-        window = make_stub_main_window()
+        window = make_stub_main_window(mock_metadata_controller)
 
         event = QCloseEvent()
         window.closeEvent(event)
 
-        # MetadataController.instance().is_abort_requested should be set to True
+        # metadata_controller.is_abort_requested should be set to True
         assert mock_metadata_controller.is_abort_requested is True
 
     def test_close_event_calls_abort_loading(
@@ -72,7 +72,7 @@ class TestMainWindowCloseEvent:
         mock_metadata_controller: MagicMock,
     ) -> None:
         """Verify closeEvent calls abort_loading on the main content panel."""
-        window = make_stub_main_window()
+        window = make_stub_main_window(mock_metadata_controller)
 
         event = QCloseEvent()
         window.closeEvent(event)


### PR DESCRIPTION
Phase 1 of signal-based view communication. Replaces \MetadataController.instance()\ singleton calls in views/windows with explicit constructor injection. The singleton is preserved as a fallback for backward compat (controllers/utils still use it).

### Changes (19 files)
- **Views** (6): \main_window.py\, \main_content_panel.py\, \mods_panel.py\, \mod_info_panel.py\, \cf_log_reader.py\, \deletion_menu.py\
- **Windows** (7): \ase_mods_panel.py\, \missing_mods_panel.py\, \workshop_mod_updater_panel.py\, \missing_mod_properties_panel.py\, \duplicate_mods_panel.py\, \use_this_instead_panel.py\, \github_mods_panel.py\, \missing_dependencies_dialog.py\
- **Controllers** (2): \pp_controller.py\ — passes \self.metadata_controller\ to \MainWindow\, \main_window_controller.py\ — passes to \MissingDependenciesDialog\
- **Tests** (3): updated fixtures/stubs

### Design
- All view/window constructors accept \metadata_controller: MetadataController | None = None\
- If \None\, fallback to \MetadataController.instance()\ (zero breakage)
- Controllers/utils can keep using the singleton for now

### Quality Gates
- ✅ ruff — all checks passed
- ✅ mypy — no issues found
- ✅ pytest — 1064 passed, 12 skipped