### PR TITLE
refactor: switch non-critical buttons from secondaryButton to primary…

### DIFF
--- a/app/views/troubleshooting_dialog.py
+++ b/app/views/troubleshooting_dialog.py
@@ -242,7 +242,7 @@ class TroubleshootingDialog(QDialog):
         button_layout.addWidget(self.integrity_apply_button)
 
         self.integrity_cancel_button = QPushButton(self.tr("Cancel"))
-        self.integrity_cancel_button.setObjectName("secondaryButton")
+        self.integrity_cancel_button.setObjectName("primaryButton")
         self.integrity_cancel_button.setShortcut("Ctrl+C")
         button_layout.addWidget(self.integrity_cancel_button)
 

--- a/app/windows/base_mods_panel.py
+++ b/app/windows/base_mods_panel.py
@@ -337,8 +337,8 @@ class BaseModsPanel(QWidget):
             editor_select_all_button=QPushButton(self.tr("Select all")),
             editor_cancel_button=QPushButton(self.tr("Do nothing and exit")),
         )
-        self.ui_elements.editor_deselect_all_button.setObjectName("secondaryButton")
-        self.ui_elements.editor_select_all_button.setObjectName("secondaryButton")
+        self.ui_elements.editor_deselect_all_button.setObjectName("primaryButton")
+        self.ui_elements.editor_select_all_button.setObjectName("primaryButton")
         self.ui_elements.editor_cancel_button.setObjectName("dangerButton")
 
     def _initialize_layouts(self) -> None:
@@ -737,7 +737,7 @@ class BaseModsPanel(QWidget):
         """
         if button_type == ButtonType.REFRESH:
             return self._create_button(
-                self.tr("Refresh"), custom_callback, "secondaryButton"
+                self.tr("Refresh"), custom_callback, "primaryButton"
             )
         elif button_type == ButtonType.STEAMCMD:
             if pfid_column is not None:
@@ -774,7 +774,7 @@ class BaseModsPanel(QWidget):
             return self._create_button(text, custom_callback, "primaryButton")
 
         # Fallback
-        return self._create_button(text or "Button", custom_callback, "secondaryButton")
+        return self._create_button(text or "Button", custom_callback, "primaryButton")
 
     def _create_refresh_button(
         self, callback: Callable[[], None] | None

--- a/app/windows/missing_dependencies_dialog.py
+++ b/app/windows/missing_dependencies_dialog.py
@@ -70,7 +70,7 @@ class MissingDependenciesDialog(QDialog):
         button_layout = QHBoxLayout()
 
         select_all_button = QPushButton(self.tr("Select All"))
-        select_all_button.setObjectName("secondaryButton")
+        select_all_button.setObjectName("primaryButton")
         select_all_button.clicked.connect(self.select_all)
         button_layout.addWidget(select_all_button)
 
@@ -84,7 +84,7 @@ class MissingDependenciesDialog(QDialog):
         button_layout.addWidget(add_button)
 
         ignore_button = QPushButton(self.tr("Sort Without Adding"))
-        ignore_button.setObjectName("secondaryButton")
+        ignore_button.setObjectName("primaryButton")
         ignore_button.clicked.connect(self.reject)
         ignore_button.setShortcut("Escape")  # Esc key
         button_layout.addWidget(ignore_button)


### PR DESCRIPTION
…Button styling

The secondaryButton QSS class is visually too close to the default QPushButton across all themes, making buttons like Refresh, Select All, and Deselect All appear unstyled. Switch these to primaryButton which already has clearly distinct colors in every theme.

Affected buttons:
- Refresh, Select All, Deselect All in BaseModsPanel
- Select All, Sort Without Adding in MissingDependenciesDialog
- Cancel in TroubleshootingDialog