### PR TITLE
feat: add progress reporting to GetAppDependencies

### DIFF
--- a/app/utils/steam/steamworks/wrapper.py
+++ b/app/utils/steam/steamworks/wrapper.py
@@ -27,6 +27,8 @@ Reference:
     https://github.com/philippj/SteamworksPy/pull/76
 """
 
+from __future__ import annotations
+
 import sys
 from multiprocessing import Process
 from os import getcwd
@@ -211,15 +213,23 @@ class SteamworksInterface:
 
 
 class SteamworksAppDependenciesQuery:
+    PROGRESS_LOG_INTERVAL = 100
+
     def __init__(
         self,
         pfid_or_pfids: Union[int, list[int]],
-        interval: int = 1,
+        interval: float = 1,
         _libs: str | None = None,
+        chunk_index: int = 0,
+        total_chunks: int = 0,
+        progress_callback: Callable[[str], None] | None = None,
     ) -> None:
         self._libs = _libs
         self.interval = interval
         self.pfid_or_pfids = pfid_or_pfids
+        self.chunk_index = chunk_index
+        self.total_chunks = total_chunks
+        self.progress_callback = progress_callback
 
     def run(self) -> None | dict[int, Any]:
         """
@@ -235,36 +245,60 @@ class SteamworksAppDependenciesQuery:
         if isinstance(self.pfid_or_pfids, int):
             self.pfid_or_pfids = [self.pfid_or_pfids]
         # Create our Steamworks interface and initialize Steamworks API
+        total = len(self.pfid_or_pfids)
         steamworks_interface = SteamworksInterface(
-            callbacks=True, callbacks_total=len(self.pfid_or_pfids), _libs=self._libs
+            callbacks=True, callbacks_total=total, _libs=self._libs
         )
-        if not steamworks_interface.steam_not_running:  # Skip if True
-            while not steamworks_interface.steamworks.loaded():  # Ensure that Steamworks API is initialized before attempting any instruction
-                break
-            else:
-                for pfid in self.pfid_or_pfids:
-                    logger.debug(f"ISteamUGC/GetAppDependencies Query: {pfid}")
-                    steamworks_interface.steamworks.Workshop.SetGetAppDependenciesResultCallback(
-                        steamworks_interface._cb_app_dependencies_result_callback
-                    )
-                    steamworks_interface.steamworks.Workshop.GetAppDependencies(pfid)
-                    # Sleep for the interval if we have more than one pfid to action on
-                    if len(self.pfid_or_pfids) > 1:
-                        sleep(self.interval)
-                # Patience, but don't wait forever
-                steamworks_interface._wait_for_callbacks(timeout=60)
-                # This means that the callbacks thread has ended. We are done with Steamworks API now, so we dispose of everything.
-                logger.info("Thread completed. Unloading Steamworks...")
-                steamworks_interface.steamworks_thread.join()
-                # Grab the data and return it
-                logger.warning(
-                    f"Returning {len(steamworks_interface.get_app_deps_query_result.keys())} results..."
-                )
-                return steamworks_interface.get_app_deps_query_result
-        else:
+        if steamworks_interface.steam_not_running:  # Skip if True
             steamworks_interface.steamworks.unload()
+            return None
 
-        return None
+        start_time = time()
+        while not steamworks_interface.steamworks.loaded():
+            if time() - start_time > STEAMWORKS_TIMEOUT:
+                logger.error(
+                    f"Timeout waiting for Steamworks to load (>{STEAMWORKS_TIMEOUT}s)"
+                )
+                return None
+            sleep(OPERATION_INTERVAL)
+
+        chunk_tag = (
+            f" [chunk {self.chunk_index}/{self.total_chunks}]"
+            if self.total_chunks
+            else ""
+        )
+        # Initialize the progress bar
+        if self.progress_callback is not None:
+            self.progress_callback(f"Progress: 0/{total}")
+        for idx, pfid in enumerate(self.pfid_or_pfids):
+            logger.debug(f"ISteamUGC/GetAppDependencies Query: {pfid}")
+            steamworks_interface.steamworks.Workshop.SetGetAppDependenciesResultCallback(
+                steamworks_interface._cb_app_dependencies_result_callback
+            )
+            steamworks_interface.steamworks.Workshop.GetAppDependencies(pfid)
+            # Sleep for the interval if we have more than one pfid to action on
+            if total > 1:
+                sleep(self.interval)
+            if idx % self.PROGRESS_LOG_INTERVAL == 0 and idx > 0:
+                logger.info(f"GetAppDependencies progress: {idx}/{total}{chunk_tag}")
+                if self.progress_callback is not None:
+                    self.progress_callback(f"Progress: {idx}/{total}")
+        # Patience, but don't wait forever
+        steamworks_interface._wait_for_callbacks(timeout=60)
+        # This means that the callbacks thread has ended. We are done with Steamworks API now, so we dispose of everything.
+        logger.info("Thread completed. Unloading Steamworks...")
+        steamworks_interface.steamworks_thread.join()
+        # Grab the data and return it
+        received = len(steamworks_interface.get_app_deps_query_result.keys())
+        summary = (
+            f"GetAppDependencies chunk {self.chunk_index}/{self.total_chunks} complete: "
+            f"{received}/{total} results received"
+        )
+        logger.info(summary)
+        if self.progress_callback is not None:
+            self.progress_callback(f"Progress: {total}/{total}")
+            self.progress_callback(summary)
+        return steamworks_interface.get_app_deps_query_result
 
 
 class SteamworksGameLaunch(Process):

--- a/app/utils/steam/webapi/wrapper.py
+++ b/app/utils/steam/webapi/wrapper.py
@@ -1,9 +1,10 @@
+from __future__ import annotations
+
 import sys
 import traceback
 from collections.abc import Callable
 from logging import WARNING, getLogger
 from math import ceil
-from multiprocessing import Pool, cpu_count
 from time import sleep, time
 from typing import TYPE_CHECKING, Any, Optional
 from urllib.parse import urlparse
@@ -19,6 +20,7 @@ from app.utils import http
 from app.utils.app_info import AppInfo
 from app.utils.constants import RIMWORLD_DLC_METADATA
 from app.utils.generic import chunks
+from app.utils.steam.availability import check_steam_available
 from app.utils.steam.steamworks.wrapper import SteamworksAppDependenciesQuery
 from app.views.dialogue import show_warning
 
@@ -683,35 +685,41 @@ class DynamicQuery(QObject):
         RimPy db_data["database"] format, or the skeleton of one from local_metadata
         :return: Dict containing the updated json data from PublishedFileIds query
         """
+        total_mods = len(publishedfileids)
+        # Estimate: each mod takes ~0.2s (API call + interval sleep)
+        est_seconds = int(total_mods * 0.2)
+        if est_seconds < 60:
+            est_str = f"{est_seconds}s"
+        else:
+            est_str = f"{est_seconds // 60}m {est_seconds % 60}s"
         self._emit_message(
-            f"\nSteamworks API: ISteamUGC/GetAppDependencies initializing for {len(publishedfileids)} mods\n\nThis may take a while. Please wait..."
+            f"\nSteamworks API: ISteamUGC/GetAppDependencies initializing for "
+            f"{total_mods} mods (single process)\n"
+            f"Estimated time: ~{est_str}.\n"
+            f"Please wait..."
         )
-        # Maximum processes
-        num_processes = cpu_count()
-        # Create a pool of worker processes
-        with Pool(processes=num_processes) as pool:
-            # Create instances of SteamworksAppDependenciesQuery for each chunk
-            queries = [
-                SteamworksAppDependenciesQuery(
-                    pfid_or_pfids=[int(str_pfid) for str_pfid in chunk],
-                    interval=1,
-                    _libs=str(AppInfo().libs_folder),
-                )
-                for chunk in list(
-                    chunks(
-                        _list=publishedfileids,
-                        limit=ceil(len(publishedfileids) / num_processes),
-                    )
-                )
-            ]
-            # Map the execution of the queries to the pool of processes
-            results = pool.map(SteamworksAppDependenciesQuery.run, queries)
-        # Merge the results from all processes into a single dictionary
-        self._emit_message("Processes completed!\nCollecting results")
+        # Check Steam availability before spawning processes
+        if not check_steam_available(str(AppInfo().libs_folder)):
+            self._emit_message(
+                "\nSteam is not available. Skipping AppID dependency retrieval."
+            )
+            return
+        # Run all queries in a single process — the Steamworks SDK cannot
+        # be initialized from multiple processes simultaneously (cross-thread
+        # pipe stalls)
+        deps_query = SteamworksAppDependenciesQuery(
+            pfid_or_pfids=[int(str_pfid) for str_pfid in publishedfileids],
+            interval=0.2,
+            _libs=str(AppInfo().libs_folder),
+            chunk_index=1,
+            total_chunks=1,
+            progress_callback=self._emit_message,
+        )
+        result = deps_query.run()
+        # Merge results into a single dictionary
         pfids_appid_deps: dict[int, list[int]] = {}
-        for result in results:
-            if result is not None:
-                pfids_appid_deps.update(result)
+        if result is not None:
+            pfids_appid_deps.update(result)
         self._emit_message(f"\nTotal: {len(pfids_appid_deps.keys())}")
         # Uncomment to see the total metadata returned from all Processes
         # logger.debug(pfids_appid_deps)

--- a/app/windows/runner_panel.py
+++ b/app/windows/runner_panel.py
@@ -487,7 +487,7 @@ class RunnerPanel(QWidget):
             self.progress_bar.setRange(0, int(end))
             self.progress_bar.setValue(int(start))
             return True
-        return False
+        return self._handle_todds_output(line)
 
     def _overwrite_last_line(self, text: str) -> None:
         """Replace the last line in the text display with the given text."""


### PR DESCRIPTION
- Replace multiprocessing Pool(8) with single-process execution to avoid Steamworks SDK cross-thread pipe crashes
- Reduce per-call interval from 1s to 0.2s
- Add Steam availability check before query with graceful skip
- Add 30s timeout for Steamworks loaded() initialization to fix race condition where the query was silently skipped
- Add progress_callback to emit Progress: X/Y every 100 mods, updating both the runner panel text and progress bar
- Fix double tilde in estimate format, remove unused cpu_count import
- Reuse _handle_todds_output for Progress: parsing via _handle_query_output