### PR TITLE
Move database_expiry setting to database builder tab

### DIFF
--- a/app/controllers/settings_tabs/database_builder_tab_controller.py
+++ b/app/controllers/settings_tabs/database_builder_tab_controller.py
@@ -43,6 +43,7 @@ class DatabaseBuilderTabController(BaseTabController):
             self.settings.build_steam_database_update_toggle
         )
         self.dialog.db_builder_steam_api_key.setText(self.settings.steam_apikey)
+        self.dialog.database_expiry.setText(str(self.settings.database_expiry))
 
     def update_model_from_view(self) -> None:
         if self.dialog.db_builder_include_all_radio.isChecked():
@@ -56,6 +57,7 @@ class DatabaseBuilderTabController(BaseTabController):
             self.dialog.db_builder_update_instead_of_overwriting_checkbox.isChecked()
         )
         self.settings.steam_apikey = self.dialog.db_builder_steam_api_key.text()
+        self.settings.database_expiry = int(self.dialog.database_expiry.text())
 
     # --- Action button handlers ---
 

--- a/app/controllers/settings_tabs/databases_tab_controller.py
+++ b/app/controllers/settings_tabs/databases_tab_controller.py
@@ -1,6 +1,5 @@
 from typing import Callable
 
-from loguru import logger
 from PySide6.QtWidgets import QApplication
 
 from app.controllers.settings_tabs.base_tab_controller import BaseTabController
@@ -246,13 +245,7 @@ class DatabasesTabController(BaseTabController):
     def update_view_from_model(self) -> None:
         for group in self._groups:
             group.update_view(self.dialog, self.settings)
-        self.dialog.database_expiry.setText(str(self.settings.database_expiry))
 
     def update_model_from_view(self) -> None:
         for group in self._groups:
             group.update_model(self.dialog, self.settings)
-        try:
-            self.settings.database_expiry = int(self.dialog.database_expiry.text())
-        except Exception:
-            logger.warning("Failed setting database_expiry, falling back to 0")
-            self.settings.database_expiry = 0

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -75,8 +75,6 @@ class Settings(QObject):
         )
         self.external_community_rules_url: str = "https://github.com/RimSort/Community-Rules-Database/archive/refs/heads/main.zip"
 
-        # Disable by default previously this was 7 days "604800"
-        self.database_expiry: int = 0
         # Default (-1) means do not delete data from Aux Metadata DB
         self.aux_db_time_limit: int = -1
 
@@ -137,6 +135,8 @@ class Settings(QObject):
         self.build_steam_database_dlc_data: bool = True
         self.build_steam_database_update_toggle: bool = False
         self.steam_apikey: str = ""
+        # Disable by default previously this was 7 days "604800"
+        self.database_expiry: int = 0
 
         # SteamCMD
         self.steamcmd_validate_downloads: bool = True

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -608,7 +608,7 @@ class SettingsDialog(QDialog):
         none_lbl = self.tr("Steam Workshop database")
 
         (
-            group_layout,
+            _,
             self.steam_workshop_db_none_radio,
             self.steam_workshop_db_github_radio,
             self.steam_workshop_db_github_url,
@@ -621,13 +621,6 @@ class SettingsDialog(QDialog):
             self.steam_workshop_db_local_file,
             self.steam_workshop_db_local_file_choose_button,
         ) = self.__create_db_group(section_lbl, none_lbl, tab_layout)
-        database_expiry_label = self._make_section_label(
-            "Database expiry in seconds for example, 604800 for 7 days. and 0 for no expiry."
-        )
-        group_layout.addWidget(database_expiry_label)
-
-        self.database_expiry = self._style_line_edit(QLineEdit())
-        group_layout.addWidget(self.database_expiry)
 
     def _do_no_version_warning_db_group(self, tab_layout: QBoxLayout) -> None:
         section_lbl = self.tr('"No Version Warning" Database')
@@ -670,9 +663,9 @@ class SettingsDialog(QDialog):
             "Auxiliary Metadata DB deletion time limit in seconds. (Delete instantly 0, Never Delete -1)"
         )
         aux_db_tooltip = self.tr("""To enable editing of this time limit, enable the checkbox (Enable editing) on the right.
-After a mod is deleted, this is the time we wait until this mod item is deleted from the Auxiliary Metadata DB. 
-This Auxiliary DB contains info for mod colors, toggled warning, user notes etc. 
-This basically preserves your mod coloring, user notes etc. for this many seconds after deletion. 
+After a mod is deleted, this is the time we wait until this mod item is deleted from the Auxiliary Metadata DB.
+This Auxiliary DB contains info for mod colors, toggled warning, user notes etc.
+This basically preserves your mod coloring, user notes etc. for this many seconds after deletion.
 (This applies to deletion outside of RimSort too)""")
         self.aux_db_time_limit_label.setToolTip(aux_db_tooltip)
 
@@ -994,6 +987,17 @@ This basically preserves your mod coloring, user notes etc. for this many second
             self.db_builder_compare_databases_button.sizeHint().width()
         )
         item_layout.addWidget(self.db_builder_build_database_button)
+
+        # Database expiry
+        _, db_expiry_group_layout = self._add_group_box(tab_layout)
+
+        database_expiry_label = self._make_section_label(
+            "Database expiry in seconds for example, 604800 for 7 days. and 0 for no expiry."
+        )
+        db_expiry_group_layout.addWidget(database_expiry_label)
+
+        self.database_expiry = self._style_line_edit(QLineEdit())
+        db_expiry_group_layout.addWidget(self.database_expiry)
 
     def _do_internal_tools_tab(self) -> None:
         scroll_area = QScrollArea()


### PR DESCRIPTION
Relocated the database_expiry configuration from the Databases tab to the Database Builder tab, making it more logically grouped with other database building settings. Updated the corresponding model initialization and controller logic to match the new UI organization.