### PR TITLE
feat: replace single SteamCMD button with dropdown and move creation …

### DIFF
--- a/app/utils/button_factory.py
+++ b/app/utils/button_factory.py
@@ -63,8 +63,26 @@ class ButtonFactory:
         return self.panel._create_refresh_button(callback)
 
     def create_steamcmd_button(self, pfid_column: int) -> QPushButton:
-        """Create a SteamCMD download button."""
-        return self.panel._create_steamcmd_button(pfid_column)
+        """Create a SteamCMD button with dropdown menu."""
+        button = QPushButton()
+        button.setText(self.panel.tr("SteamCMD"))
+        button.setObjectName("actionButton")
+
+        from app.windows.base_mods_panel import OperationMode
+
+        menu = QMenu(button)
+
+        download_action = QAction(self.panel.tr("Download with SteamCMD"), self.panel)
+        download_action.triggered.connect(
+            self.panel._create_update_callback(pfid_column, OperationMode.STEAMCMD)
+        )
+        menu.addAction(download_action)
+
+        button.setMenu(menu)
+        button.clicked.connect(
+            lambda: menu.exec(button.mapToGlobal(button.rect().bottomLeft()))
+        )
+        return button
 
     def create_steam_button(
         self,

--- a/app/windows/base_mods_panel.py
+++ b/app/windows/base_mods_panel.py
@@ -704,13 +704,6 @@ class BaseModsPanel(QWidget):
             return self._create_button(
                 self.tr("Refresh"), custom_callback, "primaryButton"
             )
-        elif button_type == ButtonType.STEAMCMD:
-            if pfid_column is not None:
-                return self._create_button(
-                    self.tr("Download selected with SteamCMD"),
-                    self._create_update_callback(pfid_column, OperationMode.STEAMCMD),
-                    "actionButton",
-                )
         elif button_type == ButtonType.CUSTOM:
             return self._create_button(text, custom_callback, "primaryButton")
 
@@ -723,12 +716,6 @@ class BaseModsPanel(QWidget):
         """Create a standardized refresh button."""
         return self._create_standardized_button(
             ButtonType.REFRESH, custom_callback=callback
-        )
-
-    def _create_steamcmd_button(self, pfid_column: int) -> QPushButton:
-        """Create a standardized SteamCMD button."""
-        return self._create_standardized_button(
-            ButtonType.STEAMCMD, pfid_column=pfid_column
         )
 
     def _create_steam_button(


### PR DESCRIPTION
…to factory

Convert the single 'Download selected with SteamCMD' button into a dropdown button labeled 'SteamCMD' containing a 'Download with SteamCMD' menu item. Move the button creation logic from BaseModsPanel into ButtonFactory.create_steamcmd_button for consistency with the factory pattern. Remove the now-dead STEAMCMD branch from _create_standardized_button.