### PR TITLE
feat(http): add retry logic with backoff for transient failures

### DIFF
--- a/app/utils/http.py
+++ b/app/utils/http.py
@@ -1,33 +1,72 @@
-"""HTTP utility module providing request functions with default timeouts.
+"""HTTP utility module providing request functions with retries and timeouts.
 
 All HTTP requests in the application should use these functions instead of
 calling requests.get/post/head directly, to ensure consistent timeout behavior.
+
+Transient failures (connection errors and the status codes in
+RETRY_STATUS_CODES) are retried automatically for idempotent methods using
+exponential backoff. A fresh Session is created per request so no state is
+shared between threads.
 """
 
 from typing import Any
 
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 DEFAULT_TIMEOUT: int | float = 15
+
+# Maximum number of retry attempts for transient failures.
+DEFAULT_RETRIES: int = 4
+# Backoff factor (seconds); urllib3 uses this for exponential backoff between
+# retries.
+DEFAULT_BACKOFF_FACTOR: float = 1
+# Status codes treated as transient and retried (rate limit + server errors).
+RETRY_STATUS_CODES: tuple[int, ...] = (429, 500, 502, 503, 504)
+
+
+def _new_session() -> requests.Session:
+    """Create a Session with retry/backoff mounted for HTTP and HTTPS."""
+    retry = Retry(
+        total=DEFAULT_RETRIES,
+        read=0,
+        backoff_factor=DEFAULT_BACKOFF_FACTOR,
+        status_forcelist=RETRY_STATUS_CODES,
+        allowed_methods=frozenset(["GET", "HEAD"]),
+        respect_retry_after_header=True,
+        # Return the final response instead of raising so callers keep using
+        # response.raise_for_status() as before.
+        raise_on_status=False,
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session = requests.Session()
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    return session
+
+
+def _request(method: str, url: str, **kwargs: Any) -> requests.Response:
+    """Send a request through a Session with a default timeout."""
+    kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
+    with _new_session() as session:
+        return session.request(method, url, **kwargs)
 
 
 # jscpd:ignore-start
 def get(url: str, **kwargs: Any) -> requests.Response:
-    """Perform a GET request with default timeout."""
-    kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
-    return requests.get(url, **kwargs)
+    """Perform a GET request with retries and default timeout."""
+    return _request("GET", url, **kwargs)
 
 
 def post(url: str, **kwargs: Any) -> requests.Response:
-    """Perform a POST request with default timeout."""
-    kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
-    return requests.post(url, **kwargs)
+    """Perform a POST request with a default timeout."""
+    return _request("POST", url, **kwargs)
 
 
 def head(url: str, **kwargs: Any) -> requests.Response:
-    """Perform a HEAD request with default timeout."""
-    kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
-    return requests.head(url, **kwargs)
+    """Perform a HEAD request with retries and default timeout."""
+    return _request("HEAD", url, **kwargs)
 
 
 # jscpd:ignore-end

--- a/tests/utils/test_http.py
+++ b/tests/utils/test_http.py
@@ -1,0 +1,78 @@
+import unittest.mock as mock
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+from app.utils import http
+
+
+def _get_retry_for_url(url: str) -> Retry:
+    adapter = http._new_session().get_adapter(url)
+    assert isinstance(adapter, HTTPAdapter)
+    retry = adapter.max_retries
+    assert isinstance(retry, Retry)
+    return retry
+
+
+class TestRequestWrappers:
+    """The get/post/head wrappers dispatch correctly and apply a timeout."""
+
+    def test_get_sets_default_timeout(self) -> None:
+        with mock.patch.object(requests.Session, "request") as request:
+            http.get("https://example.com")
+        method, url = request.call_args.args
+        assert method == "GET"
+        assert url == "https://example.com"
+        assert request.call_args.kwargs["timeout"] == http.DEFAULT_TIMEOUT
+
+    def test_explicit_timeout_is_preserved(self) -> None:
+        with mock.patch.object(requests.Session, "request") as request:
+            http.get("https://example.com", timeout=5)
+        assert request.call_args.kwargs["timeout"] == 5
+
+    def test_post_and_head_dispatch_to_correct_method(self) -> None:
+        with mock.patch.object(requests.Session, "request") as request:
+            http.post("https://example.com")
+            http.head("https://example.com")
+        methods = [call.args[0] for call in request.call_args_list]
+        assert methods == ["POST", "HEAD"]
+
+
+class TestRetryConfiguration:
+    """A retry-enabled adapter is mounted for both HTTP and HTTPS."""
+
+    def test_adapter_is_mounted_with_retries(self) -> None:
+        session = http._new_session()
+        for scheme in ("http://", "https://"):
+            adapter = session.get_adapter(scheme)
+            assert isinstance(adapter, HTTPAdapter)
+            retry = adapter.max_retries
+            assert isinstance(retry, Retry)
+            assert http.DEFAULT_RETRIES == 4
+            assert retry.total == http.DEFAULT_RETRIES
+            assert retry.backoff_factor == http.DEFAULT_BACKOFF_FACTOR
+
+    def test_retries_only_idempotent_methods_by_default(self) -> None:
+        retry = _get_retry_for_url("https://example.com")
+        assert retry.allowed_methods == frozenset(["GET", "HEAD"])
+
+    def test_read_errors_are_not_retried(self) -> None:
+        retry = _get_retry_for_url("https://example.com")
+        assert retry.read == 0
+
+    def test_transient_status_codes_are_retried(self) -> None:
+        retry = _get_retry_for_url("https://example.com")
+        assert retry.status_forcelist is not None
+        for code in (429, 500, 502, 503, 504):
+            assert code in retry.status_forcelist
+
+    def test_retry_after_headers_are_respected(self) -> None:
+        retry = _get_retry_for_url("https://example.com")
+        assert retry.respect_retry_after_header is True
+
+    def test_final_status_is_returned_not_raised(self) -> None:
+        # raise_on_status=False keeps the existing contract: callers decide
+        # whether to call response.raise_for_status().
+        retry = _get_retry_for_url("https://example.com")
+        assert retry.raise_on_status is False


### PR DESCRIPTION
Builds on #1841 (the `app/utils/http.py` timeout wrappers) to add automatic
retry-with-backoff for transient HTTP failures, as requested in #1845.

A `urllib3` `Retry` adapter is mounted on a fresh per-request `Session`, so
requests through `get()` / `post()` / `head()` now retry transient failures
automatically.

## Behavior

- **Retries:** 4 attempts, exponential backoff (factor 1).
- **Transient conditions:** connection errors + status codes `429, 500, 502, 503, 504`.
- **Idempotent-only:** retries limited to `GET`/`HEAD`; `POST` is not retried.
- **Streaming-safe:** `read=0` so partial reads on streaming downloads aren't re-attempted.
- **Rate limits:** honors `Retry-After` headers (`respect_retry_after_header=True`).
- **Unchanged contract:** `raise_on_status=False` keeps `response.raise_for_status()` behaving as before.
- **Thread-safe:** a fresh `Session` per request, so no state is shared across threads.

## Testing

`tests/utils/test_http.py` covers wrapper dispatch, default/explicit timeouts,
adapter mounting, the status forcelist, idempotent-only methods, no read
retries, `Retry-After` handling, and the non-raising contract. Locally: ruff,
ruff-format, mypy, and pyright all pass; 9 tests pass.