### PR TITLE
refactor: replace json.dump with atomic_json_dump for crash-safe writes

### DIFF
--- a/app/controllers/troubleshooting_controller.py
+++ b/app/controllers/troubleshooting_controller.py
@@ -16,6 +16,7 @@ from app.utils.gui_info import (
     show_dialogue_conditional,
     show_dialogue_file,
 )
+from app.utils.json_utils import atomic_json_dump
 from app.views.dialogue import show_information, show_warning
 from app.views.troubleshooting_dialog import TroubleshootingDialog
 
@@ -488,8 +489,7 @@ class TroubleshootingController:
                 "knownExpansions": known_expansions_list,
             }
 
-            with open(save_path, "w") as f:
-                json.dump(export_data, f, indent=2)
+            atomic_json_dump(export_data, save_path, indent=2)
         except Exception as e:
             logger.error(f"Failed to export mod list: {e}")
             show_warning(

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -28,6 +28,7 @@ from app.utils.constants import (
 )
 from app.utils.event_bus import EventBus
 from app.utils.generic import handle_remove_read_only
+from app.utils.json_utils import atomic_json_dump
 from app.views.dialogue import BinaryChoiceDialog, InformationBox
 
 
@@ -426,8 +427,7 @@ class Settings(QObject):
 
         self._validate_steam_integration_config()
 
-        with open(str(self._settings_file), "w") as file:
-            json.dump(self._to_dict(), file, indent=4)
+        atomic_json_dump(self._to_dict(), str(self._settings_file), indent=4)
 
     def handle_corrupted_settings(self) -> None:
         use_old_backup = False

--- a/app/utils/app_info.py
+++ b/app/utils/app_info.py
@@ -1,4 +1,3 @@
-import json
 import os
 import sys
 from pathlib import Path
@@ -8,6 +7,7 @@ from lxml import etree, objectify
 from platformdirs import PlatformDirs
 
 from app.utils.constants import DEFAULT_USER_RULES
+from app.utils.json_utils import atomic_json_dump
 
 
 class AppInfo:
@@ -118,8 +118,7 @@ class AppInfo:
         # Initialize user rules file if it does not exist
         if not self._user_rules_file.exists():
             self._user_rules_file.parent.mkdir(parents=True, exist_ok=True)
-            with open(self._user_rules_file, "w", encoding="utf-8") as output:
-                json.dump(DEFAULT_USER_RULES, output, indent=4)
+            atomic_json_dump(DEFAULT_USER_RULES, str(self._user_rules_file), indent=4)
 
         # AppImage: clean up .bak from a previous successful update
         self._cleanup_appimage_backup()

--- a/app/utils/db_builder.py
+++ b/app/utils/db_builder.py
@@ -15,6 +15,7 @@ from app.models.settings import Settings
 from app.utils.app_info import AppInfo
 from app.utils.dict_utils import recursively_update_dict
 from app.utils.event_bus import EventBus
+from app.utils.json_utils import atomic_json_dump
 from app.utils.steam.db_builder_thread import SteamDatabaseBuilder
 from app.windows.runner_panel import RunnerPanel
 
@@ -515,8 +516,7 @@ class DatabaseBuilder(QObject):
             return
 
         try:
-            with open(output_path, "w", encoding="utf-8") as output_file:
-                json.dump(db_output_c, output_file, indent=4)
+            atomic_json_dump(db_output_c, output_path, indent=4)
             logger.info(f"Successfully saved merged database to {output_path}")
         except OSError as e:
             logger.error(f"Failed to save merged database: {e}")

--- a/app/utils/db_builder_core.py
+++ b/app/utils/db_builder_core.py
@@ -16,6 +16,7 @@ from app.utils.constants import (
     RIMWORLD_DLC_METADATA,
 )
 from app.utils.dict_utils import recursively_update_dict
+from app.utils.json_utils import atomic_json_dump
 from app.utils.steam.webapi.wrapper import DynamicQuery
 
 
@@ -90,8 +91,7 @@ def output_database(
                 prune_exceptions=DB_BUILDER_PRUNE_EXCEPTIONS,
                 recurse_exceptions=DB_BUILDER_RECURSE_EXCEPTIONS,
             )
-            with open(output_database_path, "w", encoding="utf-8") as output:
-                json.dump(db_to_update, output, indent=4)
+            atomic_json_dump(db_to_update, output_database_path, indent=4)
         else:
             progress_callback(
                 "Unable to load database from specified path! Does the file exist...?"
@@ -101,12 +101,10 @@ def output_database(
                 / ("NEW_" + Path(output_database_path).name)
             )
             progress_callback(f"\nCaching DynamicQuery result:\n\n{appended_path}")
-            with open(appended_path, "w", encoding="utf-8") as output_f:
-                json.dump(database, output_f, indent=4)
+            atomic_json_dump(database, appended_path, indent=4)
     else:
         progress_callback(f"\nCaching DynamicQuery result:\n{output_database_path}")
-        with open(output_database_path, "w", encoding="utf-8") as output_f:
-            json.dump(database, output_f, indent=4)
+        atomic_json_dump(database, output_database_path, indent=4)
 
 
 class DBBuilderCore:

--- a/app/utils/ignore_manager.py
+++ b/app/utils/ignore_manager.py
@@ -5,6 +5,7 @@ from typing import Any
 from loguru import logger
 
 from app.utils.app_info import AppInfo
+from app.utils.json_utils import atomic_json_dump
 
 
 class IgnoreManager:
@@ -87,8 +88,7 @@ class IgnoreManager:
                 "description": "Mods to ignore when checking for missing properties (identified by packageid)",
             }
 
-            with open(ignore_file, "w", encoding="utf-8") as f:
-                json.dump(data, f, indent=4)
+            atomic_json_dump(data, str(ignore_file), indent=4)
 
             logger.info(f"Saved {len(ignored_mods)} ignored mods to {ignore_file}")
             return True

--- a/app/utils/json_utils.py
+++ b/app/utils/json_utils.py
@@ -1,0 +1,18 @@
+import json
+import os
+import tempfile
+from typing import Any
+
+
+def atomic_json_dump(data: Any, path: str, **kwargs: Any) -> None:
+    dirpath = os.path.dirname(path) or "."
+    fd, tmp = tempfile.mkstemp(suffix=".json", dir=dirpath)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, **kwargs)
+            f.flush()
+            os.fsync(fd)
+        os.replace(tmp, path)
+    except BaseException:
+        os.unlink(tmp)
+        raise

--- a/app/views/file_search_dialog.py
+++ b/app/views/file_search_dialog.py
@@ -26,6 +26,7 @@ from PySide6.QtWidgets import (
 
 from app.utils.app_info import AppInfo
 from app.utils.generic import platform_specific_open
+from app.utils.json_utils import atomic_json_dump
 
 
 class FileSearchDialog(QDialog):
@@ -809,8 +810,12 @@ class FileSearchDialog(QDialog):
         recent_searches_file = app_info.app_storage_folder / "recent_searches.json"
 
         try:
-            with open(recent_searches_file, "w", encoding="utf-8") as f:
-                json.dump(self._recent_searches, f, ensure_ascii=False, indent=4)
+            atomic_json_dump(
+                self._recent_searches,
+                str(recent_searches_file),
+                ensure_ascii=False,
+                indent=4,
+            )
         except Exception as e:
             logger.error(f"Failed to save recent searches: {e}")
 

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -58,6 +58,7 @@ from app.utils.generic import (
     platform_specific_open,
     upload_data_to_0x0_st,
 )
+from app.utils.json_utils import atomic_json_dump
 from app.utils.rentry.wrapper import RentryImport
 from app.utils.steam.availability import check_steam_available
 from app.utils.steam.steambrowser.browser import SteamBrowser
@@ -2763,8 +2764,7 @@ class MainContent(QObject):
             ).format(rules_source=rules_source, path=path),
         )
         if answer == QMessageBox.StandardButton.Yes:
-            with open(path, "w", encoding="utf-8") as output:
-                json.dump(db_output_c, output, indent=4)
+            atomic_json_dump(db_output_c, path, indent=4)
             # Do a full refresh of metadata and UI
             self._do_refresh()
         else:

--- a/tests/controllers/test_troubleshooting.py
+++ b/tests/controllers/test_troubleshooting.py
@@ -529,11 +529,13 @@ class TestModListImportExport:
                 return_value=True,
             ),
             patch("builtins.open", create=True) as mock_open,
-            patch("json.dump") as mock_json_dump,
+            patch(
+                "app.controllers.troubleshooting_controller.atomic_json_dump"
+            ) as mock_atomic_dump,
         ):
             controller._on_mod_export_list_button_clicked()
             mock_open.assert_called()
-            mock_json_dump.assert_called()
+            mock_atomic_dump.assert_called()
 
     def test_mod_import_list_button(
         self,


### PR DESCRIPTION
Writes to a temp file, fsyncs to disk, then atomically renames over the target. Prevents partially-written/corrupt JSON files on process crash or power loss on Windows.

- Add app/utils/json_utils.py with atomic_json_dump()
- Update 8 production files and 1 test file