### PR TITLE
theme: add per-theme QSS styling to Player Log Tab

### DIFF
--- a/app/views/player_log_tab.py
+++ b/app/views/player_log_tab.py
@@ -458,6 +458,7 @@ class PlayerLogTab(QWidget):
         self.log_display.customContextMenuRequested.connect(self.show_context_menu)
 
         self.horizontal_splitter = QSplitter(Qt.Orientation.Horizontal)
+        self.horizontal_splitter.setObjectName("logSplitter")
         self.horizontal_splitter.setSizePolicy(
             QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding
         )
@@ -499,6 +500,7 @@ class PlayerLogTab(QWidget):
         self.middle_layout.setContentsMargins(8, 8, 8, 8)
 
         self.log_display = QTextEdit()
+        self.log_display.setObjectName("logDisplay")
         self.log_display.setReadOnly(True)
         self.log_display.setFont(QFont("Consolas", 10))
         self.log_display.setMinimumSize(400, 200)
@@ -513,6 +515,7 @@ class PlayerLogTab(QWidget):
 
     def _init_file_info_group(self) -> None:
         file_info_group = QGroupBox(self.tr("File Info"))
+        file_info_group.setObjectName("fileInfoGroup")
         file_info_layout = QVBoxLayout()
         file_info_group.setLayout(file_info_layout)
 
@@ -524,17 +527,20 @@ class PlayerLogTab(QWidget):
         )
 
         self.file_path_label = QLabel(self.tr("Path:"))
+        self.file_path_label.setObjectName("filePathLabel")
         self.file_path_label.setWordWrap(True)
         file_info_layout.addWidget(self.file_path_label)
 
         self.file_size_label = QLabel(self.tr("Size:"))
+        self.file_size_label.setObjectName("fileSizeLabel")
         file_info_layout.addWidget(self.file_size_label)
 
         self.last_modified_label = QLabel(self.tr("Modified:"))
+        self.last_modified_label.setObjectName("lastModifiedLabel")
         file_info_layout.addWidget(self.last_modified_label)
 
         self.growth_label = QLabel("")
-        self.growth_label.setStyleSheet("color: green; font-weight: bold;")
+        self.growth_label.setObjectName("growthLabel")
         file_info_layout.addWidget(self.growth_label)
 
         self.left_layout.addWidget(file_info_group)
@@ -551,16 +557,17 @@ class PlayerLogTab(QWidget):
 
     def _init_statistics_group(self) -> None:
         stats_group = QGroupBox(self.tr("Statistics"))
+        stats_group.setObjectName("statsGroup")
         stats_layout = QVBoxLayout()
         stats_group.setLayout(stats_layout)
         stats_layout.setSpacing(1)
         stats_layout.setContentsMargins(1, 1, 1, 1)
 
-        def create_stat_button(text: str, color: str, filter_name: str) -> QPushButton:
+        def create_stat_button(
+            text: str, obj_name: str, filter_name: str
+        ) -> QPushButton:
             btn = QPushButton(text)
-            btn.setStyleSheet(
-                f"color: {color}; background: transparent; border: none; text-align: left;"
-            )
+            btn.setObjectName(obj_name)
             btn.setCursor(Qt.CursorShape.PointingHandCursor)
             btn.setFlat(True)
             btn.clicked.connect(lambda: self._on_stat_button_clicked(filter_name))
@@ -568,28 +575,28 @@ class PlayerLogTab(QWidget):
             return btn
 
         self.total_lines_label = create_stat_button(
-            self.tr("Total Lines: 0"), "#00FF00", self.tr("All Entries")
+            self.tr("Total Lines: 0"), "statButtonGreen", self.tr("All Entries")
         )
         self.info_label = create_stat_button(
-            self.tr("Infos: 0"), "#00FF00", self.tr("Infos Only")
+            self.tr("Infos: 0"), "statButtonGreen", self.tr("Infos Only")
         )
         self.keybind_label = create_stat_button(
-            self.tr("Keybinds: 0"), "#EEFF00", self.tr("Keybinds Only")
+            self.tr("Keybinds: 0"), "statButtonYellow", self.tr("Keybinds Only")
         )
         self.mod_issues_label = create_stat_button(
-            self.tr("Mod Issues: 0"), "#FF8C00", self.tr("Mod Issues")
+            self.tr("Mod Issues: 0"), "statButtonOrange", self.tr("Mod Issues")
         )
         self.warnings_label = create_stat_button(
-            self.tr("Warnings: 0"), "#FF8C00", self.tr("Warnings Only")
+            self.tr("Warnings: 0"), "statButtonOrange", self.tr("Warnings Only")
         )
         self.errors_label = create_stat_button(
-            self.tr("Errors: 0"), "#FF0000", self.tr("Errors Only")
+            self.tr("Errors: 0"), "statButtonRed", self.tr("Errors Only")
         )
         self.exceptions_label = create_stat_button(
-            self.tr("Exceptions: 0"), "#FF0000", self.tr("Exceptions Only")
+            self.tr("Exceptions: 0"), "statButtonRed", self.tr("Exceptions Only")
         )
         self.all_issues_label = create_stat_button(
-            self.tr("All Issues: 0"), "#FF0000", self.tr("All Issues")
+            self.tr("All Issues: 0"), "statButtonRed", self.tr("All Issues")
         )
 
         stats_layout.addWidget(self.total_lines_label)
@@ -612,6 +619,7 @@ class PlayerLogTab(QWidget):
 
     def _init_controls_group(self) -> None:
         controls_group = QGroupBox(self.tr("Controls"))
+        controls_group.setObjectName("controlsGroup")
         controls_layout = QVBoxLayout()
         controls_group.setLayout(controls_layout)
         controls_layout.setSpacing(1)
@@ -679,6 +687,7 @@ class PlayerLogTab(QWidget):
         controls_layout.addLayout(load_buttons_layout)
 
         self.progress_bar = QProgressBar()
+        self.progress_bar.setObjectName("logProgressBar")
         self.progress_bar.setVisible(False)
         controls_layout.addWidget(self.progress_bar)
         controls_group.setLayout(controls_layout)
@@ -688,6 +697,7 @@ class PlayerLogTab(QWidget):
     def _init_search_filter_group(self) -> None:
         """Initialize the Search and Filter group UI components."""
         search_filter_group = QGroupBox(self.tr("Search and Filter"))
+        search_filter_group.setObjectName("searchFilterGroup")
         search_filter_layout = QVBoxLayout()
         search_filter_group.setLayout(search_filter_layout)
         search_filter_layout.setSpacing(1)
@@ -697,6 +707,7 @@ class PlayerLogTab(QWidget):
         search_input_layout = QHBoxLayout()
         search_input_layout.setSpacing(1)
         self.search_input = QLineEdit()
+        self.search_input.setObjectName("searchInput")
         self.search_input.setPlaceholderText(self.tr("Search log entries..."))
         self._search_debounce_timer = QTimer(self)
         self._search_debounce_timer.setSingleShot(True)
@@ -714,6 +725,7 @@ class PlayerLogTab(QWidget):
         filter_layout = QHBoxLayout()
         filter_layout.setSpacing(1)
         self.filter_combo = QComboBox()
+        self.filter_combo.setObjectName("filterCombo")
         self.filter_combo.setMinimumWidth(140)
         self.filter_combo.addItems(
             [
@@ -733,6 +745,7 @@ class PlayerLogTab(QWidget):
         filter_layout.addWidget(self.filter_combo)
 
         self.mod_filter_input = QLineEdit()
+        self.mod_filter_input.setObjectName("modFilterInput")
         self.mod_filter_input.setPlaceholderText(self.tr("Filter by mod name..."))
         self.mod_filter_input.textChanged.connect(
             lambda _: self.apply_filter(clear_log=True, filter_type="Search")
@@ -778,6 +791,7 @@ class PlayerLogTab(QWidget):
             text: str, tooltip: str, callback: Callable[[], None]
         ) -> QPushButton:
             btn = QPushButton(text)
+            btn.setObjectName("navButton")
             btn.setToolTip(tooltip)
             btn.clicked.connect(callback)
             btn.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
@@ -787,6 +801,7 @@ class PlayerLogTab(QWidget):
             return btn
 
         self.nav_group = QGroupBox(self.tr("Quick Navigation"))
+        self.nav_group.setObjectName("navGroup")
         nav_layout = QGridLayout()
         self.nav_group.setLayout(nav_layout)
         nav_layout.setSpacing(4)
@@ -816,6 +831,7 @@ class PlayerLogTab(QWidget):
                 self._make_next_callback(pattern),
             )
             label = QLabel(label_text)
+            label.setObjectName("navLabel")
             label.setAlignment(Qt.AlignmentFlag.AlignCenter)
             label.setMinimumWidth(80)
             label.setMaximumWidth(100)

--- a/themes/Modern/style.qss
+++ b/themes/Modern/style.qss
@@ -1013,3 +1013,176 @@ QListWidget#TagEditDialogList::indicator:unchecked {
     border: 1px solid #4a5a7a;
     background-color: #3b4a64;
 }
+
+/* Player Log Tab styling */
+QLabel#growthLabel {
+    color: green;
+    font-weight: bold;
+}
+
+QPushButton#statButtonGreen {
+    color: #00FF00;
+    background: transparent;
+    border: none;
+    text-align: left;
+}
+
+QPushButton#statButtonGreen:hover {
+    background: transparent;
+    border: none;
+}
+
+QPushButton#statButtonGreen:pressed {
+    background: transparent;
+    border: none;
+}
+
+QPushButton#statButtonYellow {
+    color: #EEFF00;
+    background: transparent;
+    border: none;
+    text-align: left;
+}
+
+QPushButton#statButtonYellow:hover {
+    background: transparent;
+    border: none;
+}
+
+QPushButton#statButtonYellow:pressed {
+    background: transparent;
+    border: none;
+}
+
+QPushButton#statButtonOrange {
+    color: #FF8C00;
+    background: transparent;
+    border: none;
+    text-align: left;
+}
+
+QPushButton#statButtonOrange:hover {
+    background: transparent;
+    border: none;
+}
+
+QPushButton#statButtonOrange:pressed {
+    background: transparent;
+    border: none;
+}
+
+QPushButton#statButtonRed {
+    color: #FF0000;
+    background: transparent;
+    border: none;
+    text-align: left;
+}
+
+QPushButton#statButtonRed:hover {
+    background: transparent;
+    border: none;
+}
+
+QPushButton#statButtonRed:pressed {
+    background: transparent;
+    border: none;
+}
+
+/* Player Log Tab - Group boxes */
+QGroupBox#fileInfoGroup,
+QGroupBox#statsGroup,
+QGroupBox#controlsGroup,
+QGroupBox#searchFilterGroup,
+QGroupBox#navGroup {
+    background-color: transparent;
+    border: 1px solid #2b4a6f;
+    border-radius: 4px;
+    margin-top: 14px;
+    padding: 12px 4px 4px 4px;
+    font-size: 12px;
+}
+
+QGroupBox#fileInfoGroup::title,
+QGroupBox#statsGroup::title,
+QGroupBox#controlsGroup::title,
+QGroupBox#searchFilterGroup::title,
+QGroupBox#navGroup::title {
+    subcontrol-origin: margin;
+    subcontrol-position: top left;
+    padding: 2px 8px;
+    background-color: #1f2e38;
+    color: #d6e0f3;
+    border-radius: 3px;
+}
+
+/* Player Log Tab - Log display */
+QTextEdit#logDisplay {
+    background-color: #0a1218;
+    color: #d6e0f3;
+    border: 1px solid #2b4a6f;
+    border-radius: 4px;
+    padding: 4px;
+}
+
+/* Player Log Tab - Splitter */
+QSplitter#logSplitter::handle {
+    background-color: #2b4a6f;
+    width: 1px;
+}
+
+/* Player Log Tab - File info labels */
+QLabel#filePathLabel,
+QLabel#fileSizeLabel,
+QLabel#lastModifiedLabel {
+    color: #bfbfbf;
+    font-size: 11px;
+    padding: 2px 4px;
+}
+
+/* Player Log Tab - Navigation buttons */
+QPushButton#navButton {
+    background-color: #1f2e38;
+    color: #d6e0f3;
+    border: 1px solid #2b3d4e;
+    border-radius: 3px;
+    padding: 2px 4px;
+    font-size: 11px;
+}
+
+QPushButton#navButton:hover {
+    background-color: #2b3d4e;
+}
+
+QPushButton#navButton:pressed {
+    background-color: #1a2a34;
+}
+
+/* Player Log Tab - Navigation labels */
+QLabel#navLabel {
+    color: #d6e0f3;
+    font-size: 11px;
+    padding: 0px 4px;
+}
+
+/* Player Log Tab - Match count label */
+QLabel#match_count_label {
+    color: #bfbfbf;
+    font-size: 11px;
+    padding: 0px 4px;
+}
+
+/* Player Log Tab - Progress bar */
+QProgressBar#logProgressBar {
+    background-color: #101820;
+    border: 1px solid #2b4a6f;
+    border-radius: 3px;
+    text-align: center;
+    color: #d6e0f3;
+    font-size: 11px;
+    height: 18px;
+}
+
+QProgressBar#logProgressBar::chunk {
+    background-color: #1f2e38;
+    border-radius: 2px;
+}

--- a/themes/Nature/style.qss
+++ b/themes/Nature/style.qss
@@ -921,3 +921,176 @@ QLabel#clearWarning {
 QSplitter::handle {
     background-color: #4A5B4A;
 }
+
+/* Player Log Tab styling */
+QLabel#growthLabel {
+    color: green;
+    font-weight: bold;
+}
+
+QPushButton#statButtonGreen {
+    color: #00FF00;
+    background: transparent;
+    border: none;
+    text-align: left;
+}
+
+QPushButton#statButtonGreen:hover {
+    background: transparent;
+    border: none;
+}
+
+QPushButton#statButtonGreen:pressed {
+    background: transparent;
+    border: none;
+}
+
+QPushButton#statButtonYellow {
+    color: #EEFF00;
+    background: transparent;
+    border: none;
+    text-align: left;
+}
+
+QPushButton#statButtonYellow:hover {
+    background: transparent;
+    border: none;
+}
+
+QPushButton#statButtonYellow:pressed {
+    background: transparent;
+    border: none;
+}
+
+QPushButton#statButtonOrange {
+    color: #FF8C00;
+    background: transparent;
+    border: none;
+    text-align: left;
+}
+
+QPushButton#statButtonOrange:hover {
+    background: transparent;
+    border: none;
+}
+
+QPushButton#statButtonOrange:pressed {
+    background: transparent;
+    border: none;
+}
+
+QPushButton#statButtonRed {
+    color: #FF0000;
+    background: transparent;
+    border: none;
+    text-align: left;
+}
+
+QPushButton#statButtonRed:hover {
+    background: transparent;
+    border: none;
+}
+
+QPushButton#statButtonRed:pressed {
+    background: transparent;
+    border: none;
+}
+
+/* Player Log Tab - Group boxes */
+QGroupBox#fileInfoGroup,
+QGroupBox#statsGroup,
+QGroupBox#controlsGroup,
+QGroupBox#searchFilterGroup,
+QGroupBox#navGroup {
+    background-color: transparent;
+    border: 1px solid #4a5b4a;
+    border-radius: 4px;
+    margin-top: 14px;
+    padding: 12px 4px 4px 4px;
+    font-size: 12px;
+}
+
+QGroupBox#fileInfoGroup::title,
+QGroupBox#statsGroup::title,
+QGroupBox#controlsGroup::title,
+QGroupBox#searchFilterGroup::title,
+QGroupBox#navGroup::title {
+    subcontrol-origin: margin;
+    subcontrol-position: top left;
+    padding: 2px 8px;
+    background-color: #4a5b4a;
+    color: #ffffff;
+    border-radius: 3px;
+}
+
+/* Player Log Tab - Log display */
+QTextEdit#logDisplay {
+    background-color: #223022;
+    color: #ffffff;
+    border: 1px solid #4a5b4a;
+    border-radius: 4px;
+    padding: 4px;
+}
+
+/* Player Log Tab - Splitter */
+QSplitter#logSplitter::handle {
+    background-color: #4a5b4a;
+    width: 1px;
+}
+
+/* Player Log Tab - File info labels */
+QLabel#filePathLabel,
+QLabel#fileSizeLabel,
+QLabel#lastModifiedLabel {
+    color: #f0e68c;
+    font-size: 11px;
+    padding: 2px 4px;
+}
+
+/* Player Log Tab - Navigation buttons */
+QPushButton#navButton {
+    background-color: #4a5b4a;
+    color: #ffffff;
+    border: 1px solid #5a6b5a;
+    border-radius: 3px;
+    padding: 2px 4px;
+    font-size: 11px;
+}
+
+QPushButton#navButton:hover {
+    background-color: #5a6b5a;
+}
+
+QPushButton#navButton:pressed {
+    background-color: #3a4b3a;
+}
+
+/* Player Log Tab - Navigation labels */
+QLabel#navLabel {
+    color: #ffffff;
+    font-size: 11px;
+    padding: 0px 4px;
+}
+
+/* Player Log Tab - Match count label */
+QLabel#match_count_label {
+    color: #f0e68c;
+    font-size: 11px;
+    padding: 0px 4px;
+}
+
+/* Player Log Tab - Progress bar */
+QProgressBar#logProgressBar {
+    background-color: #2e3d2f;
+    border: 1px solid #4a5b4a;
+    border-radius: 3px;
+    text-align: center;
+    color: #ffffff;
+    font-size: 11px;
+    height: 18px;
+}
+
+QProgressBar#logProgressBar::chunk {
+    background-color: #4a5b4a;
+    border-radius: 2px;
+}

--- a/themes/RimPy/style.qss
+++ b/themes/RimPy/style.qss
@@ -1015,3 +1015,176 @@ QPushButton#TagEditDialogButton:hover {
 QPushButton#TagEditDialogButton:pressed {
     background-color: #3e4a52;
 }
+
+/* Player Log Tab styling */
+QLabel#growthLabel {
+    color: green;
+    font-weight: bold;
+}
+
+QPushButton#statButtonGreen {
+    color: #00FF00;
+    background: transparent;
+    border: none;
+    text-align: left;
+}
+
+QPushButton#statButtonGreen:hover {
+    background: transparent;
+    border: none;
+}
+
+QPushButton#statButtonGreen:pressed {
+    background: transparent;
+    border: none;
+}
+
+QPushButton#statButtonYellow {
+    color: #EEFF00;
+    background: transparent;
+    border: none;
+    text-align: left;
+}
+
+QPushButton#statButtonYellow:hover {
+    background: transparent;
+    border: none;
+}
+
+QPushButton#statButtonYellow:pressed {
+    background: transparent;
+    border: none;
+}
+
+QPushButton#statButtonOrange {
+    color: #FF8C00;
+    background: transparent;
+    border: none;
+    text-align: left;
+}
+
+QPushButton#statButtonOrange:hover {
+    background: transparent;
+    border: none;
+}
+
+QPushButton#statButtonOrange:pressed {
+    background: transparent;
+    border: none;
+}
+
+QPushButton#statButtonRed {
+    color: #FF0000;
+    background: transparent;
+    border: none;
+    text-align: left;
+}
+
+QPushButton#statButtonRed:hover {
+    background: transparent;
+    border: none;
+}
+
+QPushButton#statButtonRed:pressed {
+    background: transparent;
+    border: none;
+}
+
+/* Player Log Tab - Group boxes */
+QGroupBox#fileInfoGroup,
+QGroupBox#statsGroup,
+QGroupBox#controlsGroup,
+QGroupBox#searchFilterGroup,
+QGroupBox#navGroup {
+    background-color: transparent;
+    border: 1px solid #455364;
+    border-radius: 4px;
+    margin-top: 14px;
+    padding: 12px 4px 4px 4px;
+    font-size: 12px;
+}
+
+QGroupBox#fileInfoGroup::title,
+QGroupBox#statsGroup::title,
+QGroupBox#controlsGroup::title,
+QGroupBox#searchFilterGroup::title,
+QGroupBox#navGroup::title {
+    subcontrol-origin: margin;
+    subcontrol-position: top left;
+    padding: 2px 8px;
+    background-color: #22303d;
+    color: #e6edf3;
+    border-radius: 3px;
+}
+
+/* Player Log Tab - Log display */
+QTextEdit#logDisplay {
+    background-color: #0f1923;
+    color: #e6edf3;
+    border: 1px solid #455364;
+    border-radius: 4px;
+    padding: 4px;
+}
+
+/* Player Log Tab - Splitter */
+QSplitter#logSplitter::handle {
+    background-color: #455364;
+    width: 1px;
+}
+
+/* Player Log Tab - File info labels */
+QLabel#filePathLabel,
+QLabel#fileSizeLabel,
+QLabel#lastModifiedLabel {
+    color: #cfcfcf;
+    font-size: 11px;
+    padding: 2px 4px;
+}
+
+/* Player Log Tab - Navigation buttons */
+QPushButton#navButton {
+    background-color: #22303d;
+    color: #e6edf3;
+    border: 1px solid #2b3d4e;
+    border-radius: 3px;
+    padding: 2px 4px;
+    font-size: 11px;
+}
+
+QPushButton#navButton:hover {
+    background-color: #2b3d4e;
+}
+
+QPushButton#navButton:pressed {
+    background-color: #1B2838;
+}
+
+/* Player Log Tab - Navigation labels */
+QLabel#navLabel {
+    color: #e6edf3;
+    font-size: 11px;
+    padding: 0px 4px;
+}
+
+/* Player Log Tab - Match count label */
+QLabel#match_count_label {
+    color: #cfcfcf;
+    font-size: 11px;
+    padding: 0px 4px;
+}
+
+/* Player Log Tab - Progress bar */
+QProgressBar#logProgressBar {
+    background-color: #19232d;
+    border: 1px solid #455364;
+    border-radius: 3px;
+    text-align: center;
+    color: #e6edf3;
+    font-size: 11px;
+    height: 18px;
+}
+
+QProgressBar#logProgressBar::chunk {
+    background-color: #22303d;
+    border-radius: 2px;
+}

--- a/themes/SunSet/style.qss
+++ b/themes/SunSet/style.qss
@@ -924,3 +924,176 @@ QLabel#clearWarning {
 QSplitter::handle {
     background-color: #4A3A3A;
 }
+
+/* Player Log Tab styling */
+QLabel#growthLabel {
+    color: green;
+    font-weight: bold;
+}
+
+QPushButton#statButtonGreen {
+    color: #00FF00;
+    background: transparent;
+    border: none;
+    text-align: left;
+}
+
+QPushButton#statButtonGreen:hover {
+    background: transparent;
+    border: none;
+}
+
+QPushButton#statButtonGreen:pressed {
+    background: transparent;
+    border: none;
+}
+
+QPushButton#statButtonYellow {
+    color: #EEFF00;
+    background: transparent;
+    border: none;
+    text-align: left;
+}
+
+QPushButton#statButtonYellow:hover {
+    background: transparent;
+    border: none;
+}
+
+QPushButton#statButtonYellow:pressed {
+    background: transparent;
+    border: none;
+}
+
+QPushButton#statButtonOrange {
+    color: #FF8C00;
+    background: transparent;
+    border: none;
+    text-align: left;
+}
+
+QPushButton#statButtonOrange:hover {
+    background: transparent;
+    border: none;
+}
+
+QPushButton#statButtonOrange:pressed {
+    background: transparent;
+    border: none;
+}
+
+QPushButton#statButtonRed {
+    color: #FF0000;
+    background: transparent;
+    border: none;
+    text-align: left;
+}
+
+QPushButton#statButtonRed:hover {
+    background: transparent;
+    border: none;
+}
+
+QPushButton#statButtonRed:pressed {
+    background: transparent;
+    border: none;
+}
+
+/* Player Log Tab - Group boxes */
+QGroupBox#fileInfoGroup,
+QGroupBox#statsGroup,
+QGroupBox#controlsGroup,
+QGroupBox#searchFilterGroup,
+QGroupBox#navGroup {
+    background-color: transparent;
+    border: 1px solid #4a3a3a;
+    border-radius: 4px;
+    margin-top: 14px;
+    padding: 12px 4px 4px 4px;
+    font-size: 12px;
+}
+
+QGroupBox#fileInfoGroup::title,
+QGroupBox#statsGroup::title,
+QGroupBox#controlsGroup::title,
+QGroupBox#searchFilterGroup::title,
+QGroupBox#navGroup::title {
+    subcontrol-origin: margin;
+    subcontrol-position: top left;
+    padding: 2px 8px;
+    background-color: #4a3a3a;
+    color: #ffffff;
+    border-radius: 3px;
+}
+
+/* Player Log Tab - Log display */
+QTextEdit#logDisplay {
+    background-color: #1f0f0f;
+    color: #ffffff;
+    border: 1px solid #4a3a3a;
+    border-radius: 4px;
+    padding: 4px;
+}
+
+/* Player Log Tab - Splitter */
+QSplitter#logSplitter::handle {
+    background-color: #4a3a3a;
+    width: 1px;
+}
+
+/* Player Log Tab - File info labels */
+QLabel#filePathLabel,
+QLabel#fileSizeLabel,
+QLabel#lastModifiedLabel {
+    color: #ffe4b5;
+    font-size: 11px;
+    padding: 2px 4px;
+}
+
+/* Player Log Tab - Navigation buttons */
+QPushButton#navButton {
+    background-color: #4a3a3a;
+    color: #ffffff;
+    border: 1px solid #5a4a4a;
+    border-radius: 3px;
+    padding: 2px 4px;
+    font-size: 11px;
+}
+
+QPushButton#navButton:hover {
+    background-color: #5a4a4a;
+}
+
+QPushButton#navButton:pressed {
+    background-color: #3a2a2a;
+}
+
+/* Player Log Tab - Navigation labels */
+QLabel#navLabel {
+    color: #ffffff;
+    font-size: 11px;
+    padding: 0px 4px;
+}
+
+/* Player Log Tab - Match count label */
+QLabel#match_count_label {
+    color: #ffe4b5;
+    font-size: 11px;
+    padding: 0px 4px;
+}
+
+/* Player Log Tab - Progress bar */
+QProgressBar#logProgressBar {
+    background-color: #2e1a1a;
+    border: 1px solid #4a3a3a;
+    border-radius: 3px;
+    text-align: center;
+    color: #ffffff;
+    font-size: 11px;
+    height: 18px;
+}
+
+QProgressBar#logProgressBar::chunk {
+    background-color: #4a3a3a;
+    border-radius: 2px;
+}

--- a/themes/Wood/style.qss
+++ b/themes/Wood/style.qss
@@ -915,3 +915,176 @@ QLabel#clearWarning {
 QSplitter::handle {
     background-color: #5A4A4A;
 }
+
+/* Player Log Tab styling */
+QLabel#growthLabel {
+    color: green;
+    font-weight: bold;
+}
+
+QPushButton#statButtonGreen {
+    color: #00FF00;
+    background: transparent;
+    border: none;
+    text-align: left;
+}
+
+QPushButton#statButtonGreen:hover {
+    background: transparent;
+    border: none;
+}
+
+QPushButton#statButtonGreen:pressed {
+    background: transparent;
+    border: none;
+}
+
+QPushButton#statButtonYellow {
+    color: #EEFF00;
+    background: transparent;
+    border: none;
+    text-align: left;
+}
+
+QPushButton#statButtonYellow:hover {
+    background: transparent;
+    border: none;
+}
+
+QPushButton#statButtonYellow:pressed {
+    background: transparent;
+    border: none;
+}
+
+QPushButton#statButtonOrange {
+    color: #FF8C00;
+    background: transparent;
+    border: none;
+    text-align: left;
+}
+
+QPushButton#statButtonOrange:hover {
+    background: transparent;
+    border: none;
+}
+
+QPushButton#statButtonOrange:pressed {
+    background: transparent;
+    border: none;
+}
+
+QPushButton#statButtonRed {
+    color: #FF0000;
+    background: transparent;
+    border: none;
+    text-align: left;
+}
+
+QPushButton#statButtonRed:hover {
+    background: transparent;
+    border: none;
+}
+
+QPushButton#statButtonRed:pressed {
+    background: transparent;
+    border: none;
+}
+
+/* Player Log Tab - Group boxes */
+QGroupBox#fileInfoGroup,
+QGroupBox#statsGroup,
+QGroupBox#controlsGroup,
+QGroupBox#searchFilterGroup,
+QGroupBox#navGroup {
+    background-color: transparent;
+    border: 1px solid #5a4a4a;
+    border-radius: 4px;
+    margin-top: 14px;
+    padding: 12px 4px 4px 4px;
+    font-size: 12px;
+}
+
+QGroupBox#fileInfoGroup::title,
+QGroupBox#statsGroup::title,
+QGroupBox#controlsGroup::title,
+QGroupBox#searchFilterGroup::title,
+QGroupBox#navGroup::title {
+    subcontrol-origin: margin;
+    subcontrol-position: top left;
+    padding: 2px 8px;
+    background-color: #5a4a4a;
+    color: #ffffff;
+    border-radius: 3px;
+}
+
+/* Player Log Tab - Log display */
+QTextEdit#logDisplay {
+    background-color: #2a2020;
+    color: #ffffff;
+    border: 1px solid #5a4a4a;
+    border-radius: 4px;
+    padding: 4px;
+}
+
+/* Player Log Tab - Splitter */
+QSplitter#logSplitter::handle {
+    background-color: #5a4a4a;
+    width: 1px;
+}
+
+/* Player Log Tab - File info labels */
+QLabel#filePathLabel,
+QLabel#fileSizeLabel,
+QLabel#lastModifiedLabel {
+    color: #ffe4c4;
+    font-size: 11px;
+    padding: 2px 4px;
+}
+
+/* Player Log Tab - Navigation buttons */
+QPushButton#navButton {
+    background-color: #5a4a4a;
+    color: #ffffff;
+    border: 1px solid #6a5a5a;
+    border-radius: 3px;
+    padding: 2px 4px;
+    font-size: 11px;
+}
+
+QPushButton#navButton:hover {
+    background-color: #6a5a5a;
+}
+
+QPushButton#navButton:pressed {
+    background-color: #4a3a3a;
+}
+
+/* Player Log Tab - Navigation labels */
+QLabel#navLabel {
+    color: #ffffff;
+    font-size: 11px;
+    padding: 0px 4px;
+}
+
+/* Player Log Tab - Match count label */
+QLabel#match_count_label {
+    color: #ffe4c4;
+    font-size: 11px;
+    padding: 0px 4px;
+}
+
+/* Player Log Tab - Progress bar */
+QProgressBar#logProgressBar {
+    background-color: #3b2f2f;
+    border: 1px solid #5a4a4a;
+    border-radius: 3px;
+    text-align: center;
+    color: #ffffff;
+    font-size: 11px;
+    height: 18px;
+}
+
+QProgressBar#logProgressBar::chunk {
+    background-color: #5a4a4a;
+    border-radius: 2px;
+}


### PR DESCRIPTION
Replace inline setStyleSheet calls with setObjectName and per-theme QSS rules for growth label, stat buttons (green/yellow/orange/red semantic colors), and add setObjectName + QSS rules for widgets needing unique styling: log display, splitter, file info labels, nav buttons/labels, match count label, progress bar, and QGroupBox containers. Add object names on search/filter inputs (searchInput, filterCombo, modFilterInput) relying on global QLineEdit/QComboBox rules. Control buttons and checkboxes rely on global QPushButton/QCheckBox rules. Include explicit hover/pressed states on flat stat buttons.