### PR TITLE
Disable BLE001 and strip inline noqa comments project-wide

### DIFF
--- a/app/__main__.py
+++ b/app/__main__.py
@@ -111,7 +111,7 @@ def main_thread() -> None:
     try:
         app_controller = AppController()
         sys.exit(app_controller.run())
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         # Catch exceptions during initial application instantiation
         # Uncaught exceptions during the application loop are caught with excepthook
         stacktrace: str = ""
@@ -140,7 +140,7 @@ def main_thread() -> None:
             try:
                 logger.debug("Stopping watchdog...")
                 app_controller.shutdown_watchdog()
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 stacktrace = traceback.format_exc()
                 logger.warning(f"Exception: {e}")
                 logger.warning(
@@ -171,7 +171,7 @@ if __name__ == "__main__":
                 sys.stdin = open("CONIN$", "r", encoding="utf-8", errors="replace")  # noqa: SIM115
                 sys.stdout = open("CONOUT$", "w", encoding="utf-8", buffering=1)  # noqa: SIM115
                 sys.stderr = open("CONOUT$", "w", encoding="utf-8", buffering=1)  # noqa: SIM115
-            except Exception:  # noqa: BLE001, S110
+            except Exception:  # noqa: S110
                 pass  # No console available; carry on silently.
 
         import runpy
@@ -189,7 +189,7 @@ if __name__ == "__main__":
             from app.cli.main import cli
 
             cli()
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             # Handle CLI errors without Qt dialogs
             import traceback
 
@@ -262,7 +262,7 @@ if __name__ == "__main__":
             msg.setStandardButtons(QMessageBox.StandardButton.Ok)
             msg.exec()
             sys.exit(1)
-    except Exception:  # noqa: BLE001
+    except Exception:
         logger.warning(
             "Failed to acquire single-instance lock, continuing without lock",
             exc_info=True,

--- a/app/cli/build_db.py
+++ b/app/cli/build_db.py
@@ -94,7 +94,7 @@ def build_db(
                     api_key = settings.get("steam_apikey")
                     if api_key and not quiet:
                         click.echo("Using Steam API key from settings.json", err=True)
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 if not quiet:
                     click.echo(
                         f"Warning: Could not read settings.json: {e}",
@@ -193,7 +193,7 @@ def build_db(
     except KeyboardInterrupt:
         click.echo("\n\nInterrupted by user.", err=True)
         sys.exit(2)
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         click.secho(
             f"✗ Error: {e}",
             fg="red",

--- a/app/controllers/file_search_controller.py
+++ b/app/controllers/file_search_controller.py
@@ -137,7 +137,7 @@ class SearchWorker(QThread):
                 self.memory_warning_shown = True
 
             return memory_percent <= self.memory_warning_threshold
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"Error checking memory usage: {e}")
             return True
 
@@ -179,7 +179,7 @@ class SearchWorker(QThread):
                             binary_content.decode("utf-8", errors="replace")
                             + "\n\n[File truncated due to size...]"
                         )
-                except Exception as e:  # noqa: BLE001
+                except Exception as e:
                     logger.warning(f"Failed to read large file {file_path}: {e}")
                     return ""
         except OSError as e:
@@ -208,7 +208,7 @@ class SearchWorker(QThread):
         except ImportError:
             # charset_normalizer not available, continue with fallbacks
             pass
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.debug(f"Error detecting encoding: {e}")
 
         # Try common encodings
@@ -233,7 +233,7 @@ class SearchWorker(QThread):
                 binary_content = f.read()
                 # Try to decode with 'replace' option to substitute invalid chars
                 return binary_content.decode("utf-8", errors="replace")
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.warning(f"Failed to read file {file_path} after all attempts: {e}")
             return ""
 
@@ -394,7 +394,7 @@ class SearchWorker(QThread):
 
             joined_preview = "\n".join(preview_lines)
             return f"{header}\n{prefix}{joined_preview}{suffix}"
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.warning(f"Failed to get preview for {file_path}: {e}")
             return f"Error generating preview: {e}"
 
@@ -486,7 +486,7 @@ class SearchWorker(QThread):
             # If element not found, return empty string to fall back to standard preview
             return ""
 
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.warning(f"Error generating XML preview for {file_path}: {e}")
             # Return empty string to fall back to standard preview
             return ""
@@ -575,7 +575,7 @@ class SearchWorker(QThread):
             self.finished.emit()
             self.stats.emit(self.tr("Search complete"))
 
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"Unexpected error during search: {e}")
             self.error.emit(str(e))
 
@@ -698,7 +698,7 @@ class FileSearchController(QObject):
                 self.search_worker.quit()
                 if not self.search_worker.wait(1000):  # Wait up to 1 second
                     self.search_worker.terminate()
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 logger.warning(f"Error cleaning up previous search worker: {e}")
 
         # Log search parameters

--- a/app/controllers/instance_controller.py
+++ b/app/controllers/instance_controller.py
@@ -278,7 +278,7 @@ class InstanceController(QObject):
             test_file.unlink()
         except PermissionError:
             return False, f"No write permission for: {override_path}"
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             return False, f"Cannot access folder: {e}"
 
         return True, ""

--- a/app/controllers/main_content_controller.py
+++ b/app/controllers/main_content_controller.py
@@ -154,7 +154,7 @@ class MainContentController(QObject):
                 count = session.query(GitHubModEntry).count()
             if count == 0:
                 return
-        except Exception:  # noqa: BLE001
+        except Exception:
             return
 
         cache_session = self._get_github_cache_session()
@@ -484,7 +484,7 @@ class MainContentController(QObject):
                 github_paths = {
                     entry.mod_path for entry in session.query(GitHubModEntry).all()
                 }
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.debug(f"Could not check GitHub mods table: {e}")
             return list(repos_paths)
 
@@ -874,7 +874,7 @@ class MainContentController(QObject):
                 self._http_download_worker.download_finished.disconnect()
                 self._http_download_worker.quit()
                 self._http_download_worker.wait()
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 logger.debug(f"Error during HTTP worker cleanup: {e}")
             self._http_download_worker = None
 
@@ -969,7 +969,7 @@ class MainContentController(QObject):
                 self._git_clone_worker.error.disconnect()
                 self._git_clone_worker.quit()
                 self._git_clone_worker.wait()
-            except Exception:  # noqa: BLE001, S110
+            except Exception:  # noqa: S110
                 pass
             self._git_clone_worker = None
 
@@ -1007,7 +1007,7 @@ class MainContentController(QObject):
                 self._git_clone_worker.finished.disconnect()
                 self._git_clone_worker.progress.disconnect()
                 self._git_clone_worker.error.disconnect()
-            except Exception:  # noqa: BLE001, S110
+            except Exception:  # noqa: S110
                 pass
             self._git_clone_worker = None
 
@@ -1069,7 +1069,7 @@ class MainContentController(QObject):
                 text=str(e),
             ).exec()
             releases = []
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"Failed to query GitHub releases: {e}")
             releases = []
 
@@ -1412,7 +1412,7 @@ class MainContentController(QObject):
         try:
             repo_user_or_org = extract_git_user_or_org(repo_url)
             repo_folder_name = extract_git_dir_name(repo_url)
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"Failed to parse repository URL: {e}")
             InformationBox(
                 title=self.tr("Invalid repository URL"),
@@ -1509,7 +1509,7 @@ class MainContentController(QObject):
         try:
             g = Github(github_username, github_token)
             original_repo = g.get_repo(f"{repo_user_or_org}/{repo_folder_name}")
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"Failed to initialize GitHub API: {e}")
             InformationBox(
                 title=self.tr("GitHub API error"),
@@ -1523,7 +1523,7 @@ class MainContentController(QObject):
             # Try to get existing fork
             fork_repo = g.get_repo(f"{github_username}/{repo_folder_name}")
             logger.info(f"Found existing fork: {fork_repo.full_name}")
-        except Exception:  # noqa: BLE001
+        except Exception:
             # Fork doesn't exist, create one
             try:
                 logger.info(f"Creating fork of {original_repo.full_name}")
@@ -1538,7 +1538,7 @@ class MainContentController(QObject):
                         "Fork: {fork_name}<br>Please wait a moment for GitHub to set up the fork."
                     ).format(fork_name=fork_repo.full_name),
                 ).exec()
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 logger.error(f"Failed to create fork: {e}")
                 InformationBox(
                     title=self.tr("Fork creation failed"),
@@ -1753,7 +1753,7 @@ class MainContentController(QObject):
                                         "Your original changes are preserved in the database file and will be committed."
                                     ),
                                 ).exec()
-                        except Exception as e:  # noqa: BLE001
+                        except Exception as e:
                             logger.warning(f"Could not check for merge conflicts: {e}")
 
                         # If conflicts were detected and resolved, continue with clean state
@@ -1796,7 +1796,7 @@ class MainContentController(QObject):
                     logger.info(
                         f"Created branch: {branch_name} (will switch after commit)"
                     )
-                except Exception as e:  # noqa: BLE001
+                except Exception as e:
                     logger.error(f"Failed to create branch {branch_name}: {e}")
                     InformationBox(
                         title=self.tr("Branch creation failed"),
@@ -1826,7 +1826,7 @@ class MainContentController(QObject):
                 try:
                     status = repo.status()
                     logger.info(f"Git status before staging: {dict(status)}")
-                except Exception as e:  # noqa: BLE001
+                except Exception as e:
                     logger.warning(f"Could not get git status: {e}")
 
                 # Stage and commit the database file (this will be on main branch initially)
@@ -1862,7 +1862,7 @@ class MainContentController(QObject):
                         logger.info(
                             f"Moved commit to branch: {branch_name} and reset main branch"
                         )
-                    except Exception:  # noqa: BLE001
+                    except Exception:
                         logger.exception("Failed to move commit to new branch")
                         # If this fails, the commit is still on main, but we can continue
                         # Just switch to the new branch and the commit will be duplicated
@@ -1929,7 +1929,7 @@ class MainContentController(QObject):
                                     information=str(push_result_force),
                                 ).exec()
 
-                        except Exception as e:  # noqa: BLE001
+                        except Exception as e:
                             logger.exception("Error during force push")
                             InformationBox(
                                 title=self.tr("Force push error"),
@@ -1962,7 +1962,7 @@ class MainContentController(QObject):
                         information=str(stage_commit_result),
                     ).exec()
 
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.exception("Git operations failed")
             InformationBox(
                 title=self.tr("Git operation error"),
@@ -1984,9 +1984,9 @@ class MainContentController(QObject):
                                 logger.warning(
                                     "Main branch not found, staying on current branch"
                                 )
-                        except Exception as e:  # noqa: BLE001
+                        except Exception as e:
                             logger.warning(f"Failed to switch to main branch: {e}")
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 logger.warning(f"Failed to switch back to main branch: {e}")
 
     def _create_pull_request(
@@ -2041,10 +2041,10 @@ class MainContentController(QObject):
                     import webbrowser
 
                     webbrowser.open(pull_request.html_url)
-                except Exception:  # noqa: BLE001
+                except Exception:
                     logger.exception("Failed to open browser")
 
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.exception("Failed to create pull request")
             InformationBox(
                 title=self.tr("Pull request failed"),

--- a/app/controllers/metadata_controller.py
+++ b/app/controllers/metadata_controller.py
@@ -127,7 +127,7 @@ class MetadataController(QObject):
                     entry = self.metadata_db_controller.get_or_create(session, path)
                     entry.type = str(mod_data.mod_type)
                     entry.published_file_id = mod_data.published_file_id
-                except Exception:  # noqa: BLE001
+                except Exception:
                     session.rollback()
                     logger.exception(f"Failed to update aux metadata for mod at {path}")
 

--- a/app/controllers/metadata_db_controller.py
+++ b/app/controllers/metadata_db_controller.py
@@ -19,7 +19,7 @@ class MetadataDbController:
         try:
             if db_path.parent:
                 db_path.parent.mkdir(parents=True, exist_ok=True)
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.exception(
                 f"Failed to ensure database directory exists for {db_path}: {e}"
             )
@@ -296,7 +296,7 @@ class AuxMetadataController(MetadataDbController):
 
         try:
             acf_data = acf_to_dict(str(acf_path))
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"Error reading .acf file at {acf_path}: {e}")
             return
 

--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -154,7 +154,7 @@ class SettingsController(QObject):
         except JSONDecodeError:
             logger.error("Unable to parse settings file")
             show_settings_error()
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"Failed to load settings: {e}")
             show_settings_error()
 

--- a/app/controllers/settings_tabs/advanced_tab_controller.py
+++ b/app/controllers/settings_tabs/advanced_tab_controller.py
@@ -111,7 +111,7 @@ class AdvancedTabController(BaseTabController):
         # Auxiliary DB
         try:
             self.settings.aux_db_time_limit = int(self.dialog.aux_db_time_limit.text())
-        except Exception:  # noqa: BLE001
+        except Exception:
             logger.warning("Failed setting Aux DB time limit, falling back to -1")
             self.settings.aux_db_time_limit = -1
         self.settings.enable_aux_db_behavior_editing = (

--- a/app/controllers/theme_controller.py
+++ b/app/controllers/theme_controller.py
@@ -99,7 +99,7 @@ class ThemeController:
                         """
                         # return f.read()
                         return font_style + raw_stylesheet
-                except Exception as e:  # noqa: BLE001
+                except Exception as e:
                     logger.error(f"Error loading theme: {e}")
         else:
             logger.error(f"Attempted to load unsupported theme: {theme_name}")

--- a/app/controllers/troubleshooting_controller.py
+++ b/app/controllers/troubleshooting_controller.py
@@ -88,7 +88,7 @@ class TroubleshootingController:
                     item.unlink()
                 elif item.is_dir():
                     rmtree(item)
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 logger.error(f"Failed to delete {item}: {e}")
                 self.show_failed_warning(item, e)
 
@@ -114,7 +114,7 @@ class TroubleshootingController:
             temp_mods = game_dir / "Mods_temp"
             try:
                 mods_dir.rename(temp_mods)
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 item = temp_mods
                 logger.error(f"Failed to rename {item} folder: {e}")
                 self.show_failed_warning(item, e)
@@ -128,7 +128,7 @@ class TroubleshootingController:
         if temp_mods.exists():
             try:
                 temp_mods.rename(mods_dir)
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 item = temp_mods
                 logger.error(f"Failed to restore {item} folder: {e}")
                 self.show_failed_warning(item, e)
@@ -145,7 +145,7 @@ class TroubleshootingController:
                     "Process complete, wait for steam to complete further process.",
                 ),
             )
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"Failed to launch Steam installation: {e}")
             show_dialogue_conditional(
                 title=self.translate(
@@ -201,7 +201,7 @@ class TroubleshootingController:
                     f"steam://workshop_download_item/294100/{mod_id}"
                 )
                 logger.info(f"opening: steam://workshop_download_item/294100/{mod_id}")
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"Failed to trigger Steam workshop redownload: {e}")
             show_dialogue_conditional(
                 title=self.translate(
@@ -236,7 +236,7 @@ class TroubleshootingController:
                     item.unlink()
                     deleted_any = True
                     logger.info(f"Deleted {item} successfully.")
-                except Exception as e:  # noqa: BLE001
+                except Exception as e:
                     logger.error(f"Failed to delete config file {item}: {e}")
                     self.show_failed_warning(item, e)
 
@@ -287,7 +287,7 @@ class TroubleshootingController:
                             "TroubleshootingController", "Deleted {item} successfully."
                         ).format(item=item),
                     )
-                except Exception as e:  # noqa: BLE001
+                except Exception as e:
                     logger.error(f"Failed to delete game config file {item}: {e}")
                     self.show_failed_warning(item, e)
 
@@ -352,7 +352,7 @@ class TroubleshootingController:
             try:
                 rmtree(mods_dir)
                 mods_dir.mkdir()  # recreate empty Mods folder
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 item = mods_dir
                 logger.error(f"Failed to clear {item} folder: {e}")
                 self.show_failed_warning(item, e)
@@ -390,7 +390,7 @@ class TroubleshootingController:
                         "Successfully deleted all mods and resetting ModsConfig.xml to vanilla state.",
                     ),
                 )
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 logger.error(f"Failed to reset ModsConfig.xml: {e}")
                 show_dialogue_conditional(
                     title=self.translate("TroubleshootingController", "Error"),
@@ -491,7 +491,7 @@ class TroubleshootingController:
             }
 
             atomic_json_dump(export_data, save_path, indent=2)
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"Failed to export mod list: {e}")
             show_warning(
                 title=self.translate("TroubleshootingController", "Error"),
@@ -563,7 +563,7 @@ class TroubleshootingController:
                     "Details: {e}",
                 ).format(e=str(e)),
             )
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"Failed to import mod list: {e}")
             show_dialogue_conditional(
                 self.translate("TroubleshootingController", "Error"),
@@ -596,7 +596,7 @@ class TroubleshootingController:
                     steam_root = steam_root.parent
                 if steam_root.name.lower() == "steam":
                     return steam_root
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             item = workshop_path
             logger.error(f"Failed to get steam root from {item} : {e}")
             self.show_failed_warning(item, e)
@@ -656,7 +656,7 @@ class TroubleshootingController:
                     buttons=["Ok"],
                 )
 
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"Failed to clear Steam cache: {e}")
             show_dialogue_conditional(
                 title=self.translate("TroubleshootingController", "Cache Clear Failed"),
@@ -723,7 +723,7 @@ class TroubleshootingController:
                 icon="info",
             )
 
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"Failed to repair Steam library: {e}")
             show_dialogue_conditional(
                 title=self.translate(
@@ -796,7 +796,7 @@ class TroubleshootingController:
                         "No orphaned workshop entries were found. The ACF file is clean.",
                     ),
                 )
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"Failed to clean orphaned workshop items: {e}")
             show_warning(
                 title=self.translate("TroubleshootingController", "Cleanup Failed"),

--- a/app/models/animations.py
+++ b/app/models/animations.py
@@ -147,7 +147,7 @@ class WorkThread(QThread):
     def run(self) -> None:
         try:
             self.data = self.target()
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             self.exception = e
             logger.error(f"{type(e).__name__}: {e!s}\n{traceback.format_exc()}")
         logger.debug("WorkThread completed, returning to main thread")

--- a/app/models/metadata/metadata_factory.py
+++ b/app/models/metadata/metadata_factory.py
@@ -114,7 +114,7 @@ def read_mods_config(path: Path) -> ModsConfig | None:
         return ModsConfig(
             version=version, activeMods=activeMods, knownExpansions=knownExpansions
         )
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         logger.error(f"Failed to read mods config: {e}")
         return None
 
@@ -131,7 +131,7 @@ def write_mods_config(path: Path, mods_config: ModsConfig) -> bool:
             {"ModsConfigData": mods_config.to_dict()}, str(path), raise_errs=True
         )
         return True
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         logger.error(f"Failed to write mods config: {e}")
         return False
 
@@ -672,7 +672,7 @@ def _create_about_mod_from_xml(
 ) -> tuple[bool, AboutXmlMod]:
     try:
         mod_data = xml_path_to_json(str(mod_xml_path))
-    except Exception:  # noqa: BLE001
+    except Exception:
         logger.error(
             f"Unable to parse {mod_xml_path} with the exception: {traceback.format_exc()}"
         )
@@ -696,7 +696,7 @@ def _create_scenario_mod_from_rsc(
 ) -> tuple[bool, ScenarioMod]:
     try:
         mod_data = xml_path_to_json(str(mod_rsc_path))
-    except Exception:  # noqa: BLE001
+    except Exception:
         logger.error(
             f"Unable to parse {mod_rsc_path} with the exception: {traceback.format_exc()}"
         )

--- a/app/models/metadata/metadata_mediator.py
+++ b/app/models/metadata/metadata_mediator.py
@@ -280,7 +280,7 @@ class MetadataMediator:
                         f"Retrieved game version from Version.txt: {self.game_version}"
                     )
                     return True
-            except Exception:  # noqa: BLE001
+            except Exception:
                 logger.error(
                     f"Unable to parse Version.txt from game folder: {version_file_path}"
                 )
@@ -395,7 +395,7 @@ class MetadataMediator:
                             )
 
                     results[mod.uuid] = mod
-                except Exception as e:  # noqa: BLE001
+                except Exception as e:
                     logger.error(f"Error parsing mod at path: {path}")
                     logger.error(e)
 

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -390,7 +390,7 @@ class Settings(QObject):
                                 ignore_errors=False,
                                 onerror=handle_remove_read_only,
                             )
-                        except Exception as e:  # noqa: BLE001
+                        except Exception as e:
                             logger.error(
                                 f"Failed to migrate SteamCMD install path. Error: {e}"
                             )
@@ -475,7 +475,7 @@ class Settings(QObject):
         if dlg.exec_is_positive():
             try:
                 self.recover_backup(use_old_backup=use_old_backup)
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 logger.error(f"Failed to recover settings from backup: {e}")
                 InformationBox(
                     title=self.tr("Settings Recovery Failed"),
@@ -499,7 +499,7 @@ class Settings(QObject):
                 copy2(self._settings_file, backup_path)
                 return True
             return False
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"Failed to update settings backup: {e}")
             return False
 
@@ -526,7 +526,7 @@ class Settings(QObject):
 
             return True
 
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"Failed to recover settings from backup: {e}")
             return False
 

--- a/app/services/dependency_resolver.py
+++ b/app/services/dependency_resolver.py
@@ -75,7 +75,7 @@ def _resolve_from_about_xml(
                 try:
                     major, minor = metadata_controller.game_version.split(".")[:2]
                     target_keys = [f"v{major}.{minor}", f"{major}.{minor}"]
-                except Exception:  # noqa: BLE001
+                except Exception:
                     target_keys = []
 
                 deps_by_version = root.find("modDependenciesByVersion")
@@ -108,7 +108,7 @@ def _resolve_from_about_xml(
 
             if workshop_id:
                 return workshop_id
-        except Exception:  # noqa: BLE001, S112
+        except Exception:  # noqa: S112
             continue
     return None
 

--- a/app/services/http_download_service.py
+++ b/app/services/http_download_service.py
@@ -67,7 +67,7 @@ class HttpDownloadService(QObject):
                 self._worker.download_finished.disconnect()
                 self._worker.quit()
                 self._worker.wait()
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 logger.debug(f"Error during HTTP worker cleanup: {e}")
             self._worker = None
 
@@ -99,7 +99,7 @@ class HttpDownloadService(QObject):
         if self._worker:
             try:
                 self._worker.download_finished.disconnect()
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 logger.debug(f"Error during HTTP worker cleanup: {e}")
             self._worker = None
 

--- a/app/services/instance_service.py
+++ b/app/services/instance_service.py
@@ -68,7 +68,7 @@ class InstanceService:
                 f"Copying game folder from {existing_instance_game_folder} to {target_game_folder}"
             )
             copytree(existing_instance_game_folder, target_game_folder, symlinks=True)
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"An error occurred while copying game folder: {e}")
 
     @staticmethod
@@ -95,7 +95,7 @@ class InstanceService:
                 target_config_folder,
                 symlinks=True,
             )
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"An error occurred while copying config folder: {e}")
 
     @staticmethod
@@ -120,7 +120,7 @@ class InstanceService:
                 target_local_folder,
                 symlinks=True,
             )
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"An error occurred while copying local folder: {e}")
 
     @staticmethod
@@ -143,7 +143,7 @@ class InstanceService:
                         os.path.join(target_local_folder, subdir),
                         symlinks=True,
                     )
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"An error occurred while cloning Workshop mods: {e}")
 
     @staticmethod
@@ -281,7 +281,7 @@ class InstanceService:
                         "Compressing [{instance_name}] instance folder to archive...",
                     ).format(instance_name=instance_name),
                 )
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 show_fatal_error(
                     title=QCoreApplication.translate(
                         "InstanceService", "Error compressing instance"
@@ -331,7 +331,7 @@ class InstanceService:
             instance_controller = InstanceController.from_archive(input_path)
         except InvalidArchivePathError:
             return
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"An error occurred while reading instance archive: {e}")
             show_fatal_error(
                 title=QCoreApplication.translate(
@@ -931,7 +931,7 @@ class InstanceService:
                         ignore_errors=False,
                         onerror=handle_remove_read_only,
                     )
-                except Exception as e:  # noqa: BLE001
+                except Exception as e:
                     logger.error(f"Error deleting instance: {e}")
                 self.settings.instances.pop(self.settings.current_instance)
                 EventBus().do_activate_current_instance.emit(DEFAULT_INSTANCE_NAME)

--- a/app/services/version_data_service.py
+++ b/app/services/version_data_service.py
@@ -35,7 +35,7 @@ class VersionDataService:
                     data = json.load(f)
                     self._depots_data = data.get("depots", {})
                     self._versions_data = data.get("versions", {})
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 logger.error(
                     f"Failed to load versions data from {self.versions_path}: {e}"
                 )

--- a/app/services/window_manager.py
+++ b/app/services/window_manager.py
@@ -38,14 +38,14 @@ class WindowManager:
             if window is not None:
                 try:
                     window.close()
-                except Exception:  # noqa: BLE001, S110
+                except Exception:  # noqa: S110
                     # Avoid RuntimeError: libshiboken: Internal C++ object (Panel) already deleted.
                     pass
         for window in self._child_windows:
             if window is not None:
                 try:
                     window.close()
-                except Exception:  # noqa: BLE001, S110
+                except Exception:  # noqa: S110
                     # Avoid RuntimeError: libshiboken: Internal C++ object (Panel) already deleted.
                     pass
         self._child_windows.clear()

--- a/app/sort/mod_sorting.py
+++ b/app/sort/mod_sorting.py
@@ -198,7 +198,7 @@ def path_to_mod_tags(
 
     try:
         tags = auxdb_get_mod_tags(settings, path)
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         logger.debug(f"Failed to retrieve tags for sorting path {path}: {e}")
         return ""
 
@@ -287,7 +287,7 @@ def _get_path_to_color_map(
                 aux_entry = aux_controller.get(aux_session, path)
                 if aux_entry and aux_entry.color_hex:
                     path_to_color[path] = aux_entry.color_hex
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         logger.warning(f"Failed to fetch auxiliary metadata for batch: {e}")
     return path_to_color
 
@@ -312,7 +312,7 @@ def _get_path_to_updated_map(
                 aux_entry = aux_controller.get(aux_session, path)
                 if aux_entry and aux_entry.acf_time_updated > 0:
                     path_to_updated[path] = aux_entry.acf_time_updated
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         logger.warning(f"Failed to fetch update times from auxiliary metadata: {e}")
     return path_to_updated
 

--- a/app/utils/acf_utils.py
+++ b/app/utils/acf_utils.py
@@ -63,7 +63,7 @@ def load_acf_from_path(acf_path: str | Path) -> dict[str, Any]:
     # Parse the ACF file using the steamfiles wrapper
     try:
         return acf_to_dict(str(acf_path))
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         logger.error(f"Failed to parse ACF file at {acf_path}: {e}")
         return {}
 
@@ -428,7 +428,7 @@ def steamcmd_purge_mods(
             logger.debug(f"Removing mod manifest file: {manifest_path}")
             try:
                 manifest_path.unlink()
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 logger.error(f"Failed to remove manifest file {manifest_path}: {e}")
 
 
@@ -482,7 +482,7 @@ def validate_acf_file_exists(steam_mods_location: str) -> bool:
             logger.debug(f"ACF file not found at expected location: {acf_file_path}")
 
         return exists
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         logger.warning(f"Error validating ACF file path for {steam_mods_location}: {e}")
         return False
 

--- a/app/utils/csv_export_utils.py
+++ b/app/utils/csv_export_utils.py
@@ -69,7 +69,7 @@ def export_to_csv(panel: BaseModsPanel) -> None:
             EXPORT_FILESYSTEM_ERROR.format(e=str(e)),
             "Export File System Error",
         )
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         _handle_csv_export_error(
             panel,
             EXPORT_UNKNOWN_ERROR,

--- a/app/utils/file_search.py
+++ b/app/utils/file_search.py
@@ -151,7 +151,7 @@ class FileSearch:
                                         result_callback(result)
                                 yield result
                                 break
-                    except Exception as e:  # noqa: BLE001
+                    except Exception as e:
                         logger.error(f"Error reading file {file_path}: {e}")
 
     def _read_file_in_chunks(
@@ -175,7 +175,7 @@ class FileSearch:
             with open(file_path, "rb") as f:
                 while chunk := f.read(chunk_size):
                     yield chunk.decode("utf-8", errors="ignore")
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"Failed to read file {file_path} in chunks: {e}")
 
     def _create_search_method(
@@ -261,7 +261,7 @@ class FileSearch:
             try:
                 with open(file_path, "r", encoding=encoding, errors="ignore") as f:
                     return f.read()
-            except Exception:  # noqa: BLE001, S112
+            except Exception:  # noqa: S112
                 continue
         return ""
 
@@ -288,7 +288,7 @@ class FileSearch:
                     encoding = results.encoding
                     if encoding:
                         return raw_data.decode(encoding, errors="ignore")
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(
                 f"Failed to read file {file_path} with charset_normalizer: {e}"
             )

--- a/app/utils/files.py
+++ b/app/utils/files.py
@@ -38,7 +38,7 @@ def subfolder_contains_candidate_path(
         subfolder_paths.extend(
             [subfolder / folder for folder in subfolder.iterdir() if folder.is_dir()]
         )
-    except Exception:  # noqa: BLE001
+    except Exception:
         # Could not list subdirectories, return False
         return False
 
@@ -88,7 +88,7 @@ def cleanup_old_backups(backup_dir: Path, keep: int) -> None:
             for old_backup in backups[keep:]:
                 logger.info(f"Deleting old backup: {old_backup}")
                 os.remove(old_backup)
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         logger.error(f"An error occurred during backup cleanup: {e}")
 
 
@@ -147,7 +147,7 @@ def create_saves_backup(
 
         return str(backup_archive_path)
 
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         logger.error(f"An error occurred during save backup: {e}")
         return None
 

--- a/app/utils/generic.py
+++ b/app/utils/generic.py
@@ -48,7 +48,7 @@ def copy_to_clipboard_safely(text: str) -> None:
     try:
         clipboard = QApplication.clipboard()
         clipboard.setText(text)
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         logger.error(f"Failed to copy to clipboard: {e}")
         dialogue.show_fatal_error(
             title=translate("copy_to_clipboard_safely", "Failed to copy to clipboard."),
@@ -216,7 +216,7 @@ def attempt_chmod(
         try:
             func(path)
             return True
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.warning(
                 f"attempt_chmod for {func.__name__} double failure at {path}: {e}"
             )
@@ -501,7 +501,7 @@ def platform_specific_open(path: str | Path) -> None:
                 # Try to open with notepad as fallback
                 try:
                     subprocess.Popen(["notepad.exe", path])
-                except Exception as notepad_error:  # noqa: BLE001
+                except Exception as notepad_error:
                     logger.error(f"Failed to open with notepad: {notepad_error}")
                     dialogue.show_warning(
                         title="Failed to open file",
@@ -694,7 +694,7 @@ def find_steam_rimworld(steam_folder: Path | str) -> str:
         try:
             with open(steam_folder / primary_library, "r") as f:
                 rimworld_path = __load_data(f)
-        except Exception:  # noqa: BLE001
+        except Exception:
             logger.warning(f"Failed to parse {primary_library}", exc_info=True)
             return rimworld_path
     elif os.path.exists(steam_folder / backup_library):
@@ -702,7 +702,7 @@ def find_steam_rimworld(steam_folder: Path | str) -> str:
         try:
             with open(steam_folder / backup_library, "r") as f:
                 rimworld_path = __load_data(f)
-        except Exception:  # noqa: BLE001
+        except Exception:
             logger.warning(f"Failed to parse {backup_library}", exc_info=True)
             return rimworld_path
     else:

--- a/app/utils/git_utils.py
+++ b/app/utils/git_utils.py
@@ -135,7 +135,7 @@ def _fetch_with_timeout(repo: Repository, remote: pygit2.Remote, timeout: int) -
         try:
             remote.fetch()
             result["success"] = True
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             result["error"] = e
 
     fetch_thread = threading.Thread(target=fetch_target)
@@ -176,7 +176,7 @@ def _is_repository_corrupted(repo_path: str | Path) -> bool:
                 pass
         repo.free()
         return False
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         error_str = str(e).lower()
         # Check for common corruption indicators
         corruption_indicators = [
@@ -217,7 +217,7 @@ def _attempt_repository_repair(
                 repo.state_cleanup()
                 repo.free()
                 logger.debug(f"Cleaned up repository object: {repo_path_str}")
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 logger.warning(f"Failed to cleanup repository object: {e}")
 
         # Try to delete the corrupted repository
@@ -269,7 +269,7 @@ def _attempt_repository_repair(
 
         return True
 
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         logger.error(f"Failed to repair repository {repo_path_str}: {e}")
         return False
 
@@ -607,7 +607,7 @@ def parse_git_url(repo_url: str) -> ParsedGitUrl | None:
             return _parse_ssh_git_url(repo_url)
         else:
             return None
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         logger.warning(f"Failed to parse git URL '{repo_url}': {e}")
         return None
 
@@ -795,7 +795,7 @@ def git_clone(
                             f"Successfully cloned after renaming backup: {repo_path}"
                         )
                         return repo, GitCloneResult.CLONED
-                    except Exception as e:  # noqa: BLE001
+                    except Exception as e:
                         logger.error(f"Failed to clone after renaming backup: {e}")
                         return None, GitCloneResult.PATH_DELETE_ERROR
 
@@ -850,7 +850,7 @@ def git_check_updates(
                     f"Fetch operation timed out after {config.fetch_timeout} seconds"
                 )
                 return None
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"Fetch operation failed: {e!s}")
             return None
 
@@ -882,7 +882,7 @@ def git_check_updates(
         try:
             remote = repo.remotes["origin"]
             remote_url = remote.url
-        except Exception:  # noqa: BLE001, S110
+        except Exception:  # noqa: S110
             pass
 
         _handle_git_error(
@@ -953,7 +953,7 @@ def git_pull(
                     f"Fetch operation timed out after {config.fetch_timeout} seconds"
                 )
                 return GitPullResult.GIT_ERROR
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"Fetch operation failed: {e!s}")
             # Check for corruption and attempt repair
             error_str = str(e).lower()
@@ -961,7 +961,7 @@ def git_pull(
                 remote_url = None
                 try:
                     remote_url = remote.url
-                except Exception:  # noqa: BLE001, S110
+                except Exception:  # noqa: S110
                     pass
                 repaired = _handle_git_error(
                     GitOperationType.PULL,
@@ -983,7 +983,7 @@ def git_pull(
                 stash_result = git_stash(repo, message="Auto-stash before pull")
                 if stash_result.is_error():
                     logger.warning("Failed to stash changes before pull")
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 logger.warning(f"Exception during stash before pull: {e}")
 
         # Get remote branch reference
@@ -1044,7 +1044,7 @@ def git_pull(
                             logger.warning(f"Conflict found in: {path_value}")
                         else:
                             logger.warning("Conflict found in unknown file")
-                    except Exception:  # noqa: BLE001
+                    except Exception:
                         logger.warning("Conflict found in unknown file")
 
                 if config.notify_errors:
@@ -1062,7 +1062,7 @@ def git_pull(
                     logger.info(
                         "Aborted merge due to conflicts and reset repository state."
                     )
-                except Exception:  # noqa: BLE001
+                except Exception:
                     logger.exception("Failed to abort merge and reset state")
 
                 return GitPullResult.CONFLICT
@@ -1092,7 +1092,7 @@ def git_pull(
         try:
             if remote:
                 remote_url = remote.url
-        except Exception:  # noqa: BLE001, S110
+        except Exception:  # noqa: S110
             pass
 
         repaired = _handle_git_error(
@@ -1142,7 +1142,7 @@ def git_push(
     if branch is None:
         try:
             branch = repo.head.shorthand
-        except Exception:  # noqa: BLE001
+        except Exception:
             logger.error("No active branch found")
             return GitPushResult.GIT_ERROR
 
@@ -1152,7 +1152,7 @@ def git_push(
         if local_oid is None:
             logger.info("No commits to push")
             return GitPushResult.NO_COMMITS
-    except Exception:  # noqa: BLE001
+    except Exception:
         logger.error("Failed to get local commit")
         return GitPushResult.GIT_ERROR
 
@@ -1260,7 +1260,7 @@ def git_stage_commit(
                     if tree_id == parent_tree.id:
                         logger.info("No changes to commit")
                         return GitStageCommitResult.NO_CHANGES
-                except Exception:  # noqa: BLE001
+                except Exception:
                     # This might be the first commit or no staged changes
                     logger.info("No changes to commit")
                     return GitStageCommitResult.NO_CHANGES
@@ -1284,7 +1284,7 @@ def git_stage_commit(
             if tree_id == parent_tree.id:
                 logger.info("No changes to commit after staging")
                 return GitStageCommitResult.NO_CHANGES
-        except Exception:  # noqa: BLE001
+        except Exception:
             # This might be the first commit
             logger.debug("First commit or no parent - proceeding with commit")
 
@@ -1295,7 +1295,7 @@ def git_stage_commit(
             parents = []
             try:
                 parents = [repo.head.target]
-            except Exception:  # noqa: BLE001, S110
+            except Exception:  # noqa: S110
                 # This might be the first commit (no HEAD yet)
                 pass
 
@@ -1809,7 +1809,7 @@ def get_latest_commit_info(repo: Repository, short_format: bool = True) -> str:
         else:
             return "The HEAD is not a commit."
 
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         return f"Latest commit info unavailable: {e!s}"
 
 
@@ -1824,7 +1824,7 @@ def get_repository_latest_commit(
             commit_info = get_latest_commit_info(repo, short_format=True)
             return True, commit_info, None
 
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         error_msg = str(e)
         logger.error(f"Error getting latest commit for {repo_path}: {error_msg}")
         return False, None, error_msg

--- a/app/utils/git_worker.py
+++ b/app/utils/git_worker.py
@@ -109,7 +109,7 @@ def process_batch_repository(
             else:
                 return False, str(result)
 
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         error_msg = str(e)
         error_lower = error_msg.lower()
 
@@ -148,7 +148,7 @@ def process_batch_repository(
                                         False,
                                         f"Operation failed after repair: {result}",
                                     )
-                    except Exception as retry_e:  # noqa: BLE001
+                    except Exception as retry_e:
                         logger.error(f"Failed {operation_name} after repair: {retry_e}")
                         return (
                             False,
@@ -157,7 +157,7 @@ def process_batch_repository(
                 else:
                     logger.error(f"Failed to repair corrupted repository: {repo_path}")
                     return False, f"Corrupted repository - repair failed: {error_msg}"
-            except Exception as repair_e:  # noqa: BLE001
+            except Exception as repair_e:
                 logger.error(f"Exception during corruption repair: {repair_e}")
                 return False, f"Corruption repair failed: {repair_e!s}"
         else:
@@ -301,7 +301,7 @@ class GitCloneWorker(BaseGitWorker):
             else:
                 self.emit_error(f"Clone failed: {result}")
 
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             if not self.isInterruptionRequested():
                 self.handle_exception("clone", e)
         finally:
@@ -309,7 +309,7 @@ class GitCloneWorker(BaseGitWorker):
                 git_utils.git_cleanup(repo)
                 try:
                     gc.collect()
-                except Exception:  # noqa: BLE001, S110
+                except Exception:  # noqa: S110
                     pass
 
 
@@ -368,7 +368,7 @@ class GitPushWorker(BaseGitWorker):
                 else:
                     self.emit_error(f"Push failed: {result}")
 
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             if not self.isInterruptionRequested():
                 self.handle_exception("push", e)
 
@@ -427,7 +427,7 @@ class GitStageCommitWorker(BaseGitWorker):
                 else:
                     self.emit_error(f"Stage and commit failed: {result}")
 
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             if not self.isInterruptionRequested():
                 self.handle_exception("stage and commit", e)
 
@@ -448,7 +448,7 @@ def check_repository_updates(
             else:
                 return True, [], None  # No updates found
 
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         error_msg = str(e)
         logger.error(f"Error checking updates for {repo_path}: {error_msg}")
         return False, None, error_msg

--- a/app/utils/github/provider.py
+++ b/app/utils/github/provider.py
@@ -66,7 +66,7 @@ def parse_github_url(url: str) -> tuple[str, str] | None:
     """
     try:
         parsed = urlparse(url)
-    except Exception:  # noqa: BLE001
+    except Exception:
         return None
 
     if parsed.hostname not in ("github.com", "www.github.com"):

--- a/app/utils/github/updater.py
+++ b/app/utils/github/updater.py
@@ -64,7 +64,7 @@ def check_for_updates(
         except GitHubRateLimitError:
             logger.warning(f"Rate limit hit while checking {mod.owner_repo}, skipping")
             continue
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"Error checking updates for {mod.owner_repo}: {e}")
             continue
 

--- a/app/utils/github/worker.py
+++ b/app/utils/github/worker.py
@@ -56,7 +56,7 @@ class GitHubInstallWorker(QThread):
                     )
                 else:
                     self.finished.emit(False, "Clone failed", self._target_dir)
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"GitHub install failed: {e}")
             self.finished.emit(False, str(e), self._target_dir)
 
@@ -107,7 +107,7 @@ class GitHubVersionSwitchWorker(QThread):
             GitHubInstaller.delete_backup(backup_path)
             self.finished.emit(True, new_version, str(self._mod_path))
 
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"Version switch failed for {self._owner_repo}: {e}")
             if backup_path and backup_path.exists():
                 self.progress.emit("Restoring backup...")
@@ -148,6 +148,6 @@ class GitHubUpdateCheckWorker(QThread):
                 self.finished.emit(updates)
             finally:
                 session.close()
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"GitHub update check failed: {e}")
             self.error.emit(str(e))

--- a/app/utils/ignore_manager.py
+++ b/app/utils/ignore_manager.py
@@ -61,7 +61,7 @@ class IgnoreManager:
         except json.JSONDecodeError as e:
             logger.error(f"Failed to parse ignore file {ignore_file}: {e}")
             return set()
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"Failed to load ignored mods from {ignore_file}: {e}")
             return set()
 
@@ -92,7 +92,7 @@ class IgnoreManager:
 
             logger.info(f"Saved {len(ignored_mods)} ignored mods to {ignore_file}")
             return True
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"Failed to save ignored mods to {ignore_file}: {e}")
             return False
 

--- a/app/utils/mod_info.py
+++ b/app/utils/mod_info.py
@@ -207,7 +207,7 @@ class ModInfo:
         """Parse mod name from metadata with fallbacks."""
         try:
             return metadata.get("name", metadata.get("steamName", ""))
-        except Exception:  # noqa: BLE001
+        except Exception:
             return UNKNOWN
 
     @staticmethod
@@ -220,7 +220,7 @@ class ModInfo:
             elif isinstance(authors, str):
                 return authors
             return UNKNOWN
-        except Exception:  # noqa: BLE001
+        except Exception:
             return UNKNOWN
 
     @staticmethod

--- a/app/utils/pygit2_loader.py
+++ b/app/utils/pygit2_loader.py
@@ -24,7 +24,7 @@ try:
     import pygit2
     from pygit2.enums import CheckoutStrategy, ResetMode, SortMode
     from pygit2.repository import Repository
-except Exception:  # noqa: BLE001
+except Exception:
     import certifi
 
     os.environ["SSL_CERT_FILE"] = certifi.where()

--- a/app/utils/rentry/wrapper.py
+++ b/app/utils/rentry/wrapper.py
@@ -106,7 +106,7 @@ class RentryUpload:
         except requests.RequestException as e:
             # Handle any exceptions that occur during the process
             RentryError().show_request_exception(e)
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             # Handle any other exceptions that occur during the process
             logger.error(f"An error occurred while Uploading rentry.co content: {e!s}")
             show_fatal_error(
@@ -286,7 +286,7 @@ class RentryImport:
         except requests.RequestException as e:
             # Handle any exceptions that occur during the process
             RentryError().show_request_exception(e)
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             # Handle any other exceptions that occur during the process
             logger.error(f"An error occurred while fetching rentry.co content: {e!s}")
             show_fatal_error(

--- a/app/utils/schema.py
+++ b/app/utils/schema.py
@@ -73,7 +73,7 @@ def validate_rimworld_mods_list(
         ):
             logger.info("Validated XML formatting (RimWorld .rml modlist)")
             return mods_config_data["savedModList"]["meta"]["modIds"]["li"]
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         logger.error(f"Error trying to validate data: {e}")
         show_warning(
             title=translate("validate_rimworld_mods_list", "Unable to read data"),

--- a/app/utils/steam/availability.py
+++ b/app/utils/steam/availability.py
@@ -16,7 +16,7 @@ from app.utils.generic import show_no_steam_warning, show_snap_steam_warning
 try:
     if "__compiled__" not in globals():
         sys.path.append(str(Path.cwd() / "submodules" / "SteamworksPy"))
-except Exception:  # noqa: BLE001, S110
+except Exception:  # noqa: S110
     pass
 
 SLEEP_TIME = 15
@@ -97,7 +97,7 @@ def _is_steam_running() -> bool:
                 sleep(2)
 
         return False
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         logger.warning(f"Error checking if Steam is running: {e}")
         return False
 
@@ -220,7 +220,7 @@ def _launch_steam(
                 # Give Steam a bit more time to fully initialize
                 sleep(SLEEP_TIME)
                 return True
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 error_msg = f"{e.__class__.__name__}: {e}"
                 logger.debug(
                     f"Steam API not ready yet (attempt {attempt + 1}/{MAX_ATTEMPTS}): {error_msg}"
@@ -243,7 +243,7 @@ def _launch_steam(
             status_callback(msg)
         return False
 
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         logger.warning(f"Error launching Steam: {e}")
         return False
 

--- a/app/utils/steam/steambrowser/browser.py
+++ b/app/utils/steam/steambrowser/browser.py
@@ -920,7 +920,7 @@ class SteamBrowser(QWidget):
                 self.web_view.page().runJavaScript(
                     setup_web_channel_script, 0, lambda result: None
                 )
-            except Exception as exc:  # noqa: BLE001
+            except Exception as exc:
                 logger.error(f"Failed to inject workshop badge script: {exc}")
 
             if is_item_page or is_collection_page:
@@ -1129,7 +1129,7 @@ class SteamBrowser(QWidget):
                 self.web_view.loadProgress.disconnect()
                 self.web_view.loadFinished.disconnect()
                 self.web_view.urlChanged.disconnect()
-            except Exception:  # noqa: BLE001, S110
+            except Exception:  # noqa: S110
                 pass
 
             # Clean up page

--- a/app/utils/steam/steamcmd/wrapper.py
+++ b/app/utils/steam/steamcmd/wrapper.py
@@ -205,7 +205,7 @@ class SteamcmdInterface:
                 runner,
             )
 
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             if runner is not None:
                 runner.message(
                     f"Failed to create symlink. Error: {type(e).__name__}: {e!s}"
@@ -734,7 +734,7 @@ class SteamcmdInterface:
                         tarobj.extractall(self.steamcmd_install_path)
                     runner.message("Installation completed")
                     installed = True
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 runner.message("Installation failed")
                 show_fatal_error(
                     "SteamcmdInterface",

--- a/app/utils/steam/steamworks/wrapper.py
+++ b/app/utils/steam/steamworks/wrapper.py
@@ -122,7 +122,7 @@ class SteamworksInterface:
         self.steamworks = STEAMWORKS(_libs=_libs)
         try:
             self.steamworks.initialize()  # Init the Steamworks API
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.warning(
                 f"Unable to initialize Steamworks API due to exception: {e.__class__.__name__}"
             )
@@ -511,7 +511,7 @@ class SteamworksSubscriptionHandler(Process):
                     f"⚠ Timeout after {STEAMWORKS_TIMEOUT}s (callbacks: {steamworks_interface.callbacks_count}). Operations queued - Steam will process in background."
                 )
 
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(
                 f"✗ Error during subscription action {self.action}: {e}", exc_info=True
             )
@@ -650,7 +650,7 @@ class SteamworksSubscriptionHandler(Process):
                     logger.warning(
                         "DownloadItem skipped: not supported by SteamworksPy library."
                     )
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 logger.error(
                     f"Failed to trigger download for {pfid}: {e}", exc_info=True
                 )
@@ -703,7 +703,7 @@ class SteamworksSubscriptionHandler(Process):
                     )
                 else:
                     logger.debug(f"✓ {operation.capitalize()} callback fired")
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 logger.debug(f"{operation.capitalize()} callback: {e}")
 
         return callback

--- a/app/utils/steam/webapi/wrapper.py
+++ b/app/utils/steam/webapi/wrapper.py
@@ -149,7 +149,7 @@ class CollectionImport:
 
                         try:
                             steam_response = http.get(steam_link).text
-                        except Exception as e:  # noqa: BLE001
+                        except Exception as e:
                             logger.exception(e)
                             steam_response = ""
                         if STEAM_THERE_WAS_A_PROBLEM_FLAG in steam_response:
@@ -176,7 +176,7 @@ class CollectionImport:
                         ),
                         details="\n".join(failed_mods),
                     )
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"An error occurred while fetching collection content: {e!s}")
 
     def _get_package_id_from_pfid(self, pfid: str | int | None) -> str | None:
@@ -395,7 +395,7 @@ class DynamicQuery(QObject):
         logger.debug("WebAPI is not active!")
         try:  # Try to initialize the API
             self.api = WebAPI(self.apikey, format="json", https=True)
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             self.api = None
             # Catch exceptions that can potentially leak Steam API key
             stacktrace = traceback.format_exc()
@@ -564,7 +564,7 @@ class DynamicQuery(QObject):
                     admin_query=False,
                 )
                 all_details.extend(response["response"]["publishedfiledetails"])
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 stacktrace = traceback.format_exc()
                 if (
                     e.__class__.__name__ == "HTTPError"
@@ -738,7 +738,7 @@ class DynamicQuery(QObject):
         if self.output_database_path:
             try:
                 atomic_json_dump(query, self.output_database_path, indent=4)
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 logger.warning(f"Failed to save database before Steamworks: {e}")
 
         # Check Steam availability
@@ -820,7 +820,7 @@ class DynamicQuery(QObject):
         if self.output_database_path:
             try:
                 atomic_json_dump(query, self.output_database_path, indent=4)
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 logger.warning(f"Failed to save database after Steamworks: {e}")
 
 
@@ -851,7 +851,7 @@ def ISteamRemoteStorage_GetCollectionDetails(
             data[f"publishedfileids[{count}]"] = publishedfileid
         try:  # Make a request to the Steam Web API
             request = http.post(url, data=data, timeout=(5, 60))
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.warning(
                 f"Unable to complete request! Are you connected to the internet? Received exception: {e.__class__.__name__}"
             )

--- a/app/utils/update_utils.py
+++ b/app/utils/update_utils.py
@@ -400,7 +400,7 @@ class TarExtractThread(QThread):
                 f"Time elapsed: {elapsed:.2f} seconds",
             )
 
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.exception("tar.gz extraction failed")
             self.finished.emit(False, f"Extraction error: {e!s}")
 
@@ -622,7 +622,7 @@ class UpdateManager(QObject):
             total_time = (datetime.now() - start_time).total_seconds()  # noqa: DTZ005
             logger.info(f"Update check process completed in {total_time:.2f}s")
 
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             total_time = (datetime.now() - start_time).total_seconds()  # noqa: DTZ005
             logger.exception(f"Update check failed after {total_time:.2f}s")
             dialogue.show_warning(
@@ -741,7 +741,7 @@ class UpdateManager(QObject):
                     return version.parse("999.999.999")
 
             return version.parse(current_version)
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.warning(f"Failed to parse version '{current_version}': {e}")
             return version.parse("0.0.0")
 
@@ -817,7 +817,7 @@ class UpdateManager(QObject):
             # Parse version
             try:
                 latest_version = version.parse(normalized_tag)
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 logger.warning(f"Failed to parse version from tag {tag_name}: {e}")
                 self.show_update_error()
                 return None
@@ -852,7 +852,7 @@ class UpdateManager(QObject):
                 text=self.tr(ERR_API_CONNECTION_TEXT).format(error=str(e)),
             )
             return None
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.warning(f"Unexpected error fetching release info: {e}")
             self.show_update_error()
             return None
@@ -1089,7 +1089,7 @@ class UpdateManager(QObject):
         try:
             self._download_update(url)
             self.download_complete.emit(True, "")
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             self.download_complete.emit(False, str(e))
 
     def _perform_update(
@@ -1146,7 +1146,7 @@ class UpdateManager(QObject):
                             self.mod_info_panel.panel.removeWidget(
                                 self._progress_widget
                             )
-                except Exception:  # noqa: BLE001, S110
+                except Exception:  # noqa: S110
                     pass
 
             self.download_complete.connect(on_complete)
@@ -1260,7 +1260,7 @@ class UpdateManager(QObject):
                 text=self.tr(ERR_LAUNCH_FAILED_TEXT),
                 information=f"Error: {e!s}",
             )
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.exception("Unexpected update process failure")
             dialogue.show_warning(
                 title=self.tr(ERR_UPDATE_FAILED_TITLE),
@@ -1275,7 +1275,7 @@ class UpdateManager(QObject):
                     self.mod_info_panel.info_panel_frame.show()
                     if hasattr(self.main_content, "disable_enable_widgets_signal"):
                         self.main_content.disable_enable_widgets_signal.emit(True)
-                except Exception:  # noqa: BLE001, S110
+                except Exception:  # noqa: S110
                     pass
 
     def _get_file_size(self, url: str) -> int:
@@ -1291,7 +1291,7 @@ class UpdateManager(QObject):
         try:
             head_response = http.head(url, timeout=API_TIMEOUT, allow_redirects=True)
             return int(head_response.headers.get("content-length", 0))
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.debug(f"Failed to get file size: {e}")
             return 0
 
@@ -1526,7 +1526,7 @@ class UpdateManager(QObject):
                             # Restore panel visibility
                             # jscpd:ignore-end
                             self.mod_info_panel.info_panel_frame.show()
-                except Exception as e:  # noqa: BLE001
+                except Exception as e:
                     logger.debug(f"Error closing progress widget: {e}")
 
             extract_thread = ZipExtractThread(
@@ -1568,7 +1568,7 @@ class UpdateManager(QObject):
             if temp_zip_path.exists():
                 try:
                     temp_zip_path.unlink()
-                except Exception as e:  # noqa: BLE001
+                except Exception as e:
                     logger.debug(f"Failed to clean up temp ZIP file: {e}")
 
     def _extract_tar_gz(self, content: bytes, temp_base: Path) -> int:
@@ -1647,7 +1647,7 @@ class UpdateManager(QObject):
                                 self._progress_widget
                             )
                             self.mod_info_panel.info_panel_frame.show()
-                except Exception as e:  # noqa: BLE001
+                except Exception as e:
                     logger.debug(f"Error closing progress widget: {e}")
 
             extract_thread = TarExtractThread(
@@ -1682,7 +1682,7 @@ class UpdateManager(QObject):
             if temp_tar_path.exists():
                 try:
                     temp_tar_path.unlink()
-                except Exception as e:  # noqa: BLE001
+                except Exception as e:
                     logger.debug(f"Failed to clean up temp tar.gz file: {e}")
 
     def _normalize_structure(self, temp_base: Path, extracted_files: int) -> None:
@@ -1719,7 +1719,7 @@ class UpdateManager(QObject):
             try:
                 self._normalize_extracted_structure(temp_base, extracted_files)
                 normalization_result["success"] = True
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 normalization_result["error"] = e
             finally:
                 logger.debug("Structure normalization worker thread completed")
@@ -1738,7 +1738,7 @@ class UpdateManager(QObject):
                     self.mod_info_panel.panel.removeWidget(self._progress_widget)
                     # Restore panel visibility
                     self.mod_info_panel.info_panel_frame.show()
-        except Exception:  # noqa: BLE001, S110
+        except Exception:  # noqa: S110
             pass
 
         if not normalization_result["success"]:
@@ -2136,7 +2136,7 @@ class UpdateManager(QObject):
                         update_manager=self,
                     )
                     logger.debug(f"Updated script path to: {script_path}")
-                except Exception as e:  # noqa: BLE001
+                except Exception as e:
                     logger.warning(
                         f"Failed to copy update.bat to app storage, using original: {e}"
                     )
@@ -2425,7 +2425,7 @@ class UpdateManager(QObject):
                 lf.write(
                     f"\n===== RimSort updater launched: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')} ({system}) =====\n"  # noqa: DTZ005
                 )
-        except Exception:  # noqa: BLE001, S110
+        except Exception:  # noqa: S110
             # Non-fatal; continue without preface
             pass
 
@@ -2512,7 +2512,7 @@ class UpdateManager(QObject):
                 if self.mod_info_panel:
                     self.mod_info_panel.panel.removeWidget(progress_widget)
                     self.mod_info_panel.info_panel_frame.show()
-        except Exception:  # noqa: BLE001
+        except Exception:
             logger.exception("Error cleaning up progress widget")
 
     def _create_backup_with_progress(self) -> None:
@@ -2574,7 +2574,7 @@ class UpdateManager(QObject):
                 # Use emit for thread safety, or call directly if on main thread
                 try:
                     self._progress_widget.update_progress(percent, message)
-                except Exception as e:  # noqa: BLE001
+                except Exception as e:
                     logger.debug(f"Error updating backup progress: {e}")
 
         try:
@@ -2592,7 +2592,7 @@ class UpdateManager(QObject):
             else:
                 logger.warning("Backup file not created")
 
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.warning(f"Failed to create backup: {e}")
             logger.error(f"Backup creation error traceback: {traceback.format_exc()}")
             # show dialog and ask user to if they want to proceed with update anyway
@@ -2631,7 +2631,7 @@ class UpdateManager(QObject):
                 try:
                     backup_file.unlink()
                     logger.info(f"Removed old backup: {backup_file.name}")
-                except Exception as e:  # noqa: BLE001
+                except Exception as e:
                     logger.warning(
                         f"Failed to remove old backup {backup_file.name}: {e}"
                     )
@@ -2640,7 +2640,7 @@ class UpdateManager(QObject):
                 f"Cleaned up {len(backups_to_remove)} old backups, keeping {max_backups} most recent"
             )
 
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.warning(f"Failed to cleanup old backups: {e}")
 
     def show_update_error(self) -> None:

--- a/app/utils/watchdog.py
+++ b/app/utils/watchdog.py
@@ -73,7 +73,7 @@ class WatchdogHandler(FileSystemEventHandler, QObject):
                     self.watchdog_mods_observer.start()
             else:
                 logger.warning("Watchdog Mods Observer is None. Unable to start.")
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.warning(
                 f"Unable to start Watchdog Observer(s) due to exception: {e!s}"
             )

--- a/app/utils/xml.py
+++ b/app/utils/xml.py
@@ -102,7 +102,7 @@ def xml_path_to_json(path: str) -> dict[str, Any]:
             tree = ET.parse(f)
             root = tree.getroot()
             data = etree_to_dict(root)
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         # If ET parsing fails, attempt parsing with BeautifulSoup
         logger.debug(f"Error parsing XML file with xml.etree.ElementTree: {e}")
         logger.debug("Trying to parse with BeautifulSoup as a fallback")
@@ -117,7 +117,7 @@ def xml_path_to_json(path: str) -> dict[str, Any]:
                     empty_tag.extract()
                 # Convert the BeautifulSoup object to a dictionary
                 data = bs4_to_dict(soup)
-        except Exception as e2:  # noqa: BLE001
+        except Exception as e2:
             logger.debug(f"Error parsing XML file with BeautifulSoup: {e2}")
             logger.error(f"Error parsing XML file: {path}")
             return data
@@ -191,7 +191,7 @@ def extract_xml_package_ids(path: str) -> set[str]:
 
         return package_ids
 
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         logger.error(f"Error running XML package id extraction: {e}")
         return set()
 
@@ -237,7 +237,7 @@ def fast_rimworld_xml_save_validation(path: str) -> bool:
                     return False
 
                 elem.clear()
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         logger.error(f"Error running RimWorld XML save validation: {e}")
         return False
 
@@ -254,7 +254,7 @@ def using_gzip(fp: str) -> bool:
     try:
         with open(fp, "rb") as f:
             return f.read(2) == b"\x1f\x8b"
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         logger.error(f"Failed checking if save file is using gzip: {e}")
         return False
 
@@ -269,7 +269,7 @@ def using_zstd(fp: str) -> bool:
     try:
         with open(fp, "rb") as f:
             return f.read(4) == b"\x28\xb5\x2f\xfd"
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         logger.error(f"Failed checking if save file is using zstd: {e}")
         return False
 

--- a/app/utils/zip_extractor.py
+++ b/app/utils/zip_extractor.py
@@ -114,7 +114,7 @@ class ZipExtractThread(QThread):
             if self.delete:
                 os.remove(self.zip_path)
 
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"ZIP extraction failed: {e}")
             self.finished.emit(False, f"Extraction error: {e!s}")
 
@@ -154,7 +154,7 @@ def validate_zip_integrity(zip_path: str | Path) -> tuple[bool, str]:
     except BadZipFile as e:
         logger.error(f"Invalid ZIP file: {e}")
         return False, f"Invalid ZIP file: {e!s}"
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         logger.error(f"Failed to validate ZIP: {e}")
         return False, f"Error validating ZIP: {e!s}"
 
@@ -241,7 +241,7 @@ def create_zip_backup(
                 # Update progress
                 if progress_callback:
                     progress_callback(current_file, total_files)
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 logger.error(f"Failed to add {file_path} to backup: {e}")
 
     logger.info(f"Created backup: {backup_file}")

--- a/app/views/acf_log_reader.py
+++ b/app/views/acf_log_reader.py
@@ -255,7 +255,7 @@ class AcfLogReader(BaseModsPanel):
 
                 all_rows.append(base_items)
                 row_metadata.append((path, workshop_url))
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 logger.error(f"Failed to prepare ACF entry {pfid}: {e}", exc_info=True)
                 continue
 

--- a/app/views/deletion_menu.py
+++ b/app/views/deletion_menu.py
@@ -391,7 +391,7 @@ class ModDeletionMenu(QMenu):
                 mod_metadata, deletion_fn, result, mod_name
             )
 
-        except Exception as general_error:  # noqa: BLE001
+        except Exception as general_error:
             logger.error(f"Critical error processing mod {mod_name}: {general_error}")
             result.failed_count += 1
             return False
@@ -401,7 +401,7 @@ class ModDeletionMenu(QMenu):
         try:
             self.delete_mod_from_aux_db(mod_path)
             return True
-        except Exception as db_error:  # noqa: BLE001
+        except Exception as db_error:
             logger.error(f"Failed to update database for mod {mod_name}: {db_error}")
             return False
 
@@ -434,7 +434,7 @@ class ModDeletionMenu(QMenu):
             result.failed_count += 1
             return False
 
-        except Exception as deletion_error:  # noqa: BLE001
+        except Exception as deletion_error:
             logger.error(
                 f"Unexpected error during deletion of mod {mod_name}: {deletion_error}"
             )
@@ -706,7 +706,7 @@ class ModDeletionMenu(QMenu):
                 f"Successfully initiated {action} for {len(publishedfileids)} mods."
             )
 
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"Failed to initiate Steam {action}: {e}")
             show_warning(
                 title=self.tr("{action} Error").format(

--- a/app/views/download_rimworld_dialog.py
+++ b/app/views/download_rimworld_dialog.py
@@ -152,5 +152,5 @@ class DownloadRimWorldDialog(QDialog):
                     "SteamCMD has been launched in a new terminal window.\nPlease follow the prompts to complete the download."
                 ),
             )
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             show_warning(self.tr("Error"), self.tr(f"Failed to start download: {e}"))

--- a/app/views/file_search_dialog.py
+++ b/app/views/file_search_dialog.py
@@ -518,7 +518,7 @@ class FileSearchDialog(QDialog):
                     subprocess.Popen(["code", path])
                 else:
                     self._open_file(path)
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"Error opening file with {program}: {e}")
             # Fallback to default opener
             self._open_file(path)
@@ -527,7 +527,7 @@ class FileSearchDialog(QDialog):
     def _results_viewport_width(self) -> int:
         try:
             return max(0, int(self.results_table.viewport().width()))
-        except Exception:  # noqa: BLE001
+        except Exception:
             return max(0, int(self.results_table.width()))
 
     def _init_or_sync_results_weights(self) -> None:
@@ -731,7 +731,7 @@ class FileSearchDialog(QDialog):
                 self.results_table.setUpdatesEnabled(True)
                 self.results_table.setSortingEnabled(True)
 
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"Error adding result: {e}")
             self.results_table.setUpdatesEnabled(True)
 
@@ -814,7 +814,7 @@ class FileSearchDialog(QDialog):
                 ensure_ascii=False,
                 indent=4,
             )
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"Failed to save recent searches: {e}")
 
     def _load_recent_searches(self) -> None:
@@ -826,7 +826,7 @@ class FileSearchDialog(QDialog):
             try:
                 with open(recent_searches_file, "r", encoding="utf-8") as f:
                     self._recent_searches = json.load(f)
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 logger.error(f"Failed to load recent searches: {e}")
 
     def _on_filter_changed(self, text: str) -> None:

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -706,7 +706,7 @@ class MainContent(QObject):
                 Qt.WindowModality.ApplicationModal
             )
             missing_mod_properties_panel.show()
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"Error checking mod properties: {e}")
 
     def __mod_list_slot(self, uuid: str, item: CustomListWidgetItem) -> None:
@@ -1186,7 +1186,7 @@ class MainContent(QObject):
             logger.info(f"Trying to append mods list from XML: {file_path}")
             (
                 active_mods_uuids,
-                inactive_mods_uuids,
+                _inactive_mods_uuids,
                 new_duplicate_mods,
                 new_missing_mods,
             ) = self.metadata_controller.get_mods_from_list(mod_list=file_path)
@@ -1239,7 +1239,7 @@ class MainContent(QObject):
             )
             try:
                 self._import_export_service.export_to_xml(data.active_mods, file_path)
-            except Exception:  # noqa: BLE001
+            except Exception:
                 dialogue.show_fatal_error(
                     title=self.tr("Failed to export to file"),
                     text=self.tr("Failed to export active mods to file:"),
@@ -1757,7 +1757,7 @@ class MainContent(QObject):
 
         try:
             self._import_export_service.save_to_mods_config(data.active_mods)
-        except Exception:  # noqa: BLE001
+        except Exception:
             logger.error("Could not save active mods")
             dialogue.show_fatal_error(
                 title=self.tr("Could not save active mods"),
@@ -1971,7 +1971,7 @@ class MainContent(QObject):
             )
             logger.error(f"Export failed due to Permission: {error_msg}")
             dialogue.show_warning(title=self.tr("Export Error"), text=error_msg)
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             error_msg = self.tr("Export failed: {e}").format(e=str(e))
             logger.error(f"Export failed: {error_msg}")
             dialogue.show_warning(title=self.tr("Export Error"), text=error_msg)
@@ -2527,7 +2527,7 @@ class MainContent(QObject):
                             os.remove(temp_path)
                         logger.info("Download cancelled, cleaned up temporary file")
 
-                except Exception as e:  # noqa: BLE001
+                except Exception as e:
                     # Clean up progress widget
                     self.mod_info_panel.panel.removeWidget(progress_widget)
                     progress_widget.close()
@@ -2882,7 +2882,7 @@ class MainContent(QObject):
                 logger.debug(
                     f"Retrieved copy of existing {rules_source} database to update."
                 )
-        except Exception:  # noqa: BLE001
+        except Exception:
             logger.error("Failed to read info from existing database")
             dialogue.show_warning(
                 title=self.tr("Failed to read existing database"),

--- a/app/views/mod_info_panel.py
+++ b/app/views/mod_info_panel.py
@@ -87,7 +87,7 @@ class ClickablePathLabel(QLabel):
                 try:
                     webbrowser.open(self.path)
                     logger.info(f"Opening URL: {self.path}")
-                except Exception as e:  # noqa: BLE001
+                except Exception as e:
                     logger.error(f"Failed to open URL {self.path}: {e}")
             else:
                 try:
@@ -100,7 +100,7 @@ class ClickablePathLabel(QLabel):
                             logger.warning(f"Path is not a directory: {self.path}")
                     else:
                         logger.warning(f"Mod folder does not exist: {self.path}")
-                except Exception as e:  # noqa: BLE001
+                except Exception as e:
                     logger.error(f"Failed to open mod folder {self.path}: {e}")
         super().mousePressEvent(event)
 
@@ -520,7 +520,7 @@ class ModInfoPanel:
             mod_path = getattr(self, "_github_mod_path", None)
             if mod_path:
                 self._update_github_info(mod_path)
-        except Exception:  # noqa: BLE001
+        except Exception:
             logger.debug("Could not refresh GitHub info for current mod")
 
     def _update_github_info(self, mod_path: str | None) -> None:
@@ -585,7 +585,7 @@ class ModInfoPanel:
                                 update_available = True
                 finally:
                     cache_session.close()
-            except Exception:  # noqa: BLE001
+            except Exception:
                 logger.debug("Could not load cached releases for {}", owner_repo)
 
             self.show_github_info(
@@ -595,7 +595,7 @@ class ModInfoPanel:
                 update_available=update_available,
                 mod_path=mod_path,
             )
-        except Exception:  # noqa: BLE001
+        except Exception:
             logger.debug("Could not check GitHub mod status for {}", mod_path)
             self.hide_github_info()
 
@@ -691,7 +691,7 @@ class ModInfoPanel:
         """Set user-defined tags information."""
         try:
             tags = auxdb_get_mod_tags(self.settings, uuid)
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.debug(f"Failed to load tags for mod info panel UUID {uuid}: {e}")
             tags = []
 
@@ -708,7 +708,7 @@ class ModInfoPanel:
         try:
             size_bytes = path_to_folder_size(uuid)
             self.mod_info_folder_size_value.setText(format_file_size(size_bytes))
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"Error calculating folder size for UUID {uuid}: {e}")
             self.mod_info_folder_size_value.setText("Not available")
 

--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -467,7 +467,7 @@ class ModListItemInner(QWidget):
             try:
                 if widget.isHidden():
                     return 0
-            except Exception:  # noqa: BLE001, S110
+            except Exception:  # noqa: S110
                 pass
             pixmap = widget.pixmap()
             if pixmap and not pixmap.isNull():
@@ -1000,7 +1000,7 @@ class TagEditDialog(QDialog):
     def populate_tags(self) -> None:
         try:
             tags = auxdb_get_all_tags(self.settings)
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.debug(f"Unable to load existing tags: {e}")
             tags = []
 
@@ -2235,7 +2235,7 @@ class ModListWidget(QListWidget):
                                     logger.debug(
                                         f'Successfully "converted" local mod -> SteamCMD by renaming from {folder_name} -> {publishedfileid}'
                                     )
-                                except Exception as e:  # noqa: BLE001
+                                except Exception as e:
                                     stacktrace = format_exc()
                                     logger.error(
                                         f"Failed to convert mod: {original_mod_path} - {e}"
@@ -2272,7 +2272,7 @@ class ModListWidget(QListWidget):
                                     logger.debug(
                                         f'Successfully "converted" SteamCMD mod by renaming from {publishedfileid} -> {mod_name}'
                                     )
-                                except Exception as e:  # noqa: BLE001
+                                except Exception as e:
                                     stacktrace = format_exc()
                                     logger.error(
                                         f"Failed to convert mod: {original_mod_path} - {e}"
@@ -2385,7 +2385,7 @@ class ModListWidget(QListWidget):
                                 logger.debug(
                                     f'Successfully "converted" Steam mod by copying {publishedfileid_from_folder_name} -> {mod_name} and migrating mod to local mods directory'
                                 )
-                            except Exception as e:  # noqa: BLE001
+                            except Exception as e:
                                 stacktrace = format_exc()
                                 logger.error(f"Failed to convert mod: {path} - {e}")
                                 logger.error(stacktrace)
@@ -3083,7 +3083,7 @@ class ModListWidget(QListWidget):
                 try:
                     data["list_type"] = self.list_type
                     item.setData(Qt.ItemDataRole.UserRole, data)
-                except Exception:  # noqa: BLE001, S110
+                except Exception:  # noqa: S110
                     pass
                 uuid = data["path"]
                 self.paths.insert(idx, uuid)
@@ -3563,7 +3563,7 @@ class ModListWidget(QListWidget):
                     else:
                         current_item_data.__dict__["is_new"] = False
                         current_item_data.__dict__["in_save"] = is_in_save
-                except Exception:  # noqa: BLE001
+                except Exception:
                     current_item_data.__dict__["is_new"] = False
                     current_item_data.__dict__["in_save"] = False
             else:
@@ -3851,7 +3851,7 @@ class ModListWidget(QListWidget):
             # Normalize to lowercase
             self._latest_save_package_ids = {str(i).lower() for i in ids_set}
             return self._latest_save_package_ids
-        except Exception:  # noqa: BLE001
+        except Exception:
             return None
 
     def _has_replacement(
@@ -4153,7 +4153,7 @@ class ModListWidget(QListWidget):
             if data is not None:
                 data["list_type"] = self.list_type
                 item.setData(Qt.ItemDataRole.UserRole, data)
-        except Exception:  # noqa: BLE001, S110
+        except Exception:  # noqa: S110
             pass
 
         # Reconnect to ALL slots
@@ -4204,7 +4204,7 @@ class ModsPanel(QWidget):
         # Select the combo box entry by matching stored enum name to item userData
         try:
             desired_enum = ModsPanelSortKey[self.inactive_mods_sort_key]
-        except Exception:  # noqa: BLE001
+        except Exception:
             desired_enum = ModsPanelSortKey.FILESYSTEM_MODIFIED_TIME
         idx = self.inactive_mods_sort_combobox.findData(desired_enum)
         if idx >= 0:
@@ -4605,7 +4605,7 @@ class ModsPanel(QWidget):
         # FILESYSTEM_MODIFIED_TIME if the stored value is invalid.
         try:
             desired_enum = ModsPanelSortKey[self.inactive_mods_sort_key]
-        except Exception:  # noqa: BLE001
+        except Exception:
             desired_enum = ModsPanelSortKey.FILESYSTEM_MODIFIED_TIME
         idx = self.inactive_mods_sort_combobox.findData(desired_enum)
         if idx >= 0:
@@ -4793,7 +4793,7 @@ class ModsPanel(QWidget):
             if hasattr(self, "_size_worker") and self._size_worker:
                 try:
                     self._size_worker.deleteLater()
-                except Exception:  # noqa: BLE001, S110
+                except Exception:  # noqa: S110
                     pass
                 self._size_worker = None
 
@@ -4963,7 +4963,7 @@ class ModsPanel(QWidget):
         """Refresh the available tags in both filter panels from the aux DB."""
         try:
             tags = auxdb_get_all_tags(self.settings)
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.debug(f"Unable to load tag filter list: {e}")
             tags = []
         self.active_filter_button.filter_panel.set_available_tags(tags)
@@ -5034,7 +5034,7 @@ class ModsPanel(QWidget):
                             "is_new", False
                         ):
                             new_count += 1
-                except Exception:  # noqa: BLE001, S110
+                except Exception:  # noqa: S110
                     pass
 
             # Count recently-updated mods. Only if the indicator is enabled
@@ -5046,7 +5046,7 @@ class ModsPanel(QWidget):
                             "is_recently_updated", False
                         ):
                             updated_count += 1
-                except Exception:  # noqa: BLE001, S110
+                except Exception:  # noqa: S110
                     pass
 
             padding = " "

--- a/app/views/player_log_tab.py
+++ b/app/views/player_log_tab.py
@@ -278,7 +278,7 @@ class LogHighlighter(QSyntaxHighlighter):
                 for match in self._search_regex.finditer(text):
                     start, end = match.span()
                     self.setFormat(start, end - start, self.search_format)
-            except Exception:  # noqa: BLE001, S110
+            except Exception:  # noqa: S110
                 pass
         # Apply other patterns
         for pattern, fmt in self.patterns:
@@ -432,7 +432,7 @@ class PlayerLogTab(QWidget):
             player_log_path: Path = Path(config_folder).parent / "Player.log"
             if player_log_path.exists():
                 return player_log_path
-        except Exception:  # noqa: BLE001, S110
+        except Exception:  # noqa: S110
             pass
         return None
 
@@ -914,7 +914,7 @@ class PlayerLogTab(QWidget):
             self._update_file_info()
             self._update_statistics()
             self.apply_filter(new_content)
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"Error reading appended log content: {e!s}")
             self._file_change_debounce_timer.start()  # Restart the debounce timer on error
 
@@ -962,7 +962,7 @@ class PlayerLogTab(QWidget):
                 logger.info(
                     f"Started real-time monitoring of Player.log at {self.player_log_path}"
                 )
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 logger.error(f"Failed to start observer: {e}")
                 show_warning(f"Failed to start real-time monitoring: {e}")
                 self.real_time_monitor_checkbox.setChecked(False)
@@ -1056,7 +1056,7 @@ class PlayerLogTab(QWidget):
             logger.info(
                 "Loaded player log file in chunks using memory-efficient storage."
             )
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"Failed to load player log file: {e}")
             self.progress_bar.hide()
             self.enable_options()
@@ -1116,7 +1116,7 @@ class PlayerLogTab(QWidget):
             self.last_modified_label.setText(
                 self.tr("Modified: {modified_str}").format(modified_str=modified_str)
             )
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"Failed to update file info: {e}")
 
     def _update_match_count(self) -> None:
@@ -1248,7 +1248,7 @@ class PlayerLogTab(QWidget):
                 # Update visual feedback
                 self._update_navigation_feedback(pattern, len(matches))
 
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"Error in goto_previous_pattern: {e}")
             self._clear_pattern_cache(pattern)
 
@@ -1280,7 +1280,7 @@ class PlayerLogTab(QWidget):
                 # Update visual feedback
                 self._update_navigation_feedback(pattern, len(matches))
 
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"Error in goto_next_pattern: {e}")
             self._clear_pattern_cache(pattern)
 
@@ -1357,7 +1357,7 @@ class PlayerLogTab(QWidget):
                     title=self.tr("Log loaded successfully from URL"),
                     text=f"{url}",
                 )
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 show_warning(
                     title=self.tr("Failed to load log from URL"),
                     text=self.tr("Failed due to error: {error}").format(error=e),
@@ -1377,7 +1377,7 @@ class PlayerLogTab(QWidget):
                 show_information(f"Log exported to {file_path}")
             except OSError as e:
                 show_warning(f"Failed to export log: {e.strerror}")
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 show_warning(f"Failed to export log: {type(e).__name__}: {e}")
 
     def show_context_menu(self, pos: QPoint) -> None:

--- a/app/windows/base_mods_panel.py
+++ b/app/windows/base_mods_panel.py
@@ -570,7 +570,7 @@ class BaseModsPanel(QWidget):
                     if mod_path and os.path.exists(mod_path):
                         try:
                             shutil.rmtree(mod_path)
-                        except Exception as e:  # noqa: BLE001
+                        except Exception as e:
                             logger.error(
                                 f"Error deleting mod directory {mod_path}: {e}"
                             )
@@ -843,7 +843,7 @@ class BaseModsPanel(QWidget):
                 return None
 
             return name_item.data(Qt.ItemDataRole.UserRole)
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.warning(f"Error accessing key from row {row}: {e}")
             return None
 
@@ -883,7 +883,7 @@ class BaseModsPanel(QWidget):
                             if isinstance(mod, AboutXmlMod):
                                 compat["packageid"] = str(mod.package_id)
                             selected_mods.append(compat)
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.warning(f"Error getting selected mod metadata: {e}")
         return selected_mods
 

--- a/app/windows/duplicate_mods_panel.py
+++ b/app/windows/duplicate_mods_panel.py
@@ -82,5 +82,5 @@ class DuplicateModsPanel(BaseModsPanel):
                         logger.warning(
                             f"Metadata not found for path: {path} in package group {packageid}"
                         )
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"Error populating table from metadata: {e}")

--- a/app/windows/github_mods_panel.py
+++ b/app/windows/github_mods_panel.py
@@ -189,7 +189,7 @@ class GitHubModsPanel(BaseModsPanel):
                 auto_item = self.editor_model.item(row_idx, _COL_AUTO_UPDATE)
                 self.editor_table_view.setIndexWidget(auto_item.index(), auto_cb)
 
-        except Exception:  # noqa: BLE001
+        except Exception:
             logger.opt(exception=True).warning("Failed to populate GitHub mods table")
 
     def _on_auto_update_toggled(self, mod_path: str, checked: bool) -> None:
@@ -210,7 +210,7 @@ class GitHubModsPanel(BaseModsPanel):
                 if entry is not None:
                     entry.auto_update = checked
                     session.commit()
-        except Exception:  # noqa: BLE001
+        except Exception:
             logger.opt(exception=True).warning(
                 f"Failed to update auto_update for {mod_path}"
             )
@@ -273,7 +273,7 @@ class GitHubModsPanel(BaseModsPanel):
                     shutil.rmtree(Path(mod_path))
                 except FileNotFoundError:
                     logger.debug(f"Mod directory already missing: {mod_path}")
-                except Exception as e:  # noqa: BLE001
+                except Exception as e:
                     logger.warning(f"Failed to delete {mod_path}: {e}")
                     fs_errors.append(mod["display_name"])
                     fs_ok = False
@@ -291,7 +291,7 @@ class GitHubModsPanel(BaseModsPanel):
                     AuxMetadataController.delete(session, Path(mod_path))
                     if fs_ok:
                         deleted += 1
-                except Exception:  # noqa: BLE001
+                except Exception:
                     session.rollback()
                     logger.opt(exception=True).warning(
                         f"Failed to clean up DB for {mod_path}"
@@ -391,7 +391,7 @@ class GitHubModsPanel(BaseModsPanel):
                     session.delete(entry)
                     session.commit()
                     converted += 1
-                except Exception:  # noqa: BLE001
+                except Exception:
                     session.rollback()
                     logger.opt(exception=True).warning(
                         f"Failed to convert {mod_path} to git tracking"
@@ -445,7 +445,7 @@ class GitHubModsPanel(BaseModsPanel):
 
             self.ui_elements.details_label.setText(self.tr("Checking for updates..."))
 
-        except Exception:  # noqa: BLE001
+        except Exception:
             logger.opt(exception=True).warning("Failed to start GitHub update check")
 
     def _on_check_updates_finished(self, updates: list[Any]) -> None:

--- a/app/windows/ignore_json_editor.py
+++ b/app/windows/ignore_json_editor.py
@@ -117,7 +117,7 @@ class IgnoreJsonEditor(QDialog):
                 self._add_mod_item(mod_packageid)
 
             logger.info(f"Loaded {len(ignored_mods)} ignored mods")
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"Failed to load ignored mods: {e}")
             QMessageBox.critical(
                 self,
@@ -167,7 +167,7 @@ class IgnoreJsonEditor(QDialog):
                     self.tr("Error"),
                     self.tr("Failed to save changes to ignore list."),
                 )
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"Error saving changes: {e}")
             QMessageBox.critical(
                 self,

--- a/app/windows/missing_mod_properties_panel.py
+++ b/app/windows/missing_mod_properties_panel.py
@@ -112,7 +112,7 @@ class MissingModPropertiesPanel(BaseModsPanel):
                 self.close()
                 # Emit event to check and warn about missing mod properties after closing the panel
                 EventBus().do_check_missing_mod_properties.emit()
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"Error adding mods to ignore list: {e}")
             self._show_message(
                 "Error",
@@ -296,7 +296,7 @@ class MissingModPropertiesPanel(BaseModsPanel):
             # Use base class method to populate the table with grouped mods
             if grouped_mods:
                 self._populate_mods(grouped_mods, add_group_headers=True)
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             # Log errors but don't raise - allow graceful degradation
             logger.error(f"Error populating table from metadata: {e}")
 

--- a/app/windows/missing_mods_panel.py
+++ b/app/windows/missing_mods_panel.py
@@ -360,7 +360,7 @@ class MissingModsPrompt(BaseModsPanel):
 
                 # Update the instance variable for compatibility with existing methods
                 self.data_by_variants = variants_by_packageid
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"Error populating table from metadata: {e}")
 
     def _find_row_for_combo_box(self, combo_box: QComboBox) -> int | None:

--- a/app/windows/runner_panel.py
+++ b/app/windows/runner_panel.py
@@ -255,7 +255,7 @@ class RunnerPanel(QWidget):
             if self._is_process_running("steamcmd"):
                 self._stop_steamcmd_log_tail()
 
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"Error killing process: {e}")
             # Try direct kill as fallback
             self.process.kill()
@@ -302,7 +302,7 @@ class RunnerPanel(QWidget):
             except OSError as e:
                 logger.error(f"Error writing to file: {e}")
 
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"Unexpected error in save operation: {e}")
 
     def change_progress_bar_color(self, state: str) -> None:
@@ -747,7 +747,7 @@ class RunnerPanel(QWidget):
                         mod_title = mod_metadata.get("title")
                         if mod_title:
                             pfids_to_name[mod_metadata["publishedfileid"]] = mod_title
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 logger.error(f"Error fetching mod details from Steam API: {e}")
 
         return pfids_to_name

--- a/app/windows/use_this_instead_panel.py
+++ b/app/windows/use_this_instead_panel.py
@@ -173,7 +173,7 @@ class UseThisInsteadPanel(BaseModsPanel):
 
             # Track row indices for selection during population to avoid double iteration
             self._track_row_indices_during_population(groups)
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"Error populating metadata: {e}")
             # Graceful degradation: clear table if error occurs
             self._clear_table_model()
@@ -468,7 +468,7 @@ class UseThisInsteadPanel(BaseModsPanel):
                 if alt is not None:
                     alternatives[mod] = alt
             return alternatives
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"Error filtering alternatives: {e}")
             return {}
 
@@ -557,7 +557,7 @@ class UseThisInsteadPanel(BaseModsPanel):
             self._add_mod_row(mod_info)
             if is_original:
                 self._original_rows.add(current_row)
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"Error accessing metadata for mod in group {package_id}: {e}")
 
     def _check_and_get_replacement_local_metadata(
@@ -579,7 +579,7 @@ class UseThisInsteadPanel(BaseModsPanel):
             exists_locally, path = self._check_replacement_exists_locally(pfid)
             local_metadata = self._get_local_metadata_for_replacement(path)
             return exists_locally, path, local_metadata
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(
                 f"Error checking local replacement metadata for pfid {pfid}: {e}"
             )

--- a/app/windows/workshop_mod_updater_panel.py
+++ b/app/windows/workshop_mod_updater_panel.py
@@ -128,5 +128,5 @@ class WorkshopModUpdaterPanel(BaseModsPanel):
             for uuid, metadata in self.eligible_metadata:
                 mod_info = ModInfo.from_metadata(uuid, metadata)
                 self._add_mod_row(mod_info)
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.error(f"Error populating table from metadata: {e}")

--- a/check_deferred_imports.py
+++ b/check_deferred_imports.py
@@ -92,7 +92,7 @@ def main() -> int:
         try:
             errors = check_file(path)
             all_errors.extend(errors)
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             print(f"Error scanning {path}: {exc}", file=sys.stderr)
             return 1
 

--- a/distribute.py
+++ b/distribute.py
@@ -47,11 +47,13 @@ _NUITKA_CMD = [
     f"--include-data-dir={glob.glob('.venv/**/qtwebengine_locales', recursive=True)[0]}=qtwebengine_locales",
 ]
 
-if _SYSTEM == "Darwin" and _PROCESSOR in ["x86_64", "arm64"]:
-    pass
-elif _SYSTEM == "Linux":
-    pass
-elif _SYSTEM == "Windows" and _ARCH == "64bit":
+if (
+    _SYSTEM == "Darwin"
+    and _PROCESSOR in ["x86_64", "arm64"]
+    or _SYSTEM == "Linux"
+    or _SYSTEM == "Windows"
+    and _ARCH == "64bit"
+):
     pass
 else:
     print(f"Unsupported SYSTEM: {_SYSTEM} {_ARCH} with {_PROCESSOR}")
@@ -410,7 +412,7 @@ def get_latest_todds_release() -> None:
         if os.path.exists(todds_executable_path):
             original_stat = os.stat(todds_executable_path)
             os.chmod(todds_executable_path, original_stat.st_mode | S_IEXEC)
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         print(f"Failed to download: {browser_download_url}")
         print(
             "Did the file/url change?\nDoes your environment have access to the Internet?"
@@ -487,7 +489,7 @@ def post_build_fixup_macos_steamworks() -> None:
                     preferred = candidates[0]
                 shutil.copyfile(preferred, generic)
                 print(f"Added SteamworksPy.dylib to bundle: {bundle}")
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         print(f"Warning: post_build_fixup_macos_steamworks failed: {e}")
 
 
@@ -510,7 +512,7 @@ def post_build_optimize_macos_bundle() -> None:
                     bundle,
                 ]
             )
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         print(f"Warning: post_build_optimize_macos_bundle failed: {e}")
 
 

--- a/packaging/optimize_macos_bundle.py
+++ b/packaging/optimize_macos_bundle.py
@@ -41,7 +41,7 @@ def _is_fat_binary(path: str) -> bool:
             text=True,
         )
         return "Architectures in the fat file" in result.stdout
-    except Exception:  # noqa: BLE001
+    except Exception:
         return False
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,9 +93,14 @@ ignore_missing_imports = true
  line-length = 88
  indent-width = 4
  lint.extend-select = ["I"]
- # E402 (import not at top of file) is intentionally allowed: several standalone
- # test scripts do sys.path.insert(...) before importing app.* for direct runs.
- lint.extend-ignore = ["E402"]
+  # E402 (import not at top of file) is intentionally allowed: several standalone
+  # test scripts do sys.path.insert(...) before importing app.* for direct runs.
+  # BLE001 (blind except) is intentionally allowed: the app uses broad `except Exception`
+  # as a deliberate top-level safety net across 100+ UI/handler call sites (surfacing
+  # unexpected errors to the user rather than crashing). Catching specific exceptions
+  # there is impractical given the mixed exception surfaces, so the rule is opted out
+  # project-wide instead of repeating `# noqa: BLE001` on every line.
+  lint.extend-ignore = ["E402", "BLE001"]
  exclude = ["submodules"]
 
 [tool.ruff.format]

--- a/tests/controllers/test_file_search.py
+++ b/tests/controllers/test_file_search.py
@@ -156,7 +156,7 @@ def setup_test_files(request: pytest.FixtureRequest) -> Generator[str, None, Non
         import shutil
 
         shutil.rmtree(mods_dir)
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         print(f"Warning: Failed to clean up test directory: {e}")
 
 

--- a/tests/controllers/test_metadata_db_controller.py
+++ b/tests/controllers/test_metadata_db_controller.py
@@ -96,7 +96,7 @@ def test_tags(temp_db: AuxMetadataController) -> None:
         # Ensure unique constraint is enforced
         try:
             session.commit()
-        except Exception:  # noqa: BLE001
+        except Exception:
             session.rollback()
         else:
             assert False
@@ -143,8 +143,9 @@ def test_aux_metadata_webapi_timestamp_fields(tmp_path: Path) -> None:
 def test_schema_migration_from_legacy_published_file_id(tmp_path: Path) -> None:
     """Test migration of auxiliary_metadata from legacy schema (published_file_id is non-nullable INTEGER)."""
     import sqlite3
+
     db_path = tmp_path / "legacy.db"
-    
+
     # 1. Create a legacy SQLite table manually
     conn = sqlite3.connect(db_path)
     cursor = conn.cursor()
@@ -157,11 +158,11 @@ def test_schema_migration_from_legacy_published_file_id(tmp_path: Path) -> None:
     # Insert legacy rows: one valid integer ID, one placeholder -1
     cursor.execute(
         "INSERT INTO auxiliary_metadata (path, published_file_id) VALUES (?, ?)",
-        (str(Path("/mods/mod_a")), 123456)
+        (str(Path("/mods/mod_a")), 123456),
     )
     cursor.execute(
         "INSERT INTO auxiliary_metadata (path, published_file_id) VALUES (?, ?)",
-        (str(Path("/mods/mod_b")), -1)
+        (str(Path("/mods/mod_b")), -1),
     )
     conn.commit()
     conn.close()
@@ -183,4 +184,3 @@ def test_schema_migration_from_legacy_published_file_id(tmp_path: Path) -> None:
 
         # Verify added fields default correctly
         assert entry_a.external_time_created == -1
-

--- a/tests/models/test_animations.py
+++ b/tests/models/test_animations.py
@@ -5,31 +5,34 @@ from app.models.animations import LoadingAnimation, WorkThread
 
 def test_work_thread_exception() -> None:
     """Test that WorkThread captures exceptions thrown by the target."""
+
     def failing_target() -> None:
         raise ValueError("test error")
-    
+
     thread = WorkThread(target=failing_target)
     thread.run()
     assert isinstance(thread.exception, ValueError)
     assert str(thread.exception) == "test error"
 
+
 def test_loading_animation_captures_thread_exception(qtbot: QtBot) -> None:
     """Test that LoadingAnimation captures the thread exception when finished."""
+
     def failing_target() -> None:
         raise ValueError("test error")
-    
+
     # Passing a nonexistent gif path is fine, QMovie will still instantiate and start
     anim = LoadingAnimation(gif_path="nonexistent.gif", target=failing_target)
-    
+
     # Wait for the thread to finish executing
     qtbot.waitUntil(lambda: anim._thread.isFinished(), timeout=2000)
-    
+
     # Call prepare_stop_animation manually to simulate movie frame loop check
     anim.prepare_stop_animation()
-    
+
     assert isinstance(anim.exception, ValueError)
     assert str(anim.exception) == "test error"
     assert anim.animation_finished is True
-    
+
     # Cleanup
     anim.deleteLater()

--- a/tests/views/test_main_content_run.py
+++ b/tests/views/test_main_content_run.py
@@ -155,7 +155,9 @@ def test_upload_file_exception(
 
     # Mock do_threaded_loading_animation to raise an Exception
     monkeypatch.setattr(
-        mc, "do_threaded_loading_animation", Mock(side_effect=RuntimeError("upload error"))
+        mc,
+        "do_threaded_loading_animation",
+        Mock(side_effect=RuntimeError("upload error")),
     )
 
     # Mock dialogue.show_warning to capture call
@@ -174,7 +176,9 @@ def test_check_for_workshop_updates_exception(
     mc, _ = main_content
     # Mock do_threaded_loading_animation to raise an Exception
     monkeypatch.setattr(
-        mc, "do_threaded_loading_animation", Mock(side_effect=RuntimeError("workshop error"))
+        mc,
+        "do_threaded_loading_animation",
+        Mock(side_effect=RuntimeError("workshop error")),
     )
 
     # Connect status_signal to a mock slot
@@ -224,4 +228,3 @@ def test_append_mod_list_cancel(
 
     # Calling this should log cancellation and return early
     mc._do_append_list_file_xml()
-

--- a/translation_helper.py
+++ b/translation_helper.py
@@ -662,7 +662,7 @@ async def retry_with_backoff(
         try:
             # Try to execute the async function with provided arguments
             return await async_func(*args, **kwargs)
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             # Check if we have more retries available
             if attempt < config.max_retries - 1:
                 # Calculate exponential backoff delay
@@ -791,7 +791,7 @@ class GoogleTranslateService(TranslationService):
                     cache.set(text, target_lang, source_lang, "google", translation)
 
                 return translation
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 error_str = str(e)
                 if attempt < self.config.retry_config.max_retries - 1:
                     if (
@@ -918,7 +918,7 @@ class DeepLService(TranslationService):
                         f"❌ DeepL translation timed out after {self.config.retry_config.max_retries} attempts"
                     )
                     return None
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 # If the request fails, check if we should retry.
                 if attempt < self.config.retry_config.max_retries - 1:
                     # Calculate the delay for the next retry.
@@ -1024,7 +1024,7 @@ Only return the translation, no explanation:
                 if config.use_cache:
                     cache.set(text, target_lang, source_lang, "openai", translation)
                 return translation
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 # If the request fails, check if we should retry.
                 error_str = str(e).lower()
                 is_timeout = "timeout" in error_str
@@ -1078,7 +1078,7 @@ def get_source_keys_from_file(source_file: Path) -> set[str]:
                     keys.add(key)
 
         return keys
-    except Exception:  # noqa: BLE001
+    except Exception:
         return set()
 
 
@@ -1169,7 +1169,7 @@ def parse_ts_file(
             "language": root.get("language", "unknown"),
         }
 
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         return {"error": str(e)}
 
 
@@ -1385,7 +1385,7 @@ async def auto_translate_file(
                     except TimeoutError:
                         print(f"❌ Translation timeout for [{i}]")
                         translated = ""  # Return empty string for failures
-                    except Exception as e:  # noqa: BLE001
+                    except Exception as e:
                         print(f"❌ Translation error for [{i}]: {e}")
                         translated = ""  # Return empty string for failures
                     return i, item, translated
@@ -1420,7 +1420,7 @@ async def auto_translate_file(
                         translation_failed_midway = True
                         break
 
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             print(f"⚠️  An unexpected error occurred during auto-translation: {e}")
             translation_failed_midway = True  # Mark as failed if an exception occurs
 
@@ -1469,7 +1469,7 @@ async def auto_translate_file(
                         get_translation_cache().save()
                         if failed > 0:  # If continue_on_failure is True but some failed
                             all_success = False
-                    except Exception as save_e:  # noqa: BLE001
+                    except Exception as save_e:
                         print(f"❌ Error saving the file: {save_e}")
                         print(f"🔄 Restoring from backup: {backup_file}")
                         if backup_file.exists():
@@ -1547,7 +1547,7 @@ def run_lupdate(language: str | None = None) -> bool:
     except FileNotFoundError:
         print("❌ pyside6-lupdate not found. Please install PySide6-Essentials.")
         return False
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         print(f"❌ Error: {e}")
         return False
 
@@ -1612,7 +1612,7 @@ def run_lrelease(language: str | None = None) -> bool:
     except FileNotFoundError:
         print("❌ pyside6-lrelease not found. Please install PySide6-Essentials.")
         return False
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         print(f"❌ Error: {e}")
         return False
 
@@ -2033,7 +2033,7 @@ def validate_translation(language: str | None = None, dry_run: bool = False) -> 
                         f.write(content)
                     print(f"💾 Saved fixes to {ts_file}")
 
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             print(f"❌ Error validating file: {e}")
 
 


### PR DESCRIPTION
Broad except Exception is used deliberately as a top-level safety net across 100+ UI/handler call sites (surfacing unexpected errors to the user rather than crashing). Catching specific exceptions there is impractical given the mixed exception surfaces, so BLE001 is now opted out in pyproject.toml instead of repeating # noqa: BLE001 on every line.

Sibling noqa codes (S110/S112) are preserved; only the BLE001 token was removed.