### PR TITLE
refactor: drop ButtonType.SELECT, promote create_dropdown_button

### DIFF
--- a/app/utils/button_factory.py
+++ b/app/utils/button_factory.py
@@ -9,7 +9,7 @@ from enum import Enum
 from typing import Any, Callable
 
 from PySide6.QtGui import QAction
-from PySide6.QtWidgets import QMenu, QPushButton, QToolButton
+from PySide6.QtWidgets import QMenu, QPushButton
 
 from app.models.operation_mode import OperationMode
 
@@ -21,7 +21,7 @@ class ButtonType(Enum):
     STEAMCMD = "steamcmd"
     STEAM = "steam"
     DELETE = "delete"
-    SELECT = "select"
+
     CUSTOM = "custom"
 
 
@@ -58,7 +58,7 @@ class ButtonFactory:
     def __init__(self, panel: Any):
         self.panel = panel
 
-    def _create_dropdown_button(
+    def create_dropdown_button(
         self,
         text: str,
         object_name: str,
@@ -92,7 +92,7 @@ class ButtonFactory:
 
     def create_steamcmd_button(self, pfid_column: int) -> QPushButton:
         """Create a SteamCMD button with dropdown menu."""
-        return self._create_dropdown_button(
+        return self.create_dropdown_button(
             "SteamCMD",
             "actionButton",
             [
@@ -107,7 +107,7 @@ class ButtonFactory:
 
     def create_select_all_button(self) -> QPushButton:
         """Create a button with Select all/Deselect all dropdown."""
-        return self._create_dropdown_button(
+        return self.create_dropdown_button(
             "Select",
             "actionButton",
             [
@@ -122,7 +122,7 @@ class ButtonFactory:
         completion_callback: Callable[[], None] | None = None,
     ) -> QPushButton:
         """Create a Steam button with subscribe/unsubscribe dropdown."""
-        return self._create_dropdown_button(
+        return self.create_dropdown_button(
             "Steam",
             "actionButton",
             [
@@ -177,20 +177,4 @@ class ButtonFactory:
         button = QPushButton(text)
         button.setObjectName("primaryButton")
         button.clicked.connect(callback)
-        return button
-
-    def create_select_button(
-        self, text: str, menu_items: list[MenuItem]
-    ) -> QToolButton:
-        """Create a select button with dropdown menu."""
-        button = QToolButton()
-        button.setText(text)
-        button.setObjectName("selectToolButton")
-        menu = QMenu(button)
-        for menu_item in menu_items:
-            action = QAction(menu_item.text, self.panel)
-            action.triggered.connect(menu_item.callback)
-            menu.addAction(action)
-        button.setMenu(menu)
-        button.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
         return button

--- a/app/windows/base_mods_panel.py
+++ b/app/windows/base_mods_panel.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Sequence, TypeVar
 
 from loguru import logger
 from PySide6.QtCore import QEvent, QObject, Qt
-from PySide6.QtGui import QAction, QKeyEvent, QStandardItem, QStandardItemModel
+from PySide6.QtGui import QKeyEvent, QStandardItem, QStandardItemModel
 from PySide6.QtWidgets import (
     QAbstractItemView,
     QCheckBox,
@@ -18,10 +18,8 @@ from PySide6.QtWidgets import (
     QHeaderView,
     QLabel,
     QLayout,
-    QMenu,
     QPushButton,
     QTableView,
-    QToolButton,
     QVBoxLayout,
     QWidget,
 )
@@ -30,7 +28,7 @@ from app.controllers.metadata_controller import MetadataController
 from app.models.metadata.metadata_structure import AboutXmlMod, ListedMod, ModType
 from app.models.operation_mode import OperationMode
 from app.models.settings import Settings
-from app.utils.button_factory import ButtonConfig, ButtonFactory, ButtonType, MenuItem
+from app.utils.button_factory import ButtonConfig, ButtonFactory, ButtonType
 from app.utils.event_bus import EventBus
 from app.utils.generic import platform_specific_open
 from app.utils.mod_info import ModInfo
@@ -739,8 +737,7 @@ class BaseModsPanel(QWidget):
             return self._create_delete_button_from_config(config, factory)
         elif config.button_type == ButtonType.CUSTOM:
             return self._create_custom_button_from_config(config, factory)
-        elif config.button_type == ButtonType.SELECT:
-            return self._create_select_button_from_config(config, factory)
+
         return None
 
     def _create_refresh_button_from_config(
@@ -791,14 +788,6 @@ class BaseModsPanel(QWidget):
             return factory.create_custom_button(config.text, config.custom_callback)
         return None
 
-    def _create_select_button_from_config(
-        self, config: ButtonConfig, factory: ButtonFactory
-    ) -> QWidget | None:
-        """Create a select button from config."""
-        if config.menu_items:
-            return factory.create_select_button(config.text, config.menu_items)
-        return None
-
     def _create_custom_button(
         self, text: str, callback: Callable[[], None]
     ) -> QPushButton:
@@ -815,31 +804,6 @@ class BaseModsPanel(QWidget):
         button = QPushButton(text)
         button.setObjectName("primaryButton")
         button.clicked.connect(callback)
-        return button
-
-    def _create_select_button(
-        self, text: str, menu_items: list[MenuItem]
-    ) -> QToolButton:
-        """
-        Create a select button with dropdown menu.
-
-        Args:
-            text: Button text
-            menu_items: List of menu items for the dropdown
-
-        Returns:
-            Configured select button with menu
-        """
-        button = QToolButton()
-        button.setText(text)
-        button.setObjectName("selectToolButton")
-        menu = QMenu(button)
-        for menu_item in menu_items:
-            action = QAction(menu_item.text, self)
-            action.triggered.connect(menu_item.callback)
-            menu.addAction(action)
-        button.setMenu(menu)
-        button.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
         return button
 
     # ===== CENTRALIZED METADATA HANDLING =====

--- a/app/windows/use_this_instead_panel.py
+++ b/app/windows/use_this_instead_panel.py
@@ -5,7 +5,7 @@ from typing import Any, Generator, Optional
 
 from loguru import logger
 from PySide6.QtGui import QStandardItem
-from PySide6.QtWidgets import QCheckBox
+from PySide6.QtWidgets import QCheckBox, QLabel, QPushButton
 
 from app.controllers.metadata_controller import MetadataController
 from app.models.metadata.metadata_structure import (
@@ -13,11 +13,12 @@ from app.models.metadata.metadata_structure import (
     ListedMod,
     ReplacementInfo,
 )
-from app.utils.button_factory import ButtonConfig, ButtonType, MenuItem
+from app.utils.button_factory import ButtonConfig, ButtonType
 from app.utils.mod_info import ModInfo
 from app.windows.base_mods_panel import (
     BaseModsPanel,
     ColumnIndex,
+    UIElements,
 )
 
 
@@ -78,23 +79,7 @@ class UseThisInsteadPanel(BaseModsPanel):
 
         steam_client_integration_enabled = self._get_steam_client_integration_enabled()
 
-        button_configs = [
-            ButtonConfig(
-                button_type=ButtonType.SELECT,
-                text=self.tr("Select"),
-                menu_items=[
-                    MenuItem(
-                        text=self.tr("Select all Originals"),
-                        callback=self._select_all_originals,
-                    ),
-                    MenuItem(
-                        text=self.tr("Select all Replacements"),
-                        callback=self._select_all_replacements,
-                    ),
-                ],
-            ),
-        ]
-        button_configs.extend(self._get_base_button_configs())
+        button_configs = list(self._get_base_button_configs())
 
         if steam_client_integration_enabled:
             button_configs.append(
@@ -115,6 +100,28 @@ class UseThisInsteadPanel(BaseModsPanel):
         # Initialize row index trackers for bulk selection operations
         self._original_rows: set[int] = set()
         self._replacement_rows: set[int] = set()
+
+    def _initialize_ui_elements(self) -> None:
+        """Initialize UI elements with custom select button."""
+        self.ui_elements = UIElements(
+            title=QLabel(),
+            details_label=QLabel(),
+            editor_select_all_button=self._create_custom_select_button(),
+            editor_cancel_button=QPushButton(self.tr("Do nothing and exit")),
+        )
+        self.ui_elements.editor_cancel_button.setObjectName("dangerButton")
+
+    def _create_custom_select_button(self) -> QPushButton:
+        """Create the select button with Originals/Replacements dropdown."""
+        factory = self.get_button_factory()
+        return factory.create_dropdown_button(
+            "Select",
+            "actionButton",
+            [
+                ("Select all Originals", self._select_all_originals),
+                ("Select all Replacements", self._select_all_replacements),
+            ],
+        )
 
     def show_if_has_alternatives(self) -> bool:
         """


### PR DESCRIPTION
- Remove ButtonType.SELECT and create_select_button() (QToolButton) from ButtonFactory — only used by one panel and inconsistent with the QPushButton pattern used by all other dropdown buttons
- Remove dead code: _create_select_button_from_config, _create_select_button, and stale imports from base_mods_panel.py
- Promote _create_dropdown_button → create_dropdown_button as a public API on ButtonFactory so panels can create dropdown buttons without duplicating the QPushButton+QMenu+QAction pattern
- UseThisInsteadPanel now overrides _initialize_ui_elements to replace the standard 'Select all / Deselect all' button with a custom 'Select all Originals / Select all Replacements' dropdown built via factory.create_dropdown_button()
- Eliminates jscpd clone between button_factory and use_this_instead_panel