### PR TITLE
Fix pygit2 OpenSSL certificate failure on bundled builds (Fedora/Arch AppImage)

### DIFF
--- a/app/models/metadata/metadata_factory.py
+++ b/app/models/metadata/metadata_factory.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from typing import Any, Sequence
 
 import msgspec
-import pygit2
 from loguru import logger
 
 from app.models.metadata.metadata_structure import (
@@ -26,6 +25,11 @@ from app.models.metadata.metadata_structure import (
     SteamDbSchema,
 )
 from app.utils.constants import DEFAULT_MISSING_PACKAGEID, RIMWORLD_DLC_METADATA
+
+# Import pygit2 through the SSL-safe loader so libgit2's TLS certificate
+# locations are initialized correctly in bundled builds. See
+# app/utils/pygit2_loader.py and https://github.com/RimSort/RimSort/issues/2234.
+from app.utils.pygit2_loader import pygit2
 from app.utils.xml import json_to_xml_write, xml_path_to_json
 
 

--- a/app/utils/git_utils.py
+++ b/app/utils/git_utils.py
@@ -2,7 +2,6 @@
 
 import datetime
 import gc
-import os
 import threading
 import time
 from contextlib import contextmanager
@@ -16,26 +15,18 @@ from loguru import logger
 from PySide6.QtWidgets import QMessageBox
 
 from app.utils.generic import check_internet_connection, delete_files_with_condition
+
+# Import pygit2 (and its submodules) through the SSL-safe loader so libgit2's
+# TLS certificate locations are initialized correctly in bundled builds. See
+# app/utils/pygit2_loader.py and https://github.com/RimSort/RimSort/issues/2234.
+from app.utils.pygit2_loader import (
+    CheckoutStrategy,
+    Repository,
+    ResetMode,
+    SortMode,
+    pygit2,
+)
 from app.views.dialogue import InformationBox
-
-try:
-    import pygit2
-    from pygit2.enums import CheckoutStrategy, ResetMode, SortMode
-    from pygit2.repository import Repository
-except Exception:
-    import certifi
-
-    os.environ["SSL_CERT_FILE"] = certifi.where()
-    os.environ["SSL_CERT_DIR"] = os.path.dirname(certifi.where())
-    logger.warning("Set SSL certificates using certifi")
-
-    try:
-        import pygit2
-        from pygit2.enums import CheckoutStrategy, ResetMode, SortMode
-        from pygit2.repository import Repository
-    except Exception as e:
-        logger.error("Failed to import pygit2 after setting SSL certificates. ")
-        raise ImportError("Failed to import pygit2. ") from e
 
 
 class GitError(Exception):

--- a/app/utils/github/installer.py
+++ b/app/utils/github/installer.py
@@ -186,7 +186,7 @@ class GitHubInstaller:
             git_utils.git_cleanup(repo)
 
         if result.is_successful():
-            import pygit2
+            from app.utils.pygit2_loader import pygit2
 
             commit_info = git_utils.git_get_commit_info(pygit2.Repository(target_dir))
             sha = commit_info["short_id"] if commit_info else None

--- a/app/utils/pygit2_loader.py
+++ b/app/utils/pygit2_loader.py
@@ -1,0 +1,48 @@
+"""Centralized, SSL-safe import of pygit2.
+
+pygit2 initializes libgit2's TLS certificate locations at import time using
+``ssl.get_default_verify_paths()``. Inside bundled builds (e.g. the AppImage),
+the embedded OpenSSL reports certificate paths that do not exist on the host
+system, so importing pygit2 raises::
+
+    _pygit2.GitError: OpenSSL error: failed to load certificates
+
+When that happens we fall back to the certificate bundle shipped by ``certifi``
+and retry the import.
+
+Every module that needs pygit2 (or its submodules) must import it from here
+rather than importing ``pygit2`` directly, so that this fallback runs before
+pygit2's first import no matter which module triggers it. See
+https://github.com/RimSort/RimSort/issues/2234.
+"""
+
+import os
+
+from loguru import logger
+
+try:
+    import pygit2
+    from pygit2.enums import CheckoutStrategy, ResetMode, SortMode
+    from pygit2.repository import Repository
+except Exception:
+    import certifi
+
+    os.environ["SSL_CERT_FILE"] = certifi.where()
+    os.environ["SSL_CERT_DIR"] = os.path.dirname(certifi.where())
+    logger.warning("Set SSL certificates using certifi for pygit2 import")
+
+    try:
+        import pygit2
+        from pygit2.enums import CheckoutStrategy, ResetMode, SortMode
+        from pygit2.repository import Repository
+    except Exception as e:
+        logger.error("Failed to import pygit2 after setting SSL certificates.")
+        raise ImportError("Failed to import pygit2.") from e
+
+__all__ = [
+    "CheckoutStrategy",
+    "Repository",
+    "ResetMode",
+    "SortMode",
+    "pygit2",
+]


### PR DESCRIPTION
Fixes #2234.

### Problem
On bundled builds (AppImage), RimSort 1.5.0+ crashes at startup on Fedora/Arch/CachyOS/Bazzite/etc. with:
```
_pygit2.GitError: OpenSSL error: failed to load certificates
```
pygit2 initializes libgit2's TLS certificate locations at import time via `ssl.get_default_verify_paths()`. The AppImage's bundled OpenSSL reports certificate paths that don't exist on the host system, so the import aborts before RimSort's own error handling can run.

### Root cause
A fallback already existed in `git_utils.py` (catch the failure, set `SSL_CERT_FILE`/`SSL_CERT_DIR` from `certifi`, retry the import). But `metadata_factory.py` did a bare `import pygit2` at module scope, and it sits **earlier** in the startup import chain (`app_controller → main_window_controller → metadata_controller → metadata_mediator → metadata_factory`), so pygit2's first import — and the crash — always happened before the fallback in `git_utils.py` could run.

### Fix
Centralize the SSL-safe import into a new `app/utils/pygit2_loader.py` and route every consumer (`metadata_factory`, `git_utils`, `installer`) through it, so the `certifi` fallback runs before pygit2's first import regardless of module load order.

- Add `pygit2_loader` module holding the try/except `certifi` fallback.
- Re-export `CheckoutStrategy`/`Repository`/`ResetMode`/`SortMode` from the loader so consumers import everything as first-party. This also prevents isort from reordering a raw `from pygit2.enums import ...` above the loader (which would reintroduce the crash).
- Remove the now-duplicated fallback from `git_utils.py`.

### Testing
- All 1099 tests pass (`uv run pytest`); `ruff check`, `ruff format --check`, and `mypy` are clean.
- Verified the original crashing import chain (`AppController` → ... → `metadata_factory`) now loads cleanly.
- Windows/macOS behavior is unchanged: the `certifi` fallback only executes when the initial `import pygit2` fails, which does not happen on those platforms.

> Note: I could not reproduce the AppImage failure locally (pygit2 imports cleanly in a normal dev env, so the fallback branch isn't exercised here). The fallback is exactly the community-confirmed `SSL_CERT_FILE` workaround from the issue thread, now applied automatically and before any pygit2 import. Confirmation on an actual AppImage build would be appreciated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
