### PR TITLE
Fix thread priority setting logic in SearchWorker

### DIFF
--- a/app/controllers/file_search_controller.py
+++ b/app/controllers/file_search_controller.py
@@ -72,10 +72,10 @@ class SearchWorker(QThread):
         self.memory_warning_shown = False
 
         # Set thread priority to lower to avoid UI freezing
-        if not self.isRunning():
+        if self.isRunning():
+            self.setPriority(QThread.Priority.LowPriority)
+        else:
             logger.warning("Thread is not running. Skipping priority setting.")
-            return
-        self.setPriority(QThread.Priority.LowPriority)
 
         # Validate regex pattern if using regex
         if options.get("use_regex", False):


### PR DESCRIPTION
Adjust the logic for setting thread priority to ensure it only applies when the thread is running, preventing unnecessary warnings.