### PR TITLE
Fix missing mods panel variant selection and workshop button update

### DIFF
--- a/app/windows/missing_mods_panel.py
+++ b/app/windows/missing_mods_panel.py
@@ -334,14 +334,9 @@ class MissingModsPrompt(BaseModsPanel):
             items: List of QStandardItem for the row.
             published_file_id: Initial published file ID for the combo box.
         """
-        combo_box = QComboBox()
-        combo_box.setEditable(True)
+        combo_box = self._add_combo_box_to_row(items, 4, [published_file_id])
         combo_box.setObjectName("missing_mods_variant_cb")
-        combo_box.addItem(published_file_id)
-        # Connect the currentTextChanged signal
         combo_box.currentTextChanged.connect(self._update_mod_info)
-        # Set the combo_box as the index widget
-        self.editor_table_view.setIndexWidget(items[4].index(), combo_box)
 
     def _populate_from_metadata(self) -> None:
         """
@@ -368,6 +363,45 @@ class MissingModsPrompt(BaseModsPanel):
         except Exception as e:
             logger.error(f"Error populating table from metadata: {e}")
 
+    def _find_row_for_combo_box(self, combo_box: QComboBox) -> int | None:
+        """
+        Find the table row containing the given combo box widget.
+
+        Args:
+            combo_box: The combo box widget to search for.
+
+        Returns:
+            Row index if found, None otherwise.
+        """
+        for row in range(self.editor_model.rowCount()):
+            item = self.editor_model.item(row, 5)
+            if item is None:
+                continue
+            widget = self.editor_table_view.indexWidget(item.index())
+            if widget is combo_box:
+                return row
+        return None
+
+    def _update_workshop_button(self, row: int, published_file_id: str) -> None:
+        """
+        Update the workshop button for a row to point to a new published file ID.
+
+        Args:
+            row: Row index to update.
+            published_file_id: The new published file ID.
+        """
+        item = self.editor_model.item(row, 6)
+        if item is None:
+            return
+        existing = self.editor_table_view.indexWidget(item.index())
+        if existing is not None:
+            existing.deleteLater()
+        workshop_button = self._create_workshop_button(
+            f"https://steamcommunity.com/sharedfiles/filedetails/?id={published_file_id}",
+            "workshopButton",
+        )
+        self.editor_table_view.setIndexWidget(item.index(), workshop_button)
+
     def _update_mod_info(self, published_file_id: str) -> None:
         """
         Update mod information when variant selection changes.
@@ -378,16 +412,20 @@ class MissingModsPrompt(BaseModsPanel):
         combo_box = self.sender()
         if not isinstance(combo_box, QComboBox):
             raise ValueError(f"Sender is not a QComboBox!: {combo_box}")
-        index = self.editor_table_view.indexAt(combo_box.pos())
-        if index.isValid():
-            row = index.row()
-            packageid = self.editor_model.item(row, 1).text()
-            variant_data = self.data_by_variants.get(packageid, {}).get(
-                published_file_id, {}
-            )
-            self.editor_model.item(row, 0).setText(
-                variant_data.get("name", self.DEFAULT_NOT_FOUND)
-            )
-            self.editor_model.item(row, 2).setText(
-                str(variant_data.get("gameVersions", self.DEFAULT_NOT_FOUND))
-            )
+        row = self._find_row_for_combo_box(combo_box)
+        if row is None:
+            return
+        packageid = self.editor_model.item(row, 2).text()
+        variant_data = self.data_by_variants.get(packageid, {}).get(
+            published_file_id, {}
+        )
+        if not variant_data:
+            return
+        self.editor_model.item(row, 1).setText(
+            variant_data.get("name", self.DEFAULT_NOT_FOUND)
+        )
+        self.editor_model.item(row, 3).setText(
+            str(variant_data.get("gameVersions", self.DEFAULT_NOT_FOUND))
+        )
+        if published_file_id:
+            self._update_workshop_button(row, published_file_id)


### PR DESCRIPTION
- Fix column index offsets in _update_mod_info that caused packageId lookup to read from the Name column, name writes to go to the checkbox column, and version writes to go to the packageId column.
- Replace fragile indexAt(combo_box.pos()) row detection with _find_row_for_combo_box that iterates the model to match the sender widget by identity — robust against scrolling and layout timing.
- Add _update_workshop_button to replace the workshop button at column 6 when a different variant is selected, so the 'Open Page' link points to the correct Steam Workshop URL.
- Simplify _setup_variant_combo_box to reuse base class _add_combo_box_to_row instead of manually creating the widget.