### PR TITLE
Make metadata_controller a required constructor param in views/windows

### DIFF
--- a/app/controllers/file_search_controller.py
+++ b/app/controllers/file_search_controller.py
@@ -594,6 +594,7 @@ class FileSearchController(QObject):
         self,
         settings: Settings,
         dialog: FileSearchDialog,
+        metadata_controller: MetadataController,
         active_mod_ids: Optional[set[str]] = None,
     ) -> None:
         """
@@ -602,22 +603,23 @@ class FileSearchController(QObject):
         Args:
             settings (Settings): Application settings instance.
             dialog (FileSearchDialog): The file search dialog UI component.
+            metadata_controller (MetadataController): Metadata controller instance.
             active_mod_ids (Optional[Set[str]]): Set of active mod IDs for filtering.
         """
         super().__init__()
         self.settings = settings
         self.dialog = dialog
+        self.metadata_controller = metadata_controller
         self.mods_panel = ModsPanel(
             settings=self.settings,
+            metadata_controller=metadata_controller,
         )
         self.active_mod_ids = (
             active_mod_ids or set()
         )  # This is used for the controller, not the worker
         self.search_results: list[SearchResult] = []
         self.search_worker: Optional[SearchWorker] = None
-        self.searcher = FileSearch()
-        # Initialize MetadataController
-        self.metadata_controller = MetadataController.instance()
+        self.searcher = FileSearch(metadata_controller=metadata_controller)
 
         # connect signals
         self.dialog.search_button.clicked.connect(self._on_search_clicked)
@@ -853,7 +855,7 @@ class FileSearchController(QObject):
             mod_ids (Optional[Set[str]]): Set of mod IDs for filtering.
             scope (str): Search scope ("active mods", "inactive mods", "all mods", etc.).
         """
-        self.searcher = FileSearch()
+        self.searcher = FileSearch(metadata_controller=self.metadata_controller)
 
         # Update the dialog's search paths
         self.dialog.set_search_paths(root_paths)

--- a/app/controllers/main_content_controller.py
+++ b/app/controllers/main_content_controller.py
@@ -11,6 +11,7 @@ from loguru import logger
 from PySide6.QtCore import QObject, QThreadPool, Slot
 from PySide6.QtWidgets import QInputDialog, QMessageBox
 
+from app.controllers.metadata_controller import MetadataController
 from app.controllers.metadata_db_controller import AuxMetadataController
 from app.models.metadata.metadata_db import Base
 from app.models.settings import Settings
@@ -71,10 +72,16 @@ if TYPE_CHECKING:
 class MainContentController(QObject):
     """Controller with concurrent checking/updating and improved structure."""
 
-    def __init__(self, view: MainContent, settings: Settings) -> None:
+    def __init__(
+        self,
+        view: MainContent,
+        settings: Settings,
+        metadata_controller: MetadataController,
+    ) -> None:
         super().__init__()
         self.view = view
         self.settings = settings
+        self.metadata_controller = metadata_controller
         self._git_clone_worker: Optional[GitCloneWorker] = None
         self._git_push_worker: Optional[GitPushWorker] = None
         self._git_stage_commit_worker: Optional[GitStageCommitWorker] = None
@@ -352,7 +359,9 @@ class MainContentController(QObject):
             self._github_mods_panel.close()
             self._github_mods_panel.deleteLater()
 
-        self._github_mods_panel = GitHubModsPanel()
+        self._github_mods_panel = GitHubModsPanel(
+            metadata_controller=self.metadata_controller
+        )
         self.view.window_manager.register(self._github_mods_panel)
         self._github_mods_panel.show()
 

--- a/app/controllers/main_window_controller.py
+++ b/app/controllers/main_window_controller.py
@@ -178,7 +178,7 @@ class MainWindowController(QObject):
 
         # Always show the dialog (even if no missing deps)
         dialog = MissingDependenciesDialog(
-            self.main_window, metadata_controller=self.metadata_controller
+            metadata_controller=self.metadata_controller, parent=self.main_window
         )
         selected_deps = dialog.show_dialog(deps_summary, missing_deps)
 

--- a/app/views/acf_log_reader.py
+++ b/app/views/acf_log_reader.py
@@ -69,8 +69,8 @@ class AcfLogReader(BaseModsPanel):
 
     def __init__(
         self,
+        metadata_controller: MetadataController,
         active_mods_list: object | None = None,
-        metadata_controller: MetadataController | None = None,
     ) -> None:
         """
         Initialize ACF Log Reader using BaseModsPanel.
@@ -79,7 +79,7 @@ class AcfLogReader(BaseModsPanel):
             active_mods_list: Optional active mods list for highlighting
         """
         self.active_mods_list = active_mods_list
-        self.metadata_controller = metadata_controller or MetadataController.instance()
+        self.metadata_controller = metadata_controller
         # Set of PFIDs that are currently active in the game
         self.active_pfids: set[str] = set()
         # Timer for debouncing search input (300ms delay)

--- a/app/views/deletion_menu.py
+++ b/app/views/deletion_menu.py
@@ -54,7 +54,7 @@ class ModDeletionMenu(QMenu):
         self,
         settings: Settings,
         get_selected_mod_metadata: Callable[[], list[ModMetadata]],
-        metadata_controller: MetadataController | None = None,
+        metadata_controller: MetadataController,
         remove_from_uuids: list[str] | None = None,
         menu_title: str = "Deletion options",
         enable_delete_mod: bool = True,
@@ -67,7 +67,7 @@ class ModDeletionMenu(QMenu):
         super().__init__(title=self.tr("Deletion options"))
         self.remove_from_uuids = remove_from_uuids
         self.get_selected_mod_metadata = get_selected_mod_metadata
-        self.metadata_controller = metadata_controller or MetadataController.instance()
+        self.metadata_controller = metadata_controller
         self.settings = settings
         self.completion_callback = completion_callback
         self._actions_initialized = False

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -121,9 +121,9 @@ class MainContent(QObject):
     def __init__(
         self,
         settings: Settings,
+        metadata_controller: MetadataController,
         show_settings_dialog: Callable[..., None] | None = None,
         settings_dialog: SettingsDialog | None = None,
-        metadata_controller: MetadataController | None = None,
     ) -> None:
         if not hasattr(self, "initialized"):
             super().__init__()
@@ -131,9 +131,7 @@ class MainContent(QObject):
             self.settings = settings
             self._show_settings_dialog = show_settings_dialog
             self._settings_dialog = settings_dialog
-            self.metadata_controller = (
-                metadata_controller or MetadataController.instance()
-            )
+            self.metadata_controller = metadata_controller
             self._init_services()
             self._init_widgets()
             self._setup_layout()
@@ -2596,7 +2594,7 @@ class MainContent(QObject):
         self, compact: bool, initial_mode: str, packageid: str | None = None
     ) -> None:
         self.rule_editor = RuleEditor(
-            # Initialization options
+            metadata_controller=self.metadata_controller,
             compact=compact,
             edit_packageid=packageid,
             initial_mode=initial_mode,

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -184,8 +184,8 @@ class MainWindow(QMainWindow):
 
         # Instantiate the AcfDataWindow and add it to the tab
         self.acf_log_reader = AcfLogReader(
-            active_mods_list=self.main_content_panel.mods_panel.active_mods_list,
             metadata_controller=self.metadata_controller,
+            active_mods_list=self.main_content_panel.mods_panel.active_mods_list,
         )
         self.acf_log_reader_layout.addWidget(self.acf_log_reader)
 
@@ -205,6 +205,7 @@ class MainWindow(QMainWindow):
         self.file_search_controller = FileSearchController(
             settings=self.settings,
             dialog=self.file_search_dialog,
+            metadata_controller=self.metadata_controller,
         )
         self.file_search_layout.addWidget(self.file_search_dialog)
 
@@ -253,6 +254,7 @@ class MainWindow(QMainWindow):
         self.main_content_controller = MainContentController(
             view=self.main_content_panel,
             settings=self.settings,
+            metadata_controller=self.metadata_controller,
         )
 
         self.todds_controller = ToddsController(

--- a/app/views/mod_info_panel.py
+++ b/app/views/mod_info_panel.py
@@ -111,7 +111,7 @@ class ModInfoPanel:
     """
 
     def __init__(
-        self, settings: Settings, metadata_controller: MetadataController | None = None
+        self, settings: Settings, metadata_controller: MetadataController
     ) -> None:
         """
         Initialize the class.
@@ -119,7 +119,7 @@ class ModInfoPanel:
         logger.debug("Initializing ModInfo")
 
         # Cache MetadataController instance
-        self.metadata_controller = metadata_controller or MetadataController.instance()
+        self.metadata_controller = metadata_controller
         self.settings = settings
 
         # Used to keep track of which mod items notes we are viewing/editing

--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -132,6 +132,7 @@ class ModListItemInner(QWidget):
         path: str,
         mod_color: QColor,
         show_tags: bool = False,
+        metadata_controller: MetadataController | None = None,
     ) -> None:
         """
         Initialize the QWidget with mod path. Metadata can be accessed via MetadataController.
@@ -160,7 +161,7 @@ class ModListItemInner(QWidget):
         self._hovered = False
 
         # Cache MetadataController instance
-        self.metadata_controller = MetadataController.instance()
+        self.metadata_controller = metadata_controller or MetadataController.instance()
 
         # Cache error and warning strings for tooltips
         self.errors_warnings = errors_warnings
@@ -1001,7 +1002,7 @@ class ModListWidget(QListWidget):
         self,
         list_type: str,
         settings: Settings,
-        metadata_controller: MetadataController | None = None,
+        metadata_controller: MetadataController,
     ) -> None:
         """
         Initialize the ListWidget with a dict of mods.
@@ -1015,7 +1016,7 @@ class ModListWidget(QListWidget):
         self.list_type = list_type
 
         # Cache MetadataController instance
-        self.metadata_controller = metadata_controller or MetadataController.instance()
+        self.metadata_controller = metadata_controller
 
         self.settings = settings
 
@@ -2759,6 +2760,7 @@ class ModListWidget(QListWidget):
                 path=uuid,
                 mod_color=mod_color,
                 show_tags=show_tags,
+                metadata_controller=self.metadata_controller,
             )
             widget.toggle_warning_signal.connect(self.toggle_warning)
             widget.toggle_error_signal.connect(self.toggle_warning)
@@ -3937,7 +3939,7 @@ class ModsPanel(QWidget):
         )
 
     def __init__(
-        self, settings: Settings, metadata_controller: MetadataController | None = None
+        self, settings: Settings, metadata_controller: MetadataController
     ) -> None:
         """
         Initialize the class.
@@ -3948,7 +3950,7 @@ class ModsPanel(QWidget):
 
         # Cache MetadataController instance and initialize panel
         logger.debug("Initializing ModsPanel")
-        self.metadata_controller = metadata_controller or MetadataController.instance()
+        self.metadata_controller = metadata_controller
         self.settings = settings
 
         # Load inactive mods sort settings

--- a/app/windows/base_mods_panel.py
+++ b/app/windows/base_mods_panel.py
@@ -152,10 +152,7 @@ class BaseModsPanel(QWidget):
 
     def _setup_metadata(self) -> None:
         """Set up metadata controller and settings controller."""
-        if self._metadata_controller is not None:
-            self.metadata_controller = self._metadata_controller
-        else:
-            self.metadata_controller = MetadataController.instance()
+        self.metadata_controller = self._metadata_controller
         self.settings = self.metadata_controller.settings
         self.metadata_controller.metadata_refreshed.connect(
             self._populate_from_metadata
@@ -359,7 +356,7 @@ class BaseModsPanel(QWidget):
         title_text: str,
         details_text: str,
         additional_columns: Sequence[HeaderColumn],
-        metadata_controller: MetadataController | None = None,
+        metadata_controller: MetadataController,
     ):
         super().__init__()
         self._metadata_controller = metadata_controller

--- a/app/windows/duplicate_mods_panel.py
+++ b/app/windows/duplicate_mods_panel.py
@@ -24,7 +24,7 @@ class DuplicateModsPanel(BaseModsPanel):
     def __init__(
         self,
         duplicate_mods: dict[str, list[str]],
-        metadata_controller: MetadataController | None = None,
+        metadata_controller: MetadataController,
     ) -> None:
         """
         Initialize the DuplicateModsPanel with duplicate mods data.

--- a/app/windows/github_mods_panel.py
+++ b/app/windows/github_mods_panel.py
@@ -36,7 +36,7 @@ class GitHubModsPanel(BaseModsPanel):
 
     def __init__(
         self,
-        metadata_controller: MetadataController | None = None,
+        metadata_controller: MetadataController,
     ) -> None:
         self._update_worker: Any = None
         self._auto_update_signals_blocked = False

--- a/app/windows/missing_dependencies_dialog.py
+++ b/app/windows/missing_dependencies_dialog.py
@@ -28,15 +28,15 @@ class MissingDependenciesDialog(QDialog):
 
     def __init__(
         self,
+        metadata_controller: MetadataController,
         parent: QWidget | None = None,
-        metadata_controller: MetadataController | None = None,
     ) -> None:
         """
         Initialize the MissingDependenciesDialog.
         """
         super().__init__(parent)
         self.setObjectName("missingDependenciesDialog")
-        self.metadata_controller = metadata_controller or MetadataController.instance()
+        self.metadata_controller = metadata_controller
         self.selected_mods: set[str] = set()
         self.checkboxes: dict[str, QCheckBox] = {}
         self._setup_ui()

--- a/app/windows/missing_mod_properties_panel.py
+++ b/app/windows/missing_mod_properties_panel.py
@@ -30,7 +30,7 @@ class MissingModPropertiesPanel(BaseModsPanel):
         self,
         missing_packageid_mods: list[str],
         missing_publishfieldid_mods: list[str],
-        metadata_controller: MetadataController | None = None,
+        metadata_controller: MetadataController,
     ) -> None:
         """
         Initialize the MissingModPropertiesPanel.

--- a/app/windows/missing_mods_panel.py
+++ b/app/windows/missing_mods_panel.py
@@ -28,7 +28,7 @@ class MissingModsPrompt(BaseModsPanel):
     def __init__(
         self,
         packageids: list[str],
-        metadata_controller: MetadataController | None = None,
+        metadata_controller: MetadataController,
     ) -> None:
         """
         Initialize the MissingModsPrompt.

--- a/app/windows/rule_editor_panel.py
+++ b/app/windows/rule_editor_panel.py
@@ -137,6 +137,7 @@ class RuleEditor(QWidget):
 
     def __init__(
         self,
+        metadata_controller: MetadataController,
         initial_mode: str,
         compact: bool | None = None,
         edit_packageid: str | None = None,
@@ -145,7 +146,7 @@ class RuleEditor(QWidget):
         logger.debug("Initializing RuleEditor")
 
         # Cache MetadataController instance
-        self.metadata_controller = MetadataController.instance()
+        self.metadata_controller = metadata_controller
 
         # STYLESHEET
         self.setObjectName("RuleEditor")

--- a/app/windows/use_this_instead_panel.py
+++ b/app/windows/use_this_instead_panel.py
@@ -56,7 +56,7 @@ class UseThisInsteadPanel(BaseModsPanel):
     def __init__(
         self,
         mod_metadata: dict[str, Any],
-        metadata_controller: MetadataController | None = None,
+        metadata_controller: MetadataController,
     ) -> None:
         """
         Initialize the UseThisInsteadPanel with mod metadata.

--- a/app/windows/workshop_mod_updater_panel.py
+++ b/app/windows/workshop_mod_updater_panel.py
@@ -25,7 +25,7 @@ class WorkshopModUpdaterPanel(BaseModsPanel):
 
     def __init__(
         self,
-        metadata_controller: MetadataController | None = None,
+        metadata_controller: MetadataController,
     ) -> None:
         """
         Initialize the WorkshopModUpdaterPanel.

--- a/tests/views/test_main_content_run.py
+++ b/tests/views/test_main_content_run.py
@@ -52,7 +52,9 @@ def main_content(
     instance.game_folder = "/fake/path"
     instance.run_args = "--test"
     # Initialize MainContent with settings from the mock settings controller
-    mc = MainContent(mock_settings_controller.settings)
+    mc = MainContent(
+        mock_settings_controller.settings, metadata_controller=mock_metadata_controller
+    )
     # Patch _do_save to capture calls
     save_calls: List[bool] = []
     monkeypatch.setattr(mc, "_do_save", lambda: save_calls.append(True))


### PR DESCRIPTION
Remove the optional \= None\ default and \or MetadataController.instance()\ fallback from all view/window classes. \metadata_controller\ is now a required constructor parameter everywhere.

### Changes by scope:
- **Views/windows**: \metadata_controller\ param made required, fallback removed (14 files)
- **RuleEditor** and **ModListItemInner**: now accept \metadata_controller\ via constructor instead of calling \MetadataController.instance()\ directly
- **Controllers**: \FileSearchController\ and \MainContentController\ accept \metadata_controller\ param, threaded from \MainWindow\
- **BaseModsPanel**: \_setup_metadata()\ simplified to direct assignment (no more \if/else\ fallback)
- **Tests**: \	est_main_content_run.py\ passes \metadata_controller\ to \MainContent\

18 files changed, +51/-38