### PR TITLE
Fix silent update failures on Linux requiring elevation

### DIFF
--- a/app/utils/update_utils.py
+++ b/app/utils/update_utils.py
@@ -2302,6 +2302,9 @@ class UpdateManager(QObject):
 
         # Try primary method first (direct bash for Linux, osascript for macOS)
         try:
+            if self._system == "Linux" and needs_elevation:
+                raise Exception("sudo requires a terminal emulator on Linux")
+
             logger.debug(f"Attempting primary launch method on {self._system}")
             p = subprocess.Popen(
                 args_repr,


### PR DESCRIPTION
fixes a critical issue where the auto-updater would silently fail on Linux if the application was installed in a protected directory. The primary launch method used `subprocess.Popen` with `shell=True`, which successfully spawned a shell but failed internally when `sudo` lacked a terminal prompt. By explicitly forcing an exception in this scenario, the intended fallback terminal emulator is successfully launched so the user can authenticate.