### PR TITLE
Add tag match mode filter toggle

### DIFF
--- a/app/models/filter_state.py
+++ b/app/models/filter_state.py
@@ -12,12 +12,14 @@ class FilterState:
     :param sources: Set of enabled mod sources (workshop, local, expansion, steamcmd, git_repo)
     :param mod_type: Mod type filter ("all", "csharp", or "xml")
     :param tags: Set of selected tags to filter by
+    :param tag_match_mode: Tag matching mode ("or" to match any tag, "and" to match all tags)
     :param include_no_tags: Whether to include mods with no tags assigned
     """
 
     sources: set[str] = field(default_factory=lambda: set(FilterState.ALL_SOURCES))
     mod_type: str = "all"
     tags: set[str] = field(default_factory=set)
+    tag_match_mode: str = "or"
     include_no_tags: bool = False
 
     ALL_SOURCES: ClassVar[frozenset[str]] = frozenset(
@@ -61,3 +63,27 @@ class FilterState:
         if self.tags or self.include_no_tags:
             count += 1
         return count
+
+    def matches_tags(self, mod_tags: set[str]) -> bool:
+        """
+        Check whether a mod's tags match the active tag filter.
+
+        The "No tags" filter is additive: when enabled, untagged mods match
+        regardless of the selected named tag mode.
+
+        :param mod_tags: Tags assigned to the mod
+        :return: True if the mod matches the tag filter
+        """
+        if not self.tags and not self.include_no_tags:
+            return True
+
+        if self.include_no_tags and len(mod_tags) == 0:
+            return True
+
+        if not self.tags:
+            return False
+
+        if self.tag_match_mode == "and":
+            return self.tags.issubset(mod_tags)
+
+        return bool(mod_tags.intersection(self.tags))

--- a/app/views/filter_panel.py
+++ b/app/views/filter_panel.py
@@ -308,6 +308,11 @@ class FilterPanel(QFrame):
         "xml": "XML-only",
     }
 
+    TAG_MATCH_MODE_LABELS: dict[str, str] = {
+        "or": "Any",
+        "and": "All",
+    }
+
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent, Qt.WindowType.Popup)
         self.setObjectName("FilterPanel")
@@ -315,6 +320,7 @@ class FilterPanel(QFrame):
 
         self._source_checkboxes: dict[str, QCheckBox] = {}
         self._type_radios: dict[str, QRadioButton] = {}
+        self._tag_match_mode_radios: dict[str, QRadioButton] = {}
         self._tag_chips: dict[str, TagChip] = {}
 
         main_layout = QVBoxLayout()
@@ -374,6 +380,18 @@ class FilterPanel(QFrame):
         tags_label = QLabel("Tags")
         tags_label.setFont(header_font)
         tags_header_row.addWidget(tags_label)
+        self._tag_match_mode_group = QButtonGroup(self)
+        for key, label in self.TAG_MATCH_MODE_LABELS.items():
+            rb = QRadioButton(label)
+            rb.setToolTip(
+                "Match any selected tag" if key == "or" else "Match all selected tags"
+            )
+            if key == "or":
+                rb.setChecked(True)
+            rb.toggled.connect(self._on_filter_changed)
+            self._tag_match_mode_radios[key] = rb
+            self._tag_match_mode_group.addButton(rb)
+            tags_header_row.addWidget(rb)
         tags_header_row.addStretch()
 
         self._select_all_label = QLabel("Select All")
@@ -496,12 +514,19 @@ class FilterPanel(QFrame):
             if key != "__no_tags__" and chip.active:
                 tags.add(key)
 
+        tag_match_mode = "or"
+        for key, rb in self._tag_match_mode_radios.items():
+            if rb.isChecked():
+                tag_match_mode = key
+                break
+
         include_no_tags = self._no_tags_chip.active
 
         return FilterState(
             sources=sources,
             mod_type=mod_type,
             tags=tags,
+            tag_match_mode=tag_match_mode,
             include_no_tags=include_no_tags,
         )
 
@@ -522,6 +547,11 @@ class FilterPanel(QFrame):
             rb.blockSignals(True)
             if key == "all":
                 rb.setChecked(True)
+            rb.blockSignals(False)
+
+        for key, rb in self._tag_match_mode_radios.items():
+            rb.blockSignals(True)
+            rb.setChecked(key == "or")
             rb.blockSignals(False)
 
         for chip in self._tag_chips.values():

--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -4998,9 +4998,7 @@ class ModsPanel(QWidget):
             # User tag filtering (from FilterState)
             if not item_filtered and (fs.tags or fs.include_no_tags):
                 tags_set = set(item_data["mod_tags"])
-                matches_selected_tags = bool(tags_set.intersection(fs.tags))
-                matches_no_tags = fs.include_no_tags and len(tags_set) == 0
-                if not matches_selected_tags and not matches_no_tags:
+                if not fs.matches_tags(tags_set):
                     item_filtered = True
 
             # Check if the item should be filtered or hidden based on filter state

--- a/tests/models/test_filter_state.py
+++ b/tests/models/test_filter_state.py
@@ -12,6 +12,7 @@ class TestFilterState:
             sources={"workshop", "local"},
             mod_type="all",
             tags=set(),
+            tag_match_mode="or",
             include_no_tags=False,
         )
         assert state.has_active_filters()
@@ -22,6 +23,7 @@ class TestFilterState:
             sources=set(FilterState.ALL_SOURCES),
             mod_type="all",
             tags=set(),
+            tag_match_mode="or",
             include_no_tags=False,
         )
         assert not state.has_active_filters()
@@ -31,6 +33,7 @@ class TestFilterState:
             sources=set(FilterState.ALL_SOURCES),
             mod_type="csharp",
             tags=set(),
+            tag_match_mode="or",
             include_no_tags=False,
         )
         assert state.has_active_filters()
@@ -41,6 +44,7 @@ class TestFilterState:
             sources=set(FilterState.ALL_SOURCES),
             mod_type="all",
             tags={"Favorites"},
+            tag_match_mode="or",
             include_no_tags=False,
         )
         assert state.has_active_filters()
@@ -51,6 +55,7 @@ class TestFilterState:
             sources=set(FilterState.ALL_SOURCES),
             mod_type="all",
             tags=set(),
+            tag_match_mode="or",
             include_no_tags=True,
         )
         assert state.has_active_filters()
@@ -61,6 +66,7 @@ class TestFilterState:
             sources={"workshop"},
             mod_type="xml",
             tags={"Cosmetic"},
+            tag_match_mode="or",
             include_no_tags=False,
         )
         assert state.active_category_count() == 3
@@ -70,4 +76,25 @@ class TestFilterState:
         assert state.sources == FilterState.ALL_SOURCES
         assert state.mod_type == "all"
         assert state.tags == set()
+        assert state.tag_match_mode == "or"
         assert state.include_no_tags is False
+
+    def test_tag_match_or_mode_matches_any_selected_tag(self) -> None:
+        state = FilterState(tags={"milira", "expansion"}, tag_match_mode="or")
+        assert state.matches_tags({"milira", "patch"}) is True
+        assert state.matches_tags({"kiiro", "patch"}) is False
+
+    def test_tag_match_and_mode_matches_all_selected_tags(self) -> None:
+        state = FilterState(tags={"milira", "expansion"}, tag_match_mode="and")
+        assert state.matches_tags({"milira", "expansion"}) is True
+        assert state.matches_tags({"milira", "patch"}) is False
+
+    def test_tag_match_no_tags_is_additive(self) -> None:
+        state = FilterState(
+            tags={"milira", "expansion"},
+            tag_match_mode="and",
+            include_no_tags=True,
+        )
+        assert state.matches_tags(set()) is True
+        assert state.matches_tags({"milira", "expansion"}) is True
+        assert state.matches_tags({"milira"}) is False

--- a/tests/views/test_filter_panel.py
+++ b/tests/views/test_filter_panel.py
@@ -107,6 +107,7 @@ class TestFilterPanel:
         assert state.sources == FilterState.ALL_SOURCES
         assert state.mod_type == "all"
         assert state.tags == set()
+        assert state.tag_match_mode == "or"
         assert state.include_no_tags is False
         assert state.has_active_filters() is False
 
@@ -130,6 +131,12 @@ class TestFilterPanel:
         state = panel.filter_state
         assert "Favorites" in state.tags
 
+    def test_tag_match_mode_updates_state(self, panel: FilterPanel) -> None:
+        """Selecting All changes tag matching to AND mode."""
+        panel._tag_match_mode_radios["and"].setChecked(True)
+        state = panel.filter_state
+        assert state.tag_match_mode == "and"
+
     def test_no_tags_chip(self, panel: FilterPanel) -> None:
         """Activating the 'no tags' chip sets include_no_tags."""
         panel._no_tags_chip.set_active(True)
@@ -152,6 +159,7 @@ class TestFilterPanel:
         assert state.sources == FilterState.ALL_SOURCES
         assert state.mod_type == "all"
         assert state.tags == set()
+        assert state.tag_match_mode == "or"
         assert state.include_no_tags is False
 
     def test_filters_changed_signal_emitted(


### PR DESCRIPTION
Add an Any/All selector to the tag filter panel so users can choose whether selected tags are matched with OR or AND logic.

Preserve the existing Any/OR behavior as the default, and route tag matching through FilterState.matches_tags so the rule is shared and easy to test.

The No tags chip remains additive, allowing untagged mods to be included alongside named tag matches.

Update filter panel and filter state tests to cover default mode, AND mode selection, clear behavior, OR matching, AND matching, and No tags handling.