### PR TITLE
Fix MissingModPropertiesPanel crash on mods without About.xml

### DIFF
--- a/app/utils/mod_info.py
+++ b/app/utils/mod_info.py
@@ -4,6 +4,7 @@ from typing import Any
 from loguru import logger
 
 from app.models.metadata.metadata_structure import AboutXmlMod, ListedMod, ModType
+from app.utils.constants import DEFAULT_MISSING_PACKAGEID
 from app.utils.generic import format_time_display
 
 # Module-level constants for better access
@@ -140,7 +141,11 @@ class ModInfo:
         :return: A populated ModInfo instance
         """
         name = mod.name or UNKNOWN
-        packageid = str(mod.package_id) if isinstance(mod, AboutXmlMod) else ""
+        packageid = (
+            str(mod.package_id)
+            if isinstance(mod, AboutXmlMod)
+            else DEFAULT_MISSING_PACKAGEID
+        )
         published_file_id = mod.published_file_id or ""
         supported_versions = cls._parse_supported_versions_static(
             sorted(mod.supported_versions) if mod.supported_versions else None

--- a/app/windows/base_mods_panel.py
+++ b/app/windows/base_mods_panel.py
@@ -1093,7 +1093,13 @@ class BaseModsPanel(QWidget):
                 self._add_group_header_row(group_key)
 
             for path_key, metadata in mod_list:
-                mod_info = self._extract_mod_info_from_metadata(path_key, metadata)
+                try:
+                    mod_info = self._extract_mod_info_from_metadata(path_key, metadata)
+                except (ValueError, TypeError) as e:
+                    logger.warning(
+                        f"Skipping mod {path_key}: failed to extract metadata ({e})"
+                    )
+                    continue
                 self._add_mod_row(mod_info)
 
     def _get_standard_mod_columns(self) -> list[HeaderColumn]:


### PR DESCRIPTION
- In ModInfo.from_listed_mod, use DEFAULT_MISSING_PACKAGEID sentinel instead of empty string for non-AboutXmlMod mods. These mods lack a package_id attribute entirely (ListedMod has none, only AboutXmlMod inherits it from PackageIdMod), so the empty string failed __post_init__ validation, crashing the table population.
- Wrap _extract_mod_info_from_metadata in _populate_mods with a try-except as a safety net so a single unparseable mod doesn't abort the entire table for any BaseModPanel subclass.