### PR TITLE
Remove inactive mods sorting toggle

### DIFF
--- a/app/controllers/settings_tabs/sorting_tab_controller.py
+++ b/app/controllers/settings_tabs/sorting_tab_controller.py
@@ -51,9 +51,6 @@ class SortingTabController(BaseTabController):
         self.dialog.hide_invalid_mods_when_filtering_checkbox.setChecked(
             self.settings.hide_invalid_mods_when_filtering
         )
-        self.dialog.inactive_mods_sorting_checkbox.setChecked(
-            self.settings.inactive_mods_sorting
-        )
         self.dialog.save_inactive_mods_sort_state_checkbox.setChecked(
             self.settings.save_inactive_mods_sort_state
         )
@@ -82,9 +79,6 @@ class SortingTabController(BaseTabController):
         )
         self.settings.hide_invalid_mods_when_filtering = (
             self.dialog.hide_invalid_mods_when_filtering_checkbox.isChecked()
-        )
-        self.settings.inactive_mods_sorting = (
-            self.dialog.inactive_mods_sorting_checkbox.isChecked()
         )
         self.settings.save_inactive_mods_sort_state = (
             self.dialog.save_inactive_mods_sort_state_checkbox.isChecked()

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -123,8 +123,6 @@ class Settings(QObject):
         self.mod_type_filter: bool = True
         # Whether to hide invalid mods
         self.hide_invalid_mods_when_filtering: bool = False
-        # Whether to enable inactive mods sorting options
-        self.inactive_mods_sorting: bool = True
         # Inactive mods sort state saving
         self.save_inactive_mods_sort_state: bool = False
         self.inactive_mods_sort_key: str = "FILESYSTEM_MODIFIED_TIME"

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -550,14 +550,9 @@ class MainContent(QObject):
         # Restore dividers into the active list
         if saved_dividers:
             self.mods_panel.active_mods_list.restore_dividers(saved_dividers)
-        # Determine sort key and descending for inactive mods
-        if self.settings.inactive_mods_sorting:
-            # Use current UI state from the combobox and button
-            sort_key = ModsPanelSortKey[self.mods_panel.inactive_mods_sort_key]
-            descending = self.mods_panel.inactive_sort_descending
-        else:
-            sort_key = ModsPanelSortKey.FILESYSTEM_MODIFIED_TIME
-            descending = True
+        # Use current UI state from the combobox and button for inactive mods.
+        sort_key = ModsPanelSortKey[self.mods_panel.inactive_mods_sort_key]
+        descending = self.mods_panel.inactive_sort_descending
         self.mods_panel.inactive_mods_list.recreate_mod_list_and_sort(
             list_type="inactive",
             uuids=inactive_mods_uuids,

--- a/app/views/mod_info_panel.py
+++ b/app/views/mod_info_panel.py
@@ -703,11 +703,8 @@ class ModInfoPanel:
     def _set_folder_size_info(self, uuid: str) -> None:
         """Set folder size information using optimized calculation."""
         try:
-            if self.settings.inactive_mods_sorting:
-                size_bytes = path_to_folder_size(uuid)
-                self.mod_info_folder_size_value.setText(format_file_size(size_bytes))
-            else:
-                self.mod_info_folder_size_value.setText("Not available")
+            size_bytes = path_to_folder_size(uuid)
+            self.mod_info_folder_size_value.setText(format_file_size(size_bytes))
         except Exception as e:
             logger.error(f"Error calculating folder size for UUID {uuid}: {e}")
             self.mod_info_folder_size_value.setText("Not available")
@@ -729,11 +726,7 @@ class ModInfoPanel:
 
     def _set_filesystem_time_info(self, mod_path: str | None) -> None:
         """Set filesystem modification time information."""
-        if (
-            self.settings.inactive_mods_sorting
-            and mod_path
-            and os.path.exists(mod_path)
-        ):
+        if mod_path and os.path.exists(mod_path):
             try:
                 fs_time = int(os.path.getmtime(mod_path))
                 self._set_timestamp_info(

--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -489,11 +489,10 @@ class ModListItemInner(QWidget):
         # Add folder size and filesystem modification time information without heavy IO on hover
         # Folder size: read from in-memory cache only; avoid computing on tooltip
         folder_size_line = "Folder Size: Not available\n"
-        if self.settings.inactive_mods_sorting:
-            if mod is not None and mod.mod_path is not None:
-                cached = _FOLDER_SIZE_CACHE.get(str(mod.mod_path))
-                if cached:
-                    folder_size_line = f"Folder Size: {format_file_size(cached[1])}\n"
+        if mod is not None and mod.mod_path is not None:
+            cached = _FOLDER_SIZE_CACHE.get(str(mod.mod_path))
+            if cached:
+                folder_size_line = f"Folder Size: {format_file_size(cached[1])}\n"
 
         # Filesystem modified time: prefer cached metadata value
         fs_time_val = mod.internal_time_touched if mod is not None else None
@@ -3613,18 +3612,13 @@ class ModListWidget(QListWidget):
         Returns:
             None
         """
-        filtering = self.settings.inactive_mods_sorting
-
-        if filtering:
-            sorted_uuids = sort_paths(
-                uuids,
-                key=key,
-                descending=descending,
-                settings=self.settings,
-            )
-            self.recreate_mod_list(list_type, sorted_uuids, filtering=filtering)
-        else:
-            self.recreate_mod_list(list_type, uuids)
+        sorted_uuids = sort_paths(
+            uuids,
+            key=key,
+            descending=descending,
+            settings=self.settings,
+        )
+        self.recreate_mod_list(list_type, sorted_uuids, filtering=True)
 
     def recreate_mod_list(
         self, list_type: str, uuids: list[str], filtering: bool = False
@@ -3639,11 +3633,7 @@ class ModListWidget(QListWidget):
         # Skip sorting if UUIDs are already filtered/sorted (filtering=True)
         if not filtering:
             # Sort inactive mods using saved settings if enabled
-            if (
-                list_type == "Inactive"
-                and self.settings.save_inactive_mods_sort_state
-                and self.settings.inactive_mods_sorting
-            ):
+            if list_type == "Inactive" and self.settings.save_inactive_mods_sort_state:
                 sort_key = ModsPanelSortKey[self.settings.inactive_mods_sort_key]
                 descending = self.settings.inactive_mods_sort_descending
                 uuids = sort_paths(
@@ -3962,10 +3952,7 @@ class ModsPanel(QWidget):
         self.settings = settings
 
         # Load inactive mods sort settings
-        if (
-            self.settings.inactive_mods_sorting
-            and self.settings.save_inactive_mods_sort_state
-        ):
+        if self.settings.save_inactive_mods_sort_state:
             self.inactive_mods_sort_key = self.settings.inactive_mods_sort_key
             self.inactive_mods_sort_descending = (
                 self.settings.inactive_mods_sort_descending
@@ -4329,11 +4316,6 @@ class ModsPanel(QWidget):
         )
         self.inactive_mods_search_layout.addWidget(self.inactive_mods_sort_order_button)
 
-        # Set initial visibility based on settings
-        if self.settings.inactive_mods_sorting:
-            self.inactive_mods_sort_combobox.setVisible(True)
-            self.inactive_mods_sort_order_button.setVisible(True)
-
     def connect_signals(self) -> None:
         self.active_mods_list.list_update_signal.connect(
             self.on_active_mods_list_updated
@@ -4374,18 +4356,14 @@ class ModsPanel(QWidget):
         )
 
         # Save if enabled
-        if (
-            self.settings.inactive_mods_sorting
-            and self.settings.save_inactive_mods_sort_state
-        ):
+        if self.settings.save_inactive_mods_sort_state:
             self.settings.inactive_mods_sort_descending = self.inactive_sort_descending
             self.settings.save()
 
         # Apply updated sort direction - re-sort with new descending flag
-        if self.settings.inactive_mods_sorting:
-            current_text = self.inactive_mods_sort_combobox.currentText()
-            # Re-sort list with updated descending flag
-            self.on_inactive_mods_sort_changed(current_text)
+        current_text = self.inactive_mods_sort_combobox.currentText()
+        # Re-sort list with updated descending flag
+        self.on_inactive_mods_sort_changed(current_text)
 
     @Slot(int, int)
     def _on_folder_size_progress(self, current: int, total: int) -> None:
@@ -4549,10 +4527,6 @@ class ModsPanel(QWidget):
         Args:
             text: The selected sort option text from the combobox
         """
-        # Check if inactive mods sorting is enabled
-        if not self.settings.inactive_mods_sorting:
-            return
-
         # Prefer the enum stored in the combobox itemData (userData). This is
         # robust across locales and reordering. Fall back to the text->enum map
         # if no userData is available.
@@ -4612,10 +4586,7 @@ class ModsPanel(QWidget):
                 self._sort_debounce_timer.start(200)
 
                 # Save the sort key immediately if enabled
-                if (
-                    self.settings.inactive_mods_sorting
-                    and self.settings.save_inactive_mods_sort_state
-                ):
+                if self.settings.save_inactive_mods_sort_state:
                     self.settings.inactive_mods_sort_key = sort_key.name
                     self.settings.save()
                 self.inactive_mods_sort_key = sort_key.name

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -826,35 +826,19 @@ This basically preserves your mod coloring, user notes etc. for this many second
         )
 
         # Inactive mods sorting group
-        self.inactive_mods_sorting_group_box = QGroupBox()
-        tab_layout.addWidget(self.inactive_mods_sorting_group_box)
+        self.inactive_mods_sort_group_box = QGroupBox()
+        tab_layout.addWidget(self.inactive_mods_sort_group_box)
 
-        inactive_mods_sorting_group_box_layout = QVBoxLayout()
-        self.inactive_mods_sorting_group_box.setLayout(
-            inactive_mods_sorting_group_box_layout
-        )
+        inactive_mods_sort_group_box_layout = QVBoxLayout()
+        self.inactive_mods_sort_group_box.setLayout(inactive_mods_sort_group_box_layout)
 
-        inactive_mods_sorting_label = self._make_section_label("Inactive Mods Sorting")
-        inactive_mods_sorting_group_box_layout.addWidget(inactive_mods_sorting_label)
-
-        # Inactive mods sorting options checkbox
-        self.inactive_mods_sorting_checkbox = QCheckBox(
-            self.tr("Enable inactive mods sorting")
-        )
-        self.inactive_mods_sorting_checkbox.setToolTip(
-            self.tr(
-                "Additional options like name, author, folder size, modified date will be available in the mods panel for sorting inactive mods \n"
-                "Disabling this can improve performance by avoiding heavy calculations."
-            )
-        )
-        inactive_mods_sorting_group_box_layout.addWidget(
-            self.inactive_mods_sorting_checkbox
-        )
+        inactive_mods_sort_label = self._make_section_label("Inactive Mods Sorting")
+        inactive_mods_sort_group_box_layout.addWidget(inactive_mods_sort_label)
 
         self.save_inactive_mods_sort_state_checkbox = QCheckBox(
             self.tr("Save inactive mods sort state")
         )
-        inactive_mods_sorting_group_box_layout.addWidget(
+        inactive_mods_sort_group_box_layout.addWidget(
             self.save_inactive_mods_sort_state_checkbox
         )
 

--- a/locales/de_DE.ts
+++ b/locales/de_DE.ts
@@ -4415,16 +4415,6 @@ z. B. (modDependenciesByVersion, LoadAfterByVersion, LoadBeforeByVersion, inkomp
         <translation>Versteckt ungültige Mods, deren Aktivierung wird nicht empfohlen</translation>
     </message>
     <message>
-        <source>Enable inactive mods sorting</source>
-        <translation>Aktivieren Sie die Sortierung inaktiver Mods</translation>
-    </message>
-    <message>
-        <source>Additional options like name, author, folder size, modified date will be available in the mods panel for sorting inactive mods 
-Disabling this can improve performance by avoiding heavy calculations.</source>
-        <translation>Im Mods-Bereich stehen zusätzliche Optionen wie Name, Autor, Ordnergröße und Änderungsdatum zum Sortieren inaktiver Mods zur Verfügung 
-Wenn Sie dies deaktivieren, kann die Leistung verbessert werden, da aufwändige Berechnungen vermieden werden.</translation>
-    </message>
-    <message>
         <source>Save inactive mods sort state</source>
         <translation>Sortierstatus inaktiver Mods speichern</translation>
     </message>

--- a/locales/en_US.ts
+++ b/locales/en_US.ts
@@ -4313,15 +4313,6 @@ e.g.(modDependenciesByVersion, loadAfterByVersion, loadBeforeByVersion, incompat
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enable inactive mods sorting</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Additional options like name, author, folder size, modified date will be available in the mods panel for sorting inactive mods 
-Disabling this can improve performance by avoiding heavy calculations.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Save inactive mods sort state</source>
         <translation type="unfinished"></translation>
     </message>

--- a/locales/es_ES.ts
+++ b/locales/es_ES.ts
@@ -4407,16 +4407,6 @@ por ejemplo (modDependenciesByVersion, loadAfterByVersion, loadBeforeByVersion, 
         <translation>Oculta modificaciones no válidas, no se recomienda habilitarlas</translation>
     </message>
     <message>
-        <source>Enable inactive mods sorting</source>
-        <translation>Habilitar la clasificación de mods inactivos</translation>
-    </message>
-    <message>
-        <source>Additional options like name, author, folder size, modified date will be available in the mods panel for sorting inactive mods 
-Disabling this can improve performance by avoiding heavy calculations.</source>
-        <translation>Opciones adicionales como nombre, autor, tamaño de carpeta y fecha de modificación estarán disponibles en el panel de modificaciones para ordenar modificaciones inactivas. 
-Deshabilitar esto puede mejorar el rendimiento al evitar cálculos pesados.</translation>
-    </message>
-    <message>
         <source>Save inactive mods sort state</source>
         <translation>Guardar estado de clasificación de mods inactivos</translation>
     </message>

--- a/locales/fr_FR.ts
+++ b/locales/fr_FR.ts
@@ -4524,16 +4524,6 @@ par exemple (modDependenciesByVersion,loadAfterByVersion,loadBeforeByVersion, in
         <translation>Hides invalid mods, not recommended to enable</translation>
     </message>
     <message>
-        <source>Enable inactive mods sorting</source>
-        <translation>Enable inactive mods sorting</translation>
-    </message>
-    <message>
-        <source>Additional options like name, author, folder size, modified date will be available in the mods panel for sorting inactive mods 
-Disabling this can improve performance by avoiding heavy calculations.</source>
-        <translation>Des options supplémentaires telles que le nom, l'auteur, la taille du dossier et la date de modification seront disponibles dans le panneau des mods pour trier les mods inactifs. 
-La désactivation de cette option peut améliorer les performances en évitant des calculs lourds.</translation>
-    </message>
-    <message>
         <source>Save inactive mods sort state</source>
         <translation>Enregistrer l'état de tri des mods inactifs</translation>
     </message>

--- a/locales/ja_JP.ts
+++ b/locales/ja_JP.ts
@@ -4431,16 +4431,6 @@ e.g.(modDependenciesByVersion, loadAfterByVersion, loadBeforeByVersion, incompat
         <translation>無効な MOD を非表示にします。有効にすることはお勧めしません</translation>
     </message>
     <message>
-        <source>Enable inactive mods sorting</source>
-        <translation>非アクティブなMODのソートを有効にする</translation>
-    </message>
-    <message>
-        <source>Additional options like name, author, folder size, modified date will be available in the mods panel for sorting inactive mods 
-Disabling this can improve performance by avoiding heavy calculations.</source>
-        <translation>名前、作成者、フォルダーのサイズ、変更日などの追加オプションが、非アクティブな MOD を並べ替えるための MOD パネルで利用可能になります。 
-これを無効にすると、大量の計算が回避され、パフォーマンスが向上します。</translation>
-    </message>
-    <message>
         <source>Save inactive mods sort state</source>
         <translation>非アクティブなMODのソート状態を保存する</translation>
     </message>

--- a/locales/ko_KR.ts
+++ b/locales/ko_KR.ts
@@ -4431,16 +4431,6 @@ e.g.(modDependenciesByVersion, loadAfterByVersion, loadBeforeByVersion, incompat
         <translation>유효하지 않은 모드를 숨깁니다. 활성화하는 것을 권장하지 않습니다.</translation>
     </message>
     <message>
-        <source>Enable inactive mods sorting</source>
-        <translation>비활성 모드 정렬 활성화</translation>
-    </message>
-    <message>
-        <source>Additional options like name, author, folder size, modified date will be available in the mods panel for sorting inactive mods 
-Disabling this can improve performance by avoiding heavy calculations.</source>
-        <translation>이름, 제작자, 폴더 크기, 수정 날짜 등의 추가 옵션을 비활성 모드 정렬을 위한 모드 패널에서 사용할 수 있게 됩니다. 
-이 기능을 비활성화하면 대량의 계산을 방지하여 성능이 향상됩니다.</translation>
-    </message>
-    <message>
         <source>Save inactive mods sort state</source>
         <translation>비활성 모드 정렬 상태 저장</translation>
     </message>

--- a/locales/pt_BR.ts
+++ b/locales/pt_BR.ts
@@ -4435,16 +4435,6 @@ por exemplo (modDependenciesByVersion, loadAfterByVersion, loadBeforeByVersion, 
         <translation>Oculta mods inválidos, não recomendado para ativar</translation>
     </message>
     <message>
-        <source>Enable inactive mods sorting</source>
-        <translation>Ativar classificação de mods inativos</translation>
-    </message>
-    <message>
-        <source>Additional options like name, author, folder size, modified date will be available in the mods panel for sorting inactive mods 
-Disabling this can improve performance by avoiding heavy calculations.</source>
-        <translation>Opções adicionais como nome, autor, tamanho da pasta e data de modificação estarão disponíveis no painel de mods para classificar mods inativos 
-Desabilitar isso pode melhorar o desempenho, evitando cálculos pesados.</translation>
-    </message>
-    <message>
         <source>Save inactive mods sort state</source>
         <translation>Salvar estado de classificação de mods inativos</translation>
     </message>

--- a/locales/ru_RU.ts
+++ b/locales/ru_RU.ts
@@ -4429,16 +4429,6 @@ e.g.(modDependenciesByVersion, loadAfterByVersion, loadBeforeByVersion, incompat
         <translation>Скрывает недействительные моды, не рекомендуется включать.</translation>
     </message>
     <message>
-        <source>Enable inactive mods sorting</source>
-        <translation>Включить сортировку неактивных модов</translation>
-    </message>
-    <message>
-        <source>Additional options like name, author, folder size, modified date will be available in the mods panel for sorting inactive mods 
-Disabling this can improve performance by avoiding heavy calculations.</source>
-        <translation>Дополнительные параметры, такие как имя, автор, размер папки, дата изменения, будут доступны на панели модов для сортировки неактивных модов. 
-Отключение этого параметра может повысить производительность, избегая тяжелых вычислений.</translation>
-    </message>
-    <message>
         <source>Save inactive mods sort state</source>
         <translation>Сохранить состояние сортировки неактивных модов</translation>
     </message>

--- a/locales/tr_TR.ts
+++ b/locales/tr_TR.ts
@@ -4413,16 +4413,6 @@ Eşleşen bir sürüm etiketi mevcut ancak boşsa temel etiket dikkate alınmaz.
         <translation>Geçersiz modları gizler, etkinleştirilmesi önerilmez</translation>
     </message>
     <message>
-        <source>Enable inactive mods sorting</source>
-        <translation>Etkin olmayan modların sıralamasını etkinleştir</translation>
-    </message>
-    <message>
-        <source>Additional options like name, author, folder size, modified date will be available in the mods panel for sorting inactive mods 
-Disabling this can improve performance by avoiding heavy calculations.</source>
-        <translation>Etkin olmayan modları sıralamak için ad, yazar, klasör boyutu, değiştirilme tarihi gibi ek seçenekler mod panelinde mevcut olacak 
-Bunu devre dışı bırakmak, ağır hesaplamalardan kaçınarak performansı artırabilir.</translation>
-    </message>
-    <message>
         <source>Save inactive mods sort state</source>
         <translation>Etkin olmayan modların sıralama durumunu kaydet</translation>
     </message>

--- a/locales/zh_CN.ts
+++ b/locales/zh_CN.ts
@@ -4445,16 +4445,6 @@ e.g.(modDependenciesByVersion, loadAfterByVersion, loadBeforeByVersion, incompat
         <translation>隐藏无效模组，不建议启用</translation>
     </message>
     <message>
-        <source>Enable inactive mods sorting</source>
-        <translation>开启未启用模组排序</translation>
-    </message>
-    <message>
-        <source>Additional options like name, author, folder size, modified date will be available in the mods panel for sorting inactive mods 
-Disabling this can improve performance by avoiding heavy calculations.</source>
-        <translation>在模组面板中将提供额外选项，如名称、作者、文件夹大小、修改日期，用于对未启用的模组进行排序
-禁用此选项可通过避免大量计算来提升性能。</translation>
-    </message>
-    <message>
         <source>Save inactive mods sort state</source>
         <translation>保存未启用模组排序状态</translation>
     </message>

--- a/locales/zh_TW.ts
+++ b/locales/zh_TW.ts
@@ -4434,16 +4434,6 @@ e.g.(modDependenciesByVersion, loadAfterByVersion, loadBeforeByVersion, incompat
         <translation>隱藏無效模組，不建議啟用</translation>
     </message>
     <message>
-        <source>Enable inactive mods sorting</source>
-        <translation>啟用未啟用模組排序</translation>
-    </message>
-    <message>
-        <source>Additional options like name, author, folder size, modified date will be available in the mods panel for sorting inactive mods 
-Disabling this can improve performance by avoiding heavy calculations.</source>
-        <translation>在模組面板中將提供額外選項，如名稱、作者、資料夾大小、修改日期，用於對未啟用的模組進行排序
-禁用此選項可通過避免大量計算來提升性能。</translation>
-    </message>
-    <message>
         <source>Save inactive mods sort state</source>
         <translation>保存未啟用模組排序狀態</translation>
     </message>

--- a/tests/controllers/settings_tabs/test_sorting_tab_controller.py
+++ b/tests/controllers/settings_tabs/test_sorting_tab_controller.py
@@ -37,13 +37,15 @@ class TestSortingTabUpdateView:
         controller, settings, dialog = sorting_tab
         settings.try_download_missing_mods = True
         settings.duplicate_mods_warning = False
-        settings.inactive_mods_sorting = False
+        settings.save_inactive_mods_sort_state = False
 
         controller.update_view_from_model()
 
         dialog.download_missing_mods_checkbox.setChecked.assert_called_with(True)
         dialog.show_duplicate_mods_warning_checkbox.setChecked.assert_called_with(False)
-        dialog.inactive_mods_sorting_checkbox.setChecked.assert_called_with(False)
+        dialog.save_inactive_mods_sort_state_checkbox.setChecked.assert_called_with(
+            False
+        )
 
     def test_if_guarded_checkboxes_only_set_when_true(
         self, sorting_tab: tuple[SortingTabController, Settings, MagicMock]
@@ -102,7 +104,6 @@ class TestSortingTabUpdateModel:
         dialog.download_missing_mods_checkbox.isChecked.return_value = False
         dialog.show_duplicate_mods_warning_checkbox.isChecked.return_value = True
         dialog.hide_invalid_mods_when_filtering_checkbox.isChecked.return_value = True
-        dialog.inactive_mods_sorting_checkbox.isChecked.return_value = False
         dialog.save_inactive_mods_sort_state_checkbox.isChecked.return_value = True
 
         controller.update_model_from_view()
@@ -114,5 +115,4 @@ class TestSortingTabUpdateModel:
         assert settings.try_download_missing_mods is False
         assert settings.duplicate_mods_warning is True
         assert settings.hide_invalid_mods_when_filtering is True
-        assert settings.inactive_mods_sorting is False
         assert settings.save_inactive_mods_sort_state is True


### PR DESCRIPTION
Inactive mods sorting no longer depends on a separate settings flag.

The sort controls remain available, list rebuilds always apply the current inactive sort state, and saved inactive sort preferences continue to work independently.

Also removes the obsolete settings checkbox and stale translation entries, and updates the sorting tab controller tests.