### PR TITLE
feat: merge subscribe/unsubscribe into a single Steam dropdown button

### DIFF
--- a/app/utils/button_factory.py
+++ b/app/utils/button_factory.py
@@ -2,11 +2,44 @@
 Button factory utilities for creating standardized buttons in mod panels.
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any, Callable
 
 from PySide6.QtGui import QAction
 from PySide6.QtWidgets import QMenu, QPushButton, QToolButton
+
+
+class ButtonType(Enum):
+    """Enumeration of button types for standardized button creation."""
+
+    REFRESH = "refresh"
+    STEAMCMD = "steamcmd"
+    STEAM = "steam"
+    DELETE = "delete"
+    SELECT = "select"
+    CUSTOM = "custom"
+
+
+@dataclass
+class ButtonConfig:
+    """Configuration for creating standardized buttons."""
+
+    button_type: ButtonType
+    text: str = ""
+    pfid_column: int | None = None
+    completion_callback: Callable[[], None] | None = None
+    menu_items: list[MenuItem] | None = None
+    get_selected_mod_metadata: Callable[[], list[dict[str, Any]]] | None = None
+    menu_title: str | None = None
+    enable_delete_mod: bool = True
+    enable_delete_keep_dds: bool = False
+    enable_delete_dds_only: bool = False
+    enable_delete_and_unsubscribe: bool = True
+    enable_delete_and_resubscribe: bool = False
+    custom_callback: Callable[[], None] | None = None
 
 
 @dataclass
@@ -33,21 +66,13 @@ class ButtonFactory:
         """Create a SteamCMD download button."""
         return self.panel._create_steamcmd_button(pfid_column)
 
-    def create_subscribe_button(
+    def create_steam_button(
         self,
         pfid_column: int,
         completion_callback: Callable[[], None] | None = None,
     ) -> QPushButton:
-        """Create a subscribe button."""
-        return self.panel._create_subscribe_button(pfid_column, completion_callback)
-
-    def create_unsubscribe_button(
-        self,
-        pfid_column: int,
-        completion_callback: Callable[[], None] | None = None,
-    ) -> QPushButton:
-        """Create an unsubscribe button."""
-        return self.panel._create_unsubscribe_button(pfid_column, completion_callback)
+        """Create a Steam button with subscribe/unsubscribe dropdown."""
+        return self.panel._create_steam_button(pfid_column, completion_callback)
 
     def create_delete_button(
         self,

--- a/app/windows/base_mods_panel.py
+++ b/app/windows/base_mods_panel.py
@@ -29,7 +29,7 @@ from PySide6.QtWidgets import (
 from app.controllers.metadata_controller import MetadataController
 from app.models.metadata.metadata_structure import AboutXmlMod, ListedMod, ModType
 from app.models.settings import Settings
-from app.utils.button_factory import ButtonFactory, MenuItem
+from app.utils.button_factory import ButtonConfig, ButtonFactory, ButtonType, MenuItem
 from app.utils.event_bus import EventBus
 from app.utils.generic import platform_specific_open
 from app.utils.mod_info import ModInfo
@@ -83,46 +83,11 @@ class ColumnIndex(Enum):
     WORKSHOP_PAGE = 10
 
 
-class ButtonType(Enum):
-    """Enumeration of button types for standardized button creation."""
-
-    REFRESH = "refresh"
-    STEAMCMD = "steamcmd"
-    SUBSCRIBE = "subscribe"
-    UNSUBSCRIBE = "unsubscribe"
-    DELETE = "delete"
-    SELECT = "select"
-    CUSTOM = "custom"
-
-
 class OperationMode(Enum):
     """Enumeration for mod update operation modes."""
 
     STEAMCMD = "SteamCMD"
     STEAM = "Steam"
-
-
-@dataclass
-class ButtonConfig:
-    """Configuration for creating standardized buttons."""
-
-    button_type: ButtonType
-    text: str = ""
-    pfid_column: int | None = None
-    # Callbacks to refresh the panel after deletion
-    completion_callback: Callable[[], None] | None = None
-    menu_items: list[MenuItem] | None = None
-    # For delete buttons
-    get_selected_mod_metadata: Callable[[], list[dict[str, Any]]] | None = None
-    # deletion menu
-    menu_title: str | None = None
-    enable_delete_mod: bool = True
-    enable_delete_keep_dds: bool = False
-    enable_delete_dds_only: bool = False
-    enable_delete_and_unsubscribe: bool = True
-    enable_delete_and_resubscribe: bool = False
-    # For custom buttons
-    custom_callback: Callable[[], None] | None = None
 
 
 class BaseModsPanel(QWidget):
@@ -746,30 +711,6 @@ class BaseModsPanel(QWidget):
                     self._create_update_callback(pfid_column, OperationMode.STEAMCMD),
                     "actionButton",
                 )
-        elif button_type == ButtonType.SUBSCRIBE:
-            if pfid_column is not None:
-                return self._create_button(
-                    self.tr("Subscribe selected"),
-                    self._create_update_callback(
-                        pfid_column,
-                        OperationMode.STEAM,
-                        "subscribe",
-                        completion_callback,
-                    ),
-                    "actionButton",
-                )
-        elif button_type == ButtonType.UNSUBSCRIBE:
-            if pfid_column is not None:
-                return self._create_button(
-                    self.tr("Unsubscribe selected"),
-                    self._create_update_callback(
-                        pfid_column,
-                        OperationMode.STEAM,
-                        "unsubscribe",
-                        completion_callback,
-                    ),
-                    "dangerButton",
-                )
         elif button_type == ButtonType.CUSTOM:
             return self._create_button(text, custom_callback, "primaryButton")
 
@@ -790,25 +731,43 @@ class BaseModsPanel(QWidget):
             ButtonType.STEAMCMD, pfid_column=pfid_column
         )
 
-    def _create_subscribe_button(
+    def _create_steam_button(
         self, pfid_column: int, completion_callback: Callable[[], None] | None = None
     ) -> QPushButton:
-        """Create a standardized subscribe button."""
-        return self._create_standardized_button(
-            ButtonType.SUBSCRIBE,
-            pfid_column=pfid_column,
-            completion_callback=completion_callback,
-        )
+        """Create a Steam button with dropdown for subscribe/unsubscribe."""
+        button = QPushButton()
+        button.setText(self.tr("Steam"))
+        button.setObjectName("actionButton")
 
-    def _create_unsubscribe_button(
-        self, pfid_column: int, completion_callback: Callable[[], None] | None = None
-    ) -> QPushButton:
-        """Create a standardized unsubscribe button."""
-        return self._create_standardized_button(
-            ButtonType.UNSUBSCRIBE,
-            pfid_column=pfid_column,
-            completion_callback=completion_callback,
+        menu = QMenu(button)
+
+        subscribe_action = QAction(self.tr("Subscribe selected"), self)
+        subscribe_action.triggered.connect(
+            self._create_update_callback(
+                pfid_column,
+                OperationMode.STEAM,
+                "subscribe",
+                completion_callback,
+            )
         )
+        menu.addAction(subscribe_action)
+
+        unsubscribe_action = QAction(self.tr("Unsubscribe selected"), self)
+        unsubscribe_action.triggered.connect(
+            self._create_update_callback(
+                pfid_column,
+                OperationMode.STEAM,
+                "unsubscribe",
+                completion_callback,
+            )
+        )
+        menu.addAction(unsubscribe_action)
+
+        button.setMenu(menu)
+        button.clicked.connect(
+            lambda: menu.exec(button.mapToGlobal(button.rect().bottomLeft()))
+        )
+        return button
 
     def _create_deletion_button(
         self,
@@ -908,10 +867,8 @@ class BaseModsPanel(QWidget):
             return self._create_refresh_button_from_config(config, factory)
         elif config.button_type == ButtonType.STEAMCMD:
             return self._create_steamcmd_button_from_config(config, factory)
-        elif config.button_type == ButtonType.SUBSCRIBE:
-            return self._create_subscribe_button_from_config(config, factory)
-        elif config.button_type == ButtonType.UNSUBSCRIBE:
-            return self._create_unsubscribe_button_from_config(config, factory)
+        elif config.button_type == ButtonType.STEAM:
+            return self._create_steam_button_from_config(config, factory)
         elif config.button_type == ButtonType.DELETE:
             return self._create_delete_button_from_config(config, factory)
         elif config.button_type == ButtonType.CUSTOM:
@@ -934,22 +891,12 @@ class BaseModsPanel(QWidget):
             return factory.create_steamcmd_button(config.pfid_column)
         return None
 
-    def _create_subscribe_button_from_config(
+    def _create_steam_button_from_config(
         self, config: ButtonConfig, factory: ButtonFactory
     ) -> QWidget | None:
-        """Create a subscribe button from config."""
+        """Create a Steam button from config."""
         if config.pfid_column is not None:
-            return factory.create_subscribe_button(
-                config.pfid_column, config.completion_callback
-            )
-        return None
-
-    def _create_unsubscribe_button_from_config(
-        self, config: ButtonConfig, factory: ButtonFactory
-    ) -> QWidget | None:
-        """Create an unsubscribe button from config."""
-        if config.pfid_column is not None:
-            return factory.create_unsubscribe_button(
+            return factory.create_steam_button(
                 config.pfid_column, config.completion_callback
             )
         return None
@@ -1359,17 +1306,11 @@ class BaseModsPanel(QWidget):
         """
         steam_client_integration_enabled = self._get_steam_client_integration_enabled()
         if steam_client_integration_enabled:
-            button_configs.extend(
-                [
-                    ButtonConfig(
-                        button_type=ButtonType.SUBSCRIBE,
-                        pfid_column=ColumnIndex.PUBLISHED_FILE_ID.value,
-                    ),
-                    ButtonConfig(
-                        button_type=ButtonType.UNSUBSCRIBE,
-                        pfid_column=ColumnIndex.PUBLISHED_FILE_ID.value,
-                    ),
-                ]
+            button_configs.append(
+                ButtonConfig(
+                    button_type=ButtonType.STEAM,
+                    pfid_column=ColumnIndex.PUBLISHED_FILE_ID.value,
+                ),
             )
         return button_configs
 

--- a/app/windows/missing_mod_properties_panel.py
+++ b/app/windows/missing_mod_properties_panel.py
@@ -5,11 +5,12 @@ from PySide6.QtWidgets import QMessageBox
 
 from app.controllers.metadata_controller import MetadataController
 from app.models.metadata.metadata_structure import ListedMod
+from app.utils.button_factory import ButtonConfig, ButtonType
 from app.utils.constants import DEFAULT_MISSING_PACKAGEID
 from app.utils.event_bus import EventBus
 from app.utils.ignore_manager import IgnoreManager
 from app.utils.mod_info import ModInfo
-from app.windows.base_mods_panel import BaseModsPanel, ButtonConfig, ButtonType
+from app.windows.base_mods_panel import BaseModsPanel
 
 
 class MissingModPropertiesPanel(BaseModsPanel):

--- a/app/windows/use_this_instead_panel.py
+++ b/app/windows/use_this_instead_panel.py
@@ -13,14 +13,11 @@ from app.models.metadata.metadata_structure import (
     ListedMod,
     ReplacementInfo,
 )
+from app.utils.button_factory import ButtonConfig, ButtonType, MenuItem
 from app.utils.mod_info import ModInfo
-from app.views import dialogue
 from app.windows.base_mods_panel import (
     BaseModsPanel,
-    ButtonConfig,
-    ButtonType,
     ColumnIndex,
-    MenuItem,
 )
 
 
@@ -100,19 +97,11 @@ class UseThisInsteadPanel(BaseModsPanel):
         button_configs.extend(self._get_base_button_configs())
 
         if steam_client_integration_enabled:
-            button_configs.extend(
-                [
-                    ButtonConfig(
-                        button_type=ButtonType.SUBSCRIBE,
-                        pfid_column=ColumnIndex.PUBLISHED_FILE_ID.value,
-                        completion_callback=self._on_subscribe_completed,
-                    ),
-                    ButtonConfig(
-                        button_type=ButtonType.UNSUBSCRIBE,
-                        pfid_column=ColumnIndex.PUBLISHED_FILE_ID.value,
-                        completion_callback=self._on_unsubscribe_completed,
-                    ),
-                ]
+            button_configs.append(
+                ButtonConfig(
+                    button_type=ButtonType.STEAM,
+                    pfid_column=ColumnIndex.PUBLISHED_FILE_ID.value,
+                ),
             )
 
         button_configs.append(
@@ -141,31 +130,6 @@ class UseThisInsteadPanel(BaseModsPanel):
             self.showNormal()
             return True
         return False
-
-    def _on_mod_action_completed(self, action: str, count: int) -> None:
-        """Handle successful mod action completion."""
-        dialogue.show_information(
-            self.tr("Use This Instead"),
-            self.tr(f"Successfully {action}d {count} mods"),
-        )
-
-    def _on_subscribe_completed(self) -> None:
-        """Handle subscribe completion."""
-        count = self._get_selected_count()
-        self._on_mod_action_completed("subscribe", count)
-
-    def _on_unsubscribe_completed(self) -> None:
-        """Handle unsubscribe completion."""
-        count = self._get_selected_count()
-        self._on_mod_action_completed("unsubscribe", count)
-
-    def _get_selected_count(self) -> int:
-        """Get the count of selected mods."""
-        count = 0
-        for row in range(self.editor_model.rowCount()):
-            if self._row_is_checked(row):
-                count += 1
-        return count
 
     def _populate_from_metadata(self) -> None:
         """


### PR DESCRIPTION
Consolidate the separate Subscribe Selected and Unsubscribe Selected buttons into a single **Steam** button with a dropdown menu, following the same pattern as the Delete button.

Changes:
- Add ButtonType.STEAM enum, _create_steam_button method, factory support, and config routing
- Replace both ButtonType.SUBSCRIBE/ButtonType.UNSUBSCRIBE configs in _extend_button_configs_with_steam_actions and UseThisInsteadPanel with a single ButtonType.STEAM config
- Remove all dead SUBSCRIBE/UNSUBSCRIBE code: enum values, button creation methods, factory methods, config routing, and orphaned helper methods
- Move ButtonType and ButtonConfig from ase_mods_panel.py to utton_factory.py for better co-location with the factory that consumes them