### PR TITLE
fix: use attribute access on SteamDbEntry struct instead of dict get

### DIFF
--- a/app/windows/runner_panel.py
+++ b/app/windows/runner_panel.py
@@ -626,7 +626,7 @@ class RunnerPanel(QWidget):
             for failed_mod_pfid in self.steamcmd_download_tracking:
                 mod_info = self.steam_db.get(failed_mod_pfid)
                 if mod_info:
-                    mod_name = mod_info.get("steamName") or mod_info.get("name")
+                    mod_name = mod_info.steamName or mod_info.name
                     if mod_name:
                         pfids_to_name[failed_mod_pfid] = mod_name
                     else:


### PR DESCRIPTION
SteamDbEntry is a msgspec.Struct with typed fields, not a dict. Calling .get() on it raised an AttributeError when resolving mod names after failed SteamCMD downloads.