### PR TITLE
Add delete button to workshop mod updater panel

### DIFF
--- a/app/windows/workshop_mod_updater_panel.py
+++ b/app/windows/workshop_mod_updater_panel.py
@@ -75,6 +75,11 @@ class WorkshopModUpdaterPanel(BaseModsPanel):
                 )
             )
 
+        # Add delete button
+        button_configs.append(
+            self._create_delete_button_config(self.tr("Delete Selected Mods"))
+        )
+
         # Set up buttons based on configurations
         self._setup_buttons_from_config(button_configs)
 


### PR DESCRIPTION
Adds a delete button to WorkshopModUpdaterPanel so users can delete mods that fail to update properly via Steam, then force Steam to re-download them.

The button provides:
- Delete mod completely
- Delete mod and resubscribe using Steam (when Steam integration enabled)
- Delete mod and unsubscribe from Steam (when Steam integration enabled)

Table auto-refreshes after deletion via the standard _refresh_metadata_and_panel callback. The key is already set correctly in the existing ModInfo.from_metadata(uuid, ...) call, so the deletion menu can properly look up selected mods.

Closes #2266