### PR TITLE
Re-enable metadata/UI refresh after Steam actions

### DIFF
--- a/app/views/main_content_panel.py
+++ b/app/views/main_content_panel.py
@@ -2453,12 +2453,7 @@ class MainContent(QObject):
             ),
         )
         # Do a full refresh of metadata and UI
-        # self._do_refresh()
-        # TODO  check if this is necessary
-        """       
-        Disabled refresh since steam downloads are not instant and in the background in its own time
-        Refreshing metadata and UI here could tag mods as invalid or cause crashes due to key errors etc
-        """
+        self._do_refresh()
 
         # GIT MOD ACTIONS
 

--- a/app/views/settings_dialog.py
+++ b/app/views/settings_dialog.py
@@ -465,9 +465,7 @@ class SettingsDialog(QDialog):
         retention_layout = QHBoxLayout()
         retention_label = QLabel(self.tr("Number of snapshots to keep:"))
         retention_label.setToolTip(
-            self.tr(
-                "The number of mod list snapshots to keep. Set to -1 to keep all."
-            )
+            self.tr("The number of mod list snapshots to keep. Set to -1 to keep all.")
         )
         retention_layout.addWidget(retention_label)
         self.modlist_history_retention_count_spinbox = QSpinBox()


### PR DESCRIPTION
Restore the call to self._do_refresh() after processing Steam subscription actions. Removed the previous multiline comment that had disabled the refresh (which was avoided due to asynchronous Steam downloads causing potential invalid mod states). Re-enabling the refresh updates metadata and UI after Steamworks API operations.