### PR TITLE
 Add confirmation before verifying game files from menu bar

### DIFF
--- a/app/controllers/menu_bar_controller.py
+++ b/app/controllers/menu_bar_controller.py
@@ -8,6 +8,7 @@ from PySide6.QtWidgets import QApplication, QLineEdit, QPlainTextEdit, QTextEdit
 from app.models.settings import Settings
 from app.utils.event_bus import EventBus
 from app.utils.generic import open_url_browser
+from app.utils.gui_info import show_dialogue_conditional
 from app.views.menu_bar import MenuBar
 
 
@@ -149,7 +150,7 @@ class MenuBarController(QObject):
             EventBus().do_check_for_git_updates
         )
         self.menu_bar.steam_verify_game_files_action.triggered.connect(
-            EventBus().do_steam_verify_game_files
+            self._on_steam_verify_game_files_triggered
         )
 
         # View menu
@@ -232,6 +233,21 @@ class MenuBarController(QObject):
         )
         if initialize:
             EventBus().do_activate_current_instance.emit(current_instance)
+
+    @Slot()
+    def _on_steam_verify_game_files_triggered(self) -> None:
+        """Confirm before verifying RimWorld game files through Steam."""
+        if not show_dialogue_conditional(
+            title=self.tr("Verify Game Files"),
+            text=self.tr(
+                "Are you sure you want to verify RimWorld's game files through Steam?"
+                "<br><br>This process cannot be canceled once it has started."
+            ),
+            icon="warning",
+        ):
+            return
+
+        EventBus().do_steam_verify_game_files.emit()
 
     def _on_menu_bar_reset_warnings_triggered(self) -> None:
         EventBus().reset_warnings_signal.emit()

--- a/tests/views/test_menu_bar.py
+++ b/tests/views/test_menu_bar.py
@@ -167,13 +167,20 @@ class TestMenuBarGameFileVerification:
                 return_value=False,
             ) as mock_dialog,
         ):
-            MenuBarController(
+            controller = MenuBarController(
                 menu_bar_instance, mock_settings_controller.settings, lambda: None
             )
 
             menu_bar_instance.steam_verify_game_files_action.trigger()
 
-            mock_dialog.assert_called_once()
+            mock_dialog.assert_called_once_with(
+                title=controller.tr("Verify Game Files"),
+                text=controller.tr(
+                    "Are you sure you want to verify RimWorld's game files through Steam?"
+                    "<br><br>This process cannot be canceled once it has started."
+                ),
+                icon="warning",
+            )
             mock_event_bus.return_value.do_steam_verify_game_files.emit.assert_not_called()
 
 class TestDisableUpdaterFlag:

--- a/tests/views/test_menu_bar.py
+++ b/tests/views/test_menu_bar.py
@@ -183,6 +183,7 @@ class TestMenuBarGameFileVerification:
             )
             mock_event_bus.return_value.do_steam_verify_game_files.emit.assert_not_called()
 
+
 class TestDisableUpdaterFlag:
     """Test the --disable-updater command-line flag processing."""
 

--- a/tests/views/test_menu_bar.py
+++ b/tests/views/test_menu_bar.py
@@ -122,6 +122,60 @@ class TestMenuBarControllerWithDisabledUpdater:
             assert controller is not None
 
 
+class TestMenuBarGameFileVerification:
+    """Test confirmation before verifying game files from the menu bar."""
+
+    def test_verify_game_files_confirmed_emits_event(
+        self,
+        menu_bar_instance: MenuBar,
+        mock_settings_controller: MagicMock,
+    ) -> None:
+        """Confirming the warning emits the game-file verification event."""
+        with (
+            patch("app.controllers.menu_bar_controller.EventBus") as mock_event_bus,
+            patch(
+                "app.controllers.menu_bar_controller.show_dialogue_conditional",
+                return_value=True,
+            ) as mock_dialog,
+        ):
+            controller = MenuBarController(
+                menu_bar_instance, mock_settings_controller.settings, lambda: None
+            )
+
+            menu_bar_instance.steam_verify_game_files_action.trigger()
+
+            mock_dialog.assert_called_once_with(
+                title=controller.tr("Verify Game Files"),
+                text=controller.tr(
+                    "Are you sure you want to verify RimWorld's game files through Steam?"
+                    "<br><br>This process cannot be canceled once it has started."
+                ),
+                icon="warning",
+            )
+            mock_event_bus.return_value.do_steam_verify_game_files.emit.assert_called_once_with()
+
+    def test_verify_game_files_cancelled_does_not_emit_event(
+        self,
+        menu_bar_instance: MenuBar,
+        mock_settings_controller: MagicMock,
+    ) -> None:
+        """Cancelling the warning does not start game-file verification."""
+        with (
+            patch("app.controllers.menu_bar_controller.EventBus") as mock_event_bus,
+            patch(
+                "app.controllers.menu_bar_controller.show_dialogue_conditional",
+                return_value=False,
+            ) as mock_dialog,
+        ):
+            MenuBarController(
+                menu_bar_instance, mock_settings_controller.settings, lambda: None
+            )
+
+            menu_bar_instance.steam_verify_game_files_action.trigger()
+
+            mock_dialog.assert_called_once()
+            mock_event_bus.return_value.do_steam_verify_game_files.emit.assert_not_called()
+
 class TestDisableUpdaterFlag:
     """Test the --disable-updater command-line flag processing."""
 

--- a/tests/views/test_menu_bar.py
+++ b/tests/views/test_menu_bar.py
@@ -125,17 +125,27 @@ class TestMenuBarControllerWithDisabledUpdater:
 class TestMenuBarGameFileVerification:
     """Test confirmation before verifying game files from the menu bar."""
 
-    def test_verify_game_files_confirmed_emits_event(
+    @pytest.mark.parametrize(
+        ("dialog_result", "should_emit"),
+        [
+            (True, True),
+            (False, False),
+        ],
+        ids=["confirmed_emits_event", "cancelled_does_not_emit_event"],
+    )
+    def test_verify_game_files_confirmation_flow(
         self,
         menu_bar_instance: MenuBar,
         mock_settings_controller: MagicMock,
+        dialog_result: bool,
+        should_emit: bool,
     ) -> None:
-        """Confirming the warning emits the game-file verification event."""
+        """Verify confirm and cancel behavior for menu-bar game-file verification."""
         with (
             patch("app.controllers.menu_bar_controller.EventBus") as mock_event_bus,
             patch(
                 "app.controllers.menu_bar_controller.show_dialogue_conditional",
-                return_value=True,
+                return_value=dialog_result,
             ) as mock_dialog,
         ):
             controller = MenuBarController(
@@ -152,36 +162,12 @@ class TestMenuBarGameFileVerification:
                 ),
                 icon="warning",
             )
-            mock_event_bus.return_value.do_steam_verify_game_files.emit.assert_called_once_with()
 
-    def test_verify_game_files_cancelled_does_not_emit_event(
-        self,
-        menu_bar_instance: MenuBar,
-        mock_settings_controller: MagicMock,
-    ) -> None:
-        """Cancelling the warning does not start game-file verification."""
-        with (
-            patch("app.controllers.menu_bar_controller.EventBus") as mock_event_bus,
-            patch(
-                "app.controllers.menu_bar_controller.show_dialogue_conditional",
-                return_value=False,
-            ) as mock_dialog,
-        ):
-            controller = MenuBarController(
-                menu_bar_instance, mock_settings_controller.settings, lambda: None
-            )
-
-            menu_bar_instance.steam_verify_game_files_action.trigger()
-
-            mock_dialog.assert_called_once_with(
-                title=controller.tr("Verify Game Files"),
-                text=controller.tr(
-                    "Are you sure you want to verify RimWorld's game files through Steam?"
-                    "<br><br>This process cannot be canceled once it has started."
-                ),
-                icon="warning",
-            )
-            mock_event_bus.return_value.do_steam_verify_game_files.emit.assert_not_called()
+            emit_mock = mock_event_bus.return_value.do_steam_verify_game_files.emit
+            if should_emit:
+                emit_mock.assert_called_once_with()
+            else:
+                emit_mock.assert_not_called()
 
 
 class TestDisableUpdaterFlag:


### PR DESCRIPTION
## What does this PR do?

This PR adds a confirmation dialog before game-file verification is triggered from the menu bar. If the user confirms, RimSort continues into the existing verification flow. If the user cancels, the verification event is not emitted.

## Why was this PR needed?

The **Verify Game Files** menu action previously continued directly into a process that cannot be canceled once started. Adding a confirmation step helps prevent users from launching that action accidentally while preserving the existing verification behavior.

The confirmation is intentionally scoped to the menu-bar entry point so the separate Troubleshooting verification flow remains unchanged.

## What are the relevant issue numbers?

Closes #1735

## Testing

- [x] Added automated tests for both confirm and cancel behavior
- [x] Confirmed that selecting the actual **Verify Game Files** menu action emits the existing verification event after confirmation
- [x] Confirmed that canceling does not emit the verification event
- [x] Confirmed that the separate Troubleshooting flow remains unchanged
- [x] Ran the full project test suite

**Final full-suite result:** `1120 passed, 13 skipped in 91.19s`

## Does this PR meet the acceptance criteria?

- [x] Tests added for new or changed behavior
- [x] All tests passing
- [x] Follows existing project patterns by reusing `show_dialogue_conditional`
- [x] No breaking changes introduced
- [x] Change is limited to the menu-bar verification flow