### PR TITLE
Don't send packages with id 0 in PublishedFileId.txt 

### DIFF
--- a/app/models/metadata/metadata_structure.py
+++ b/app/models/metadata/metadata_structure.py
@@ -387,8 +387,9 @@ class ListedMod(BaseMod):
                     f"PublishedFileId.txt at {expected_path} contains non-numeric value: {content!r}"
                 )
                 return None
-            if content:
+            if int(content) > 0:
                 return content
+            return None
 
         if self.mod_folder is not None and self.mod_folder.isnumeric():
             candidate = int(self.mod_folder)

--- a/tests/models/metadata/test_metadata_structure.py
+++ b/tests/models/metadata/test_metadata_structure.py
@@ -280,6 +280,15 @@ class TestPublishedFileId:
         mod.mod_path = tmp_path
         assert mod.published_file_id is None
 
+    def test_zero_id_returns_none(self, tmp_path: Path) -> None:
+        """A zero placeholder is not a valid Steam Workshop ID."""
+        about = tmp_path / "About"
+        about.mkdir()
+        (about / "PublishedFileId.txt").write_text("0")
+        mod = ListedMod()
+        mod.mod_path = tmp_path
+        assert mod.published_file_id is None
+
     def test_bom_handled(self, tmp_path: Path) -> None:
         """UTF-8 BOM is stripped by utf-8-sig encoding."""
         about = tmp_path / "About"


### PR DESCRIPTION
There are local mods with a placeholder publishedFileId. Rimsort is also trying to send those to steam and the steam request fails.