### PR TITLE
feat: mod list history with snapshot diff viewer (closes #1678)

### DIFF
--- a/app/controllers/menu_bar_controller.py
+++ b/app/controllers/menu_bar_controller.py
@@ -72,6 +72,9 @@ class MenuBarController(QObject):
         self.menu_bar.export_to_rentry_action.triggered.connect(
             EventBus().do_export_mod_list_to_rentry
         )
+        self.menu_bar.modlist_history_action.triggered.connect(
+            EventBus().do_open_modlist_history.emit
+        )
 
         for action in self.menu_bar.upload_log_actions:
             action.triggered.connect(

--- a/app/controllers/settings_tabs/advanced_tab_controller.py
+++ b/app/controllers/settings_tabs/advanced_tab_controller.py
@@ -27,6 +27,10 @@ class AdvancedTabController(BaseTabController):
             self._on_include_mod_notes_in_mod_name_filter_changed
         )
 
+        self.dialog.modlist_history_enabled_checkbox.toggled.connect(
+            self._on_toggle_modlist_history_enabled
+        )
+
     def update_view_from_model(self) -> None:
         try:
             self.dialog.show_save_comparison_indicators_checkbox.setChecked(
@@ -64,6 +68,13 @@ class AdvancedTabController(BaseTabController):
             self.settings.enable_backup_before_update
         )
         self.dialog.max_backups_spinbox.setValue(self.settings.max_backups)
+
+        self.dialog.modlist_history_enabled_checkbox.setChecked(
+            self.settings.modlist_history_enabled
+        )
+        self.dialog.modlist_history_retention_count_spinbox.setValue(
+            self.settings.modlist_history_retention_count
+        )
 
         # Auxiliary DB
         self.dialog.aux_db_time_limit.setText(str(self.settings.aux_db_time_limit))
@@ -108,6 +119,13 @@ class AdvancedTabController(BaseTabController):
         )
         self.settings.max_backups = self.dialog.max_backups_spinbox.value()
 
+        self.settings.modlist_history_enabled = (
+            self.dialog.modlist_history_enabled_checkbox.isChecked()
+        )
+        self.settings.modlist_history_retention_count = (
+            self.dialog.modlist_history_retention_count_spinbox.value()
+        )
+
         # Auxiliary DB
         try:
             self.settings.aux_db_time_limit = int(self.dialog.aux_db_time_limit.text())
@@ -126,6 +144,11 @@ class AdvancedTabController(BaseTabController):
     @Slot(bool)
     def _on_toggle_show_save_comparison_indicators(self, checked: bool) -> None:
         self.settings.show_save_comparison_indicators = checked
+        self.settings.save()
+
+    @Slot(bool)
+    def _on_toggle_modlist_history_enabled(self, checked: bool) -> None:
+        self.settings.modlist_history_enabled = checked
         self.settings.save()
 
     @Slot()

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -216,6 +216,9 @@ class Settings(QObject):
         self.include_mod_notes_in_mod_name_filter: bool = False
         # UI: Save-comparison labels and icons
         self.show_save_comparison_indicators: bool = True
+        # Mod list history: write a timestamped snapshot on every save
+        self.modlist_history_enabled: bool = True
+        self.modlist_history_retention_count: int = 100
         # Clear button behavior
         self.clear_moves_dlc: bool = False
 

--- a/app/services/modlist_history_service.py
+++ b/app/services/modlist_history_service.py
@@ -1,0 +1,462 @@
+"""Service for recording and comparing mod list history snapshots.
+
+Every time the active mod list is saved to ``ModsConfig.xml`` the application
+also writes a timestamped JSON snapshot of the full mod setup (active +
+inactive) here. Each snapshot carries a content-hash identifier so identical
+lists can be recognised across time, and the snapshots form a ``previousId``
+chain. The :class:`ModlistHistoryService` also diffs any two snapshots so the
+user can see exactly which mods were added, removed or reordered between two
+saves.
+"""
+
+from __future__ import annotations
+
+import difflib
+import hashlib
+import json
+import re
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from app.controllers.metadata_controller import MetadataController
+from app.models.divider import is_divider_uuid
+from app.models.settings import Settings
+from app.utils.app_info import AppInfo
+from app.utils.constants import RIMWORLD_PACKAGE_IDS
+from app.utils.json_utils import atomic_json_dump
+
+_SHORT_ID_LEN = 12
+# Filename-safe timestamp (microsecond precision so snapshots written within the
+# same second still sort chronologically by name). Stored on the Snapshot and used
+# as the sort key; ``display_timestamp`` parses it back for the UI.
+_TIMESTAMP_FMT = "%Y-%m-%dT%H-%M-%S.%f"
+_META_KEY = "rimsortSnapshot"
+
+
+def _sanitize_folder_name(name: str) -> str:
+    """Reduce an instance name to something safe to use as a folder name."""
+    cleaned = re.sub(r"[^\w.\- ]", "_", name).strip()
+    return cleaned or "instance"
+
+
+@dataclass
+class SnapshotEntry:
+    """A single mod recorded in a snapshot."""
+
+    package_id: str
+    name: str
+    published_file_id: str | None
+    source: str
+
+    @property
+    def label(self) -> str:
+        return f"{self.name} [{self.package_id}]" if self.name else self.package_id
+
+
+@dataclass
+class Snapshot:
+    """A parsed mod list history snapshot."""
+
+    id: str
+    short_id: str
+    timestamp: str
+    rimsort_version: str
+    game_version: str
+    instance: str
+    previous_id: str | None
+    note: str
+    active: list[SnapshotEntry]
+    inactive: list[SnapshotEntry]
+    path: Path
+
+    @property
+    def active_package_ids(self) -> list[str]:
+        return [entry.package_id for entry in self.active]
+
+    @property
+    def display_timestamp(self) -> str:
+        """Human-friendly timestamp, falling back to the raw stored value."""
+        for fmt in (_TIMESTAMP_FMT, "%Y-%m-%dT%H-%M-%S"):
+            try:
+                parsed = datetime.strptime(self.timestamp, fmt)  # noqa: DTZ007
+            except ValueError:
+                continue
+            return parsed.strftime("%Y-%m-%d %H:%M:%S")
+        return self.timestamp
+
+
+@dataclass
+class ModListDiff:
+    """The difference between two snapshots."""
+
+    active_added: list[SnapshotEntry] = field(default_factory=list)
+    active_removed: list[SnapshotEntry] = field(default_factory=list)
+    active_reordered: list[SnapshotEntry] = field(default_factory=list)
+    inactive_added: list[SnapshotEntry] = field(default_factory=list)
+    inactive_removed: list[SnapshotEntry] = field(default_factory=list)
+
+    @property
+    def is_empty(self) -> bool:
+        return not (
+            self.active_added
+            or self.active_removed
+            or self.active_reordered
+            or self.inactive_added
+            or self.inactive_removed
+        )
+
+    @property
+    def summary(self) -> str:
+        """Compact ``+a -r ~m`` counts, active list only."""
+        return (
+            f"+{len(self.active_added)} "
+            f"-{len(self.active_removed)} "
+            f"~{len(self.active_reordered)}"
+        )
+
+
+def compute_list_id(package_ids: list[str]) -> str:
+    """Return the SHA-256 hex digest identifying an ordered active mod list.
+
+    Package IDs are lower-cased so casing differences do not change the id, but
+    order is significant because RimWorld load order matters.
+    """
+    joined = "\n".join(package_id.lower() for package_id in package_ids)
+    return hashlib.sha256(joined.encode("utf-8")).hexdigest()
+
+
+class ModlistHistoryService:
+    """Read/write and diff mod list history snapshots for the current instance."""
+
+    def __init__(
+        self,
+        metadata_controller: MetadataController,
+        settings: Settings,
+    ) -> None:
+        self.metadata_controller = metadata_controller
+        self.settings = settings
+
+    # ------------------------------------------------------------------ paths
+    def history_dir(self) -> Path:
+        """Per-instance history folder, created on demand."""
+        directory = (
+            AppInfo().saved_modlists_folder
+            / "history"
+            / _sanitize_folder_name(self.settings.current_instance)
+        )
+        directory.mkdir(parents=True, exist_ok=True)
+        return directory
+
+    def _log_file(self) -> Path:
+        return self.history_dir() / "history.log"
+
+    # --------------------------------------------------------------- collect
+    def _entries_from_uuids(self, uuids: list[str]) -> list[SnapshotEntry]:
+        """Resolve list-widget UUIDs to snapshot entries, de-duplicated by id."""
+        entries: list[SnapshotEntry] = []
+        seen: set[str] = set()
+        for uuid in uuids:
+            if is_divider_uuid(uuid):
+                continue
+            mod = self.metadata_controller.get_mod(uuid)
+            if mod is None:
+                continue
+            package_id = str(getattr(mod, "package_id", "") or "").strip()
+            if not package_id or package_id.lower() in seen:
+                continue
+            seen.add(package_id.lower())
+            pfid = getattr(mod, "published_file_id", None)
+            mod_type = getattr(mod, "mod_type", None)
+            entries.append(
+                SnapshotEntry(
+                    package_id=package_id,
+                    name=str(getattr(mod, "name", "") or ""),
+                    published_file_id=str(pfid) if pfid else None,
+                    source=mod_type.name.lower() if mod_type is not None else "unknown",
+                )
+            )
+        return entries
+
+    # ----------------------------------------------------------------- write
+    def write_snapshot(
+        self,
+        active_uuids: list[str],
+        inactive_uuids: list[str],
+    ) -> Snapshot | None:
+        """Write a snapshot of the current mod setup.
+
+        :return: the written :class:`Snapshot`, or ``None`` when the active
+            list is identical to the most recent snapshot (nothing is written).
+        """
+        active = self._entries_from_uuids(active_uuids)
+        inactive = self._entries_from_uuids(inactive_uuids)
+        active_package_ids = [entry.package_id for entry in active]
+        list_id = compute_list_id(active_package_ids)
+
+        existing = self.list_snapshots()
+        if existing and existing[0].id == list_id:
+            logger.info(
+                "Mod list unchanged since last snapshot "
+                f"({existing[0].short_id}); skipping history write"
+            )
+            return None
+
+        previous_id = existing[0].id if existing else None
+        now = datetime.now()  # noqa: DTZ005 - local time matches the app's logs
+        # Filename-/sort-safe form; the meta block keeps the ISO form with colons.
+        timestamp = now.strftime(_TIMESTAMP_FMT)
+        short_id = list_id[:_SHORT_ID_LEN]
+        game_version = self.metadata_controller.game_version or ""
+
+        known_expansions = [
+            package_id
+            for package_id in active_package_ids
+            if package_id.lower() in {p.lower() for p in RIMWORLD_PACKAGE_IDS}
+            and package_id.lower() != "ludeon.rimworld"
+        ]
+
+        payload: dict[str, Any] = {
+            "version": game_version,
+            "activeMods": active_package_ids,
+            "knownExpansions": known_expansions,
+            _META_KEY: {
+                "id": list_id,
+                "shortId": short_id,
+                "timestamp": now.strftime("%Y-%m-%dT%H:%M:%S.%f"),
+                "rimsortVersion": AppInfo().app_version,
+                "gameVersion": game_version,
+                "instance": self.settings.current_instance,
+                "previousId": previous_id,
+                "note": "",
+                "activeMods": [self._entry_to_dict(e) for e in active],
+                "inactiveMods": [self._entry_to_dict(e) for e in inactive],
+            },
+        }
+
+        history_dir = self.history_dir()
+        filename = f"{timestamp}__{short_id}.json"
+        target = history_dir / filename
+        # Microsecond-precision names collide only in pathological cases; guard anyway.
+        counter = 1
+        while target.exists():
+            target = history_dir / f"{timestamp}__{short_id}.{counter}.json"
+            counter += 1
+
+        atomic_json_dump(payload, str(target), indent=2)
+        self._append_log_line(now, list_id, active, inactive, existing)
+        logger.info(f"Wrote mod list history snapshot: {target.name}")
+
+        self.prune(self.settings.modlist_history_retention_count)
+
+        return Snapshot(
+            id=list_id,
+            short_id=short_id,
+            timestamp=timestamp,
+            rimsort_version=AppInfo().app_version,
+            game_version=game_version,
+            instance=self.settings.current_instance,
+            previous_id=previous_id,
+            note="",
+            active=active,
+            inactive=inactive,
+            path=target,
+        )
+
+    @staticmethod
+    def _entry_to_dict(entry: SnapshotEntry) -> dict[str, Any]:
+        return {
+            "packageId": entry.package_id,
+            "name": entry.name,
+            "publishedFileId": entry.published_file_id,
+            "source": entry.source,
+        }
+
+    def _append_log_line(
+        self,
+        now: datetime,
+        list_id: str,
+        active: list[SnapshotEntry],
+        inactive: list[SnapshotEntry],
+        existing: list[Snapshot],
+    ) -> None:
+        delta = ""
+        if existing:
+            diff = self._diff_entries(
+                existing[0].active, active, existing[0].inactive, inactive
+            )
+            delta = f"  {diff.summary}"
+        line = (
+            f"{now.strftime('%Y-%m-%d %H:%M:%S')}  "
+            f"id={list_id[:_SHORT_ID_LEN]}  "
+            f"active={len(active)} inactive={len(inactive)}{delta}\n"
+        )
+        try:
+            with open(self._log_file(), "a", encoding="utf-8") as handle:
+                handle.write(line)
+        except OSError as exc:
+            logger.warning(f"Could not append to mod list history log: {exc}")
+
+    # ------------------------------------------------------------------ read
+    def list_snapshots(self) -> list[Snapshot]:
+        """All snapshots for the current instance, newest first."""
+        snapshots: list[Snapshot] = []
+        for path in self.history_dir().glob("*.json"):
+            try:
+                snapshots.append(self.load_snapshot(path))
+            except (OSError, ValueError, TypeError, json.JSONDecodeError) as exc:
+                logger.warning(
+                    f"Skipping unreadable history snapshot {path.name}: {exc}"
+                )
+        snapshots.sort(key=lambda snap: (snap.timestamp, snap.path.name), reverse=True)
+        return snapshots
+
+    def load_snapshot(self, path: str | Path) -> Snapshot:
+        """Parse a single snapshot file."""
+        path = Path(path)
+        with open(path, "r", encoding="utf-8-sig") as handle:
+            data = json.load(handle)
+        if not isinstance(data, dict):
+            raise TypeError("snapshot root is not an object")
+
+        meta = data.get(_META_KEY)
+        if isinstance(meta, dict):
+            active = [
+                self._entry_from_dict(item) for item in meta.get("activeMods", [])
+            ]
+            inactive = [
+                self._entry_from_dict(item) for item in meta.get("inactiveMods", [])
+            ]
+            list_id = str(
+                meta.get("id") or compute_list_id([e.package_id for e in active])
+            )
+            raw_timestamp = str(meta.get("timestamp") or "")
+            return Snapshot(
+                id=list_id,
+                short_id=str(meta.get("shortId") or list_id[:_SHORT_ID_LEN]),
+                timestamp=raw_timestamp.replace(":", "-"),
+                rimsort_version=str(meta.get("rimsortVersion") or ""),
+                game_version=str(meta.get("gameVersion") or data.get("version") or ""),
+                instance=str(meta.get("instance") or ""),
+                previous_id=(
+                    str(meta["previousId"]) if meta.get("previousId") else None
+                ),
+                note=str(meta.get("note") or ""),
+                active=active,
+                inactive=inactive,
+                path=path,
+            )
+
+        # Fall back: a plain RimSort JSON mod list without our metadata block.
+        active_ids = data.get("activeMods") or []
+        if isinstance(active_ids, dict):
+            active_ids = active_ids.get("li", [])
+        active = [
+            SnapshotEntry(str(pid), "", None, "unknown")
+            for pid in active_ids
+            if isinstance(pid, str)
+        ]
+        list_id = compute_list_id([e.package_id for e in active])
+        return Snapshot(
+            id=list_id,
+            short_id=list_id[:_SHORT_ID_LEN],
+            timestamp=path.stem.split("__")[0],
+            rimsort_version="",
+            game_version=str(data.get("version") or ""),
+            instance="",
+            previous_id=None,
+            note="",
+            active=active,
+            inactive=[],
+            path=path,
+        )
+
+    @staticmethod
+    def _entry_from_dict(item: Any) -> SnapshotEntry:
+        if not isinstance(item, dict):
+            return SnapshotEntry(str(item), "", None, "unknown")
+        pfid = item.get("publishedFileId")
+        return SnapshotEntry(
+            package_id=str(item.get("packageId") or ""),
+            name=str(item.get("name") or ""),
+            published_file_id=str(pfid) if pfid else None,
+            source=str(item.get("source") or "unknown"),
+        )
+
+    # ------------------------------------------------------------------ note
+    def set_note(self, path: str | Path, note: str) -> None:
+        """Update the free-text note stored on a snapshot file."""
+        path = Path(path)
+        with open(path, "r", encoding="utf-8-sig") as handle:
+            data = json.load(handle)
+        meta = data.get(_META_KEY)
+        if not isinstance(meta, dict):
+            meta = {}
+            data[_META_KEY] = meta
+        meta["note"] = note
+        atomic_json_dump(data, str(path), indent=2)
+
+    # ----------------------------------------------------------------- prune
+    def prune(self, keep: int) -> None:
+        """Delete the oldest snapshots beyond ``keep`` (``-1`` keeps everything)."""
+        if keep < 0:
+            return
+        files = sorted(
+            self.history_dir().glob("*.json"),
+            key=lambda p: p.name,
+            reverse=True,
+        )
+        for stale in files[max(keep, 0) :]:
+            try:
+                stale.unlink()
+                logger.debug(f"Pruned old mod list history snapshot: {stale.name}")
+            except OSError as exc:
+                logger.warning(f"Could not prune history snapshot {stale.name}: {exc}")
+
+    # ------------------------------------------------------------------ diff
+    def diff(self, old: Snapshot, new: Snapshot) -> ModListDiff:
+        """Diff two snapshots (``old`` -> ``new``)."""
+        return self._diff_entries(old.active, new.active, old.inactive, new.inactive)
+
+    @staticmethod
+    def _diff_entries(
+        old_active: list[SnapshotEntry],
+        new_active: list[SnapshotEntry],
+        old_inactive: list[SnapshotEntry],
+        new_inactive: list[SnapshotEntry],
+    ) -> ModListDiff:
+        def key(entry: SnapshotEntry) -> str:
+            return entry.package_id.lower()
+
+        old_active_map = {key(e): e for e in old_active}
+        new_active_map = {key(e): e for e in new_active}
+        old_inactive_map = {key(e): e for e in old_inactive}
+        new_inactive_map = {key(e): e for e in new_inactive}
+
+        result = ModListDiff()
+        result.active_added = [e for e in new_active if key(e) not in old_active_map]
+        result.active_removed = [e for e in old_active if key(e) not in new_active_map]
+
+        # Reorder detection: compare the two sequences restricted to the mods
+        # that are present in both, then flag the mods difflib does not place
+        # in an "equal" block (the minimal moved set).
+        common_old = [key(e) for e in old_active if key(e) in new_active_map]
+        common_new = [key(e) for e in new_active if key(e) in old_active_map]
+        moved: set[str] = set()
+        matcher = difflib.SequenceMatcher(a=common_old, b=common_new, autojunk=False)
+        for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+            if tag != "equal":
+                moved.update(common_old[i1:i2])
+                moved.update(common_new[j1:j2])
+        result.active_reordered = [e for e in new_active if key(e) in moved]
+
+        result.inactive_added = [
+            e for e in new_inactive if key(e) not in old_inactive_map
+        ]
+        result.inactive_removed = [
+            e for e in old_inactive if key(e) not in new_inactive_map
+        ]
+        return result

--- a/app/utils/event_bus.py
+++ b/app/utils/event_bus.py
@@ -33,6 +33,7 @@ class EventBus(QObject):
     do_import_mod_list_from_save_file = Signal()
     do_export_mod_list_to_clipboard = Signal()
     do_export_mod_list_to_rentry = Signal()
+    do_open_modlist_history = Signal()
 
     # Shortcuts submenu signals
     do_open_app_directory = Signal()

--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -43,6 +43,7 @@ from app.models.settings import Settings
 from app.services.dependency_resolver import build_dependencies_dialog_context
 from app.services.import_export_service import ImportExportService
 from app.services.mod_list_parser import ModListFormatError, parse_mod_list_file
+from app.services.modlist_history_service import ModlistHistoryService
 from app.services.window_manager import WindowManager
 from app.sort.mod_sorting import ModsPanelSortKey
 from app.utils import http
@@ -99,6 +100,7 @@ from app.windows.ignore_json_editor import IgnoreJsonEditor
 from app.windows.missing_dependencies_dialog import MissingDependenciesDialog
 from app.windows.missing_mod_properties_panel import MissingModPropertiesPanel
 from app.windows.missing_mods_panel import MissingModsPrompt
+from app.windows.modlist_history_panel import ModlistHistoryPanel
 from app.windows.rule_editor_panel import RuleEditor
 from app.windows.runner_panel import RunnerPanel
 from app.windows.use_this_instead_panel import UseThisInsteadPanel
@@ -156,6 +158,9 @@ class MainContent(QObject):
         self._import_export_service = ImportExportService(
             self.metadata_controller, self.settings
         )
+        self._modlist_history_service = ModlistHistoryService(
+            self.metadata_controller, self.settings
+        )
         self.query_runner: RunnerPanel | None = None
         self.steamworks_in_use = False
         self.todds_runner: RunnerPanel | None = None
@@ -207,6 +212,7 @@ class MainContent(QObject):
             self._do_export_list_clipboard
         )
         EventBus().do_export_mod_list_to_rentry.connect(self._do_upload_list_rentry)
+        EventBus().do_open_modlist_history.connect(self._do_open_modlist_history)
         EventBus().do_upload_log.connect(self._upload_file)
         EventBus().do_open_default_editor.connect(self._open_in_default_editor)
         EventBus().do_download_all_mods_via_steamcmd.connect(
@@ -1145,27 +1151,35 @@ class MainContent(QObject):
                     information=str(exc),
                 )
                 return
-            (
-                active_mods_uuids,
-                inactive_mods_uuids,
-                self.duplicate_mods,
-                self.missing_mods,
-            ) = self.metadata_controller.get_mods_from_list(mod_list=parsed.package_ids)
-            logger.info("Got new mods according to imported XML")
-            # Normal RimWorld XML mod lists only contain package IDs, not RimSort UI
-            # divider metadata. Clear persisted divider state so dividers from the
-            # previously loaded list are not reinserted at stale numeric positions.
-            self.settings.active_mods_dividers = []
-            self.settings.save()
-            self._insert_data_into_lists(active_mods_uuids, inactive_mods_uuids)
-
-            # check if we have duplicate mods, prompt user
-            self.__duplicate_mods_prompt()
-
-            # check if we have missing mods, prompt user
-            self.__missing_mods_prompt()
+            self._apply_imported_package_ids(parsed.package_ids)
         else:
             logger.info("USER ACTION: pressed cancel, passing")
+
+    def _apply_imported_package_ids(self, package_ids: list[str]) -> None:
+        """Load a plain list of package IDs into the active/inactive lists.
+
+        Shared by file import and mod list history restore. Only updates the
+        in-memory lists; the user still has to press Save to persist.
+        """
+        (
+            active_mods_uuids,
+            inactive_mods_uuids,
+            self.duplicate_mods,
+            self.missing_mods,
+        ) = self.metadata_controller.get_mods_from_list(mod_list=package_ids)
+        logger.info("Got new mods according to imported list")
+        # Plain package-ID lists carry no RimSort UI divider metadata. Clear
+        # persisted divider state so dividers from the previously loaded list are
+        # not reinserted at stale numeric positions.
+        self.settings.active_mods_dividers = []
+        self.settings.save()
+        self._insert_data_into_lists(active_mods_uuids, inactive_mods_uuids)
+
+        # check if we have duplicate mods, prompt user
+        self.__duplicate_mods_prompt()
+
+        # check if we have missing mods, prompt user
+        self.__missing_mods_prompt()
 
     def _do_append_list_file_xml(self) -> None:
         """
@@ -1248,6 +1262,24 @@ class MainContent(QObject):
                 )
         else:
             logger.debug("USER ACTION: pressed cancel, passing")
+
+    def _do_open_modlist_history(self) -> None:
+        """Open the Mod List History dialog for the current instance."""
+        panel = ModlistHistoryPanel(
+            history_service=self._modlist_history_service,
+            restore_callback=self._restore_modlist_snapshot,
+        )
+        self.window_manager.register(panel)
+        panel.show()
+
+    def _restore_modlist_snapshot(self, package_ids: list[str]) -> None:
+        """Load a history snapshot's active list into the UI (does not save)."""
+        self.mods_panel.reset_all_filters_and_search("Active")
+        self.mods_panel.reset_all_filters_and_search("Inactive")
+        logger.info(
+            f"Restoring mod list from history snapshot ({len(package_ids)} active mods)"
+        )
+        self._apply_imported_package_ids(package_ids)
 
     def _do_import_list_rentry(self) -> None:
         """
@@ -1755,8 +1787,10 @@ class MainContent(QObject):
         self.active_mods_uuids_last_save = active_mods_uuids
         logger.info(f"Collected {len(data.active_mods)} active mods for saving")
 
+        save_succeeded = False
         try:
             self._import_export_service.save_to_mods_config(data.active_mods)
+            save_succeeded = True
         except Exception:
             logger.error("Could not save active mods")
             dialogue.show_fatal_error(
@@ -1764,6 +1798,15 @@ class MainContent(QObject):
                 text=self.tr("Failed to save active mods to file:"),
                 details=traceback.format_exc(),
             )
+
+        if save_succeeded and self.settings.modlist_history_enabled:
+            try:
+                self._modlist_history_service.write_snapshot(
+                    active_mods_uuids, inactive_mods_uuids
+                )
+            except Exception:
+                logger.exception("Failed to write mod list history snapshot")
+
         EventBus().do_save_button_animation_stop.emit()
         # Save current modlists to their respective restore states
         self.active_mods_uuids_restore_state = active_mods_uuids

--- a/app/views/menu_bar.py
+++ b/app/views/menu_bar.py
@@ -37,6 +37,7 @@ class MenuBar(QObject):
         self.import_from_save_file_action: QAction
         self.export_to_clipboard_action: QAction
         self.export_to_rentry_action: QAction
+        self.modlist_history_action: QAction
         self.upload_log_actions: list[QAction] = []
         self.default_open_log_actions: list[QAction] = []
         self.upload_rimsort_log_action: QAction
@@ -155,6 +156,10 @@ class MenuBar(QObject):
         )
         self.export_to_rentry_action = self._add_action(
             self.export_submenu, self.tr("To Rentry.co…")
+        )
+        file_menu.addSeparator()
+        self.modlist_history_action = self._add_action(
+            file_menu, self.tr("Mod List History…")
         )
         file_menu.addSeparator()
 

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -442,6 +442,43 @@ class SettingsDialog(QDialog):
         row_layout.addWidget(self.show_save_comparison_indicators_checkbox)
         tab_layout.addLayout(row_layout)
 
+        self._do_modlist_history_group(tab_layout)
+
+    def _do_modlist_history_group(self, tab_layout: QBoxLayout) -> None:
+        section_label = self._make_section_label(
+            self.tr("Mod list history"), Qt.AlignmentFlag.AlignCenter
+        )
+        tab_layout.addWidget(section_label)
+
+        self.modlist_history_enabled_checkbox = QCheckBox(
+            self.tr("Save a snapshot of the mod list every time it is saved")
+        )
+        self.modlist_history_enabled_checkbox.setToolTip(
+            self.tr(
+                "If enabled, RimSort writes a timestamped copy of the active and "
+                "inactive mod lists on every save so you can compare them later "
+                "(File → Mod List History…)."
+            )
+        )
+        tab_layout.addWidget(self.modlist_history_enabled_checkbox)
+
+        retention_layout = QHBoxLayout()
+        retention_label = QLabel(self.tr("Number of snapshots to keep:"))
+        retention_label.setToolTip(
+            self.tr(
+                "The number of mod list snapshots to keep. Set to -1 to keep all."
+            )
+        )
+        retention_layout.addWidget(retention_label)
+        self.modlist_history_retention_count_spinbox = QSpinBox()
+        self.modlist_history_retention_count_spinbox.setRange(-1, 9999)
+        self.modlist_history_retention_count_spinbox.setSizePolicy(
+            QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed
+        )
+        retention_layout.addWidget(self.modlist_history_retention_count_spinbox)
+        retention_layout.addStretch()
+        tab_layout.addLayout(retention_layout)
+
     def __create_db_group(
         self, section_lbl: str, none_lbl: str, tab_layout: QBoxLayout
     ) -> tuple[

--- a/app/windows/modlist_history_panel.py
+++ b/app/windows/modlist_history_panel.py
@@ -1,0 +1,323 @@
+"""Dialog for browsing and comparing mod list history snapshots."""
+
+from collections.abc import Callable
+
+from loguru import logger
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QAbstractItemView,
+    QDialog,
+    QHBoxLayout,
+    QInputDialog,
+    QLabel,
+    QListWidget,
+    QListWidgetItem,
+    QPushButton,
+    QSplitter,
+    QTreeWidget,
+    QTreeWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from app.services.modlist_history_service import (
+    ModListDiff,
+    ModlistHistoryService,
+    Snapshot,
+    SnapshotEntry,
+)
+from app.utils.generic import platform_specific_open
+from app.views import dialogue
+
+
+class ModlistHistoryPanel(QDialog):
+    """Lists mod list snapshots for the current instance and diffs any two."""
+
+    def __init__(
+        self,
+        history_service: ModlistHistoryService,
+        restore_callback: Callable[[list[str]], None],
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.setObjectName("modlistHistoryPanel")
+        self.setWindowTitle(self.tr("Mod List History"))
+        self._service = history_service
+        self._restore_callback = restore_callback
+        self._snapshots: list[Snapshot] = []
+
+        self._setup_ui()
+        self.resize(1000, 620)
+        self._reload()
+
+    # ------------------------------------------------------------------ setup
+    def _setup_ui(self) -> None:
+        layout = QVBoxLayout(self)
+
+        description = QLabel(
+            self.tr(
+                "Every save writes a snapshot of your mod list. Select a snapshot "
+                "to compare it with the one before it, or hold Ctrl and select two "
+                "snapshots to compare them directly."
+            )
+        )
+        description.setWordWrap(True)
+        layout.addWidget(description)
+
+        splitter = QSplitter(Qt.Orientation.Horizontal)
+        layout.addWidget(splitter, stretch=1)
+
+        self.snapshot_list = QListWidget()
+        self.snapshot_list.setSelectionMode(
+            QAbstractItemView.SelectionMode.ExtendedSelection
+        )
+        self.snapshot_list.itemSelectionChanged.connect(self._on_selection_changed)
+        splitter.addWidget(self.snapshot_list)
+
+        self.diff_tree = QTreeWidget()
+        self.diff_tree.setHeaderLabels([self.tr("Change"), self.tr("Mod")])
+        self.diff_tree.setColumnWidth(0, 160)
+        self.diff_tree.setRootIsDecorated(True)
+        splitter.addWidget(self.diff_tree)
+
+        splitter.setStretchFactor(0, 1)
+        splitter.setStretchFactor(1, 2)
+
+        button_row = QHBoxLayout()
+
+        self.restore_button = QPushButton(self.tr("Restore Selected"))
+        self.restore_button.setObjectName("actionButton")
+        self.restore_button.clicked.connect(self._on_restore)
+        button_row.addWidget(self.restore_button)
+
+        self.export_button = QPushButton(self.tr("Export Selected…"))
+        self.export_button.clicked.connect(self._on_export)
+        button_row.addWidget(self.export_button)
+
+        self.note_button = QPushButton(self.tr("Edit Note…"))
+        self.note_button.clicked.connect(self._on_edit_note)
+        button_row.addWidget(self.note_button)
+
+        button_row.addStretch()
+
+        open_folder_button = QPushButton(self.tr("Open History Folder"))
+        open_folder_button.clicked.connect(self._on_open_folder)
+        button_row.addWidget(open_folder_button)
+
+        close_button = QPushButton(self.tr("Close"))
+        close_button.clicked.connect(self.close)
+        button_row.addWidget(close_button)
+
+        layout.addLayout(button_row)
+
+    # ------------------------------------------------------------------ data
+    def _reload(self) -> None:
+        self._snapshots = self._service.list_snapshots()
+        self.snapshot_list.clear()
+        for index, snap in enumerate(self._snapshots):
+            note = f"  —  {snap.note}" if snap.note else ""
+            text = (
+                f"{snap.display_timestamp}   "
+                f"{len(snap.active)} active / {len(snap.inactive)} inactive   "
+                f"[{snap.short_id}]{note}"
+            )
+            item = QListWidgetItem(text)
+            item.setData(Qt.ItemDataRole.UserRole, index)
+            self.snapshot_list.addItem(item)
+
+        self._update_buttons()
+        if self._snapshots:
+            self.snapshot_list.setCurrentRow(0)
+        else:
+            self.diff_tree.clear()
+            placeholder = QTreeWidgetItem(
+                [
+                    self.tr("No snapshots yet"),
+                    self.tr("Save your mod list to create one"),
+                ]
+            )
+            self.diff_tree.addTopLevelItem(placeholder)
+
+    def _selected_indices(self) -> list[int]:
+        indices = [
+            item.data(Qt.ItemDataRole.UserRole)
+            for item in self.snapshot_list.selectedItems()
+        ]
+        return sorted(int(i) for i in indices)
+
+    def _selected_pair(self) -> tuple[Snapshot, Snapshot] | None:
+        """Return (older, newer) snapshots to diff, or None."""
+        indices = self._selected_indices()
+        if len(indices) >= 2:
+            older = self._snapshots[indices[-1]]
+            newer = self._snapshots[indices[0]]
+            return older, newer
+        if len(indices) == 1:
+            newer = self._snapshots[indices[0]]
+            if indices[0] + 1 < len(self._snapshots):
+                older = self._snapshots[indices[0] + 1]
+                return older, newer
+        return None
+
+    # --------------------------------------------------------------- events
+    def _on_selection_changed(self) -> None:
+        self._update_buttons()
+        self.diff_tree.clear()
+
+        pair = self._selected_pair()
+        if pair is None:
+            indices = self._selected_indices()
+            if len(indices) == 1:
+                self.diff_tree.addTopLevelItem(
+                    QTreeWidgetItem(
+                        [
+                            self.tr("Oldest snapshot"),
+                            self.tr("Nothing to compare against"),
+                        ]
+                    )
+                )
+            return
+
+        older, newer = pair
+        try:
+            diff = self._service.diff(older, newer)
+        except Exception:
+            logger.exception("Failed to diff mod list snapshots")
+            return
+        self._render_diff(older, newer, diff)
+
+    def _render_diff(self, older: Snapshot, newer: Snapshot, diff: ModListDiff) -> None:
+        header = QTreeWidgetItem(
+            [
+                self.tr("Comparing"),
+                self.tr("{old} → {new}").format(
+                    old=older.display_timestamp, new=newer.display_timestamp
+                ),
+            ]
+        )
+        self.diff_tree.addTopLevelItem(header)
+
+        if diff.is_empty:
+            self.diff_tree.addTopLevelItem(
+                QTreeWidgetItem([self.tr("No differences"), ""])
+            )
+            return
+
+        self._add_diff_group(self.tr("Added to active ({n})"), diff.active_added, "+")
+        self._add_diff_group(
+            self.tr("Removed from active ({n})"), diff.active_removed, "−"
+        )
+        self._add_diff_group(self.tr("Reordered ({n})"), diff.active_reordered, "~")
+        self._add_diff_group(
+            self.tr("Newly installed / disabled ({n})"), diff.inactive_added, "+"
+        )
+        self._add_diff_group(
+            self.tr("No longer installed ({n})"), diff.inactive_removed, "−"
+        )
+        self.diff_tree.expandAll()
+
+    def _add_diff_group(
+        self, title_template: str, entries: list[SnapshotEntry], marker: str
+    ) -> None:
+        if not entries:
+            return
+        group = QTreeWidgetItem([title_template.format(n=len(entries)), ""])
+        self.diff_tree.addTopLevelItem(group)
+        for entry in entries:
+            child = QTreeWidgetItem([marker, entry.label])
+            if entry.source and entry.source != "unknown":
+                child.setToolTip(1, self.tr("Source: {src}").format(src=entry.source))
+            group.addChild(child)
+
+    def _update_buttons(self) -> None:
+        one_selected = len(self._selected_indices()) == 1
+        self.restore_button.setEnabled(one_selected)
+        self.export_button.setEnabled(one_selected)
+        self.note_button.setEnabled(one_selected)
+
+    def _current_snapshot(self) -> Snapshot | None:
+        indices = self._selected_indices()
+        if len(indices) != 1:
+            return None
+        return self._snapshots[indices[0]]
+
+    # --------------------------------------------------------------- actions
+    def _on_restore(self) -> None:
+        snap = self._current_snapshot()
+        if snap is None:
+            return
+        confirmed = dialogue.show_dialogue_conditional(
+            title=self.tr("Restore Mod List"),
+            text=self.tr("Load the active mod list from this snapshot ({ts})?").format(
+                ts=snap.display_timestamp
+            ),
+            information=self.tr(
+                "This replaces the mods currently loaded in RimSort. Nothing is "
+                "written to disk until you press Save."
+            ),
+            button_text_override=[self.tr("Restore")],
+        )
+        if confirmed != self.tr("Restore"):
+            return
+        try:
+            self._restore_callback(list(snap.active_package_ids))
+        except Exception:
+            logger.exception("Failed to restore mod list snapshot")
+            dialogue.show_warning(
+                title=self.tr("Restore failed"),
+                text=self.tr("Could not restore the selected snapshot."),
+            )
+            return
+        self.close()
+
+    def _on_export(self) -> None:
+        snap = self._current_snapshot()
+        if snap is None:
+            return
+        target = dialogue.show_dialogue_file(
+            mode="save",
+            caption=self.tr("Export snapshot"),
+            _dir=f"{snap.timestamp}__{snap.short_id}.json",
+            _filter="JSON (*.json)",
+        )
+        if not target:
+            return
+        try:
+            destination = target if target.endswith(".json") else target + ".json"
+            with (
+                open(snap.path, "r", encoding="utf-8-sig") as src,
+                open(destination, "w", encoding="utf-8") as dst,
+            ):
+                dst.write(src.read())
+        except OSError:
+            logger.exception("Failed to export mod list snapshot")
+            dialogue.show_warning(
+                title=self.tr("Export failed"),
+                text=self.tr("Could not write the snapshot file."),
+            )
+
+    def _on_edit_note(self) -> None:
+        snap = self._current_snapshot()
+        if snap is None:
+            return
+        note, ok = QInputDialog.getMultiLineText(
+            self,
+            self.tr("Snapshot Note"),
+            self.tr("Note for {ts}:").format(ts=snap.display_timestamp),
+            snap.note,
+        )
+        if not ok:
+            return
+        try:
+            self._service.set_note(snap.path, note.strip())
+        except (OSError, ValueError):
+            logger.exception("Failed to write snapshot note")
+            dialogue.show_warning(
+                title=self.tr("Could not save note"),
+                text=self.tr("The snapshot note could not be written."),
+            )
+            return
+        self._reload()
+
+    def _on_open_folder(self) -> None:
+        platform_specific_open(str(self._service.history_dir()))

--- a/locales/en_US.ts
+++ b/locales/en_US.ts
@@ -2453,6 +2453,10 @@ Manage mods installed from GitHub releases.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Mod List History…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Open...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3403,6 +3407,149 @@ Alternative Dependencies:</source>
     </message>
     <message>
         <source>Open folder(s) in text editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ModlistHistoryPanel</name>
+    <message>
+        <source>Mod List History</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Every save writes a snapshot of your mod list. Select a snapshot to compare it with the one before it, or hold Ctrl and select two snapshots to compare them directly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Change</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mod</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore Selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Selected…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Note…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open History Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No snapshots yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save your mod list to create one</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Oldest snapshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Nothing to compare against</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Comparing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>{old} → {new}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No differences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Added to active ({n})</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Removed from active ({n})</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reordered ({n})</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Newly installed / disabled ({n})</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No longer installed ({n})</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Source: {src}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore Mod List</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load the active mod list from this snapshot ({ts})?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This replaces the mods currently loaded in RimSort. Nothing is written to disk until you press Save.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not restore the selected snapshot.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export snapshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not write the snapshot file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Snapshot Note</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note for {ts}:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not save note</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The snapshot note could not be written.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4494,6 +4641,26 @@ Alternative Dependencies:</source>
     </message>
     <message>
         <source>Integration with recent save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mod list history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save a snapshot of the mod list every time it is saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If enabled, RimSort writes a timestamped copy of the active and inactive mod lists on every save so you can compare them later (File → Mod List History…).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of snapshots to keep:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The number of mod list snapshots to keep. Set to -1 to keep all.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/tests/models/test_settings_defaults.py
+++ b/tests/models/test_settings_defaults.py
@@ -92,6 +92,15 @@ class TestRecentlyUpdatedIndicatorDefaults:
         assert settings.mod_list_updated_threshold_days == 3
 
 
+class TestModlistHistoryDefaults:
+    """Test defaults for the mod list history feature."""
+
+    def test_modlist_history_defaults(self, settings: Settings) -> None:
+        """History is on by default and keeps 100 snapshots."""
+        assert settings.modlist_history_enabled is True
+        assert settings.modlist_history_retention_count == 100
+
+
 class TestRimWorldVersionsDefaults:
     """Test defaults for the new RimWorld Versions DB feature."""
 

--- a/tests/services/test_modlist_history_service.py
+++ b/tests/services/test_modlist_history_service.py
@@ -1,0 +1,146 @@
+"""Tests for the mod list history snapshot service."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+from app.models.metadata.metadata_structure import ModType
+from app.services.modlist_history_service import (
+    ModlistHistoryService,
+    compute_list_id,
+)
+
+
+@dataclass
+class _StubMod:
+    package_id: str
+    name: str = ""
+    published_file_id: str | None = None
+    mod_type: ModType = ModType.LOCAL
+
+
+class _StubMetadataController:
+    """Minimal stand-in: uuid == package_id for test convenience."""
+
+    game_version = "1.5"
+
+    def __init__(self, mods: dict[str, _StubMod]) -> None:
+        self._mods = mods
+
+    def get_mod(self, uuid: str) -> _StubMod | None:
+        return self._mods.get(uuid)
+
+
+class _StubSettings:
+    current_instance = "Default"
+    modlist_history_retention_count = 100
+
+
+def _make_service(
+    package_ids: list[str],
+) -> tuple[ModlistHistoryService, _StubSettings]:
+    mods = {
+        pid: _StubMod(
+            package_id=pid,
+            name=pid.split(".")[-1].title(),
+            mod_type=ModType.STEAM_WORKSHOP if "steam" in pid else ModType.LOCAL,
+        )
+        for pid in package_ids
+    }
+    settings = _StubSettings()
+    service = ModlistHistoryService(_StubMetadataController(mods), settings)  # type: ignore[arg-type]
+    return service, settings
+
+
+class TestComputeListId:
+    def test_deterministic(self) -> None:
+        assert compute_list_id(["a.b", "c.d"]) == compute_list_id(["a.b", "c.d"])
+
+    def test_case_insensitive(self) -> None:
+        assert compute_list_id(["A.B"]) == compute_list_id(["a.b"])
+
+    def test_order_sensitive(self) -> None:
+        assert compute_list_id(["a.b", "c.d"]) != compute_list_id(["c.d", "a.b"])
+
+
+class TestWriteSnapshot:
+    def test_writes_file_and_log(self) -> None:
+        service, _ = _make_service(["ludeon.rimworld", "a.mod", "b.mod", "c.mod"])
+        snap = service.write_snapshot(["ludeon.rimworld", "a.mod", "b.mod"], ["c.mod"])
+
+        assert snap is not None
+        assert snap.path.exists()
+        assert snap.active_package_ids == ["ludeon.rimworld", "a.mod", "b.mod"]
+        assert len(snap.inactive) == 1
+
+        payload = json.loads(snap.path.read_text(encoding="utf-8"))
+        assert payload["activeMods"] == ["ludeon.rimworld", "a.mod", "b.mod"]
+        assert payload["rimsortSnapshot"]["id"] == snap.id
+
+        log = service.history_dir() / "history.log"
+        assert log.exists()
+        assert snap.short_id in log.read_text(encoding="utf-8")
+
+    def test_identical_list_is_not_rewritten(self) -> None:
+        service, _ = _make_service(["a.mod", "b.mod"])
+        first = service.write_snapshot(["a.mod", "b.mod"], [])
+        second = service.write_snapshot(["a.mod", "b.mod"], [])
+
+        assert first is not None
+        assert second is None
+        assert len(list(service.history_dir().glob("*.json"))) == 1
+
+    def test_previous_id_chains(self) -> None:
+        service, _ = _make_service(["a.mod", "b.mod"])
+        first = service.write_snapshot(["a.mod"], ["b.mod"])
+        second = service.write_snapshot(["a.mod", "b.mod"], [])
+
+        assert first is not None and second is not None
+        assert second.previous_id == first.id
+
+
+class TestPrune:
+    def test_keeps_newest(self) -> None:
+        service, _ = _make_service(["a.mod", "b.mod", "c.mod"])
+        service.write_snapshot(["a.mod"], [])
+        service.write_snapshot(["a.mod", "b.mod"], [])
+        service.write_snapshot(["a.mod", "b.mod", "c.mod"], [])
+
+        service.prune(keep=2)
+        remaining = sorted(p.name for p in service.history_dir().glob("*.json"))
+        assert len(remaining) == 2
+
+        newest = service.list_snapshots()[0]
+        assert newest.active_package_ids == ["a.mod", "b.mod", "c.mod"]
+
+    def test_negative_keeps_all(self) -> None:
+        service, _ = _make_service(["a.mod", "b.mod"])
+        service.write_snapshot(["a.mod"], [])
+        service.write_snapshot(["a.mod", "b.mod"], [])
+        service.prune(keep=-1)
+        assert len(list(service.history_dir().glob("*.json"))) == 2
+
+
+class TestDiff:
+    def test_detects_add_remove_reorder(self) -> None:
+        service, _ = _make_service(["a.mod", "b.mod", "c.mod", "d.mod"])
+        old = service.write_snapshot(["a.mod", "b.mod", "c.mod"], ["d.mod"])
+        new = service.write_snapshot(["a.mod", "c.mod", "b.mod", "d.mod"], [])
+
+        assert old is not None and new is not None
+        diff = service.diff(old, new)
+
+        assert [e.package_id for e in diff.active_added] == ["d.mod"]
+        assert diff.active_removed == []
+        reordered = {e.package_id for e in diff.active_reordered}
+        # b and c swapped; difflib flags the minimal moved set (at least one of them).
+        assert reordered
+        assert reordered <= {"b.mod", "c.mod"}
+        assert [e.package_id for e in diff.inactive_removed] == ["d.mod"]
+
+    def test_empty_diff_for_same_snapshot(self) -> None:
+        service, _ = _make_service(["a.mod", "b.mod"])
+        snap = service.write_snapshot(["a.mod", "b.mod"], [])
+        assert snap is not None
+        assert service.diff(snap, snap).is_empty

--- a/tests/views/test_menu_bar.py
+++ b/tests/views/test_menu_bar.py
@@ -138,6 +138,23 @@ class TestMenuBarAppendAction:
             mock_event_bus.return_value.do_append_mod_list.emit.assert_called_once()
 
 
+class TestMenuBarModlistHistory:
+    """Test the Mod List History menu action."""
+
+    def test_modlist_history_action_emits_event(
+        self,
+        menu_bar_instance: MenuBar,
+        mock_settings_controller: MagicMock,
+    ) -> None:
+        """Triggering modlist_history_action emits do_open_modlist_history."""
+        with patch("app.controllers.menu_bar_controller.EventBus") as mock_event_bus:
+            _controller = MenuBarController(
+                menu_bar_instance, mock_settings_controller.settings, lambda: None
+            )
+            menu_bar_instance.modlist_history_action.trigger()
+            mock_event_bus.return_value.do_open_modlist_history.emit.assert_called_once()
+
+
 class TestMenuBarGameFileVerification:
     """Test confirmation before verifying game files from the menu bar."""
 


### PR DESCRIPTION
### Summary

Implements #1678 — keep a history of the active mod list so a user can diff
two versions and narrow down which mod change coincided with the onset of
errors.

### Changes

- **New `ModlistHistoryService`** (`app/services/modlist_history_service.py`).
  On every save it writes a timestamped JSON snapshot of the active + inactive
  mod lists to `modlists/history/<instance>/`. Each snapshot is identified by a
  SHA-256 of the ordered active package IDs and chained to its predecessor via
  `previousId`, forming a breadcrumb trail. A save whose active list is
  identical to the last snapshot is skipped; `modlist_history_retention_count`
  prunes the oldest. Snapshot files are valid RimSort JSON mod lists (plus a
  `rimsortSnapshot` metadata block), so they re-import through the existing
  parser. A human-readable `history.log` line is appended per save.
- **New "File → Mod List History…" dialog** (`app/windows/modlist_history_panel.py`).
  Lists the snapshots and shows the added / removed / reordered mods between
  any two of them (select one to diff against its predecessor, or Ctrl-select
  two). Can restore an old list into the UI (unsaved, same behaviour as file
  import), export a snapshot, attach a note, or open the history folder.
- `MainContent._do_save` hooks the snapshot write (guarded — a failure here
  never blocks saving). The post-parse body of `_do_import_list_file_xml` is
  factored into `_apply_imported_package_ids` and reused for restore.
- Settings → Advanced gains a "Mod list history" group: `modlist_history_enabled`
  (default on) and `modlist_history_retention_count` (default 100, -1 = keep all).
- `EventBus.do_open_modlist_history` + the File-menu action wiring.

### Tests

- `tests/services/test_modlist_history_service.py` — id determinism and
  order-sensitivity, snapshot write + dedupe, `previousId` chaining, prune
  (keep-N and keep-all), and add/remove/reorder diffing.
- `tests/models/test_settings_defaults.py` — the two new defaults.
- `tests/views/test_menu_bar.py` — the new menu action emits its signal.

### Verification

- `just test` — 1346 passed, 13 skipped
- `just typecheck` clean; `ruff check` / `ruff format` clean;
  `check_deferred_imports.py` clean
- Manual: repeated save cycles produce snapshots; an unchanged save writes
  nothing; the diff view reflects activate/deactivate/reorder; restore, export,
  notes, retention pruning, and the on/off toggle all behave as expected;
  opening the dialog with no snapshots shows an empty state without crashing.

### Notes

- Only `locales/en_US.ts` is updated (new source strings, extracted with
  `-locations none` to keep the diff minimal); other locales are left for the
  usual translation-sync PRs.
- Scope nuance: #1678 phrases it as comparing the *current* active list against
  a *saved modlist file*. This PR diffs between automatically-captured snapshots
  instead. Happy to add a "compare current list to an arbitrary file" entry
  point as a follow-up if that's preferred.
