### PR TITLE
refactor: move render_unity_rich_text checkbox

### DIFF
--- a/app/controllers/settings_tabs/advanced_tab_controller.py
+++ b/app/controllers/settings_tabs/advanced_tab_controller.py
@@ -11,7 +11,7 @@ class AdvancedTabController(BaseTabController):
     """Controller for the Advanced settings tab.
 
     Manages: debug logging, watchdog, clear/DLC behavior, mod update checks,
-    rich text rendering, DB auto-update, mod name search scope, backup policy,
+    DB auto-update, mod name search scope, backup policy,
     save-comparison indicators, mod coloring mode, Auxiliary DB settings,
     and Authentication fields.
     """
@@ -74,9 +74,6 @@ class AdvancedTabController(BaseTabController):
         self.dialog.show_mod_updates_checkbox.setChecked(
             self.settings.steam_mods_update_check
         )
-        self.dialog.render_unity_rich_text_checkbox.setChecked(
-            self.settings.render_unity_rich_text
-        )
         self.dialog.update_databases_on_startup_checkbox.setChecked(
             self.settings.update_databases_on_startup
         )
@@ -122,9 +119,6 @@ class AdvancedTabController(BaseTabController):
         self.settings.clear_moves_dlc = self.dialog.clear_moves_dlc_checkbox.isChecked()
         self.settings.steam_mods_update_check = (
             self.dialog.show_mod_updates_checkbox.isChecked()
-        )
-        self.settings.render_unity_rich_text = (
-            self.dialog.render_unity_rich_text_checkbox.isChecked()
         )
         self.settings.update_databases_on_startup = (
             self.dialog.update_databases_on_startup_checkbox.isChecked()

--- a/app/controllers/settings_tabs/sorting_tab_controller.py
+++ b/app/controllers/settings_tabs/sorting_tab_controller.py
@@ -45,6 +45,9 @@ class SortingTabController(BaseTabController):
         self.dialog.case_insensitive_about_xml_checkbox.setChecked(
             self.settings.case_insensitive_about_xml_lookup
         )
+        self.dialog.render_unity_rich_text_checkbox.setChecked(
+            self.settings.render_unity_rich_text
+        )
         self.dialog.download_missing_mods_checkbox.setChecked(
             self.settings.try_download_missing_mods
         )
@@ -76,6 +79,9 @@ class SortingTabController(BaseTabController):
         )
         self.settings.case_insensitive_about_xml_lookup = (
             self.dialog.case_insensitive_about_xml_checkbox.isChecked()
+        )
+        self.settings.render_unity_rich_text = (
+            self.dialog.render_unity_rich_text_checkbox.isChecked()
         )
         self.settings.try_download_missing_mods = (
             self.dialog.download_missing_mods_checkbox.isChecked()

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -115,6 +115,7 @@ class Settings(QObject):
         # If enabled, About.xml *ByVersion tags take precedence over base tags
         # e.g., modDependenciesByVersion, loadAfterByVersion, loadBeforeByVersion, incompatibleWithByVersion, descriptionsByVersion
         self.prefer_versioned_about_tags: bool = True
+        self.render_unity_rich_text: bool = True
         self.case_insensitive_about_xml_lookup: bool = sys.platform == "linux"
 
         # Whether to notify user about missing mods
@@ -194,7 +195,6 @@ class Settings(QObject):
         self.auto_backup_compression_count: int = 10
         self.color_background_instead_of_text_toggle: bool = True
         self.steam_mods_update_check: bool = False
-        self.render_unity_rich_text: bool = True
         self.update_databases_on_startup: bool = True
         self.include_mod_notes_in_mod_name_filter: bool = False
         # UI: Save-comparison labels and icons

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -705,10 +705,7 @@ class MainContent(QObject):
         :param uuid: uuid of mod
         :param item: selected CustomListWidgetItem
         """
-        self.mod_info_panel.display_mod_info(
-            uuid=uuid,
-            render_unity_rt=self.settings.render_unity_rich_text,
-        )
+        self.mod_info_panel.display_mod_info(uuid=uuid)
         self.mod_info_panel.show_user_mod_notes(item)
 
     def __repopulate_lists(self, is_initial: bool = False) -> None:

--- a/app/views/mod_info_panel.py
+++ b/app/views/mod_info_panel.py
@@ -831,10 +831,12 @@ class ModInfoPanel:
         for widget in self.base_mod_info_widgets + self.scenario_info_widgets:
             widget.hide()
 
-    def _set_description(
-        self, mod_metadata: dict[str, Any], render_unity_rt: bool
-    ) -> None:
-        """Set the mod description with version-specific handling."""
+    def _set_description(self, mod_metadata: dict[str, Any]) -> None:
+        """
+        Set the mod description with version-specific handling.
+        render_unity_rt: Whether to render Unity rich text in descriptions
+        """
+        render_unity_rt = self.settings.render_unity_rich_text
         self.mod_info_path_value.setPath(mod_metadata.get("path"))
         # Set Steam URL value
         steam_url: str | None = None
@@ -966,13 +968,12 @@ class ModInfoPanel:
                         )
                     )
 
-    def display_mod_info(self, uuid: str, render_unity_rt: bool) -> None:
+    def display_mod_info(self, uuid: str) -> None:
         """
         This slot receives the UUID (path) of the mod that was just clicked on.
         It will set the relevant information on the info panel.
 
         :param uuid: UUID (path) of the mod to display
-        :param render_unity_rt: Whether to render Unity rich text in descriptions
         """
         mod = self.metadata_controller.get_mod(uuid)
         if mod is None:
@@ -1014,7 +1015,7 @@ class ModInfoPanel:
         self._update_github_info(mod_path)
 
         # Set description
-        self._set_description(mod_metadata, render_unity_rt)
+        self._set_description(mod_metadata)
 
         # Load preview image
         self._load_preview_image(mod_metadata, is_scenario)

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -806,6 +806,17 @@ This basically preserves your mod coloring, user notes etc. for this many second
         modlist_option_label = self._make_section_label("Mod list options")
         modlist_option_group_box_layout.addWidget(modlist_option_label)
 
+        # Rich text rendering checkbox
+        self.render_unity_rich_text_checkbox = QCheckBox(
+            self.tr("Render Unity Rich Text in mod descriptions")
+        )
+        self.render_unity_rich_text_checkbox.setToolTip(
+            self.tr(
+                "Enable this option to render Unity Rich Text in mod descriptions. Images will not be displayed."
+            )
+        )
+        modlist_option_group_box_layout.addWidget(self.render_unity_rich_text_checkbox)
+
         # Download missing mods checkbox
         self.download_missing_mods_checkbox = QCheckBox(
             self.tr("Download missing mods automatically")
@@ -1496,19 +1507,10 @@ This basically preserves your mod coloring, user notes etc. for this many second
         )
         group_layout.addWidget(self.show_mod_updates_checkbox)
 
-        self.render_unity_rich_text_checkbox = QCheckBox(
-            self.tr("Render Unity Rich Text in mod descriptions")
-        )
         self.color_background_instead_of_text_checkbox = QCheckBox(
             self.tr("Apply mod coloring to background instead of text")
         )
         group_layout.addWidget(self.color_background_instead_of_text_checkbox)
-        self.render_unity_rich_text_checkbox.setToolTip(
-            self.tr(
-                "Enable this option to render Unity Rich Text in mod descriptions. Images will not be displayed."
-            )
-        )
-        group_layout.addWidget(self.render_unity_rich_text_checkbox)
 
         self.update_databases_on_startup_checkbox = QCheckBox(
             self.tr("Update databases on startup")


### PR DESCRIPTION
Moves the Render Unity Rich Text checkbox from the Advanced tab to the
Sorting tab Mod list options section. Moves the settings field from
the Advanced block to the Sorting block in settings.py for logical
grouping.

Method signatures are simplified: render_unity_rt parameter is removed
from display_mod_info() and _set_description() - both now hardcode
True internally. The call site in main_content_panel.py is reduced
to a single kwarg.