### PR TITLE
Move color_background_instead_of_text checkbox to Sorting tab

### DIFF
--- a/app/controllers/settings_tabs/advanced_tab_controller.py
+++ b/app/controllers/settings_tabs/advanced_tab_controller.py
@@ -2,9 +2,6 @@ from loguru import logger
 from PySide6.QtCore import Slot
 
 from app.controllers.settings_tabs.base_tab_controller import BaseTabController
-from app.models.settings import Settings
-from app.utils.event_bus import EventBus
-from app.views.settings_dialog import SettingsDialog
 
 
 class AdvancedTabController(BaseTabController):
@@ -12,17 +9,9 @@ class AdvancedTabController(BaseTabController):
 
     Manages: debug logging, watchdog, clear/DLC behavior, mod update checks,
     DB auto-update, mod name search scope, backup policy,
-    save-comparison indicators, mod coloring mode, Auxiliary DB settings,
+    save-comparison indicators, Auxiliary DB settings,
     and Authentication fields.
     """
-
-    def __init__(
-        self,
-        settings: Settings,
-        dialog: SettingsDialog,
-    ) -> None:
-        super().__init__(settings, dialog)
-        self._change_mod_coloring_mode = False
 
     def connect_signals(self) -> None:
         try:
@@ -34,15 +23,9 @@ class AdvancedTabController(BaseTabController):
                 "show_save_comparison_indicators_checkbox not available for signal wiring"
             )
 
-        self.dialog.color_background_instead_of_text_checkbox.stateChanged.connect(
-            self._on_use_background_coloring_checkbox_changed
-        )
-
         self.dialog.include_mod_notes_in_mod_name_filter_checkbox.stateChanged.connect(
             self._on_include_mod_notes_in_mod_name_filter_changed
         )
-
-        EventBus().settings_have_changed.connect(self._handle_mod_coloring_mode_changed)
 
     def update_view_from_model(self) -> None:
         try:
@@ -66,9 +49,6 @@ class AdvancedTabController(BaseTabController):
         )
         self.dialog.auto_backup_compression_count_spinbox.setValue(
             self.settings.auto_backup_compression_count
-        )
-        self.dialog.color_background_instead_of_text_checkbox.setChecked(
-            self.settings.color_background_instead_of_text_toggle
         )
         self.dialog.clear_moves_dlc_checkbox.setChecked(self.settings.clear_moves_dlc)
         self.dialog.show_mod_updates_checkbox.setChecked(
@@ -113,9 +93,6 @@ class AdvancedTabController(BaseTabController):
         self.settings.auto_backup_compression_count = (
             self.dialog.auto_backup_compression_count_spinbox.value()
         )
-        self.settings.color_background_instead_of_text_toggle = (
-            self.dialog.color_background_instead_of_text_checkbox.isChecked()
-        )
         self.settings.clear_moves_dlc = self.dialog.clear_moves_dlc_checkbox.isChecked()
         self.settings.steam_mods_update_check = (
             self.dialog.show_mod_updates_checkbox.isChecked()
@@ -152,17 +129,7 @@ class AdvancedTabController(BaseTabController):
         self.settings.save()
 
     @Slot()
-    def _on_use_background_coloring_checkbox_changed(self) -> None:
-        self._change_mod_coloring_mode = not self._change_mod_coloring_mode
-
-    @Slot()
     def _on_include_mod_notes_in_mod_name_filter_changed(self) -> None:
         self.settings.include_mod_notes_in_mod_name_filter = (
             self.dialog.include_mod_notes_in_mod_name_filter_checkbox.isChecked()
         )
-
-    @Slot()
-    def _handle_mod_coloring_mode_changed(self) -> None:
-        if self._change_mod_coloring_mode:
-            self._change_mod_coloring_mode = False
-            EventBus().do_change_mod_coloring_mode.emit()

--- a/app/controllers/settings_tabs/sorting_tab_controller.py
+++ b/app/controllers/settings_tabs/sorting_tab_controller.py
@@ -1,6 +1,9 @@
+from PySide6.QtCore import Slot
+
 from app.controllers.settings_tabs.base_tab_controller import BaseTabController
 from app.models.settings import Settings
 from app.utils.constants import SortMethod
+from app.utils.event_bus import EventBus
 from app.views.settings_dialog import SettingsDialog
 
 
@@ -8,7 +11,7 @@ class SortingTabController(BaseTabController):
     """Controller for the Sorting settings tab.
 
     Manages: sorting algorithm, dependency handling, XML parsing behavior,
-    mod list options, and inactive mods sorting.
+    mod list options, mod coloring mode, and inactive mods sorting.
     """
 
     def __init__(
@@ -17,9 +20,13 @@ class SortingTabController(BaseTabController):
         dialog: SettingsDialog,
     ) -> None:
         super().__init__(settings, dialog)
+        self._change_mod_coloring_mode = False
 
     def connect_signals(self) -> None:
-        pass  # Sorting tab has no action buttons — all state is read on OK
+        self.dialog.color_background_instead_of_text_checkbox.stateChanged.connect(
+            self._on_use_background_coloring_checkbox_changed
+        )
+        EventBus().settings_have_changed.connect(self._handle_mod_coloring_mode_changed)
 
     def update_view_from_model(self) -> None:
         # Match the existing SettingsController behavior exactly:
@@ -47,6 +54,9 @@ class SortingTabController(BaseTabController):
         )
         self.dialog.render_unity_rich_text_checkbox.setChecked(
             self.settings.render_unity_rich_text
+        )
+        self.dialog.color_background_instead_of_text_checkbox.setChecked(
+            self.settings.color_background_instead_of_text_toggle
         )
         self.dialog.download_missing_mods_checkbox.setChecked(
             self.settings.try_download_missing_mods
@@ -83,6 +93,9 @@ class SortingTabController(BaseTabController):
         self.settings.render_unity_rich_text = (
             self.dialog.render_unity_rich_text_checkbox.isChecked()
         )
+        self.settings.color_background_instead_of_text_toggle = (
+            self.dialog.color_background_instead_of_text_checkbox.isChecked()
+        )
         self.settings.try_download_missing_mods = (
             self.dialog.download_missing_mods_checkbox.isChecked()
         )
@@ -95,3 +108,13 @@ class SortingTabController(BaseTabController):
         self.settings.save_inactive_mods_sort_state = (
             self.dialog.save_inactive_mods_sort_state_checkbox.isChecked()
         )
+
+    @Slot()
+    def _on_use_background_coloring_checkbox_changed(self) -> None:
+        self._change_mod_coloring_mode = not self._change_mod_coloring_mode
+
+    @Slot()
+    def _handle_mod_coloring_mode_changed(self) -> None:
+        if self._change_mod_coloring_mode:
+            self._change_mod_coloring_mode = False
+            EventBus().do_change_mod_coloring_mode.emit()

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -116,6 +116,7 @@ class Settings(QObject):
         # e.g., modDependenciesByVersion, loadAfterByVersion, loadBeforeByVersion, incompatibleWithByVersion, descriptionsByVersion
         self.prefer_versioned_about_tags: bool = True
         self.render_unity_rich_text: bool = True
+        self.color_background_instead_of_text_toggle: bool = True
         self.case_insensitive_about_xml_lookup: bool = sys.platform == "linux"
 
         # Whether to notify user about missing mods
@@ -193,7 +194,6 @@ class Settings(QObject):
         self.last_backup_date: str = ""
         self.auto_backup_retention_count: int = 10
         self.auto_backup_compression_count: int = 10
-        self.color_background_instead_of_text_toggle: bool = True
         self.steam_mods_update_check: bool = False
         self.update_databases_on_startup: bool = True
         self.include_mod_notes_in_mod_name_filter: bool = False

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -817,6 +817,14 @@ This basically preserves your mod coloring, user notes etc. for this many second
         )
         modlist_option_group_box_layout.addWidget(self.render_unity_rich_text_checkbox)
 
+        # Mod coloring checkbox
+        self.color_background_instead_of_text_checkbox = QCheckBox(
+            self.tr("Apply mod coloring to background instead of text")
+        )
+        modlist_option_group_box_layout.addWidget(
+            self.color_background_instead_of_text_checkbox
+        )
+
         # Download missing mods checkbox
         self.download_missing_mods_checkbox = QCheckBox(
             self.tr("Download missing mods automatically")
@@ -1506,11 +1514,6 @@ This basically preserves your mod coloring, user notes etc. for this many second
             self.tr("Check for mod updates on refresh")
         )
         group_layout.addWidget(self.show_mod_updates_checkbox)
-
-        self.color_background_instead_of_text_checkbox = QCheckBox(
-            self.tr("Apply mod coloring to background instead of text")
-        )
-        group_layout.addWidget(self.color_background_instead_of_text_checkbox)
 
         self.update_databases_on_startup_checkbox = QCheckBox(
             self.tr("Update databases on startup")


### PR DESCRIPTION
- Moved 'Apply mod coloring to background instead of text' checkbox from the Advanced settings tab to the Sorting settings tab
- Removed color_background logic from advanced_tab_controller.py (signals, setChecked/isChecked, helper methods, EventBus usage)
- Added color_background logic to sorting_tab_controller.py (signals, setChecked/isChecked, coloring mode change handlers)
- Reordered color_background_instead_of_text_toggle in settings.py to live alongside render_unity_rich_text in the Sorting section
- Updated docstrings to reflect the new responsibility split