### PR TITLE
fix: replace <br> with \n in details text for setDetailedText

### DIFF
--- a/app/controllers/main_content_controller.py
+++ b/app/controllers/main_content_controller.py
@@ -548,7 +548,7 @@ class MainContentController(QObject):
             information=self.tr(
                 "This will push local commits to the remote repositories."
             ),
-            details="<br>".join([str(p) for p in repos_paths]),
+            details="\n".join([str(p) for p in repos_paths]),
             positive_text=self.tr("Push"),
             negative_text=self.tr("Cancel"),
         )
@@ -606,12 +606,12 @@ class MainContentController(QObject):
                 information=self.tr("{count} repositories were pushed.").format(
                     count=len(successful)
                 ),
-                details="<br>".join([Path(p).name for p in successful]),
+                details="\n".join([Path(p).name for p in successful]),
             ).exec()
         elif not successful:
             details_msg = ""
             for repo_path, err in failed:
-                details_msg += f"{Path(repo_path).name}: {err}<br>"
+                details_msg += f"{Path(repo_path).name}: {err}\n"
 
             InformationBox(
                 title=self.tr("Push Failed"),
@@ -622,12 +622,12 @@ class MainContentController(QObject):
                 details=details_msg,
             ).exec()
         else:
-            details_msg = self.tr("Successful pushes:<br>")
+            details_msg = self.tr("Successful pushes:\n")
             for p in successful:
-                details_msg += f"  ✓ {Path(p).name}<br>"
-            details_msg += f"<br>{self.tr('Failed pushes:')}<br>"
+                details_msg += f"  \u2713 {Path(p).name}\n"
+            details_msg += f"\n{self.tr('Failed pushes:')}\n"
             for repo_path, err in failed:
-                details_msg += f"  ✗ {Path(repo_path).name}: {err}<br>"
+                details_msg += f"  \u2717 {Path(repo_path).name}: {err}\n"
 
             InformationBox(
                 title=self.tr("Partial Push Completed"),

--- a/app/sort/topo_sort.py
+++ b/app/sort/topo_sort.py
@@ -91,5 +91,5 @@ def find_circular_dependencies(dependency_graph: dict[str, set[str]]) -> None:
             "find_circular_dependencies",
             "RimSort found circular dependencies in your mods list. Please see the details for dependency loops.",
         ),
-        details="<br><br>".join(cycle_strings),
+        details="\n\n".join(cycle_strings),
     )

--- a/app/utils/steam/webapi/wrapper.py
+++ b/app/utils/steam/webapi/wrapper.py
@@ -170,7 +170,7 @@ class CollectionImport:
                             "This may happen if you don't have all the mods downloaded.<br><br>"
                             "Try subscribing to the collection first",
                         ),
-                        details="<br>".join(failed_mods),
+                        details="\n".join(failed_mods),
                     )
         except Exception as e:
             logger.error(

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -1967,7 +1967,7 @@ class MainContent(QObject):
                 text=self.tr(
                     "RimSort was unable to check your Workshop mods for updates."
                 ),
-                details="<br>".join(result.errors) if result.errors else None,
+                details="\n".join(result.errors) if result.errors else None,
             )
             return
 
@@ -1980,7 +1980,7 @@ class MainContent(QObject):
                     failed=len(result.failed_pfids),
                     total=result.mods_checked,
                 ),
-                details="<br>".join(result.errors) if result.errors else None,
+                details="\n".join(result.errors) if result.errors else None,
             )
 
         # For both "success" and "partial", show the updater panel

--- a/app/windows/runner_panel.py
+++ b/app/windows/runner_panel.py
@@ -589,7 +589,7 @@ class RunnerPanel(QWidget):
         pfids_to_name = self._resolve_mod_names()
 
         # Compile details of failed mods for the report
-        details = "<br>".join(
+        details = "\n".join(
             f"{pfids_to_name.get(pfid, f'Mod name not found (ID: {pfid})')}"
             for pfid in self.steamcmd_download_tracking
         )


### PR DESCRIPTION

setDetailedText uses QTextEdit::setPlainText internally, so <br> tags were rendered literally instead of as line breaks. Changed all details strings to use \n/\n\n instead of <br>/<br><br>.

Affected files:
- runner_panel.py: failed SteamCMD download details
- main_content_panel.py: update check error details
- main_content_controller.py: push operation details
- webapi/wrapper.py: collection import failure details
- topo_sort.py: circular dependency details

description_widget.py was left unchanged as it uses QTextBrowser with setHtml where <br> is properly rendered.