### PR TITLE
fix: retry transient atomic replace failures

### DIFF
--- a/app/utils/json_utils.py
+++ b/app/utils/json_utils.py
@@ -1,7 +1,23 @@
 import json
 import os
 import tempfile
+import time
 from typing import Any
+
+_REPLACE_ATTEMPTS = 5
+_REPLACE_RETRY_DELAY = 0.05
+
+
+def _replace_with_retry(source: str, destination: str) -> None:
+    """Replace a file, tolerating short-lived Windows file locks."""
+    for attempt in range(_REPLACE_ATTEMPTS):
+        try:
+            os.replace(source, destination)
+            return
+        except PermissionError:
+            if attempt == _REPLACE_ATTEMPTS - 1:
+                raise
+            time.sleep(_REPLACE_RETRY_DELAY * 2**attempt)
 
 
 def atomic_json_dump(data: Any, path: str, **kwargs: Any) -> None:
@@ -12,7 +28,7 @@ def atomic_json_dump(data: Any, path: str, **kwargs: Any) -> None:
             json.dump(data, f, **kwargs)
             f.flush()
             os.fsync(fd)
-        os.replace(tmp, path)
+        _replace_with_retry(tmp, path)
     except BaseException:
         os.unlink(tmp)
         raise

--- a/tests/utils/test_json_utils.py
+++ b/tests/utils/test_json_utils.py
@@ -1,0 +1,52 @@
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from app.utils.json_utils import atomic_json_dump
+
+
+def test_atomic_json_dump_retries_transient_replace_permission_error(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "settings.json"
+    real_replace = os.replace
+    attempts = 0
+
+    def flaky_replace(source: str, destination: str) -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise PermissionError("temporarily locked")
+        real_replace(source, destination)
+
+    with (
+        patch("app.utils.json_utils.os.replace", side_effect=flaky_replace),
+        patch("app.utils.json_utils.time.sleep") as sleep,
+    ):
+        atomic_json_dump({"language": "en"}, str(target))
+
+    assert attempts == 2
+    sleep.assert_called_once_with(0.05)
+    assert json.loads(target.read_text(encoding="utf-8")) == {"language": "en"}
+
+
+def test_atomic_json_dump_cleans_temp_file_after_persistent_permission_error(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "settings.json"
+
+    with (
+        patch(
+            "app.utils.json_utils.os.replace",
+            side_effect=PermissionError("still locked"),
+        ),
+        patch("app.utils.json_utils.time.sleep") as sleep,
+        pytest.raises(PermissionError, match="still locked"),
+    ):
+        atomic_json_dump({"language": "en"}, str(target))
+
+    assert list(tmp_path.iterdir()) == []
+    assert sleep.call_count == 4


### PR DESCRIPTION
Fixes #2409.

Retries transient `PermissionError` failures during the final atomic JSON replace with bounded backoff. Persistent permission failures still propagate, and their temporary files are removed.

Validation: 1,360 tests passed with 1 skip; targeted Ruff, format, and mypy checks passed.
