### PR TITLE
fix signal emit in settings failure dialog, auto-update prompt check, and appearance branch logic

### DIFF
--- a/app/controllers/main_content_controller.py
+++ b/app/controllers/main_content_controller.py
@@ -296,7 +296,7 @@ class MainContentController(QObject):
                 "Refresh now?"
             ).format(count=len(succeeded), summary="<br>".join(summary_parts)),
         )
-        if refresh_now:
+        if refresh_now == QMessageBox.StandardButton.Yes:
             EventBus().do_refresh_mods_lists.emit()
 
     def _connect_signals(self) -> None:

--- a/app/controllers/settings_tabs/appearance_tab_controller.py
+++ b/app/controllers/settings_tabs/appearance_tab_controller.py
@@ -101,7 +101,7 @@ class AppearanceTabController(BaseTabController):
         if browser_state == "maximized":
             self.dialog.browser_launch_maximized_radio.setChecked(True)
             self.dialog.disable_browser_custom_size_spinboxes()
-        if browser_state == "normal":
+        elif browser_state == "normal":
             self.dialog.browser_launch_normal_radio.setChecked(True)
             self.dialog.disable_browser_custom_size_spinboxes()
         elif browser_state == "custom":

--- a/app/views/dialogue.py
+++ b/app/views/dialogue.py
@@ -816,7 +816,7 @@ class SettingsFailureDialog(QDialog):
             generic.platform_specific_open(AppInfo().app_storage_folder)
 
         def _reset_settings_file() -> None:
-            EventBus().reset_settings_file.emit
+            EventBus().reset_settings_file.emit()
             self.accept()
 
         self.open_settings_file_btn.clicked.connect(lambda: _open_settings_file())


### PR DESCRIPTION
- added missing parentheses to `EventBus().reset_settings_file.emit()` in `SettingsFailureDialog`. Previously, clicking "Reset Settings" only referenced the bound method without invoking it, which meant the signal was never sent to `SettingsController` to overwrite the corrupted config and reload defaults.
- updated `if refresh_now:` to `if refresh_now == QMessageBox.StandardButton.Yes:` in `_on_auto_updates_complete()`. Because `show_dialogue_conditional` returns `QMessageBox.StandardButton` enums (`Yes` = 16384, `No` = 65536), checking it as a bare boolean evaluated to `True` even when clicking "No", causing an unintended mod list refresh.
- changed `if browser_state == "normal":` to `elif` in `update_view_from_model()`. The detached `if` statement caused a `"maximized"` setting to fall through the rest of the checks and execute the fallback `else:` block unnecessarily.