### PR TITLE
fix(steam): bundle setup_steam_recovery_script.js in build

### DIFF
--- a/app/utils/steam/steambrowser/browser.py
+++ b/app/utils/steam/steambrowser/browser.py
@@ -749,8 +749,13 @@ class SteamBrowser(QWidget):
 
     def _inject_steam_recovery_script(self) -> None:
         recovery_path = Path(AppInfo().setup_steam_recovery_script_file)
+        try:
+            source_code = recovery_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            logger.error(f"Failed to read Steam recovery script: {exc}")
+            return
         script = QWebEngineScript()
-        script.setSourceCode(recovery_path.read_text(encoding="utf-8"))
+        script.setSourceCode(source_code)
         script.setInjectionPoint(QWebEngineScript.InjectionPoint.DocumentCreation)
         script.setWorldId(QWebEngineScript.ScriptWorldId.MainWorld)
         script.setRunsOnSubFrames(True)

--- a/rimsort.nuitka-package.config.yml
+++ b/rimsort.nuitka-package.config.yml
@@ -12,6 +12,7 @@
         - "../update.sh"
         - "../update.bat"
         - "../setup_web_channel_script.js"
+        - "../setup_steam_recovery_script.js"
 
   dlls:
     - from_filenames:


### PR DESCRIPTION
## Summary
- `setup_steam_recovery_script.js` was never added to the Nuitka packaging config (`rimsort.nuitka-package.config.yml`) — only `setup_web_channel_script.js` was listed. Compiled builds shipped without the file.
- `_inject_steam_recovery_script()` read the missing file with `Path.read_text()` and raised an unhandled `FileNotFoundError`, crashing RimSort whenever the Workshop browser was opened.
- Added the file to the packaging data-files list, and wrapped the read in try/except (matching the existing pattern used for the sibling `setup_web_channel_script.js` injector) so a missing file logs an error instead of crashing.

Fixes #2377

## Test plan
- [x] `pytest tests/utils/steam/test_web_channel_script.py` — 22 passed
- [x] Verify a compiled build now includes `setup_steam_recovery_script.js` and Workshop browser opens without crashing