### PR TITLE
fix: honor disabled database sources

### DIFF
--- a/app/controllers/metadata_controller.py
+++ b/app/controllers/metadata_controller.py
@@ -746,7 +746,7 @@ class MetadataController(QObject):
         ``AppInfo().databases_folder / <repo-name> / <file_name>``, not
         at the settings default.
         """
-        if source == "Disabled":
+        if source in {"None", "Disabled"}:
             return None
         if source == "Configured file path":
             return Path(file_path) if file_path else None

--- a/tests/controllers/test_metadata_controller.py
+++ b/tests/controllers/test_metadata_controller.py
@@ -99,6 +99,19 @@ def test_metadata_controller_creation(metadata_controller: MetadataController) -
     assert metadata_controller.steamcmd_wrapper is not None
 
 
+@pytest.mark.parametrize("source", ["None", "Disabled"])
+def test_resolve_db_path_returns_none_for_disabled_sources(source: str) -> None:
+    assert (
+        MetadataController._resolve_db_path(
+            source,
+            "/configured/database.json",
+            "https://github.com/example/database",
+            "database.json",
+        )
+        is None
+    )
+
+
 @pytest.fixture
 def metadata_controller_p(
     metadata_controller: MetadataController,


### PR DESCRIPTION
Fixes #2324.

The database settings UI stores the disabled selection as `None`, while metadata path resolution only recognized the legacy `Disabled` value. As a result, disabling No Version Warning or Use This Instead still resolved the cached repository path and loaded the database on refresh or restart.

This change treats both values as disabled. Keeping `Disabled` support preserves existing settings files while making the current UI selection take effect.

Validation:

- Unchanged `main` resolves `None` to an on-disk database path, reproducing the bug.
- `tests/controllers/test_metadata_controller.py`: 54 passed.
- Full pytest suite: passed.
- Ruff check and format check passed for the changed files.
- Mypy passed for 167 application source files.
- Pyright reported 0 errors and 0 warnings.

## Agent Disclosure

This PR was generated by OpenAI Codex. The submitting account is operated by be-student (eunwoo song).
Human review of this PR: no — fully automated. Maintainer review is requested.
