### PR TITLE
fix: resolve perpetual update loop in Update Workshop Mods panel

### DIFF
--- a/app/utils/generic.py
+++ b/app/utils/generic.py
@@ -811,7 +811,7 @@ def format_time_display(timestamp: int | None) -> tuple[str, int | None]:
         tuple[str, int | None]: A tuple of (formatted_time_string, timestamp).
                                  If timestamp is None, returns ("Unknown", None).
     """
-    if timestamp is None:
+    if timestamp is None or timestamp <= 0:
         return "Unknown", None
 
     try:

--- a/app/utils/mod_utils.py
+++ b/app/utils/mod_utils.py
@@ -91,14 +91,16 @@ def filter_eligible_mods_for_update(
     mods_metadata: dict[str, ListedMod],
 ) -> list[dict[str, Any]]:
     """
-    Filter mods that are eligible for update.
+    Filter mods that need user action (update or initial download/population).
 
-    A mod is eligible when it originates from Steam Workshop (or SteamCMD),
-    has a valid internal timestamp, has a valid external timestamp, and the
-    external timestamp is strictly newer than the internal one.
+    A mod needs action when it originates from Steam Workshop (or SteamCMD)
+    and one of:
+    - external timestamp is strictly newer than internal (update available)
+    - no internal timestamp (needs initial download to generate one)
+    - no external timestamp (needs Steam API fetch to populate)
 
     :param mods_metadata: Dictionary of mods metadata keyed by path.
-    :return: List of metadata dictionaries for mods eligible for update.
+    :return: List of metadata dictionaries for mods needing action.
     """
     eligible: list[dict[str, Any]] = []
 
@@ -126,7 +128,17 @@ def filter_eligible_mods_for_update(
             )
             continue
 
-        # Resolve internal timestamp with fallback
+        # ── Resolve internal timestamp ──────────────────────────────────
+        # ``internal_time`` = when we last had the mod on disk.
+        # We try two sources and take the more recent one:
+        #   1. File mtime  (mod.internal_time_touched) – the mod folder's
+        #      last-modified time on the filesystem.
+        #   2. ACF time_updated  (aux DB) – the timestamp written by
+        #      Steam/SteamCMD when it last downloaded the mod.
+        #
+        # Steam/SteeamCMD often preserve original workshop upload timestamps
+        # as file mtimes, making source #1 unreliable.  We therefore prefer
+        # source #2 when it is available *and* more recent.
         internal_time: int | None = None
         timestamp_source: str = "none"
 
@@ -135,72 +147,49 @@ def filter_eligible_mods_for_update(
             internal_time = raw_touched
             timestamp_source = "internal_time_touched"
 
-        # Fallback to ACF timestamps from aux DB
-        if internal_time is None:
-            _, aux_entry = metadata_controller.get_metadata_with_path(path)
-            if aux_entry is not None and aux_entry.acf_time_updated > 0:
-                internal_time = aux_entry.acf_time_updated
-                timestamp_source = "acf_time_updated (fallback)"
-
-        if internal_time is None:
-            skipped_no_internal_time += 1
-            logger.debug(
-                "[mod_update] SKIP (no internal time) mod={mod_name!r} pfid={pfid}",
-                mod_name=mod_name,
-                pfid=pfid,
-            )
-            continue
-
-        # External timestamp from aux DB
         _, aux_entry = metadata_controller.get_metadata_with_path(path)
-        external_time = (
-            aux_entry.external_time_updated
-            if aux_entry is not None and aux_entry.external_time_updated > 0
-            else 0
-        )
-        if external_time <= 0:
-            skipped_no_external_time += 1
-            logger.debug(
-                "[mod_update] SKIP (no external time) mod={mod_name!r} pfid={pfid}",
-                mod_name=mod_name,
-                pfid=pfid,
-            )
-            continue
+        if aux_entry is not None and aux_entry.acf_time_updated > 0:
+            if internal_time is None or aux_entry.acf_time_updated > internal_time:
+                internal_time = aux_entry.acf_time_updated
+                timestamp_source = "acf_time_updated"
 
-        delta = external_time - internal_time
-        delta_days = delta / 86400
+        # 0 signals "no valid internal timestamp" in the decision logic below
+        if internal_time is None:
+            internal_time = 0
 
+        # ── External timestamp (from Steam API via aux DB) ──────────────
+        # ``external_time`` = when Steam Workshop says the mod was last
+        # updated.  Populated by query_workshop_update_data().  Falls back
+        # to acf_time_updated (from ACF WorkshopItemDetails.timeupdated)
+        # when the Steam API didn't return a value (e.g. mod removed from
+        # Workshop, network failure, etc.).
+        _, aux_entry = metadata_controller.get_metadata_with_path(path)
+        external_time = 0
+        if aux_entry is not None:
+            if aux_entry.external_time_updated > 0:
+                external_time = aux_entry.external_time_updated
+            elif aux_entry.acf_time_updated > 0:
+                external_time = aux_entry.acf_time_updated
+
+        # ── Decision ────────────────────────────────────────────────────
+        # Include the mod if it needs any form of user action:
         if external_time > internal_time:
-            # Build a compat dict for ModInfo.from_metadata consumption
-            compat_metadata: dict[str, Any] = {
-                "name": mod.name,
-                "publishedfileid": mod.published_file_id or "",
-                "path": str(mod.mod_path) if mod.mod_path else "",
-                "data_source": (
-                    "workshop" if mod.mod_type == ModType.STEAM_WORKSHOP else "steamcmd"
-                ),
-                "steamcmd": mod.mod_type == ModType.STEAM_CMD,
-                "internal_time_touched": mod.internal_time_touched,
-                "external_time_updated": external_time,
-            }
-            if isinstance(mod, AboutXmlMod):
-                compat_metadata["packageid"] = str(mod.package_id)
-                compat_metadata["authors"] = mod.authors
-                compat_metadata["supportedversions"] = sorted(mod.supported_versions)
-            eligible.append(compat_metadata)
-            logger.debug(
-                "[mod_update] ELIGIBLE mod={mod_name!r} pfid={pfid} "
-                "internal={internal_fmt} external={external_fmt} "
-                "delta={delta}s ({delta_days:.1f} days) source={source}",
-                mod_name=mod_name,
-                pfid=pfid,
-                internal_fmt=_format_timestamp(internal_time),
-                external_fmt=_format_timestamp(external_time),
-                delta=delta,
-                delta_days=delta_days,
-                source=timestamp_source,
-            )
+            # Steam reports a newer version than what we have on disk.
+            reason = "update_available"
+        elif internal_time == 0:
+            # We have no record of ever downloading this mod (missing file
+            # mtime *and* no ACF timestamp).  Include so the user can
+            # trigger an initial download that will populate the data.
+            skipped_no_internal_time += 1
+            reason = "no_internal_time"
+        elif external_time == 0:
+            # Steam API has not returned a time_updated yet (first run,
+            # API failure, etc.).  Include so the user can re-download
+            # and trigger a fresh API fetch on the next refresh.
+            skipped_no_external_time += 1
+            reason = "no_external_time"
         else:
+            # Both timestamps exist and internal >= external → up-to-date.
             skipped_up_to_date += 1
             logger.debug(
                 "[mod_update] SKIP (up to date) mod={mod_name!r} pfid={pfid} "
@@ -210,10 +199,46 @@ def filter_eligible_mods_for_update(
                 pfid=pfid,
                 internal_fmt=_format_timestamp(internal_time),
                 external_fmt=_format_timestamp(external_time),
-                delta=delta,
-                delta_days=delta_days,
+                delta=external_time - internal_time,
+                delta_days=(external_time - internal_time) / 86400,
                 source=timestamp_source,
             )
+            continue
+
+        delta = external_time - internal_time
+        delta_days = delta / 86400
+        # Build a dict compatible with ModInfo.from_metadata() so the
+        # WorkshopModUpdaterPanel table can display the mod row.
+        compat_metadata: dict[str, Any] = {
+            "name": mod.name,
+            "publishedfileid": mod.published_file_id or "",
+            "path": str(mod.mod_path) if mod.mod_path else "",
+            "data_source": (
+                "workshop" if mod.mod_type == ModType.STEAM_WORKSHOP else "steamcmd"
+            ),
+            "steamcmd": mod.mod_type == ModType.STEAM_CMD,
+            "internal_time_touched": mod.internal_time_touched,
+            "external_time_updated": external_time,
+        }
+        if isinstance(mod, AboutXmlMod):
+            compat_metadata["packageid"] = str(mod.package_id)
+            compat_metadata["authors"] = mod.authors
+            compat_metadata["supportedversions"] = sorted(mod.supported_versions)
+        eligible.append(compat_metadata)
+        logger.debug(
+            "[mod_update]{} mod={mod_name!r} pfid={pfid} "
+            "internal={internal_fmt} external={external_fmt} "
+            "delta={delta}s ({delta_days:.1f} days) reason={reason} source={source}",
+            " ELIGIBLE" if reason == "update_available" else " INCLUDED",
+            mod_name=mod_name,
+            pfid=pfid,
+            internal_fmt=_format_timestamp(internal_time),
+            external_fmt=_format_timestamp(external_time),
+            delta=delta,
+            delta_days=delta_days,
+            reason=reason,
+            source=timestamp_source,
+        )
 
     logger.info(
         "[mod_update] Eligibility summary: {eligible}/{total} eligible, "

--- a/tests/utils/test_mod_utils.py
+++ b/tests/utils/test_mod_utils.py
@@ -215,10 +215,11 @@ class TestFilterEligibleModsForUpdate:
         assert result[0]["name"] == "Test Mod"
 
     def test_internal_time_touched_preferred_over_acf_fallback(self) -> None:
-        """internal_time_touched takes priority over acf_time_updated fallback."""
+        """When file mtime is more recent than acf_time_updated, it is used."""
         mod = _make_update_mod(mod_path="/mods/test2")
         # internal_time_touched=3000 > external=2000 => not eligible
         # acf_time_updated=1000 < external=2000 => would be eligible if used
+        # max(3000, 1000) = 3000, so uses file mtime
         with (
             patch("os.path.exists", return_value=True),
             patch("os.path.getmtime", return_value=3000.0),
@@ -230,16 +231,38 @@ class TestFilterEligibleModsForUpdate:
             )
             result = filter_eligible_mods_for_update({"/mods/test2": mod})
         assert len(result) == 0, (
-            "Should use internal_time_touched, not acf_time_updated"
+            "Should use the more recent of internal_time_touched and acf_time_updated"
+        )
+
+    def test_acf_time_updated_preferred_when_more_recent_than_file_mtime(
+        self,
+    ) -> None:
+        """acf_time_updated is used when it is more recent than file mtime."""
+        mod = _make_update_mod(mod_path="/mods/test3")
+        # internal_time_touched=1000 < external=2000 => would be eligible
+        # acf_time_updated=3000 > external=2000 => not eligible (up-to-date)
+        # max(1000, 3000) = 3000, so uses acf_time_updated
+        with (
+            patch("os.path.exists", return_value=True),
+            patch("os.path.getmtime", return_value=1000.0),
+        ):
+            self._setup_aux_timestamps(
+                "/mods/test3",
+                acf_time_updated=3000,
+                external_time_updated=2000,
+            )
+            result = filter_eligible_mods_for_update({"/mods/test3": mod})
+        assert len(result) == 0, (
+            "Should use acf_time_updated when it is more recent than file mtime"
         )
 
     def test_no_internal_timestamps_at_all(self) -> None:
-        """Mods with no internal_time_touched and no acf_time_updated are skipped."""
+        """Mods with no internal_time_touched and no acf_time_updated are included."""
         mod = _make_update_mod(mod_path="/mods/nots")
         with patch("os.path.exists", return_value=False):
             # No aux entry => no fallback either
             result = filter_eligible_mods_for_update({"/mods/nots": mod})
-        assert len(result) == 0
+        assert len(result) == 1
 
     def test_up_to_date_mod_skipped(self) -> None:
         """Mods where external <= internal are skipped."""
@@ -278,7 +301,7 @@ class TestFilterEligibleModsForUpdate:
         assert len(result) == 0
 
     def test_no_external_time(self) -> None:
-        """Mods with no external_time_updated in aux DB are skipped."""
+        """Mods with no external_time_updated in aux DB are included."""
         mod = _make_update_mod(mod_path="/mods/noext")
         with (
             patch("os.path.exists", return_value=True),
@@ -286,10 +309,10 @@ class TestFilterEligibleModsForUpdate:
         ):
             # No aux entry => no external time
             result = filter_eligible_mods_for_update({"/mods/noext": mod})
-        assert len(result) == 0
+        assert len(result) == 1
 
     def test_zero_external_time_treated_as_missing(self) -> None:
-        """external_time_updated=0 should cause the mod to be skipped."""
+        """external_time_updated=0 causes the mod to be included (needs API fetch)."""
         mod = _make_update_mod(mod_path="/mods/zeroext")
         with (
             patch("os.path.exists", return_value=True),
@@ -297,7 +320,7 @@ class TestFilterEligibleModsForUpdate:
         ):
             self._setup_aux_timestamps("/mods/zeroext", external_time_updated=0)
             result = filter_eligible_mods_for_update({"/mods/zeroext": mod})
-        assert len(result) == 0
+        assert len(result) == 1
 
     def test_mixed_mods(self) -> None:
         """Only workshop/steamcmd mods with updates are returned from a mixed set."""


### PR DESCRIPTION
Multiple issues caused Steam/SteamCMD mods to appear perpetually out of date in the Update Workshop Mods panel even after a successful re-download:

1. internal_time comparison preferred file mtime over ACF timeupdated, but Steam/SteamCMD preserve the original workshop upload timestamp as the folder mtime, so it never changed on re-download.  Fix: use max(acf_time_updated, file_mtime) so a fresh ACF timestamp from SteamCMD correctly reflects the download.

2. Mods without any timestamps (no file, no ACF entry) were silently excluded from the panel, making it impossible to trigger an initial download for newly discovered SteamCMD mods. Fix: include mods when internal_time is zero (missing metadata), allowing the user to kick off the first download.

3. external_time_updated stays -1 when the Steam WebAPI returns result:9 (mod not found on Workshop).  Without an external reference the mod would always appear with reason=no_external_time. Fix: fall back to acf_time_updated as external time when the API didn't populate external_time_updated, so the mod is correctly classified as up-to-date after download.

4. format_time_display rendered -1 and 0 as 1970-01-01 instead of 'Unknown'.  Fix: treat timestamp <= 0 as Unknown.