### PR TITLE
theme: add QSS styling for filter panel widgets (FilterPanel, TagChip…

### DIFF
--- a/themes/Modern/style.qss
+++ b/themes/Modern/style.qss
@@ -1230,3 +1230,42 @@ QProgressBar#logProgressBar::chunk {
     background-color: #1f2e38;
     border-radius: 2px;
 }
+
+/* ===== Filter Panel (app/views/filter_panel.py) ===== */
+QFrame#FilterPanel {
+    background-color: #121c24;
+    border: 1px solid #2b4a6f;
+    border-radius: 8px;
+}
+
+QFrame#TagChip {
+    background-color: #1f2e38;
+    border: 1px solid #3b4a64;
+    border-radius: 4px;
+    padding: 2px 6px;
+    color: #d6e0f3;
+}
+
+QFrame#TagChip[active="true"] {
+    background-color: #2d6aa3;
+    border-color: #2d6aa3;
+}
+
+QFrame#TagChip[active="false"] {
+    background-color: #1f2e38;
+    border-color: #3b4a64;
+    color: #bfbfbf;
+}
+
+QFrame#TagChip:hover {
+    background-color: #2e3a4f;
+    border-color: #4a5a7a;
+}
+
+QLabel#FilterBadge {
+    background-color: #c4334d;
+    color: #ffffff;
+    border-radius: 8px;
+    font-size: 10px;
+    font-weight: bold;
+}

--- a/themes/Nature/style.qss
+++ b/themes/Nature/style.qss
@@ -1138,3 +1138,42 @@ QProgressBar#logProgressBar::chunk {
     background-color: #4a5b4a;
     border-radius: 2px;
 }
+
+/* ===== Filter Panel (app/views/filter_panel.py) ===== */
+QFrame#FilterPanel {
+    background-color: #3a4b3a;
+    border: 1px solid #6b8e23;
+    border-radius: 8px;
+}
+
+QFrame#TagChip {
+    background-color: #5a6b5a;
+    border: 1px solid #dcdcdc;
+    border-radius: 4px;
+    padding: 2px 6px;
+    color: #ffffff;
+}
+
+QFrame#TagChip[active="true"] {
+    background-color: #8fbc8f;
+    border-color: #8fbc8f;
+}
+
+QFrame#TagChip[active="false"] {
+    background-color: #5a6b5a;
+    border-color: #dcdcdc;
+    color: #f0e68c;
+}
+
+QFrame#TagChip:hover {
+    background-color: #556b2f;
+    border-color: #c0c0c0;
+}
+
+QLabel#FilterBadge {
+    background-color: #dc3545;
+    color: #ffffff;
+    border-radius: 8px;
+    font-size: 10px;
+    font-weight: bold;
+}

--- a/themes/RimPy/style.qss
+++ b/themes/RimPy/style.qss
@@ -1232,3 +1232,42 @@ QProgressBar#logProgressBar::chunk {
     background-color: #22303d;
     border-radius: 2px;
 }
+
+/* ===== Filter Panel (app/views/filter_panel.py) ===== */
+QFrame#FilterPanel {
+    background-color: #1B2838;
+    border: 1px solid #346792;
+    border-radius: 8px;
+}
+
+QFrame#TagChip {
+    background-color: #272e37;
+    border: 1px solid #455364;
+    border-radius: 4px;
+    padding: 2px 6px;
+    color: #e6edf3;
+}
+
+QFrame#TagChip[active="true"] {
+    background-color: #3688c3;
+    border-color: #3688c3;
+}
+
+QFrame#TagChip[active="false"] {
+    background-color: #272e37;
+    border-color: #455364;
+    color: #cfcfcf;
+}
+
+QFrame#TagChip:hover {
+    background-color: #37414f;
+    border-color: #54687a;
+}
+
+QLabel#FilterBadge {
+    background-color: #c4334d;
+    color: #ffffff;
+    border-radius: 8px;
+    font-size: 10px;
+    font-weight: bold;
+}

--- a/themes/SunSet/style.qss
+++ b/themes/SunSet/style.qss
@@ -1141,3 +1141,42 @@ QProgressBar#logProgressBar::chunk {
     background-color: #4a3a3a;
     border-radius: 2px;
 }
+
+/* ===== Filter Panel (app/views/filter_panel.py) ===== */
+QFrame#FilterPanel {
+    background-color: #3a2a2a;
+    border: 1px solid #ff4500;
+    border-radius: 8px;
+}
+
+QFrame#TagChip {
+    background-color: #5a4a4a;
+    border: 1px solid #ffd700;
+    border-radius: 4px;
+    padding: 2px 6px;
+    color: #ffffff;
+}
+
+QFrame#TagChip[active="true"] {
+    background-color: #ff6347;
+    border-color: #ff6347;
+}
+
+QFrame#TagChip[active="false"] {
+    background-color: #5a4a4a;
+    border-color: #ffd700;
+    color: #ffe4b5;
+}
+
+QFrame#TagChip:hover {
+    background-color: #ff7f50;
+    border-color: #ffa500;
+}
+
+QLabel#FilterBadge {
+    background-color: #ff4500;
+    color: #ffffff;
+    border-radius: 8px;
+    font-size: 10px;
+    font-weight: bold;
+}

--- a/themes/Wood/style.qss
+++ b/themes/Wood/style.qss
@@ -1132,3 +1132,42 @@ QProgressBar#logProgressBar::chunk {
     background-color: #5a4a4a;
     border-radius: 2px;
 }
+
+/* ===== Filter Panel (app/views/filter_panel.py) ===== */
+QFrame#FilterPanel {
+    background-color: #4a3a3a;
+    border: 1px solid #8b4513;
+    border-radius: 8px;
+}
+
+QFrame#TagChip {
+    background-color: #6a5a5a;
+    border: 1px solid #deb887;
+    border-radius: 4px;
+    padding: 2px 6px;
+    color: #ffffff;
+}
+
+QFrame#TagChip[active="true"] {
+    background-color: #a0522d;
+    border-color: #a0522d;
+}
+
+QFrame#TagChip[active="false"] {
+    background-color: #6a5a5a;
+    border-color: #deb887;
+    color: #ffe4c4;
+}
+
+QFrame#TagChip:hover {
+    background-color: #d2691e;
+    border-color: #f4a460;
+}
+
+QLabel#FilterBadge {
+    background-color: #dc3545;
+    color: #ffffff;
+    border-radius: 8px;
+    font-size: 10px;
+    font-weight: bold;
+}


### PR DESCRIPTION
…, FilterBadge)

Add per-theme QSS rules for the filter panel UI components that had no styling coverage: FilterPanel popup background/border, TagChip with active/inactive/hover states, and FilterBadge badge overlay.