### PR TITLE
fix: keep local git/SteamCMD mods active over their Workshop copy

### DIFF
--- a/app/controllers/metadata_controller.py
+++ b/app/controllers/metadata_controller.py
@@ -14,6 +14,8 @@ from PySide6.QtCore import QMutex, QObject, Signal, Slot
 from app.controllers.metadata_db_controller import AuxMetadataController
 from app.models.metadata.metadata_mediator import MetadataMediator
 from app.models.metadata.metadata_structure import (
+    SOURCE_PRIORITY_DEFAULT,
+    SOURCE_PRIORITY_STEAM,
     AboutXmlMod,
     CompiledDependencyData,
     ListedMod,
@@ -501,13 +503,6 @@ class MetadataController(QObject):
         :param mod_list: Path to .rws/.xml mod list file, or list of package IDs
         :return: (active_mod_paths, inactive_mod_paths, duplicate_mods, missing_mods)
         """
-        SOURCE_PRIORITY_STEAM: list[ModType] = [ModType.STEAM_WORKSHOP, ModType.LOCAL]
-        SOURCE_PRIORITY_DEFAULT: list[ModType] = [
-            ModType.LUDEON,
-            ModType.LOCAL,
-            ModType.STEAM_WORKSHOP,
-        ]
-
         all_mods = self.mods_metadata
         active_mod_paths: list[str] = []
         inactive_mod_paths: list[str] = []

--- a/app/models/metadata/metadata_structure.py
+++ b/app/models/metadata/metadata_structure.py
@@ -25,6 +25,34 @@ class ModType(Enum):
     UNKNOWN = "Unknown"
 
 
+# Source-priority orderings for resolving which physical copy of a mod wins when
+# several copies share the same package ID in the active list. RimWorld's
+# ModsConfig.xml identifies mods only by package ID, so when a package ID appears
+# more than once (e.g. a Steam Workshop copy alongside a local, git, or SteamCMD
+# copy) the winner is chosen by iterating one of these lists in order and taking
+# the first matching ModType. A bare package ID uses SOURCE_PRIORITY_DEFAULT
+# (local-style copies preferred over Workshop); RimWorld's "_steam" suffix forces
+# SOURCE_PRIORITY_STEAM (the Workshop copy preferred).
+#
+# Single source of truth: both MetadataController.get_mods_from_list and
+# app.models.mod_list import these. Every ModType that can back a duplicate must
+# appear, otherwise that source becomes unselectable and resolution silently
+# falls through to a lower-priority copy.
+SOURCE_PRIORITY_STEAM: list[ModType] = [
+    ModType.STEAM_WORKSHOP,
+    ModType.LOCAL,
+    ModType.STEAM_CMD,
+    ModType.GIT,
+]
+SOURCE_PRIORITY_DEFAULT: list[ModType] = [
+    ModType.LUDEON,
+    ModType.LOCAL,
+    ModType.STEAM_CMD,
+    ModType.GIT,
+    ModType.STEAM_WORKSHOP,
+]
+
+
 @dataclass
 class ReplacementInfo:
     """A recommended replacement mod from the Use This Instead database."""

--- a/app/models/mod_list.py
+++ b/app/models/mod_list.py
@@ -15,6 +15,8 @@ from loguru import logger
 from natsort import natsorted
 
 from app.models.metadata.metadata_structure import (
+    SOURCE_PRIORITY_DEFAULT,
+    SOURCE_PRIORITY_STEAM,
     AboutXmlMod,
     CaseInsensitiveStr,
     ModsConfig,
@@ -27,20 +29,6 @@ if TYPE_CHECKING:
 
 _STEAM_SUFFIX = "_steam"
 _SYNTHETIC_PID_PREFIX = "__path:"
-
-_SOURCE_PRIORITY_STEAM: list[ModType] = [
-    ModType.STEAM_WORKSHOP,
-    ModType.LOCAL,
-    ModType.STEAM_CMD,
-    ModType.GIT,
-]
-_SOURCE_PRIORITY_DEFAULT: list[ModType] = [
-    ModType.LUDEON,
-    ModType.LOCAL,
-    ModType.STEAM_CMD,
-    ModType.GIT,
-    ModType.STEAM_WORKSHOP,
-]
 
 
 @dataclass(frozen=True)
@@ -332,7 +320,7 @@ class ModList:
                 missing.append(raw_pid)
                 continue
 
-            sources = _SOURCE_PRIORITY_STEAM if is_steam else _SOURCE_PRIORITY_DEFAULT
+            sources = SOURCE_PRIORITY_STEAM if is_steam else SOURCE_PRIORITY_DEFAULT
             resolved_path = cls._resolve_path(
                 candidate_paths,
                 sources,

--- a/tests/controllers/test_metadata_controller.py
+++ b/tests/controllers/test_metadata_controller.py
@@ -868,6 +868,102 @@ def test_get_mods_from_list_steam_suffix_priority(
     assert missing == []
 
 
+def test_get_mods_from_list_git_duplicate_prefers_git_over_workshop(
+    metadata_controller: MetadataController,
+) -> None:
+    """Regression test for issue #2300.
+
+    For a bare package ID (no ``_steam`` suffix), a locally installed git-backed
+    copy of a mod must win over a Steam Workshop copy that shares the package ID.
+    If ``ModType.GIT`` is missing from the default source-priority order,
+    resolution falls through to the Workshop copy and the in-development mod is
+    deactivated on reload.
+    """
+    mod_git = _make_about_xml_mod(
+        "My Mod Git", "author.mymod", ModType.GIT, "/mods/local/mymod"
+    )
+    mod_workshop = _make_about_xml_mod(
+        "My Mod Workshop",
+        "author.mymod",
+        ModType.STEAM_WORKSHOP,
+        "/mods/workshop/mymod",
+    )
+
+    metadata_controller.metadata_mediator._mods_metadata = {
+        "/mods/local/mymod": mod_git,
+        "/mods/workshop/mymod": mod_workshop,
+    }
+
+    active, inactive, duplicates, missing = metadata_controller.get_mods_from_list(
+        ["author.mymod"]
+    )
+
+    assert active == ["/mods/local/mymod"]
+    assert "/mods/workshop/mymod" in inactive
+    assert missing == []
+
+
+def test_get_mods_from_list_steamcmd_duplicate_prefers_steamcmd_over_workshop(
+    metadata_controller: MetadataController,
+) -> None:
+    """A SteamCMD copy must also win over a Workshop copy for a bare package ID.
+
+    Like ``ModType.GIT``, ``ModType.STEAM_CMD`` must be selectable in the default
+    source-priority order rather than falling through to Steam Workshop.
+    """
+    mod_steamcmd = _make_about_xml_mod(
+        "My Mod SteamCMD", "author.mymod", ModType.STEAM_CMD, "/mods/local/mymod"
+    )
+    mod_workshop = _make_about_xml_mod(
+        "My Mod Workshop",
+        "author.mymod",
+        ModType.STEAM_WORKSHOP,
+        "/mods/workshop/mymod",
+    )
+
+    metadata_controller.metadata_mediator._mods_metadata = {
+        "/mods/local/mymod": mod_steamcmd,
+        "/mods/workshop/mymod": mod_workshop,
+    }
+
+    active, inactive, duplicates, missing = metadata_controller.get_mods_from_list(
+        ["author.mymod"]
+    )
+
+    assert active == ["/mods/local/mymod"]
+    assert "/mods/workshop/mymod" in inactive
+    assert missing == []
+
+
+def test_get_mods_from_list_steam_suffix_prefers_workshop_over_git(
+    metadata_controller: MetadataController,
+) -> None:
+    """The ``_steam`` suffix must still select the Workshop copy even when a
+    git-backed copy of the same package ID is present."""
+    mod_git = _make_about_xml_mod(
+        "My Mod Git", "author.mymod", ModType.GIT, "/mods/local/mymod"
+    )
+    mod_workshop = _make_about_xml_mod(
+        "My Mod Workshop",
+        "author.mymod",
+        ModType.STEAM_WORKSHOP,
+        "/mods/workshop/mymod",
+    )
+
+    metadata_controller.metadata_mediator._mods_metadata = {
+        "/mods/local/mymod": mod_git,
+        "/mods/workshop/mymod": mod_workshop,
+    }
+
+    active, inactive, duplicates, missing = metadata_controller.get_mods_from_list(
+        ["author.mymod_steam"]
+    )
+
+    assert active == ["/mods/workshop/mymod"]
+    assert "/mods/local/mymod" in inactive
+    assert missing == []
+
+
 def test_get_mods_from_list_no_duplicates_single_mod(
     metadata_controller: MetadataController,
 ) -> None:

--- a/tests/models/test_mod_list.py
+++ b/tests/models/test_mod_list.py
@@ -525,6 +525,24 @@ class TestFromModsConfig:
         mod_list, missing = ModList.from_mods_config(config, mc)
         assert mod_list[0].path == "/local/mymod"
 
+    def test_no_suffix_prefers_git_over_workshop(self) -> None:
+        """Git-backed local copy must win over Workshop for a bare package ID.
+
+        The resolution ordering comes from the SOURCE_PRIORITY_* constants shared
+        with MetadataController via app.models.metadata.metadata_structure, so
+        ModType.GIT (and STEAM_CMD) stay selectable at both layers. Regression
+        guard for issue #2300.
+        """
+        mc = _make_mock_metadata_controller(
+            {
+                "/local/mymod": ("author.mod", ModType.GIT),
+                "/workshop/mymod": ("author.mod", ModType.STEAM_WORKSHOP),
+            }
+        )
+        config = _config("1.5", ["author.mod"])
+        mod_list, missing = ModList.from_mods_config(config, mc)
+        assert mod_list[0].path == "/local/mymod"
+
     def test_preserves_order(self) -> None:
         mc = _make_mock_metadata_controller(
             {


### PR DESCRIPTION
## Summary

Fixes #2300. Activating a local copy of a mod that is also installed from the
Workshop (same package ID) did not stick. On restart the Workshop copy became
active again, and pressing Run reported unsaved changes immediately after a save.

## Fix

The duplicate-resolution priority lists in `MetadataController.get_mods_from_list`
only held LUDEON, LOCAL and STEAM_WORKSHOP. A local copy typed `ModType.GIT` or
`ModType.STEAM_CMD` matched no entry, so resolution fell through to the Workshop
copy. `app/models/mod_list.py` already carried the complete lists, so the two
had drifted.

Consolidated both orderings into `metadata_structure.py` next to `ModType` as a
single definition (GIT and STEAM_CMD ahead of STEAM_WORKSHOP for a bare ID, after
it for a `_steam` ID) and imported them from `metadata_controller.py` and
`mod_list.py`, deleting the local copies so they cannot drift again.

The same resolver is behind the false unsaved-changes prompt: `_do_save` builds
its "last saved" baseline by re-running resolution over what it just wrote, so
the baseline held the Workshop path while the active list held the git path. One
fix covers both symptoms.

## Testing

- Controller tests: git beats Workshop and SteamCMD beats Workshop for a bare ID,
  and a `_steam` ID still picks Workshop when a git copy is present.
- `mod_list` test: git beats Workshop via `ModList.from_mods_config`.
- metadata_controller, mod_list, metadata_parity and metadata_structure suites
  pass; ruff check and format clean.
