### PR TITLE
fix: restore No Version Warning database integration lost in metadata refactoring

### DIFF
--- a/app/controllers/metadata_controller.py
+++ b/app/controllers/metadata_controller.py
@@ -184,8 +184,11 @@ class MetadataController(QObject):
         self.metadata_mediator.workshop_mods_path = workshop_mods_path
         self.metadata_mediator.local_mods_path = local_mods_path
         self.metadata_mediator.game_path = game_path
-        self.metadata_mediator.no_version_warning_path = _get_path(
-            active_settings.external_no_version_warning_file_path
+        self.metadata_mediator.no_version_warning_path = self._resolve_db_path(
+            active_settings.external_no_version_warning_metadata_source,
+            active_settings.external_no_version_warning_file_path,
+            active_settings.external_no_version_warning_repo_path,
+            "ModIdsToFix.xml",
         )
         self.metadata_mediator.use_this_instead_path = self._resolve_db_path(
             active_settings.external_use_this_instead_metadata_source,
@@ -446,6 +449,10 @@ class MetadataController(QObject):
         mod = self.mods_metadata.get(path)
         if not isinstance(mod, AboutXmlMod):
             return False
+        if self.metadata_mediator.no_version_warning:
+            pid = str(mod.package_id).lower()
+            if pid in self.metadata_mediator.no_version_warning:
+                return False
         if not mod.supported_versions:
             return False
         game_major_minor = ".".join(self.game_version.split(".")[:2])

--- a/tests/controllers/test_metadata_controller.py
+++ b/tests/controllers/test_metadata_controller.py
@@ -39,6 +39,8 @@ def mock_settings() -> Generator[MagicMock, None, None]:
         mock_settings.external_steam_metadata_source = "Disabled"
         mock_settings.external_steam_metadata_repo = ""
         mock_settings.external_no_version_warning_file_path = ""
+        mock_settings.external_no_version_warning_metadata_source = "Disabled"
+        mock_settings.external_no_version_warning_repo_path = ""
         mock_settings.external_use_this_instead_file_path = ""
         mock_settings.external_use_this_instead_metadata_source = "Disabled"
         mock_settings.external_use_this_instead_repo_path = ""


### PR DESCRIPTION
## Summary

- **Fix path resolution**: `no_version_warning_path` was set with `_get_path()` which reads the raw settings default (`app_storage_folder/ModIdsToFix.xml`), but when the source is a git repo (the default config), the file lives at `databases_folder/NoVersionWarning/ModIdsToFix.xml`. Now uses `_resolve_db_path()` matching all other database path resolution — this was the reason the DB silently failed to load (no "Loaded N No Version Warning entries" in the log).
- **Restore No Version Warning check in `is_version_mismatch()`**: The v1.5.0 rewrite of this method dropped the check against the No Version Warning database entirely, so even if the DB loaded, whitelisted mods would still show version warnings.
- **Fix test mock**: Add missing `external_no_version_warning_metadata_source` and `external_no_version_warning_repo_path` attributes to the Settings mock.

## Context

Regression introduced in #2151 (metadata refactoring). Users upgrading from v1.4.2 to v1.5.0 report mods incorrectly marked with "mod and game version mismatch" that were not flagged before. The No Version Warning database (from `emipa606/NoVersionWarning`) is designed to suppress these warnings for mods known to work across versions.

## Test plan

- [x] All 1081 tests pass
- [x] mypy clean on modified file
- [x] ruff lint + format clean
- [ ] Manual verification: launch RimSort, confirm "Loaded N No Version Warning entries" appears in the log, and previously false-positive version mismatch warnings are gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)