### PR TITLE
refactor: consolidate button creation into ButtonFactory

### DIFF
--- a/app/models/operation_mode.py
+++ b/app/models/operation_mode.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from enum import Enum
+
+
+class OperationMode(Enum):
+    """Enumeration for mod update operation modes."""
+
+    STEAMCMD = "SteamCMD"
+    STEAM = "Steam"

--- a/app/utils/button_factory.py
+++ b/app/utils/button_factory.py
@@ -11,6 +11,8 @@ from typing import Any, Callable
 from PySide6.QtGui import QAction
 from PySide6.QtWidgets import QMenu, QPushButton, QToolButton
 
+from app.models.operation_mode import OperationMode
+
 
 class ButtonType(Enum):
     """Enumeration of button types for standardized button creation."""
@@ -56,59 +58,63 @@ class ButtonFactory:
     def __init__(self, panel: Any):
         self.panel = panel
 
+    def _create_dropdown_button(
+        self,
+        text: str,
+        object_name: str,
+        menu_items: list[tuple[str, Callable[[], None]]],
+    ) -> QPushButton:
+        """Create a QPushButton with a dropdown menu."""
+        button = QPushButton()
+        button.setText(self.panel.tr(text))
+        button.setObjectName(object_name)
+        menu = QMenu(button)
+        for label, callback in menu_items:
+            action = QAction(self.panel.tr(label), self.panel)
+            action.triggered.connect(callback)
+            menu.addAction(action)
+        button.setMenu(menu)
+        button.clicked.connect(
+            lambda: menu.exec(button.mapToGlobal(button.rect().bottomLeft()))
+        )
+        return button
+
     def create_refresh_button(
         self, callback: Callable[[], None] | None = None
     ) -> QPushButton:
         """Create a refresh button."""
-        return self.panel._create_refresh_button(callback)
+        button = QPushButton()
+        button.setText(self.panel.tr("Refresh"))
+        button.setObjectName("primaryButton")
+        if callback:
+            button.clicked.connect(callback)
+        return button
 
     def create_steamcmd_button(self, pfid_column: int) -> QPushButton:
         """Create a SteamCMD button with dropdown menu."""
-        button = QPushButton()
-        button.setText(self.panel.tr("SteamCMD"))
-        button.setObjectName("actionButton")
-
-        from app.windows.base_mods_panel import OperationMode
-
-        menu = QMenu(button)
-
-        download_action = QAction(self.panel.tr("Download with SteamCMD"), self.panel)
-        download_action.triggered.connect(
-            self.panel._create_update_callback(pfid_column, OperationMode.STEAMCMD)
+        return self._create_dropdown_button(
+            "SteamCMD",
+            "actionButton",
+            [
+                (
+                    "Download with SteamCMD",
+                    self.panel._create_update_callback(
+                        pfid_column, OperationMode.STEAMCMD
+                    ),
+                ),
+            ],
         )
-        menu.addAction(download_action)
-
-        button.setMenu(menu)
-        button.clicked.connect(
-            lambda: menu.exec(button.mapToGlobal(button.rect().bottomLeft()))
-        )
-        return button
 
     def create_select_all_button(self) -> QPushButton:
         """Create a button with Select all/Deselect all dropdown."""
-        button = QPushButton()
-        button.setText(self.panel.tr("Select"))
-        button.setObjectName("actionButton")
-
-        menu = QMenu(button)
-
-        select_all_action = QAction(self.panel.tr("Select all"), self.panel)
-        select_all_action.triggered.connect(
-            lambda: self.panel._set_all_checkbox_rows(True)
+        return self._create_dropdown_button(
+            "Select",
+            "actionButton",
+            [
+                ("Select all", lambda: self.panel._set_all_checkbox_rows(True)),
+                ("Deselect all", lambda: self.panel._set_all_checkbox_rows(False)),
+            ],
         )
-        menu.addAction(select_all_action)
-
-        deselect_all_action = QAction(self.panel.tr("Deselect all"), self.panel)
-        deselect_all_action.triggered.connect(
-            lambda: self.panel._set_all_checkbox_rows(False)
-        )
-        menu.addAction(deselect_all_action)
-
-        button.setMenu(menu)
-        button.clicked.connect(
-            lambda: menu.exec(button.mapToGlobal(button.rect().bottomLeft()))
-        )
-        return button
 
     def create_steam_button(
         self,
@@ -116,7 +122,30 @@ class ButtonFactory:
         completion_callback: Callable[[], None] | None = None,
     ) -> QPushButton:
         """Create a Steam button with subscribe/unsubscribe dropdown."""
-        return self.panel._create_steam_button(pfid_column, completion_callback)
+        return self._create_dropdown_button(
+            "Steam",
+            "actionButton",
+            [
+                (
+                    "Subscribe selected",
+                    self.panel._create_update_callback(
+                        pfid_column,
+                        OperationMode.STEAM,
+                        "subscribe",
+                        completion_callback,
+                    ),
+                ),
+                (
+                    "Unsubscribe selected",
+                    self.panel._create_update_callback(
+                        pfid_column,
+                        OperationMode.STEAM,
+                        "unsubscribe",
+                        completion_callback,
+                    ),
+                ),
+            ],
+        )
 
     def create_delete_button(
         self,

--- a/app/windows/base_mods_panel.py
+++ b/app/windows/base_mods_panel.py
@@ -28,6 +28,7 @@ from PySide6.QtWidgets import (
 
 from app.controllers.metadata_controller import MetadataController
 from app.models.metadata.metadata_structure import AboutXmlMod, ListedMod, ModType
+from app.models.operation_mode import OperationMode
 from app.models.settings import Settings
 from app.utils.button_factory import ButtonConfig, ButtonFactory, ButtonType, MenuItem
 from app.utils.event_bus import EventBus
@@ -80,13 +81,6 @@ class ColumnIndex(Enum):
     SOURCE = 8
     PATH = 9
     WORKSHOP_PAGE = 10
-
-
-class OperationMode(Enum):
-    """Enumeration for mod update operation modes."""
-
-    STEAMCMD = "SteamCMD"
-    STEAM = "Steam"
 
 
 class BaseModsPanel(QWidget):
@@ -640,108 +634,6 @@ class BaseModsPanel(QWidget):
         label.setPath(path)
         label.setObjectName(object_name)
         return label
-
-    def _create_button(
-        self,
-        text: str,
-        callback: Callable[[], None] | None = None,
-        object_name: str = "",
-    ) -> QPushButton:
-        """
-        Create a standardized button.
-
-        Args:
-            text: Button text.
-            callback: Optional callback function.
-            object_name: Optional object name for the button.
-
-        Returns:
-            QPushButton: Configured button.
-        """
-        button = QPushButton()
-        button.setText(text)
-        if object_name:
-            button.setObjectName(object_name)
-        if callback is not None:
-            button.clicked.connect(callback)
-        return button
-
-    def _create_standardized_button(
-        self,
-        button_type: ButtonType,
-        pfid_column: int | None = None,
-        completion_callback: Callable[[], None] | None = None,
-        custom_callback: Callable[[], None] | None = None,
-        text: str = "",
-    ) -> QPushButton:
-        """
-        Create a standardized button based on type.
-
-        Args:
-            button_type: Type of button to create.
-            pfid_column: Column index for published file ID (for Steam-related buttons).
-            completion_callback: Callback after operation completes.
-            custom_callback: Custom callback for custom buttons.
-            text: Custom text for the button.
-
-        Returns:
-            Configured QPushButton.
-        """
-        if button_type == ButtonType.REFRESH:
-            return self._create_button(
-                self.tr("Refresh"), custom_callback, "primaryButton"
-            )
-        elif button_type == ButtonType.CUSTOM:
-            return self._create_button(text, custom_callback, "primaryButton")
-
-        # Fallback
-        return self._create_button(text or "Button", custom_callback, "primaryButton")
-
-    def _create_refresh_button(
-        self, callback: Callable[[], None] | None
-    ) -> QPushButton:
-        """Create a standardized refresh button."""
-        return self._create_standardized_button(
-            ButtonType.REFRESH, custom_callback=callback
-        )
-
-    def _create_steam_button(
-        self, pfid_column: int, completion_callback: Callable[[], None] | None = None
-    ) -> QPushButton:
-        """Create a Steam button with dropdown for subscribe/unsubscribe."""
-        button = QPushButton()
-        button.setText(self.tr("Steam"))
-        button.setObjectName("actionButton")
-
-        menu = QMenu(button)
-
-        subscribe_action = QAction(self.tr("Subscribe selected"), self)
-        subscribe_action.triggered.connect(
-            self._create_update_callback(
-                pfid_column,
-                OperationMode.STEAM,
-                "subscribe",
-                completion_callback,
-            )
-        )
-        menu.addAction(subscribe_action)
-
-        unsubscribe_action = QAction(self.tr("Unsubscribe selected"), self)
-        unsubscribe_action.triggered.connect(
-            self._create_update_callback(
-                pfid_column,
-                OperationMode.STEAM,
-                "unsubscribe",
-                completion_callback,
-            )
-        )
-        menu.addAction(unsubscribe_action)
-
-        button.setMenu(menu)
-        button.clicked.connect(
-            lambda: menu.exec(button.mapToGlobal(button.rect().bottomLeft()))
-        )
-        return button
 
     def _create_deletion_button(
         self,

--- a/app/windows/missing_mods_panel.py
+++ b/app/windows/missing_mods_panel.py
@@ -7,12 +7,12 @@ from PySide6.QtWidgets import (
 )
 
 from app.controllers.metadata_controller import MetadataController
+from app.models.operation_mode import OperationMode
 from app.utils.constants import RIMWORLD_DLC_METADATA
 from app.windows.base_mods_panel import (
     BaseModsPanel,
     ButtonConfig,
     ButtonType,
-    OperationMode,
 )
 
 

--- a/app/windows/workshop_mod_updater_panel.py
+++ b/app/windows/workshop_mod_updater_panel.py
@@ -3,6 +3,7 @@ from typing import Any
 from loguru import logger
 
 from app.controllers.metadata_controller import MetadataController
+from app.models.operation_mode import OperationMode
 from app.utils.mod_info import ModInfo
 from app.utils.mod_utils import filter_eligible_mods_for_update
 from app.windows.base_mods_panel import (
@@ -10,7 +11,6 @@ from app.windows.base_mods_panel import (
     ButtonConfig,
     ButtonType,
     ColumnIndex,
-    OperationMode,
 )
 
 


### PR DESCRIPTION
- Extract OperationMode enum from base_mods_panel.py into app/models/operation_mode.py to eliminate circular imports
- Add _create_dropdown_button() helper to remove duplicate QPushButton + QMenu + exec pattern across 3 methods
- Move create_steam_button() and create_refresh_button() logic fully into the factory (previously delegated to panel)
- Refactor create_steamcmd_button() and create_select_all_button() to use the new dropdown helper
- Remove now-unused panel methods: _create_button, _create_standardized_button, _create_refresh_button, _create_steam_button