### PR TITLE
refactor: combine select/deselect buttons into single dropdown

### DIFF
--- a/app/utils/button_factory.py
+++ b/app/utils/button_factory.py
@@ -84,6 +84,32 @@ class ButtonFactory:
         )
         return button
 
+    def create_select_all_button(self) -> QPushButton:
+        """Create a button with Select all/Deselect all dropdown."""
+        button = QPushButton()
+        button.setText(self.panel.tr("Select"))
+        button.setObjectName("actionButton")
+
+        menu = QMenu(button)
+
+        select_all_action = QAction(self.panel.tr("Select all"), self.panel)
+        select_all_action.triggered.connect(
+            lambda: self.panel._set_all_checkbox_rows(True)
+        )
+        menu.addAction(select_all_action)
+
+        deselect_all_action = QAction(self.panel.tr("Deselect all"), self.panel)
+        deselect_all_action.triggered.connect(
+            lambda: self.panel._set_all_checkbox_rows(False)
+        )
+        menu.addAction(deselect_all_action)
+
+        button.setMenu(menu)
+        button.clicked.connect(
+            lambda: menu.exec(button.mapToGlobal(button.rect().bottomLeft()))
+        )
+        return button
+
     def create_steam_button(
         self,
         pfid_column: int,

--- a/app/windows/base_mods_panel.py
+++ b/app/windows/base_mods_panel.py
@@ -48,7 +48,6 @@ class UIElements:
 
     title: QLabel
     details_label: QLabel
-    editor_deselect_all_button: QPushButton
     editor_select_all_button: QPushButton
     editor_cancel_button: QPushButton
 
@@ -230,16 +229,6 @@ class BaseModsPanel(QWidget):
             self.layouts.editor_exit_actions_layout
         )
 
-        self.ui_elements.editor_deselect_all_button.clicked.connect(
-            partial(self._set_all_checkbox_rows, False)
-        )
-        self.layouts.editor_checkbox_actions_layout.addWidget(
-            self.ui_elements.editor_deselect_all_button
-        )
-
-        self.ui_elements.editor_select_all_button.clicked.connect(
-            partial(self._set_all_checkbox_rows, True)
-        )
         self.layouts.editor_checkbox_actions_layout.addWidget(
             self.ui_elements.editor_select_all_button
         )
@@ -295,15 +284,13 @@ class BaseModsPanel(QWidget):
 
     def _initialize_ui_elements(self) -> None:
         """Initialize UI elements dataclasses."""
+        factory = self.get_button_factory()
         self.ui_elements = UIElements(
             title=QLabel(),
             details_label=QLabel(),
-            editor_deselect_all_button=QPushButton(self.tr("Deselect all")),
-            editor_select_all_button=QPushButton(self.tr("Select all")),
+            editor_select_all_button=factory.create_select_all_button(),
             editor_cancel_button=QPushButton(self.tr("Do nothing and exit")),
         )
-        self.ui_elements.editor_deselect_all_button.setObjectName("primaryButton")
-        self.ui_elements.editor_select_all_button.setObjectName("primaryButton")
         self.ui_elements.editor_cancel_button.setObjectName("dangerButton")
 
     def _initialize_layouts(self) -> None:


### PR DESCRIPTION
Replace the two separate editor_deselect_all_button and editor_select_all_button QPushButton widgets with a single create_select_all_button() method on ButtonFactory that provides both options in a dropdown menu, matching the pattern used by create_steamcmd_button().