### PR TITLE
feat: add resolve_aux_timestamps helper for accurate timestamp displa…

### DIFF
--- a/app/utils/mod_info.py
+++ b/app/utils/mod_info.py
@@ -66,7 +66,15 @@ class ModInfo:
             else:
                 source = DATABASE
             path = metadata.get("path", "")
-            downloaded_time_raw = metadata.get("internal_time_touched")
+            # Prefer acf_time_touched (ACF WorkshopItemsInstalled.timetouched)
+            # as the actual download time for SteamCMD mods.  Falls back to
+            # internal_time_touched (file mtime) for other mod types.
+            acf_time_touched = metadata.get("acf_time_touched")
+            downloaded_time_raw = (
+                acf_time_touched
+                if acf_time_touched is not None
+                else metadata.get("internal_time_touched")
+            )
             updated_time_raw = metadata.get("external_time_updated")
             workshop_url = cls._generate_workshop_url(published_file_id)
             type = metadata.get("type", "")
@@ -116,12 +124,19 @@ class ModInfo:
         *,
         type: str = "",
         installed_status: str = "",
+        acf_time_touched: int | None = None,
+        external_time_updated: int | None = None,
     ) -> "ModInfo":
         """Create ModInfo from a typed ListedMod object.
 
         :param mod: The ListedMod (or AboutXmlMod) to convert
         :param type: Override type label (e.g. "Original", "Replacement")
         :param installed_status: Override installed status label
+        :param acf_time_touched: ACF timetouched (actual download time for
+            SteamCMD mods).  When provided, used as downloaded_time_raw in
+            preference to internal_time_touched.
+        :param external_time_updated: Workshop update time from Steam API
+            or ACF fallback.  When provided, used as updated_time_raw.
         :return: A populated ModInfo instance
         """
         name = mod.name or UNKNOWN
@@ -148,9 +163,22 @@ class ModInfo:
             authors = UNKNOWN
 
         path = str(mod.mod_path) if mod.mod_path else ""
-        downloaded_time_raw: float | None = (
-            float(mod.internal_time_touched) if mod.internal_time_touched >= 0 else None
-        )
+
+        # Prefer ACF timetouched as the actual download time when available
+        downloaded_time_raw: float | None
+        if acf_time_touched is not None and acf_time_touched > 0:
+            downloaded_time_raw = float(acf_time_touched)
+        elif mod.internal_time_touched >= 0:
+            downloaded_time_raw = float(mod.internal_time_touched)
+        else:
+            downloaded_time_raw = None
+
+        updated_time_raw: float | None
+        if external_time_updated is not None and external_time_updated > 0:
+            updated_time_raw = float(external_time_updated)
+        else:
+            updated_time_raw = None
+
         workshop_url = cls._generate_workshop_url(published_file_id)
 
         return cls(
@@ -163,7 +191,7 @@ class ModInfo:
             source=source,
             path=path,
             downloaded_time_raw=downloaded_time_raw,
-            updated_time_raw=None,
+            updated_time_raw=updated_time_raw,
             workshop_url=workshop_url,
             type=type,
             installed_status=installed_status,

--- a/app/utils/mod_utils.py
+++ b/app/utils/mod_utils.py
@@ -5,7 +5,42 @@ from typing import Any
 from loguru import logger
 
 from app.controllers.metadata_controller import MetadataController
+from app.models.metadata.metadata_db import AuxMetadataEntry
 from app.models.metadata.metadata_structure import AboutXmlMod, ListedMod, ModType
+
+
+def resolve_aux_timestamps(
+    aux_entry: AuxMetadataEntry | None,
+) -> tuple[int | None, int | None]:
+    """Extract download-time and workshop-update-time from an aux DB entry.
+
+    *Download time*:  ACF ``timetouched`` (``WorkshopItemsInstalled``) — the
+    actual moment Steam/SteamCMD last touched the mod on disk.  This is the
+    best available ``downloaded_time_raw`` for SteamCMD mods.
+
+    *Workshop update time*:  Prefers the Steam WebAPI ``external_time_updated``
+    value, falling back to the ACF ``timeupdated`` (``WorkshopItemDetails``)
+    when the API didn't return a result (e.g. mod removed from Workshop).
+
+    Returns ``(acf_time_touched, resolved_external_time_updated)`` where
+    *None* means the source was missing or not positive.
+    """
+    if aux_entry is None:
+        return None, None
+
+    raw_touched = getattr(aux_entry, "acf_time_touched", -1)
+    acf_touched = raw_touched if raw_touched is not None and raw_touched > 0 else None
+
+    ext_updated: int | None = None
+    raw_external = getattr(aux_entry, "external_time_updated", -1)
+    if raw_external is not None and raw_external > 0:
+        ext_updated = raw_external
+    else:
+        raw_acf = getattr(aux_entry, "acf_time_updated", -1)
+        if raw_acf is not None and raw_acf > 0:
+            ext_updated = raw_acf
+
+    return acf_touched, ext_updated
 
 
 def get_mod_path_from_pfid(pfid: str) -> str | None:
@@ -163,13 +198,8 @@ def filter_eligible_mods_for_update(
         # to acf_time_updated (from ACF WorkshopItemDetails.timeupdated)
         # when the Steam API didn't return a value (e.g. mod removed from
         # Workshop, network failure, etc.).
-        _, aux_entry = metadata_controller.get_metadata_with_path(path)
-        external_time = 0
-        if aux_entry is not None:
-            if aux_entry.external_time_updated > 0:
-                external_time = aux_entry.external_time_updated
-            elif aux_entry.acf_time_updated > 0:
-                external_time = aux_entry.acf_time_updated
+        acf_touched, external_time_raw = resolve_aux_timestamps(aux_entry)
+        external_time = external_time_raw if external_time_raw is not None else 0
 
         # ── Decision ────────────────────────────────────────────────────
         # Include the mod if it needs any form of user action:
@@ -207,6 +237,7 @@ def filter_eligible_mods_for_update(
 
         delta = external_time - internal_time
         delta_days = delta / 86400
+
         # Build a dict compatible with ModInfo.from_metadata() so the
         # WorkshopModUpdaterPanel table can display the mod row.
         compat_metadata: dict[str, Any] = {
@@ -219,6 +250,7 @@ def filter_eligible_mods_for_update(
             "steamcmd": mod.mod_type == ModType.STEAM_CMD,
             "internal_time_touched": mod.internal_time_touched,
             "external_time_updated": external_time,
+            "acf_time_touched": acf_touched,
         }
         if isinstance(mod, AboutXmlMod):
             compat_metadata["packageid"] = str(mod.package_id)

--- a/app/views/mod_info_panel.py
+++ b/app/views/mod_info_panel.py
@@ -33,6 +33,7 @@ from app.utils.generic import format_file_size, platform_specific_open, scanpath
 from app.utils.github.models import CacheBase, GitHubModEntry, GitHubReleaseCache
 from app.utils.github.provider import GitHubProvider, _releases_from_json
 from app.utils.mod_info import UNKNOWN, ModInfo
+from app.utils.mod_utils import resolve_aux_timestamps
 from app.views.description_widget import DescriptionWidget
 
 # Constants for layout proportions
@@ -745,7 +746,7 @@ class ModInfoPanel:
         external_time_updated = mod_metadata.get("external_time_updated")
         internal_time_updated = mod_metadata.get("internal_time_updated")
 
-        if external_time_created:
+        if external_time_created is not None and external_time_created > 0:
             try:
                 dt_created = datetime.fromtimestamp(int(external_time_created))
                 external_times.append(
@@ -754,7 +755,7 @@ class ModInfoPanel:
             except (ValueError, OSError, OverflowError):
                 external_times.append("Created: Invalid")
 
-        if external_time_updated:
+        if external_time_updated is not None and external_time_updated > 0:
             try:
                 dt_updated = datetime.fromtimestamp(int(external_time_updated))
                 external_times.append(
@@ -763,7 +764,7 @@ class ModInfoPanel:
             except (ValueError, OSError, OverflowError):
                 external_times.append("Updated: Invalid")
 
-        if internal_time_updated:
+        if internal_time_updated is not None and internal_time_updated > 0:
             try:
                 dt_int_updated = datetime.fromtimestamp(int(internal_time_updated))
                 external_times.append(
@@ -1057,7 +1058,7 @@ class ModInfoPanel:
                 f"https://steamcommunity.com/sharedfiles/filedetails/?id={pfid}"
             )
 
-        # Get external timestamps from aux DB
+        # Get timestamps from aux DB
         _, aux_entry = self.metadata_controller.get_metadata_with_path(uuid)
         if aux_entry is not None:
             metadata["external_time_created"] = getattr(
@@ -1069,5 +1070,13 @@ class ModInfoPanel:
             metadata["internal_time_updated"] = getattr(
                 aux_entry, "internal_time_updated", None
             )
+            # Use the shared resolve_aux_timestamps helper so the mod-info
+            # panel shows the same download / workshop-update values as the
+            # update panel and the main mod list.
+            acf_touched, ext_updated = resolve_aux_timestamps(aux_entry)
+            if acf_touched is not None:
+                metadata["acf_time_touched"] = acf_touched
+            if ext_updated is not None:
+                metadata["external_time_updated"] = ext_updated
 
         return metadata

--- a/app/windows/base_mods_panel.py
+++ b/app/windows/base_mods_panel.py
@@ -32,7 +32,7 @@ from app.utils.button_factory import ButtonConfig, ButtonFactory, ButtonType
 from app.utils.event_bus import EventBus
 from app.utils.generic import platform_specific_open
 from app.utils.mod_info import ModInfo
-from app.utils.mod_utils import get_mod_path_from_pfid
+from app.utils.mod_utils import get_mod_path_from_pfid, resolve_aux_timestamps
 from app.views.deletion_menu import ModDeletionMenu
 from app.views.mod_info_panel import ClickablePathLabel
 
@@ -1028,7 +1028,19 @@ class BaseModsPanel(QWidget):
             ModInfo object
         """
         if isinstance(metadata, ListedMod):
-            mod_info = ModInfo.from_listed_mod(metadata)
+            # Look up aux timestamps so the mod list can show accurate
+            # download / workshop-update times even when the metadata dict
+            # path wasn't built from filter_eligible_mods_for_update.
+            acf_touched: int | None = None
+            ext_updated: int | None = None
+            if key is not None:
+                _, aux_entry = self.metadata_controller.get_metadata_with_path(key)
+                acf_touched, ext_updated = resolve_aux_timestamps(aux_entry)
+            mod_info = ModInfo.from_listed_mod(
+                metadata,
+                acf_time_touched=acf_touched,
+                external_time_updated=ext_updated,
+            )
             mod_info.key = key
             return mod_info
         return ModInfo.from_metadata(key, metadata)

--- a/tests/utils/test_mod_utils.py
+++ b/tests/utils/test_mod_utils.py
@@ -156,11 +156,13 @@ class TestFilterEligibleModsForUpdate:
         path: str,
         acf_time_updated: int = -1,
         external_time_updated: int = -1,
+        acf_time_touched: int = -1,
     ) -> None:
         """Configure aux DB mock to return timestamps for a given path."""
         aux_entry = MagicMock()
         aux_entry.acf_time_updated = acf_time_updated
         aux_entry.external_time_updated = external_time_updated
+        aux_entry.acf_time_touched = acf_time_touched
         self.mock_controller.get_metadata_with_path.side_effect = lambda p: (
             (MagicMock(), aux_entry) if p == path else (None, None)
         )
@@ -280,9 +282,11 @@ class TestFilterEligibleModsForUpdate:
             aux_eq = MagicMock()
             aux_eq.acf_time_updated = -1
             aux_eq.external_time_updated = 2000
+            aux_eq.acf_time_touched = -1
             aux_old = MagicMock()
             aux_old.acf_time_updated = -1
             aux_old.external_time_updated = 1000
+            aux_old.acf_time_touched = -1
 
             def multi_aux(p: str) -> tuple[MagicMock | None, MagicMock | None]:
                 if p == "/mods/eq":
@@ -346,12 +350,15 @@ class TestFilterEligibleModsForUpdate:
         aux_ws = MagicMock()
         aux_ws.acf_time_updated = -1
         aux_ws.external_time_updated = 2000
+        aux_ws.acf_time_touched = -1
         aux_utd = MagicMock()
         aux_utd.acf_time_updated = -1
         aux_utd.external_time_updated = 2000
+        aux_utd.acf_time_touched = -1
         aux_cmd = MagicMock()
         aux_cmd.acf_time_updated = 500
         aux_cmd.external_time_updated = 2000
+        aux_cmd.acf_time_touched = -1
 
         def multi_aux(p: str) -> tuple[MagicMock | None, MagicMock | None]:
             mapping: dict[str, MagicMock] = {


### PR DESCRIPTION
…y across all panels

Adds a shared resolve_aux_timestamps() helper in mod_utils.py that extracts acf_time_touched (ACF WorkshopItemsInstalled.timetouched) and resolves external_time_updated with ACF fallback from a single aux entry. This deduplicates the previously-inline logic that appeared in three separate call sites.

Updates:
- filter_eligible_mods_for_update: delegates aux DB reads to the helper and includes acf_time_touched in the compat_metadata dict
- _build_mod_metadata_dict (mod_info_panel): injects resolved acf_time_touched and external_time_updated into metadata so the info panel shows correct timestamps
- _extract_mod_info_from_metadata (base_mods_panel): passes aux timestamps to ModInfo.from_listed_mod for the main mod list
- _set_external_times_info (mod_info_panel): fixes truthiness checks (if x: -> if x is not None and x > 0) to avoid showing 'Invalid' for -1 default values
- ModInfo.from_metadata: prefers acf_time_touched over internal_time_touched as downloaded_time_raw
- ModInfo.from_listed_mod: accepts optional acf_time_touched and external_time_updated params, uses them as downloaded_time_raw and updated_time_raw respectively

Tests: mock aux entries now explicitly set acf_time_touched = -1 to match the real AuxMetadataEntry model defaults.