### PR TITLE
fix: accept equivalent local mods paths

### DIFF
--- a/app/controllers/settings_controller.py
+++ b/app/controllers/settings_controller.py
@@ -278,9 +278,14 @@ class SettingsController(QObject):
         game_folder = self.settings.instances[
             self.settings.current_instance
         ].game_folder
-        if not (Path(local_folder).is_dir()) or local_folder != str(
-            Path(game_folder) / "Mods"
-        ):
+        local_path = Path(local_folder)
+        is_game_mods_folder = False
+        if local_path.is_dir():
+            try:
+                is_game_mods_folder = local_path.samefile(Path(game_folder) / "Mods")
+            except OSError:
+                is_game_mods_folder = False
+        if not is_game_mods_folder:
             return False, self.tr(
                 "The selected local mods folder location is not a valid directory.<br><br>"
                 "Please select a valid folder for local mods.<br><br>"

--- a/tests/controllers/test_settings_location_validation.py
+++ b/tests/controllers/test_settings_location_validation.py
@@ -48,3 +48,24 @@ def test_local_mods_validation_rejects_different_existing_folder(
 
     assert not is_valid
     assert "Mods" in error
+
+
+def test_local_mods_validation_rejects_folder_when_identity_check_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    game_folder = tmp_path / "RimWorld"
+    local_mods = game_folder / "Mods"
+    local_mods.mkdir(parents=True)
+
+    def raise_os_error(_self: Path, _other: Path) -> bool:
+        raise OSError("identity unavailable")
+
+    monkeypatch.setattr(Path, "samefile", raise_os_error)
+
+    is_valid, error = _controller(game_folder)._validate_local_mods_location(
+        str(local_mods)
+    )
+
+    assert not is_valid
+    assert "Mods" in error

--- a/tests/controllers/test_settings_location_validation.py
+++ b/tests/controllers/test_settings_location_validation.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from app.controllers.settings_controller import SettingsController
+
+
+def _controller(game_folder: Path) -> SettingsController:
+    controller = SettingsController.__new__(SettingsController)
+    untyped_controller = cast(Any, controller)
+    untyped_controller.settings = SimpleNamespace(
+        current_instance="default",
+        instances={"default": SimpleNamespace(game_folder=str(game_folder))},
+    )
+    untyped_controller.tr = lambda text, *args: text
+    return controller
+
+
+def test_local_mods_validation_accepts_same_folder_with_different_spelling(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    game_folder = tmp_path / "RimWorld"
+    (game_folder / "Mods").mkdir(parents=True)
+    monkeypatch.chdir(tmp_path)
+
+    is_valid, error = _controller(game_folder)._validate_local_mods_location(
+        str(Path("RimWorld") / "Mods")
+    )
+
+    assert is_valid
+    assert error == ""
+
+
+def test_local_mods_validation_rejects_different_existing_folder(
+    tmp_path: Path,
+) -> None:
+    game_folder = tmp_path / "RimWorld"
+    (game_folder / "Mods").mkdir(parents=True)
+    other_folder = tmp_path / "OtherMods"
+    other_folder.mkdir()
+
+    is_valid, error = _controller(game_folder)._validate_local_mods_location(
+        str(other_folder)
+    )
+
+    assert not is_valid
+    assert "Mods" in error


### PR DESCRIPTION
## Change

Validate the configured local Mods directory by filesystem identity instead of comparing its path string with `game_folder/Mods`. This accepts the same directory when Qt, autodetection, or the user supplies an equivalent spelling, while continuing to reject a different existing directory.

Fixes #2420.

## Verification

- Unchanged base regression: 1 failed, 1 passed.
- Focused regression: 2 passed.
- `pytest --doctest-modules --no-qt-log -q`: 1366 passed, 1 skipped.
- mypy: no issues in 283 source files.
- pyright: 0 errors and 0 warnings.
- Changed-file Ruff, formatting, and `git diff --check`: passed.

The additional worktree reused the already-initialized pinned submodule contents from the primary checkout for full-suite and type-check resolution. No submodule revision changed. This is validation-only behavior, so user documentation remains accurate without a content change.

## Agent disclosure

Generated and reviewed by OpenAI Codex for be-student. No human review occurred before submission; maintainer review is requested.
