### PR TITLE
theme: add per-theme QSS styling to BaseModsPanel and all subclasses

### DIFF
--- a/app/utils/button_factory.py
+++ b/app/utils/button_factory.py
@@ -77,6 +77,7 @@ class ButtonFactory:
     ) -> QPushButton:
         """Create a custom button."""
         button = QPushButton(text)
+        button.setObjectName("primaryButton")
         button.clicked.connect(callback)
         return button
 
@@ -86,6 +87,7 @@ class ButtonFactory:
         """Create a select button with dropdown menu."""
         button = QToolButton()
         button.setText(text)
+        button.setObjectName("selectToolButton")
         menu = QMenu(button)
         for menu_item in menu_items:
             action = QAction(menu_item.text, self.panel)

--- a/app/windows/base_mods_panel.py
+++ b/app/windows/base_mods_panel.py
@@ -180,9 +180,11 @@ class BaseModsPanel(QWidget):
         self.installEventFilter(self)
         self.setObjectName(object_name)
         self.ui_elements.title = QLabel(title_text)
+        self.ui_elements.title.setObjectName("baseModsPanelTitle")
         self.ui_elements.title.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
         self.ui_elements.details_label = QLabel(details_text)
+        self.ui_elements.details_label.setObjectName("baseModsPanelDetails")
         self.ui_elements.details_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
         self.setWindowTitle(window_title)
@@ -335,6 +337,9 @@ class BaseModsPanel(QWidget):
             editor_select_all_button=QPushButton(self.tr("Select all")),
             editor_cancel_button=QPushButton(self.tr("Do nothing and exit")),
         )
+        self.ui_elements.editor_deselect_all_button.setObjectName("secondaryButton")
+        self.ui_elements.editor_select_all_button.setObjectName("secondaryButton")
+        self.ui_elements.editor_cancel_button.setObjectName("dangerButton")
 
     def _initialize_layouts(self) -> None:
         """Initialize layout dataclasses."""
@@ -731,12 +736,15 @@ class BaseModsPanel(QWidget):
             Configured QPushButton.
         """
         if button_type == ButtonType.REFRESH:
-            return self._create_button(self.tr("Refresh"), custom_callback)
+            return self._create_button(
+                self.tr("Refresh"), custom_callback, "secondaryButton"
+            )
         elif button_type == ButtonType.STEAMCMD:
             if pfid_column is not None:
                 return self._create_button(
                     self.tr("Download selected with SteamCMD"),
                     self._create_update_callback(pfid_column, OperationMode.STEAMCMD),
+                    "actionButton",
                 )
         elif button_type == ButtonType.SUBSCRIBE:
             if pfid_column is not None:
@@ -748,6 +756,7 @@ class BaseModsPanel(QWidget):
                         "subscribe",
                         completion_callback,
                     ),
+                    "actionButton",
                 )
         elif button_type == ButtonType.UNSUBSCRIBE:
             if pfid_column is not None:
@@ -759,12 +768,13 @@ class BaseModsPanel(QWidget):
                         "unsubscribe",
                         completion_callback,
                     ),
+                    "dangerButton",
                 )
         elif button_type == ButtonType.CUSTOM:
-            return self._create_button(text, custom_callback)
+            return self._create_button(text, custom_callback, "primaryButton")
 
         # Fallback
-        return self._create_button(text or "Button", custom_callback)
+        return self._create_button(text or "Button", custom_callback, "secondaryButton")
 
     def _create_refresh_button(
         self, callback: Callable[[], None] | None
@@ -836,6 +846,7 @@ class BaseModsPanel(QWidget):
 
         button = QPushButton()
         button.setText(self.tr("Delete"))
+        button.setObjectName("dangerButton")
         deletion_menu = ModDeletionMenu(
             settings=settings,
             get_selected_mod_metadata=get_selected_mod_metadata,
@@ -989,6 +1000,7 @@ class BaseModsPanel(QWidget):
             Configured custom button
         """
         button = QPushButton(text)
+        button.setObjectName("primaryButton")
         button.clicked.connect(callback)
         return button
 
@@ -1007,6 +1019,7 @@ class BaseModsPanel(QWidget):
         """
         button = QToolButton()
         button.setText(text)
+        button.setObjectName("selectToolButton")
         menu = QMenu(button)
         for menu_item in menu_items:
             action = QAction(menu_item.text, self)

--- a/themes/Modern/style.qss
+++ b/themes/Modern/style.qss
@@ -658,6 +658,50 @@ QWidget#baseModsPanel {
     color: #d6e0f3;
 }
 
+/* GitHubModsPanel styling */
+QWidget#githubModsPanel {
+    background-color: #101820;
+    border-style: solid;
+    border-color: #3b4a64;
+    border-width: 1px;
+    border-radius: 3px;
+    margin: 7px;
+    color: #d6e0f3;
+}
+
+/* DuplicateModsPanel styling */
+QWidget#duplicateModsPanel {
+    background-color: #101820;
+    border-style: solid;
+    border-color: #3b4a64;
+    border-width: 1px;
+    border-radius: 3px;
+    margin: 7px;
+    color: #d6e0f3;
+}
+
+/* MissingModPropertiesPanel styling */
+QWidget#missingModPropertiesPanel {
+    background-color: #101820;
+    border-style: solid;
+    border-color: #3b4a64;
+    border-width: 1px;
+    border-radius: 3px;
+    margin: 7px;
+    color: #d6e0f3;
+}
+
+/* AcfLogReader styling */
+QWidget#AcfLogReader {
+    background-color: #101820;
+    border-style: solid;
+    border-color: #3b4a64;
+    border-width: 1px;
+    border-radius: 3px;
+    margin: 7px;
+    color: #d6e0f3;
+}
+
 /* MissingDependenciesDialog styling */
 QDialog#missingDependenciesDialog {
     background-color: #101820;

--- a/themes/Nature/style.qss
+++ b/themes/Nature/style.qss
@@ -658,6 +658,50 @@ QWidget#baseModsPanel {
     color: #ffffff;
 }
 
+/* GitHubModsPanel styling */
+QWidget#githubModsPanel {
+    background-color: #2e3d2f;
+    border-style: solid;
+    border-color: #4a5b4a;
+    border-width: 1px;
+    border-radius: 3px;
+    margin: 7px;
+    color: #ffffff;
+}
+
+/* DuplicateModsPanel styling */
+QWidget#duplicateModsPanel {
+    background-color: #2e3d2f;
+    border-style: solid;
+    border-color: #4a5b4a;
+    border-width: 1px;
+    border-radius: 3px;
+    margin: 7px;
+    color: #ffffff;
+}
+
+/* MissingModPropertiesPanel styling */
+QWidget#missingModPropertiesPanel {
+    background-color: #2e3d2f;
+    border-style: solid;
+    border-color: #4a5b4a;
+    border-width: 1px;
+    border-radius: 3px;
+    margin: 7px;
+    color: #ffffff;
+}
+
+/* AcfLogReader styling */
+QWidget#AcfLogReader {
+    background-color: #2e3d2f;
+    border-style: solid;
+    border-color: #4a5b4a;
+    border-width: 1px;
+    border-radius: 3px;
+    margin: 7px;
+    color: #ffffff;
+}
+
 /* MissingDependenciesDialog styling */
 QDialog#missingDependenciesDialog {
     background-color: #2e3d2f;

--- a/themes/RimPy/style.qss
+++ b/themes/RimPy/style.qss
@@ -660,6 +660,50 @@ QWidget#baseModsPanel {
     color: #e6edf3;
 }
 
+/* GitHubModsPanel styling */
+QWidget#githubModsPanel {
+    background-color: #19232d;
+    border-style: solid;
+    border-color: #455364;
+    border-width: 1px;
+    border-radius: 3px;
+    margin: 7px;
+    color: #e6edf3;
+}
+
+/* DuplicateModsPanel styling */
+QWidget#duplicateModsPanel {
+    background-color: #19232d;
+    border-style: solid;
+    border-color: #455364;
+    border-width: 1px;
+    border-radius: 3px;
+    margin: 7px;
+    color: #e6edf3;
+}
+
+/* MissingModPropertiesPanel styling */
+QWidget#missingModPropertiesPanel {
+    background-color: #19232d;
+    border-style: solid;
+    border-color: #455364;
+    border-width: 1px;
+    border-radius: 3px;
+    margin: 7px;
+    color: #e6edf3;
+}
+
+/* AcfLogReader styling */
+QWidget#AcfLogReader {
+    background-color: #19232d;
+    border-style: solid;
+    border-color: #455364;
+    border-width: 1px;
+    border-radius: 3px;
+    margin: 7px;
+    color: #e6edf3;
+}
+
 /* MissingDependenciesDialog styling */
 QDialog#missingDependenciesDialog {
     background-color: #19232d;

--- a/themes/SunSet/style.qss
+++ b/themes/SunSet/style.qss
@@ -661,6 +661,50 @@ QWidget#baseModsPanel {
     color: #ffffff;
 }
 
+/* GitHubModsPanel styling */
+QWidget#githubModsPanel {
+    background-color: #2e1a1a;
+    border-style: solid;
+    border-color: #4a3a3a;
+    border-width: 1px;
+    border-radius: 3px;
+    margin: 7px;
+    color: #ffffff;
+}
+
+/* DuplicateModsPanel styling */
+QWidget#duplicateModsPanel {
+    background-color: #2e1a1a;
+    border-style: solid;
+    border-color: #4a3a3a;
+    border-width: 1px;
+    border-radius: 3px;
+    margin: 7px;
+    color: #ffffff;
+}
+
+/* MissingModPropertiesPanel styling */
+QWidget#missingModPropertiesPanel {
+    background-color: #2e1a1a;
+    border-style: solid;
+    border-color: #4a3a3a;
+    border-width: 1px;
+    border-radius: 3px;
+    margin: 7px;
+    color: #ffffff;
+}
+
+/* AcfLogReader styling */
+QWidget#AcfLogReader {
+    background-color: #2e1a1a;
+    border-style: solid;
+    border-color: #4a3a3a;
+    border-width: 1px;
+    border-radius: 3px;
+    margin: 7px;
+    color: #ffffff;
+}
+
 /* MissingDependenciesDialog styling */
 QDialog#missingDependenciesDialog {
     background-color: #2e1a1a;

--- a/themes/Wood/style.qss
+++ b/themes/Wood/style.qss
@@ -652,6 +652,50 @@ QWidget#baseModsPanel {
     color: #ffffff;
 }
 
+/* GitHubModsPanel styling */
+QWidget#githubModsPanel {
+    background-color: #3b2f2f;
+    border-style: solid;
+    border-color: #5a4a4a;
+    border-width: 1px;
+    border-radius: 3px;
+    margin: 7px;
+    color: #ffffff;
+}
+
+/* DuplicateModsPanel styling */
+QWidget#duplicateModsPanel {
+    background-color: #3b2f2f;
+    border-style: solid;
+    border-color: #5a4a4a;
+    border-width: 1px;
+    border-radius: 3px;
+    margin: 7px;
+    color: #ffffff;
+}
+
+/* MissingModPropertiesPanel styling */
+QWidget#missingModPropertiesPanel {
+    background-color: #3b2f2f;
+    border-style: solid;
+    border-color: #5a4a4a;
+    border-width: 1px;
+    border-radius: 3px;
+    margin: 7px;
+    color: #ffffff;
+}
+
+/* AcfLogReader styling */
+QWidget#AcfLogReader {
+    background-color: #3b2f2f;
+    border-style: solid;
+    border-color: #5a4a4a;
+    border-width: 1px;
+    border-radius: 3px;
+    margin: 7px;
+    color: #ffffff;
+}
+
 /* MissingDependenciesDialog styling */
 QDialog#missingDependenciesDialog {
     background-color: #3b2f2f;


### PR DESCRIPTION
Add setObjectName to BaseModsPanel widgets and ButtonFactory buttons, wiring them to existing per-theme QSS rules (primaryButton, secondaryButton, dangerButton, actionButton). Add missing panel QWidget rules for GitHubModsPanel, DuplicateModsPanel, MissingModPropertiesPanel, and AcfLogReader across all 5 themes.