### PR TITLE
Fix DuplicateModsPanel deletion menu always showing 'No mods selected'

### DIFF
--- a/app/windows/duplicate_mods_panel.py
+++ b/app/windows/duplicate_mods_panel.py
@@ -76,6 +76,7 @@ class DuplicateModsPanel(BaseModsPanel):
                     mod = self.metadata_controller.get_mod(path)
                     if mod is not None:
                         mod_info = ModInfo.from_listed_mod(mod)
+                        mod_info.key = path
                         self._add_mod_row(mod_info)
                     else:
                         logger.warning(


### PR DESCRIPTION
DuplicateModsPanel._populate_from_metadata() created ModInfo via ModInfo.from_listed_mod() without setting mod_info.key, so the path key was never stored as UserRole data on the name column item. This caused _get_key_from_row() to return None, making
_get_selected_mod_metadata() return an empty list regardless of which checkboxes were checked, and the deletion menu would always show 'No mods selected'.

Added mod_info.key = path to match the pattern used by all other BaseModsPanel subclasses (UseThisInsteadPanel, MissingModPropertiesPanel, and the base class _extract_mod_info_from_metadata helper).