### PR TITLE
fix: classify SteamCMD mods with bundled git metadata

### DIFF
--- a/app/models/metadata/metadata_factory.py
+++ b/app/models/metadata/metadata_factory.py
@@ -400,6 +400,17 @@ def _set_mod_type(
     elif parent_path == workshop_path:
         mod.mod_type = ModType.STEAM_WORKSHOP
     elif parent_path == local_path:
+        published_file_id_path = mod.mod_path / Path("About/PublishedFileId.txt")
+        if (
+            published_file_id_path.exists()
+            and mod.published_file_id == mod.mod_path.name
+        ):
+            # SteamCMD installs Workshop items into directories named after their
+            # PublishedFileId. Some Workshop items also ship a .git directory,
+            # which must not take precedence over that SteamCMD layout.
+            mod.mod_type = ModType.STEAM_CMD
+            return mod
+
         try:
             repo = pygit2.discover_repository(str(mod.mod_path))
 
@@ -416,7 +427,7 @@ def _set_mod_type(
             )
             logger.error(e)
 
-        if (mod.mod_path / Path("About/PublishedFileId.txt")).exists():
+        if published_file_id_path.exists():
             mod.mod_type = ModType.STEAM_CMD
         else:
             mod.mod_type = ModType.LOCAL

--- a/tests/models/metadata/test_metadata_factory.py
+++ b/tests/models/metadata/test_metadata_factory.py
@@ -27,6 +27,7 @@ from app.models.metadata.metadata_structure import (
     CaseInsensitiveStr,
     ExternalRule,
     ExternalRulesSchema,
+    ListedMod,
     ModType,
     SteamDbEntry,
     SteamDbEntryBlacklist,
@@ -553,24 +554,30 @@ def test_create_listed_mod_from_path_steamcmd_mod_1() -> None:
     assert not mod.c_sharp_mod
 
 
-def test_create_listed_mod_from_path_steamcmd_mod_with_git_repository(
-    tmp_path: Path,
-) -> None:
+def _create_git_mod_from_steamcmd_fixture(
+    tmp_path: Path, directory_name: str
+) -> tuple[bool, ListedMod]:
     local_mods_path = tmp_path / "Local"
-    path = local_mods_path / "1111"
+    path = local_mods_path / directory_name
     shutil.copytree(
         Path("tests/data/mod_examples/Local/steamcmd_mod_1"),
         path,
     )
     _ = pygit2.init_repository(str(path), False)
 
-    valid, mod = create_listed_mod_from_path(
+    return create_listed_mod_from_path(
         path,
         "1.5",
         local_mods_path,
         tmp_path / "RimWorld",
         tmp_path / "Steam",
     )
+
+
+def test_create_listed_mod_from_path_steamcmd_mod_with_git_repository(
+    tmp_path: Path,
+) -> None:
+    valid, mod = _create_git_mod_from_steamcmd_fixture(tmp_path, "1111")
 
     assert valid
     assert mod.valid
@@ -580,20 +587,8 @@ def test_create_listed_mod_from_path_steamcmd_mod_with_git_repository(
 def test_create_listed_mod_from_path_git_mod_with_published_file_id(
     tmp_path: Path,
 ) -> None:
-    local_mods_path = tmp_path / "Local"
-    path = local_mods_path / "named-source-checkout"
-    shutil.copytree(
-        Path("tests/data/mod_examples/Local/steamcmd_mod_1"),
-        path,
-    )
-    _ = pygit2.init_repository(str(path), False)
-
-    valid, mod = create_listed_mod_from_path(
-        path,
-        "1.5",
-        local_mods_path,
-        tmp_path / "RimWorld",
-        tmp_path / "Steam",
+    valid, mod = _create_git_mod_from_steamcmd_fixture(
+        tmp_path, "named-source-checkout"
     )
 
     assert valid

--- a/tests/models/metadata/test_metadata_factory.py
+++ b/tests/models/metadata/test_metadata_factory.py
@@ -553,6 +553,54 @@ def test_create_listed_mod_from_path_steamcmd_mod_1() -> None:
     assert not mod.c_sharp_mod
 
 
+def test_create_listed_mod_from_path_steamcmd_mod_with_git_repository(
+    tmp_path: Path,
+) -> None:
+    local_mods_path = tmp_path / "Local"
+    path = local_mods_path / "1111"
+    shutil.copytree(
+        Path("tests/data/mod_examples/Local/steamcmd_mod_1"),
+        path,
+    )
+    _ = pygit2.init_repository(str(path), False)
+
+    valid, mod = create_listed_mod_from_path(
+        path,
+        "1.5",
+        local_mods_path,
+        tmp_path / "RimWorld",
+        tmp_path / "Steam",
+    )
+
+    assert valid
+    assert mod.valid
+    assert mod.mod_type == ModType.STEAM_CMD
+
+
+def test_create_listed_mod_from_path_git_mod_with_published_file_id(
+    tmp_path: Path,
+) -> None:
+    local_mods_path = tmp_path / "Local"
+    path = local_mods_path / "named-source-checkout"
+    shutil.copytree(
+        Path("tests/data/mod_examples/Local/steamcmd_mod_1"),
+        path,
+    )
+    _ = pygit2.init_repository(str(path), False)
+
+    valid, mod = create_listed_mod_from_path(
+        path,
+        "1.5",
+        local_mods_path,
+        tmp_path / "RimWorld",
+        tmp_path / "Steam",
+    )
+
+    assert valid
+    assert mod.valid
+    assert mod.mod_type == ModType.GIT
+
+
 def test_create_listed_mod_from_path_fishery(tmp_path: Path) -> None:
     path = Path("tests/data/mod_examples/Local/Fishery")
     # Copy entierty of path to temporary folder


### PR DESCRIPTION
Fixes #2281.

SteamCMD installs Workshop mods under a directory named after their PublishedFileId. Some Workshop archives also contain `.git`, so probing Git first classified those installs as Git-managed local mods and excluded them from SteamCMD update handling.

This recognizes the SteamCMD directory/PublishedFileId invariant before Git discovery. A normal named Git checkout that retains `PublishedFileId.txt` remains classified as Git.

Validation:

- New regression tests on unchanged `main`: 1 failed, 1 passed.
- Metadata factory tests: 51 passed.
- Full suite: 1,377 passed, 1 skipped.
- Ruff, formatting, mypy, Pyright, and diff checks passed.

No documentation change is needed because this restores existing SteamCMD classification and update behavior.

## Agent Disclosure

This PR was generated by OpenAI Codex. The submitting account is operated by be-student (eunwoo song).
Human review of this PR: no — fully automated. Maintainer review is requested.
