### PR TITLE
fix: reliable GetAppDependencies + Steam IPC stability

### DIFF
--- a/app/utils/app_info.py
+++ b/app/utils/app_info.py
@@ -43,18 +43,21 @@ class AppInfo:
         if hasattr(self, "_is_initialized") and self._is_initialized:
             return
 
-        main_file = sys.modules["__main__"].__file__
+        main_file = getattr(sys.modules.get("__main__"), "__file__", None)
 
         if main_file is None:
-            raise Exception("Unable to get the main file path.")
-
-        # Need to go one up if we are running from source
-        self._application_folder = (
-            Path(main_file).resolve().parent
-            if "__compiled__" in globals()
-            # __compiled__ will be present if Nuitka has frozen this
-            else Path(main_file).resolve().parent.parent
-        )
+            # Spawned child processes (e.g. multiprocessing on Windows) may not
+            # have __main__.__file__.  Default to the working directory, which
+            # is inherited from the parent process (the project root).
+            self._application_folder = Path.cwd()
+        else:
+            # Need to go one up if we are running from source
+            self._application_folder = (
+                Path(main_file).resolve().parent
+                if "__compiled__" in globals()
+                # __compiled__ will be present if Nuitka has frozen this
+                else Path(main_file).resolve().parent.parent
+            )
 
         # Application metadata
         self._app_name = "RimSort"

--- a/app/utils/steam/availability.py
+++ b/app/utils/steam/availability.py
@@ -2,7 +2,7 @@ import os
 import shutil
 import subprocess
 import sys
-from collections.abc import MutableMapping
+from collections.abc import Callable, MutableMapping
 from pathlib import Path
 from time import sleep
 from typing import Optional
@@ -116,12 +116,16 @@ def _setup_snap_steam_env(env: MutableMapping[str, str]) -> None:
         env["STEAMRUNTIME_PATH"] = str(SNAP_STEAM_PATH / "ubuntu12_32")
 
 
-def _launch_steam(_libs: str) -> bool:
+def _launch_steam(
+    _libs: str,
+    status_callback: Callable[[str], None] | None = None,
+) -> bool:
     """
     Launch Steam if it's not running and wait for it to start.
 
     Args:
         _libs: Path to the Steamworks library directory
+        status_callback: Optional callback to emit progress messages to UI
 
     Returns:
         bool: True if Steam was launched successfully, False otherwise
@@ -134,7 +138,10 @@ def _launch_steam(_libs: str) -> bool:
                 return False
 
             # For Linux, try to launch steam in a terminal emulator
-            logger.info("Launching Steam via 'steam' command in a terminal...")
+            msg = "Launching Steam via 'steam' command in a terminal..."
+            logger.info(msg)
+            if status_callback:
+                status_callback(msg)
             env = os.environ.copy()
             env["LD_LIBRARY_PATH"] = _libs + os.pathsep + env.get("LD_LIBRARY_PATH", "")
 
@@ -169,7 +176,10 @@ def _launch_steam(_libs: str) -> bool:
             if not steam_exe.exists():
                 logger.warning("Steam executable not found")
                 return False
-            logger.info("Launching Steam...")
+            msg = "Launching Steam..."
+            logger.info(msg)
+            if status_callback:
+                status_callback(msg)
             env = os.environ.copy()
             if sys.platform.startswith("linux"):
                 _setup_snap_steam_env(env)
@@ -186,6 +196,10 @@ def _launch_steam(_libs: str) -> bool:
 
         # Wait for Steam to start checks every SLEEP_TIME (15 seconds), MAX_ATTEMPTS (10 attempts).
         for attempt in range(MAX_ATTEMPTS):
+            msg = f"Waiting for Steam to initialize ({attempt + 1}/{MAX_ATTEMPTS})..."
+            logger.info(msg)
+            if status_callback:
+                status_callback(msg)
             sleep(SLEEP_TIME)
             # Check both process detection and API initialization
             if _is_steam_running():
@@ -200,7 +214,10 @@ def _launch_steam(_libs: str) -> bool:
                 test_steamworks = STEAMWORKS()
                 test_steamworks.initialize()
                 test_steamworks.unload()
-                logger.info("Steam launched and API initialized successfully")
+                msg = "Steam launched and API initialized successfully"
+                logger.info(msg)
+                if status_callback:
+                    status_callback(msg)
                 # Give Steam a bit more time to fully initialize
                 sleep(SLEEP_TIME)
                 return True
@@ -221,7 +238,10 @@ def _launch_steam(_libs: str) -> bool:
                         )
                 continue
 
-        logger.warning("Steam failed to start within timeout")
+        msg = "Steam failed to start within timeout"
+        logger.warning(msg)
+        if status_callback:
+            status_callback(msg)
         return False
 
     except Exception as e:
@@ -229,7 +249,10 @@ def _launch_steam(_libs: str) -> bool:
         return False
 
 
-def check_steam_available(_libs: str) -> bool:
+def check_steam_available(
+    _libs: str,
+    status_callback: Callable[[str], None] | None = None,
+) -> bool:
     """
     Check if Steam is available and running.
 
@@ -238,6 +261,7 @@ def check_steam_available(_libs: str) -> bool:
 
     Args:
         _libs: Path to the Steamworks library directory
+        status_callback: Optional callback to emit progress messages to UI
 
     Returns:
         bool: True if Steam is available, False otherwise
@@ -256,8 +280,11 @@ def check_steam_available(_libs: str) -> bool:
 
     # Check if Steam is running
     if not _is_steam_running():
-        logger.info("Steam is not running, attempting to launch...")
-        if not _launch_steam(_libs):
+        msg = "Steam is not running, attempting to launch..."
+        logger.info(msg)
+        if status_callback:
+            status_callback(msg)
+        if not _launch_steam(_libs, status_callback=status_callback):
             logger.error("Failed to launch Steam")
             # Show no steam warning
             show_no_steam_warning()

--- a/app/utils/steam/steamworks/wrapper.py
+++ b/app/utils/steam/steamworks/wrapper.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import sys
 from multiprocessing import Process
+from multiprocessing.synchronize import Lock as MpLock
 from os import getcwd
 from pathlib import Path
 from threading import Thread
@@ -38,9 +39,6 @@ from time import sleep, time
 from typing import Any, Callable, Union
 
 from loguru import logger
-
-from app.utils.constants import RIMWORLD_DLC_METADATA
-from app.utils.json_utils import atomic_json_dump
 
 # If we're running from a Python interpreter, Ensure SteamworksPy module is in Python path, sys.path ($PYTHONPATH)
 # Ensure that this is available by running via: git submodule update --init --recursive
@@ -211,137 +209,142 @@ class SteamworksInterface:
                 )
                 self.end_callbacks = True
                 return False
+            if self.callbacks_total and self.callbacks_count >= self.callbacks_total:
+                return True
             sleep(OPERATION_INTERVAL)
         return True
 
 
+# Per-process shared SteamworksInterface (set by _pool_init_worker, reused across chunks)
+WORKER_INTERFACE: list["SteamworksInterface | None"] = [None]
+
+
+def _pool_init_worker(project_root: str, libs_path: str, init_lock: MpLock) -> None:
+    """Initialize worker process: set env, chdir, create shared SteamworksInterface.
+
+    Acquires *init_lock* before calling SteamInit() so that only one worker
+    process initializes at a time. This prevents the Steam client from being
+    overwhelmed by N concurrent pipe registrations (``pipes.cpp`` stall).
+    """
+    import os
+
+    os.environ["SWPY_PATH"] = libs_path
+    os.chdir(project_root)
+    with init_lock:
+        si = SteamworksInterface(callbacks=True, callbacks_total=0, _libs=libs_path)
+        if not si.steam_not_running:
+            WORKER_INTERFACE[0] = si
+        else:
+            si.steamworks.unload()
+
+
 class SteamworksAppDependenciesQuery:
-    PROGRESS_LOG_INTERVAL = 100
+    """Query PublishedFileIDs for AppID dependency data using Steamworks API."""
 
     def __init__(
         self,
         pfid_or_pfids: Union[int, list[int]],
         interval: float = 1,
         _libs: str | None = None,
-        chunk_index: int = 0,
-        total_chunks: int = 0,
-        progress_callback: Callable[[str], None] | None = None,
-        query_db: dict[str, Any] | None = None,
-        output_database_path: str = "",
     ) -> None:
         self._libs = _libs
         self.interval = interval
-        self.pfid_or_pfids = pfid_or_pfids
-        self.chunk_index = chunk_index
-        self.total_chunks = total_chunks
-        self.progress_callback = progress_callback
-        self.query_db = query_db
-        self.output_database_path = output_database_path
-
-    def _merge_and_save(self, new_results: dict[int, list[int]]) -> None:
-        """Merge partial results into query_db and save to output file."""
-        if not self.query_db or not self.output_database_path:
-            return
-        database = self.query_db.get("database")
-        if not isinstance(database, dict):
-            return
-        for pfid_str in database:
-            try:
-                pfid = int(pfid_str)
-            except ValueError:
-                continue
-            if pfid not in new_results:
-                continue
-            for appid in new_results[pfid]:
-                appid_str = str(appid)
-                if appid_str not in RIMWORLD_DLC_METADATA:
-                    continue
-                deps = database[pfid_str].setdefault("dependencies", {})
-                if appid_str not in deps:
-                    deps[appid_str] = [
-                        RIMWORLD_DLC_METADATA[appid_str]["name"],
-                        RIMWORLD_DLC_METADATA[appid_str]["steam_url"],
-                    ]
-        try:
-            atomic_json_dump(self.query_db, self.output_database_path, indent=4)
-            logger.debug(f"Saved incremental database to {self.output_database_path}")
-        except Exception as e:
-            logger.warning(f"Failed to save incremental database: {e}")
+        self.pfid_or_pfids = (
+            pfid_or_pfids if isinstance(pfid_or_pfids, list) else [pfid_or_pfids]
+        )
 
     def run(self) -> None | dict[int, Any]:
         """
-        Query PublishedFileIDs for AppID dependency data
-        :param pfid_or_pfids: is an int that corresponds with a subscribed Steam mod's PublishedFileId
-                            OR is a list of int that corresponds with multiple Steam mod PublishedFileIds
-        :param interval: time in seconds to sleep between multiple subsequent API calls
+        Execute the AppDependencies query against Steamworks.
+
+        Uses the per-worker shared SteamworksInterface (set by _pool_init_worker),
+        firing GetAppDependencies() sequentially and pumping callbacks between
+        each query to work around CCallResult's single-pending-call limitation.
         """
-        logger.info(
-            f"Creating SteamworksInterface and passing PublishedFileID(s) {self.pfid_or_pfids}"
-        )
-        # If the chunk passed is a single int, convert it into a list in an effort to simplify procedure
-        if isinstance(self.pfid_or_pfids, int):
-            self.pfid_or_pfids = [self.pfid_or_pfids]
-
         total = len(self.pfid_or_pfids)
-
-        # Create our Steamworks interface and initialize Steamworks API
-        steamworks_interface = SteamworksInterface(
-            callbacks=True, callbacks_total=total, _libs=self._libs
+        logger.info(
+            f"GetAppDependencies handling {total} pfid(s): {self.pfid_or_pfids}"
         )
-        if steamworks_interface.steam_not_running:  # Skip if True
-            steamworks_interface.steamworks.unload()
-            return None
 
-        start_time = time()
-        while not steamworks_interface.steamworks.loaded():
-            if time() - start_time > STEAMWORKS_TIMEOUT:
-                logger.error(
-                    f"Timeout waiting for Steamworks to load (>{STEAMWORKS_TIMEOUT}s)"
+        # Prefer the per-worker shared interface (set once by _pool_init_worker)
+        # Fall back to a fresh one if the shared interface is stuck/dead
+        si = WORKER_INTERFACE[0]
+        fresh_interface = False
+        if si is not None and not si.steam_not_running and si.end_callbacks:
+            # Shared interface had a prior timeout — try to recover
+            si.steamworks_thread.join(timeout=1)
+            if si.steamworks_thread.is_alive():
+                # Thread stuck — create fresh interface for this chunk
+                si = SteamworksInterface(
+                    callbacks=True, callbacks_total=total, _libs=self._libs
                 )
-                return None
-            sleep(OPERATION_INTERVAL)
-
-        chunk_tag = (
-            f" [chunk {self.chunk_index}/{self.total_chunks}]"
-            if self.total_chunks
-            else ""
-        )
-        # Initialize the progress bar
-        if self.progress_callback is not None:
-            self.progress_callback(f"Progress: 0/{total}")
-        for idx, pfid in enumerate(self.pfid_or_pfids):
-            logger.debug(f"ISteamUGC/GetAppDependencies Query: {pfid}")
-            steamworks_interface.steamworks.Workshop.SetGetAppDependenciesResultCallback(
-                steamworks_interface._cb_app_dependencies_result_callback
+                if si.steam_not_running:
+                    si.steamworks.unload()
+                    return None
+                fresh_interface = True
+            else:
+                # Thread exited cleanly — restart for this batch
+                si.end_callbacks = False
+                si.multiple_queries = True
+                si.callbacks_count = 0
+                si.callbacks_total = total
+                si.get_app_deps_query_result = {}
+                si.steamworks_thread = si._daemon()
+                si.steamworks_thread.start()
+        elif si is None or si.steam_not_running:
+            si = SteamworksInterface(
+                callbacks=True, callbacks_total=total, _libs=self._libs
             )
-            steamworks_interface.steamworks.Workshop.GetAppDependencies(pfid)
-            # Sleep for the interval if we have more than one pfid to action on
-            if total > 1:
-                sleep(self.interval)
-            if idx % self.PROGRESS_LOG_INTERVAL == 0 and idx > 0:
-                logger.info(f"GetAppDependencies progress: {idx}/{total}{chunk_tag}")
-                if self.progress_callback is not None:
-                    self.progress_callback(f"Progress: {idx}/{total}")
-                # Save incremental results to the output database
-                new_results = steamworks_interface.get_app_deps_query_result
-                self._merge_and_save(new_results)
-        # Patience, but don't wait forever
-        steamworks_interface._wait_for_callbacks(timeout=60)
-        # This means that the callbacks thread has ended. We are done with Steamworks API now, so we dispose of everything.
-        logger.info("Thread completed. Unloading Steamworks...")
-        steamworks_interface.steamworks_thread.join()
-        # Grab the data and save final results
-        new_results = steamworks_interface.get_app_deps_query_result
-        self._merge_and_save(new_results)
-        received = len(new_results.keys())
-        summary = (
-            f"GetAppDependencies chunk {self.chunk_index}/{self.total_chunks} complete: "
-            f"{received}/{total} results received"
+            if si.steam_not_running:
+                si.steamworks.unload()
+                return None
+            fresh_interface = True
+        else:
+            # Reuse shared interface — reset callback counters
+            si.callbacks_count = 0
+            si.multiple_queries = True
+            si.callbacks_total = total
+            si.get_app_deps_query_result = {}
+            si.end_callbacks = False
+
+        si.steamworks.Workshop.SetGetAppDependenciesResultCallback(
+            si._cb_app_dependencies_result_callback
         )
-        logger.info(summary)
-        if self.progress_callback is not None:
-            self.progress_callback(f"Progress: {total}/{total}")
-            self.progress_callback(summary)
+
+        # Drain any residual callbacks from a previous chunk before starting
+        si.steamworks.run_callbacks()
+
+        # Fire queries sequentially, waiting for each pfid's callback before
+        # issuing the next query.  CCallResult can only track ONE pending call
+        # at a time — each new GetAppDependencies() unregisters the previous
+        # CCallResult, silently dropping its callback.  By pumping callbacks
+        # between queries until the expected callback count is reached, we
+        # ensure every CCallResult completes before being replaced.
+        PROGRESS_LOG_INTERVAL = 100
+        WAIT_TIMEOUT = 100  # 100 * self.interval = 100 * 0.1 = 10s per pfid
+        for idx, pfid in enumerate(self.pfid_or_pfids):
+            si.steamworks.Workshop.GetAppDependencies(pfid)
+            # Wait for THIS pfid's callback to be dispatched
+            target = si.callbacks_count + 1
+            for _ in range(WAIT_TIMEOUT):
+                si.steamworks.run_callbacks()
+                if si.callbacks_count >= target:
+                    break
+                sleep(self.interval)
+            if (idx + 1) % PROGRESS_LOG_INTERVAL == 0:
+                logger.info(f"GetAppDependencies progress: {idx + 1}/{total}")
+
+        # Wait for callbacks to complete
+        si._wait_for_callbacks(timeout=60)
+        if si.steamworks_thread.is_alive() and si.end_callbacks:
+            si.steamworks_thread.join(timeout=5)
+
+        new_results = si.get_app_deps_query_result
+        received = len(new_results.keys())
+        logger.info(f"GetAppDependencies complete: {received}/{total} results received")
+
+        if fresh_interface:
+            si.steamworks.unload()
         return new_results
 
 

--- a/app/utils/steam/webapi/wrapper.py
+++ b/app/utils/steam/webapi/wrapper.py
@@ -5,6 +5,7 @@ import traceback
 from collections.abc import Callable
 from logging import WARNING, getLogger
 from math import ceil
+from multiprocessing import Lock, Pool, cpu_count
 from time import sleep, time
 from typing import TYPE_CHECKING, Any, Optional
 from urllib.parse import urlparse
@@ -22,7 +23,10 @@ from app.utils.constants import RIMWORLD_DLC_METADATA
 from app.utils.generic import chunks
 from app.utils.json_utils import atomic_json_dump
 from app.utils.steam.availability import check_steam_available
-from app.utils.steam.steamworks.wrapper import SteamworksAppDependenciesQuery
+from app.utils.steam.steamworks.wrapper import (
+    SteamworksAppDependenciesQuery,
+    _pool_init_worker,
+)
 from app.views.dialogue import show_warning
 
 STEAM_THERE_WAS_A_PROBLEM_FLAG = "There was a problem accessing the item. "
@@ -699,12 +703,14 @@ class DynamicQuery(QObject):
         Given a list of PublishedFileIds and a query, return the query after looking up
         and appending DLC dependency data from the Steamworks API.
 
+        Uses multiprocessing.Pool with cpu_count() workers. SteamInit() calls
+        are serialized via a shared Lock to prevent pipe-registration storms.
+
         https://partner.steamgames.com/doc/api/ISteamUGC#GetAppDependencies
 
         :param publishedfileids: a list of PublishedFileIds to query metadata for
-        :param json_to_update: a Dict of json data, containing a query to update in
+        :param query: a Dict of json data, containing a query to update in
         RimPy db_data["database"] format, or the skeleton of one from local_metadata
-        :return: Dict containing the updated json data from PublishedFileIds query
         """
         # Filter pfids that already have DLC deps populated in the database
         pfids_needing_deps = []
@@ -725,7 +731,7 @@ class DynamicQuery(QObject):
 
         self._emit_message(
             f"\nSteamworks API: ISteamUGC/GetAppDependencies initializing for "
-            f"{total_to_query} mods (single process)"
+            f"{total_to_query} mods ({cpu_count()} workers)"
             + (f", {skipped} already resolved" if skipped else "")
         )
 
@@ -738,35 +744,78 @@ class DynamicQuery(QObject):
                 logger.warning(f"Failed to save database before Steamworks: {e}")
 
         # Check Steam availability
-        if not check_steam_available(str(AppInfo().libs_folder)):
+        if not check_steam_available(
+            str(AppInfo().libs_folder),
+            status_callback=self._emit_message,
+        ):
             self._emit_message(
                 "\nSteam is not available. Skipping AppID dependency retrieval."
             )
             return
 
-        # Run the Steamworks query
-        est_seconds = int(total_to_query * 0.2)
+        # Run the Steamworks query using multiprocessing Pool.
+        # Each worker has its own SteamworksInterface (separate IPC pipe),
+        # but SteamInit() in _pool_init_worker is serialized via init_lock
+        # so the Steam client is not overwhelmed by concurrent pipe registration.
+        # Leave 2 cores free for the system/Steam client; add a 30s cooldown
+        # every 6000 pfids to prevent the Steam client IPC pipe from
+        # overflowing (pipes.cpp:BWrite failed) under sustained load.
+        num_processes = max(1, cpu_count() - 2)
+        interval = 0.2
+        est_seconds = int(total_to_query * interval / num_processes)
         if est_seconds < 60:
             est_str = f"{est_seconds}s"
         else:
             est_str = f"{est_seconds // 60}m {est_seconds % 60}s"
         self._emit_message(f"Estimated time: ~{est_str}.\nPlease wait...")
 
-        deps_query = SteamworksAppDependenciesQuery(
-            pfid_or_pfids=[int(pfid) for pfid in pfids_needing_deps],
-            interval=0.2,
-            _libs=str(AppInfo().libs_folder),
-            chunk_index=1,
-            total_chunks=1,
-            progress_callback=self._emit_message,
-            query_db=query,
-            output_database_path=self.output_database_path,
-        )
-        result = deps_query.run()
-        # Merge results into the database
+        # Split pfids into fixed-size chunks so results trickle back via imap_unordered
+        CHUNK_SIZE = 100
+        pfid_chunks = list(chunks(pfids_needing_deps, limit=CHUNK_SIZE))
+
+        queries = [
+            SteamworksAppDependenciesQuery(
+                pfid_or_pfids=[int(pfid) for pfid in chunk],
+                interval=interval,
+                _libs=str(AppInfo().libs_folder),
+            )
+            for chunk in pfid_chunks
+        ]
+
         pfids_appid_deps: dict[int, list[int]] = {}
-        if result is not None:
-            pfids_appid_deps.update(result)
+        total_chunks = len(queries)
+        self._emit_message(f"Progress: 0/{total_chunks}")
+        libs_path = str(AppInfo().libs_folder)
+        project_root = str(AppInfo().application_folder)
+        init_lock = Lock()
+        COOLDOWN_INTERVAL = 6000  # pfids — give Steam client a 30s breather
+        pfids_processed = 0
+        with Pool(
+            processes=num_processes,
+            initializer=_pool_init_worker,
+            initargs=(project_root, libs_path, init_lock),
+        ) as pool:
+            for i, result in enumerate(
+                pool.imap_unordered(SteamworksAppDependenciesQuery.run, queries)
+            ):
+                if result is not None:
+                    pfids_appid_deps.update(result)
+                pfids_processed += CHUNK_SIZE
+                if pfids_processed % COOLDOWN_INTERVAL == 0:
+                    remaining = total_to_query - pfids_processed
+                    remaining_est = int(remaining * interval / num_processes) + 30
+                    if remaining_est < 60:
+                        est_str = f"{remaining_est}s"
+                    else:
+                        est_str = f"{remaining_est // 60}m {remaining_est % 60}s"
+                    self._emit_message(
+                        f"Cooldown: 30s pause after ~{pfids_processed} pfids "
+                        f"to let Steam client recover. "
+                        f"~{remaining} pfids remaining (est. {est_str})"
+                    )
+                    sleep(30)
+                self._emit_message(f"Progress: {i + 1}/{total_chunks}")
+
         self._merge_app_deps(query, pfids_appid_deps)
         self._emit_message(f"\nTotal: {len(pfids_appid_deps.keys())}")
         # Save final database

--- a/tests/utils/steam/steamworks/test_get_app_dependencies.py
+++ b/tests/utils/steam/steamworks/test_get_app_dependencies.py
@@ -1,0 +1,280 @@
+"""
+Standalone test for Steamworks GetAppDependencies.
+
+Queries DLC dependency data for given PublishedFileIDs directly via Steamworks,
+without running the full DB Builder pipeline.
+
+Usage:
+    python tests/utils/steam/steamworks/test_get_app_dependencies.py <pfid1> [pfid2] ...
+    python tests/utils/steam/steamworks/test_get_app_dependencies.py --db <path> [--limit N] [--workers N]
+"""
+
+import json
+import sys
+import time
+from multiprocessing import Lock, Pool
+from pathlib import Path
+from typing import Any
+
+# Ensure project root is on sys.path for imports
+# Supports running as `python path/to/this_script.py` from any cwd
+_script_dir = Path(__file__).resolve().parent
+_project_root = _script_dir.parents[3]
+if str(_project_root) not in sys.path:
+    sys.path.insert(0, str(_project_root))
+
+from app.utils.generic import chunks  # noqa: E402
+from app.utils.steam.availability import check_steam_available  # noqa: E402
+from app.utils.steam.steamworks.wrapper import (  # noqa: E402
+    OPERATION_INTERVAL,
+    SteamworksAppDependenciesQuery,
+    SteamworksInterface,
+    _pool_init_worker,
+)
+
+# AppInfo resolves paths from __main__.__file__, which when running this
+# standalone script points to tests/… instead of the project root.
+# Compute the correct libs path relative to the known project root.
+LIBS_PATH = str(_project_root / "libs")
+
+
+def _parse_pfids(raw: list[str]) -> list[int]:
+    """Parse PublishedFileIDs from CLI args."""
+    pfids: list[int] = []
+    for arg in raw:
+        arg = arg.strip()
+        if not arg.isdigit():
+            print(f"  [skip] Skipping invalid pfid: {arg}")
+            continue
+        pfids.append(int(arg))
+    return pfids
+
+
+def print_result(pfid: int, deps: list[int]) -> None:
+    """Print a single query result in a readable format."""
+    resolved = [str(a) for a in deps if a in RIMWORLD_DLC_METADATA]
+    unresolved = [str(a) for a in deps if a not in RIMWORLD_DLC_METADATA]
+    print(f"  [{pfid}] AppID dependencies ({len(deps)} total):")
+    if resolved:
+        print(f"         RimWorld DLCs: {', '.join(resolved)}")
+    if unresolved:
+        print(f"         Other AppIDs:  {', '.join(unresolved)}")
+    if not deps:
+        print("         (none)")
+
+
+# Inline minimal DLC metadata for display — mirrors RIMWORLD_DLC_METADATA
+RIMWORLD_DLC_METADATA: dict[str, dict[str, str]] = {
+    "871780": {"name": "RimWorld - Royalty"},
+    "1149640": {"name": "RimWorld - Ideology"},
+    "1826140": {"name": "RimWorld - Biotech"},
+    "2384480": {"name": "RimWorld - Anomaly"},
+}
+
+
+def main() -> None:
+    args = sys.argv[1:]
+    db_path: str | None = None
+    limit = 0
+    workers = 1
+
+    # Parse --db, --limit, and --workers flags, collect remaining as positional pfids
+    remaining: list[str] = []
+    i = 0
+    while i < len(args):
+        if args[i] == "--db" and i + 1 < len(args):
+            db_path = args[i + 1]
+            i += 2
+        elif args[i] == "--limit" and i + 1 < len(args):
+            limit = int(args[i + 1])
+            i += 2
+        elif args[i] == "--workers" and i + 1 < len(args):
+            workers = int(args[i + 1])
+            i += 2
+        else:
+            remaining.append(args[i])
+            i += 1
+
+    pfids: list[int] = []
+
+    # Load from database if --db provided
+    if db_path:
+        with open(db_path) as f:
+            db = json.load(f)
+        all_pfids = [int(k) for k in db.get("database", {}) if len(k) > 8]
+        all_pfids.sort()
+        if limit > 0:
+            all_pfids = all_pfids[:limit]
+        pfids.extend(all_pfids)
+        print(f"Loaded {len(all_pfids)} PfIDs from {db_path}")
+
+    # Append positional pfids
+    pfids.extend(_parse_pfids(remaining))
+
+    pfids = list(dict.fromkeys(pfids))  # deduplicate preserving order
+    if not pfids:
+        print("Usage: python test_get_app_dependencies.py <pfid1> [pfid2] ...")
+        print(
+            "       python test_get_app_dependencies.py --db <path> [--limit N] [--workers N]"
+        )
+        print("Example: python test_get_app_dependencies.py 2892354813 2966480207")
+        print(
+            "         python test_get_app_dependencies.py --db steamDB.json --limit 100"
+        )
+        sys.exit(1)
+
+    print(f"PublishedFileIDs to query: {pfids}")
+    print()
+
+    # 1. Check Steam availability
+    print(f"Checking Steam availability (libs: {LIBS_PATH})...")
+    if not check_steam_available(LIBS_PATH, status_callback=lambda m: print(f"  {m}")):
+        print("[FAIL] Steam is not available. Aborting.")
+        sys.exit(1)
+    print("OK Steam available")
+    print()
+
+    total = len(pfids)
+    print(f"PublishedFileIDs to query: {total}")
+    print()
+
+    start = time.monotonic()
+
+    if workers > 1:
+        # --- Parallel Pool path (mirrors webapi/wrapper.py) ---
+        print(f"Using {workers} worker(s) with multiprocessing Pool")
+        CHUNK_SIZE = max(
+            1, total // (workers * 2)
+        )  # 2 chunks per worker for load balancing
+        pfid_chunks = list(chunks(pfids, limit=CHUNK_SIZE))
+        queries = [
+            SteamworksAppDependenciesQuery(
+                pfid_or_pfids=[int(pfid) for pfid in chunk],
+                interval=OPERATION_INTERVAL,
+                _libs=LIBS_PATH,
+            )
+            for chunk in pfid_chunks
+        ]
+        print(f"Split into {len(queries)} chunks (size={CHUNK_SIZE})")
+
+        pfids_appid_deps: dict[int, list[int]] = {}
+        init_lock = Lock()
+        with Pool(
+            processes=workers,
+            initializer=_pool_init_worker,
+            initargs=(str(_project_root), LIBS_PATH, init_lock),
+        ) as pool:
+            for i, result in enumerate(
+                pool.imap_unordered(SteamworksAppDependenciesQuery.run, queries)
+            ):
+                if result is not None:
+                    pfids_appid_deps.update(result)
+                print(
+                    f"  Chunk {i + 1}/{len(queries)} completed ({len(result or [])} results)"
+                )
+
+        results = pfids_appid_deps
+        # Pool workers already handle cleanup; nothing to join
+        completed = True
+
+    else:
+        # --- Sequential single-process path ---
+        print(f"Initializing Steamworks interface for {total} pfid(s)...")
+        si = SteamworksInterface(callbacks=True, callbacks_total=total, _libs=LIBS_PATH)
+        if si.steam_not_running:
+            print("[FAIL] Steamworks initialization failed. Aborting.")
+            sys.exit(1)
+        print("OK Steamworks interface ready")
+        print()
+
+        # Register callback & track fired pfids
+        fired_pfids: set[int] = set()
+
+        def _tracking_callback(*args: Any, **kwargs: Any) -> None:
+            if args and hasattr(args[0], "publishedFileId"):
+                fired_pfids.add(int(args[0].publishedFileId))
+            si._cb_app_dependencies_result_callback(*args, **kwargs)
+
+        si.steamworks.Workshop.SetGetAppDependenciesResultCallback(_tracking_callback)
+
+        # 4. Query each pfid sequentially — wait for each callback before proceeding.
+        verbose = total <= 20
+        print(f"Querying {total} pfid(s) (waiting for each callback)...")
+        LOG_INTERVAL = max(1, total // 20) if not verbose else 1
+        for idx, pfid in enumerate(pfids, 1):
+            if verbose or idx % LOG_INTERVAL == 0 or idx == total:
+                print(
+                    f"  [{idx}/{total}] GetAppDependencies({pfid})", end="", flush=True
+                )
+            si.steamworks.Workshop.GetAppDependencies(pfid)
+            # Pump callbacks until this pfid's result arrives (up to 10s)
+            waited = 0
+            while waited < 100:  # 100 * 0.1s = 10s per query
+                si.steamworks.run_callbacks()
+                if pfid in fired_pfids or pfid in si.get_app_deps_query_result:
+                    break
+                time.sleep(0.1)
+                waited += 1
+            else:
+                if verbose:
+                    print(" [timeout]")
+            if verbose:
+                print()
+
+        # 5. Wait for all callbacks
+        print()
+        print("Waiting for Steamworks callbacks...")
+        completed = si._wait_for_callbacks(timeout=60)
+        if si.steamworks_thread.is_alive() and si.end_callbacks:
+            si.steamworks_thread.join(timeout=5)
+
+        results = si.get_app_deps_query_result
+
+        # Cleanup
+        print()
+        print("Cleaning up...")
+        if si.steamworks_thread.is_alive():
+            si.steamworks_thread.join(timeout=2)
+        si.steamworks.unload()
+
+    elapsed = time.monotonic() - start
+
+    # 6. Print results
+    print()
+    deps_found = len(results.keys())
+    print(f"Total time: {elapsed:.1f}s")
+    print(f"Throughput: {total / elapsed:.2f} pfids/sec")
+    print(f"Non-empty deps stored: {deps_found}/{total}")
+    print(
+        f"Estimated full DB (55k) with {workers} worker(s): "
+        f"{(55000 * elapsed / total) / 60:.1f} min"
+    )
+    if total > 20:
+        all_dlc_deps = sum(
+            1 for d in results.values() if any(a in RIMWORLD_DLC_METADATA for a in d)
+        )
+        print(f"  Mods with known DLC deps: {all_dlc_deps}")
+        print(
+            f"  Mods with unknown AppID deps: {sum(1 for d in results.values() if any(a not in RIMWORLD_DLC_METADATA for a in d))}"
+        )
+        print()
+        if results:
+            print("  Sample results (first 20):")
+            for pfid in list(results.keys())[:20]:
+                deps = results.get(pfid, [])
+                print_result(pfid, deps)
+    else:
+        print()
+        for pfid in pfids:
+            deps = results.get(pfid, [])
+            print_result(pfid, deps)
+
+    if not completed:
+        print()
+        print("[TIMEOUT] Some chunks timed out.")
+
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Replaced per-chunk subprocess spawning with multiprocessing.Pool (per-worker SteamworksInterface reused across chunks)

- Serialized SteamInit() across workers with multiprocessing.Lock

- Added per-query callback wait loop to prevent CCallResult overwrite from dropping callbacks (pump until callbacks_count increments)

- Capped workers to cpu_count() - 2 to avoid Steam client pipe crash

- Added 30s cooldown every 6000 pfids with runner panel messages

- Created standalone test script at tests/utils/steam/steamworks/