### PR TITLE
Add metadata_refreshed/steam_db_updated signals and connect views

### DIFF
--- a/app/controllers/metadata_controller.py
+++ b/app/controllers/metadata_controller.py
@@ -46,6 +46,8 @@ class MetadataController(QObject):
     mod_deleted_signal = Signal(str)
     mod_metadata_updated_signal = Signal(str)
     show_warning_signal = Signal(str, str, str, str)
+    metadata_refreshed = Signal()
+    steam_db_updated = Signal()
 
     # ---- Lifecycle ----
 
@@ -146,6 +148,7 @@ class MetadataController(QObject):
             self.workshop_acf_data = {}
 
         self._invalidate_caches()
+        self.metadata_refreshed.emit()
 
     @Slot()
     def reset_paths(self) -> None:
@@ -674,6 +677,19 @@ class MetadataController(QObject):
 
         self._invalidate_caches()
 
+    def notify_files_deleted(self, mod_path: str) -> None:
+        """Clean up metadata after a mod's files have been deleted externally.
+
+        Removes the mod from the in-memory metadata cache and invalidates
+        caches. Does not touch aux DB or filesystem — the caller is
+        responsible for those.
+
+        :param mod_path: The mod path key to remove from metadata
+        """
+        self.metadata_mediator.mods_metadata.pop(mod_path, None)
+        self._invalidate_caches()
+        self.mod_deleted_signal.emit(mod_path)
+
     def set_steam_db_blacklist(
         self,
         published_file_id: str,
@@ -704,7 +720,10 @@ class MetadataController(QObject):
         else:
             entry.blacklist = SteamDbEntryBlacklist()
 
-        return self._persist_steam_db()
+        result = self._persist_steam_db()
+        if result:
+            self.steam_db_updated.emit()
+        return result
 
     # ---- Private helpers ----
 

--- a/app/views/deletion_menu.py
+++ b/app/views/deletion_menu.py
@@ -486,8 +486,10 @@ class ModDeletionMenu(QMenu):
             return
 
         try:
-            logger.debug(f"Emitting mod_deleted_signal for {mod_metadata['uuid']}")
-            self.metadata_controller.mod_deleted_signal.emit(mod_metadata["uuid"])
+            mod_path = mod_metadata.get("path") or mod_metadata.get("uuid")
+            if mod_path:
+                logger.debug(f"Notifying MetadataController of deleted mod: {mod_path}")
+                self.metadata_controller.notify_files_deleted(mod_path)
             logger.debug(f"Removing UUID {mod_metadata['uuid']} from tracking list")
             self.remove_from_uuids.remove(mod_metadata["uuid"])
         except (ValueError, AttributeError) as uuid_error:

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -281,6 +281,7 @@ class MainContent(QObject):
         self.metadata_controller.mod_metadata_updated_signal.connect(
             self.mods_panel.on_mod_metadata_updated
         )
+        self.metadata_controller.metadata_refreshed.connect(self._on_metadata_refreshed)
         self.mods_panel.active_mods_list.key_press_signal.connect(
             self.__handle_active_mod_key_press
         )
@@ -325,6 +326,7 @@ class MainContent(QObject):
         self._extract_progress_widget: Optional[TaskProgressWindow] = None
         self.window_manager = WindowManager(self.metadata_controller)
         self._active_loading_loop: QEventLoop | None = None
+        self._refresh_in_progress: bool = False
 
     @classmethod
     def instance(cls, *args: Any, **kwargs: Any) -> "MainContent":
@@ -333,6 +335,20 @@ class MainContent(QObject):
         elif args or kwargs:
             raise ValueError("MainContent instance has already been initialized.")
         return cls._instance
+
+    @Slot()
+    def _on_metadata_refreshed(self) -> None:
+        """Handle metadata refreshes triggered outside the main refresh flow.
+
+        When ``_refresh_in_progress`` is True, the main ``_do_refresh`` flow is
+        already handling repopulation explicitly (so this is a no-op).
+        When False — e.g. from ``do_metadata_refresh_cache`` — we repopulate
+        the mod lists here so the UI reflects the updated metadata.
+        """
+        if self._refresh_in_progress:
+            return
+        self.__repopulate_lists()
+        self.mods_panel.refresh_all_tag_filter_selectors()
 
     def abort_loading(self) -> None:
         """Abort any in-progress loading animation by quitting its nested event loop.
@@ -825,6 +841,7 @@ class MainContent(QObject):
         # Check if paths are set
         if self.check_if_essential_paths_are_set(prompt=is_initial):
             # Run expensive calculations to set cache data
+            self._refresh_in_progress = True
             result = self.do_threaded_loading_animation(
                 gif_path=str(
                     AppInfo().theme_data_folder / "default-icons" / "rimsort.gif"
@@ -834,6 +851,7 @@ class MainContent(QObject):
                 ),
                 text=self.tr("Scanning mod sources and populating metadata..."),
             )
+            self._refresh_in_progress = False
 
             # If loading was aborted (e.g. window closed during scan), skip remaining work
             if result is None and self.metadata_controller.is_abort_requested:

--- a/app/windows/base_mods_panel.py
+++ b/app/windows/base_mods_panel.py
@@ -157,6 +157,9 @@ class BaseModsPanel(QWidget):
         else:
             self.metadata_controller = MetadataController.instance()
         self.settings = self.metadata_controller.settings
+        self.metadata_controller.metadata_refreshed.connect(
+            self._populate_from_metadata
+        )
 
     def _get_steam_client_integration_enabled(self) -> bool:
         """
@@ -1088,12 +1091,12 @@ class BaseModsPanel(QWidget):
         Refreshes the metadata cache and repopulates the table.
 
         This refreshes the metadata cache and repopulates the table with the updated mod data.
+        ``_populate_from_metadata`` is triggered automatically via
+        ``metadata_refreshed`` signal.
         """
         logger.warning("Refreshing metadata and repopulating table")
         # Refresh the metadata to reflect deletion changes
         self.metadata_controller.refresh_metadata()
-        # Repopulate the table with updated data
-        self._populate_from_metadata()
 
     def get_button_factory(self) -> ButtonFactory:
         """Get a button factory instance for this panel."""

--- a/app/windows/rule_editor_panel.py
+++ b/app/windows/rule_editor_panel.py
@@ -1118,8 +1118,8 @@ class RuleEditor(QWidget):
         else:
             raise ValueError(f"Invalid rule source: {rules_source}")
         self.update_database_signal.emit([rules_source, metadata])
-        # Ensure metadata and UI are refreshed after saving
-        self.metadata_controller.refresh_metadata()
+        # The signal handler (_do_update_rules_database) handles disk write and
+        # refreshes metadata via _do_refresh after the user confirms.
         self._clear_widget()
         self._populate_from_metadata()
 

--- a/tests/views/test_deletion_menu.py
+++ b/tests/views/test_deletion_menu.py
@@ -276,17 +276,13 @@ class TestModDeletionMenu:
         # Setup remove_from_uuids list to include the path (since path = uuid)
         deletion_menu.remove_from_uuids = [mod_path]
 
-        # Patch the mod_deleted_signal.emit method to track calls
-        with patch.object(
-            mock_metadata_controller.mod_deleted_signal, "emit"
-        ) as mock_emit:
-            deletion_menu._handle_uuid_removal(mod_metadata)
+        deletion_menu._handle_uuid_removal(mod_metadata)
 
-            # Assert that the UUID was set to the path
-            assert mod_metadata["uuid"] == mod_path
+        # Assert that the UUID was set to the path
+        assert mod_metadata["uuid"] == mod_path
 
-            # Assert that mod_deleted_signal.emit was called with the path
-            mock_emit.assert_called_once_with(mod_path)
+        # Assert that notify_files_deleted was called with the path
+        mock_metadata_controller.notify_files_deleted.assert_called_once_with(mod_path)
 
-            # Assert that the UUID was removed from remove_from_uuids
-            assert mod_path not in deletion_menu.remove_from_uuids
+        # Assert that the UUID was removed from remove_from_uuids
+        assert mod_path not in deletion_menu.remove_from_uuids


### PR DESCRIPTION
Phase 2: Add \`metadata_refreshed\` and \`steam_db_updated\` signals to \`MetadataController\`, emitted after \`refresh_metadata()\` and \`set_steam_db_blacklist()\` respectively.

Phase 3: Connect views to \`metadata_refreshed\` signal:
- \`MainContent._on_metadata_refreshed\` repopulates mod lists and refreshes tag filters (with \`_refresh_in_progress\` guard to prevent double-work in \`_do_refresh\`)
- \`BaseModsPanel._populate_from_metadata\` refreshes its table automatically

Additional fixes:
- New \`MetadataController.notify_files_deleted()\` for clean post-delete metadata cleanup (fixes stale mods_metadata entries from deletion_menu.py)
- \`deletion_menu.py\` now calls \`notify_files_deleted\` instead of emitting \`mod_deleted_signal\` directly
- Remove redundant \`refresh_metadata()\` call in \`rule_editor._save_editor_rules\` (disk write and refresh already handled by \`_do_update_rules_database\`)
- Fix test to verify \`notify_files_deleted\` call

Files: +56/-18 across 6 files" 2>&1