### PR TITLE
fix: isolate Linux SteamCMD user configuration

### DIFF
--- a/app/utils/steam/steamcmd/wrapper.py
+++ b/app/utils/steam/steamcmd/wrapper.py
@@ -293,6 +293,27 @@ class SteamcmdInterface:
     def console_log_path(self) -> Path:
         return Path(self.steamcmd_install_path) / "logs" / "console_log.txt"
 
+    def _get_process_environment(self) -> dict[str, str] | None:
+        """Return an isolated environment for SteamCMD on Linux.
+
+        SteamCMD otherwise shares the desktop Steam client's configuration under
+        the user's home directory and can overwrite its ``libraryfolders.vdf``.
+        Other platforms retain their existing inherited environment.
+        """
+        if self.system != "Linux":
+            return None
+
+        home_path = Path(self.steamcmd_prefix).expanduser().resolve() / "home"
+        config_path = home_path / ".config"
+        data_path = home_path / ".local" / "share"
+        config_path.mkdir(parents=True, exist_ok=True)
+        data_path.mkdir(parents=True, exist_ok=True)
+        return {
+            "HOME": str(home_path),
+            "XDG_CONFIG_HOME": str(config_path),
+            "XDG_DATA_HOME": str(data_path),
+        }
+
     def _build_download_script(self, publishedfileids: list[str]) -> str:
         """Write a SteamCMD script for *publishedfileids* and return its path.
 
@@ -370,6 +391,7 @@ class SteamcmdInterface:
         runner._pending_steamcmd_batches = batches[1:]
         runner._steamcmd_executable = self.steamcmd
         runner._steamcmd_wrapper = self
+        runner._steamcmd_environment = self._get_process_environment()
 
         # Kick off the first batch immediately.
         batch_num = 1
@@ -385,6 +407,7 @@ class SteamcmdInterface:
             self.steamcmd,
             [f'+runscript "{script_path}"'],
             total,
+            environment=runner._steamcmd_environment,
         )
 
     def download_game_version(

--- a/app/windows/runner_panel.py
+++ b/app/windows/runner_panel.py
@@ -1,5 +1,5 @@
 import os
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from platform import system
 from re import compile, search
 from typing import TYPE_CHECKING, Any
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
 
 import psutil
 from loguru import logger
-from PySide6.QtCore import QProcess, Qt, QTimer, Signal
+from PySide6.QtCore import QProcess, QProcessEnvironment, Qt, QTimer, Signal
 from PySide6.QtGui import QCloseEvent, QFont, QIcon, QKeyEvent, QTextCursor
 from PySide6.QtWidgets import (
     QHBoxLayout,
@@ -77,6 +77,7 @@ class RunnerPanel(QWidget):
         self.process_last_output = ""
         self.process_last_command = ""
         self.process_last_args: Sequence[str] = []
+        self.process_last_environment: dict[str, str] | None = None
         self.steamcmd_current_pfid: str | None = None
         self.login_error = False
         self.redownloading = False
@@ -85,6 +86,7 @@ class RunnerPanel(QWidget):
         self._pending_steamcmd_batches: list[list[str]] = []
         self._steamcmd_executable: str = ""
         self._steamcmd_wrapper: SteamcmdInterface | None = None
+        self._steamcmd_environment: dict[str, str] | None = None
         self._steamcmd_batch_index: int = 1  # 1-based; first batch already sent
 
         # SteamCMD console_log.txt tail (live logs on Windows)
@@ -263,7 +265,11 @@ class RunnerPanel(QWidget):
     def _do_restart_process(self) -> None:
         if self.process_last_command != "":
             self.message("\nRestarting last used process...\n")
-            self.execute(self.process_last_command, self.process_last_args)
+            self.execute(
+                self.process_last_command,
+                self.process_last_args,
+                environment=self.process_last_environment,
+            )
 
     def _do_save_runner_output(self) -> None:
         """
@@ -315,6 +321,7 @@ class RunnerPanel(QWidget):
         command: str,
         args: Sequence[str],
         progress_bar: int | None = None,
+        environment: Mapping[str, str] | None = None,
     ) -> None:
         """
         Execute the given command in a new terminal-like GUI
@@ -323,11 +330,13 @@ class RunnerPanel(QWidget):
             command: Path to the executable
             args: Arguments for the executable
             progress_bar: Value for the progress bar, None to hide progress bar
+            environment: Environment variables to override for the subprocess
         """
         logger.info("RunnerPanel subprocess initiating...")
         # Store command info for potential restart
         self.process_last_command = command
         self.process_last_args = args
+        self.process_last_environment = dict(environment) if environment else None
 
         # Show control buttons
         self.restart_process_button.show()
@@ -337,6 +346,7 @@ class RunnerPanel(QWidget):
         self.process = QProcess(self)
         self.process.setProgram(command)
         self.process.setArguments(args)
+        self._apply_process_environment(self.process, environment)
         self.process.setProcessChannelMode(QProcess.ProcessChannelMode.MergedChannels)
         self.process.readyReadStandardError.connect(self.handle_output)
         self.process.readyReadStandardOutput.connect(self.handle_output)
@@ -359,6 +369,19 @@ class RunnerPanel(QWidget):
 
         # Start the process
         self.process.start()
+
+    @staticmethod
+    def _apply_process_environment(
+        process: QProcess, environment: Mapping[str, str] | None
+    ) -> None:
+        """Apply environment overrides while preserving inherited variables."""
+        if not environment:
+            return
+
+        process_environment = QProcessEnvironment.systemEnvironment()
+        for name, value in environment.items():
+            process_environment.insert(name, value)
+        process.setProcessEnvironment(process_environment)
 
     def _start_steamcmd_log_tail(self) -> None:
         """Tail SteamCMD console_log.txt for live line-by-line output."""
@@ -661,6 +684,7 @@ class RunnerPanel(QWidget):
         self.process = QProcess(self)
         self.process.setProgram(self._steamcmd_executable)
         self.process.setArguments([f'+runscript "{script_path}"'])
+        self._apply_process_environment(self.process, self._steamcmd_environment)
         self.process.setProcessChannelMode(QProcess.ProcessChannelMode.MergedChannels)
         self.process.readyReadStandardError.connect(self.handle_output)
         self.process.readyReadStandardOutput.connect(self.handle_output)

--- a/docs/user-guide/steamcmd-browser.md
+++ b/docs/user-guide/steamcmd-browser.md
@@ -23,6 +23,10 @@ RimSort supports updating of mods installed via SteamCMD, meaning that you can h
 
 ## Setting up SteamCMD
 
+On Linux, RimSort keeps SteamCMD's user configuration in a dedicated `home`
+directory inside the configured SteamCMD prefix. This prevents SteamCMD from
+changing the desktop Steam client's library configuration.
+
 ## Using the Workshop Browser
 
 ## Updating SteamCMD Mods

--- a/tests/utils/steam/test_steamcmd_wrapper.py
+++ b/tests/utils/steam/test_steamcmd_wrapper.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from app.utils.steam.steamcmd.wrapper import SteamcmdInterface
 
 
@@ -10,13 +12,45 @@ def test_console_log_path() -> None:
     assert iface.console_log_path == Path("/steamcmd/logs/console_log.txt")
 
 
+def test_process_environment_is_unchanged_outside_linux(tmp_path: Path) -> None:
+    iface = SteamcmdInterface.__new__(SteamcmdInterface)
+    iface.system = "Windows"
+    iface.steamcmd_prefix = str(tmp_path)
+
+    assert iface._get_process_environment() is None
+    assert not (tmp_path / "home").exists()
+
+
+def test_process_environment_resolves_relative_prefix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    iface = SteamcmdInterface.__new__(SteamcmdInterface)
+    iface.system = "Linux"
+    iface.steamcmd_prefix = "instance"
+
+    environment = iface._get_process_environment()
+
+    assert environment is not None
+    assert environment == {
+        "HOME": str(tmp_path / "instance" / "home"),
+        "XDG_CONFIG_HOME": str(tmp_path / "instance" / "home" / ".config"),
+        "XDG_DATA_HOME": str(tmp_path / "instance" / "home" / ".local" / "share"),
+    }
+    assert Path(environment["HOME"]).is_absolute()
+
+
 @patch.object(
     SteamcmdInterface, "_build_download_script", return_value="/tmp/script.txt"
 )
-def test_download_mods_sets_console_log_path(mock_build_script: MagicMock) -> None:
+def test_download_mods_sets_console_log_path(
+    mock_build_script: MagicMock, tmp_path: Path
+) -> None:
     iface = SteamcmdInterface.__new__(SteamcmdInterface)
     iface.setup = True
-    iface.steamcmd = "/steamcmd/steamcmd.exe"
+    iface.system = "Linux"
+    iface.steamcmd_prefix = str(tmp_path)
+    iface.steamcmd = "/steamcmd/steamcmd.sh"
     iface.steamcmd_install_path = "/steamcmd"
     iface.steamcmd_steam_path = "/steam/steam"
     iface.validate_downloads = False
@@ -31,7 +65,14 @@ def test_download_mods_sets_console_log_path(mock_build_script: MagicMock) -> No
     )
     mock_build_script.assert_called_once_with(["12345"])
     runner.execute.assert_called_once_with(
-        "/steamcmd/steamcmd.exe",
+        "/steamcmd/steamcmd.sh",
         ['+runscript "/tmp/script.txt"'],
         1,
+        environment={
+            "HOME": str(tmp_path / "home"),
+            "XDG_CONFIG_HOME": str(tmp_path / "home" / ".config"),
+            "XDG_DATA_HOME": str(tmp_path / "home" / ".local" / "share"),
+        },
     )
+    assert (tmp_path / "home" / ".config").is_dir()
+    assert (tmp_path / "home" / ".local" / "share").is_dir()

--- a/tests/windows/test_runner_panel.py
+++ b/tests/windows/test_runner_panel.py
@@ -58,6 +58,12 @@ class TestRunnerPanelSteamcmdLogging:
 
 
 class TestRunnerPanelSteamcmdLogTail:
+    def test_new_panel_has_no_process_environment_overrides(self, qapp: Any) -> None:
+        panel = RunnerPanel()
+
+        assert panel.process_last_environment is None
+        assert panel._steamcmd_environment is None
+
     def test_poll_steamcmd_log_parses_new_lines(self, tmp_path: Path) -> None:
         log_path = tmp_path / "console_log.txt"
         log_path.write_text("Loading Steam API...ok\n", encoding="utf-8")

--- a/tests/windows/test_runner_panel.py
+++ b/tests/windows/test_runner_panel.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from re import compile
 from typing import Any
@@ -192,6 +193,74 @@ class TestRunnerPanelSteamcmdLogTail:
         mock_timer.timeout.connect.assert_called_once()
         mock_timer.start.assert_called_once()
         mock_process.start.assert_called_once()
+
+    @patch("app.windows.runner_panel.QProcess")
+    def test_execute_applies_process_environment(
+        self, mock_qprocess: MagicMock, tmp_path: Path
+    ) -> None:
+        mock_process = MagicMock()
+        mock_qprocess.return_value = mock_process
+
+        panel = RunnerPanel.__new__(RunnerPanel)
+        panel.system = "Linux"
+        panel.todds_dry_run_support = False
+        panel.process_last_command = ""
+        panel.process_last_args = []
+        panel.restart_process_button = MagicMock()
+        panel.kill_process_button = MagicMock()
+        panel.progress_bar = MagicMock()
+        panel.message = MagicMock()  # type: ignore[method-assign]
+        panel._steamcmd_console_log_path = ""
+
+        steamcmd_home = tmp_path / "home"
+        panel.execute(
+            "/steamcmd/steamcmd.sh",
+            ["+quit"],
+            environment={"HOME": str(steamcmd_home)},
+        )
+
+        process_environment = mock_process.setProcessEnvironment.call_args.args[0]
+        assert process_environment.value("HOME") == str(steamcmd_home)
+        assert process_environment.value("PATH") == os.environ["PATH"]
+        mock_process.start.assert_called_once()
+
+    @patch("app.windows.runner_panel.QProcess")
+    def test_next_steamcmd_batch_reuses_isolated_environment(
+        self, mock_qprocess: MagicMock, tmp_path: Path
+    ) -> None:
+        mock_process = MagicMock()
+        mock_qprocess.return_value = mock_process
+
+        panel = RunnerPanel.__new__(RunnerPanel)
+        panel._pending_steamcmd_batches = [["12345"]]
+        panel._steamcmd_batch_index = 1
+        panel._steamcmd_wrapper = MagicMock()
+        panel._steamcmd_wrapper._build_download_script.return_value = "/tmp/script.txt"
+        panel._steamcmd_executable = "/steamcmd/steamcmd.sh"
+        panel._steamcmd_environment = {"HOME": str(tmp_path / "home")}
+        panel.message = MagicMock()  # type: ignore[method-assign]
+
+        panel._start_next_steamcmd_batch()
+
+        process_environment = mock_process.setProcessEnvironment.call_args.args[0]
+        assert process_environment.value("HOME") == str(tmp_path / "home")
+        mock_process.start.assert_called_once()
+
+    def test_restart_reuses_process_environment(self, tmp_path: Path) -> None:
+        panel = RunnerPanel.__new__(RunnerPanel)
+        panel.process_last_command = "/steamcmd/steamcmd.sh"
+        panel.process_last_args = ["+quit"]
+        panel.process_last_environment = {"HOME": str(tmp_path / "home")}
+        panel.message = MagicMock()  # type: ignore[method-assign]
+        panel.execute = MagicMock()  # type: ignore[method-assign]
+
+        panel._do_restart_process()
+
+        panel.execute.assert_called_once_with(
+            "/steamcmd/steamcmd.sh",
+            ["+quit"],
+            environment={"HOME": str(tmp_path / "home")},
+        )
 
     @patch("app.windows.runner_panel.QTimer")
     def test_steamcmd_log_timer_stop_on_finished(


### PR DESCRIPTION
## Change

Run Linux workshop downloads with `HOME`, `XDG_CONFIG_HOME`, and `XDG_DATA_HOME` under a dedicated `home` directory inside the configured SteamCMD prefix. SteamCMD no longer inherits the desktop Steam client's user-configuration paths. Refs #2419.

The first download, queued batches, and manual restart retain these overrides. Other inherited variables, including `PATH`, remain available. Windows and macOS retain their existing environment. Relative prefixes resolve to absolute isolation paths before launch. User documentation describes the dedicated directory.

## Validation

Regression tests cover process wiring, absolute paths, relative prefixes, inherited variables, queued batches, restart, and non-Linux behavior.

- Final tests against base source: 6 failed, 14 passed.
- Same targeted files with the fix: 20 passed.
- `uv run pytest --doctest-modules --no-qt-log -q`: 1369 passed, 1 skipped.
- Full mypy: no issues in 282 source files; pyright: 0 errors/warnings.
- Changed-file Ruff and formatting, markdownlint, duplicate-code scan, deferred-import guard and `git diff --check`: passed.
- Whole-tree Ruff still reports an unrelated `EXE001` on untouched `app/__main__.py` (its tracked file mode is not executable).

These checks ran on macOS. They verify environment construction and QProcess wiring; no real Linux SteamCMD run or desktop-library preservation trial was performed. Directory-creation errors fail before the subprocess starts rather than falling back to the desktop environment.

## Agent disclosure

Generated and independently reviewed by OpenAI Codex for be-student. No human review has occurred before submission; maintainer review and Linux runtime verification are requested.
