### PR TITLE
fix: support author searches in mod lists

### DIFF
--- a/app/views/mods_panel.py
+++ b/app/views/mods_panel.py
@@ -5305,6 +5305,11 @@ class ModsPanel(QWidget):
             ):
                 if pattern.lower() not in str(mod_obj.package_id).lower():
                     item_filtered = True
+            elif pattern and search_filter == "authors":
+                if not isinstance(mod_obj, AboutXmlMod) or not any(
+                    pattern.lower() in author.lower() for author in mod_obj.authors
+                ):
+                    item_filtered = True
 
             # Source filtering (set-based from FilterState)
             if not item_filtered and fs.sources != FilterState.ALL_SOURCES:

--- a/tests/views/test_mods_panel_search.py
+++ b/tests/views/test_mods_panel_search.py
@@ -1,0 +1,106 @@
+from unittest.mock import MagicMock
+
+import pytest
+from PySide6.QtCore import Qt
+
+from app.models.metadata.metadata_structure import (
+    AboutXmlMod,
+    CaseInsensitiveStr,
+    ListedMod,
+)
+from app.models.settings import Settings
+from app.utils.custom_list_widget_item import CustomListWidgetItem
+from app.utils.custom_list_widget_item_metadata import CustomListWidgetItemMetadata
+from app.views.mods_panel import ModsPanel
+
+
+def _add_mod_item(panel: ModsPanel, list_type: str, path: str) -> CustomListWidgetItem:
+    mod_list = (
+        panel.active_mods_list if list_type == "Active" else panel.inactive_mods_list
+    )
+    data = object.__new__(CustomListWidgetItemMetadata)
+    data.path = path
+    data.filtered = False
+    data.invalid = False
+    data.mod_tags = []
+    item = CustomListWidgetItem()
+    item.setData(Qt.ItemDataRole.UserRole, data, avoid_emit=True)
+    mod_list.addItem(item)
+    return item
+
+
+@pytest.mark.parametrize("list_type", ["Active", "Inactive"])
+def test_author_search_filters_mods_case_insensitively(
+    qtbot: object, list_type: str
+) -> None:
+    settings = Settings()
+    matching_path = "/mods/matching"
+    other_path = "/mods/other"
+    matching_mod = AboutXmlMod(
+        name="Matching Mod",
+        package_id=CaseInsensitiveStr("example.matching"),
+        authors=["Jane Doe", "Second Author"],
+    )
+    other_mod = AboutXmlMod(
+        name="Other Mod",
+        package_id=CaseInsensitiveStr("example.other"),
+        authors=["Someone Else"],
+    )
+    metadata = MagicMock()
+    metadata.mods_metadata = {
+        matching_path: matching_mod,
+        other_path: other_mod,
+    }
+    metadata.get_mod.side_effect = metadata.mods_metadata.get
+
+    panel = ModsPanel(settings, metadata)
+    qtbot.addWidget(panel)  # type: ignore[attr-defined]
+    mod_list = (
+        panel.active_mods_list if list_type == "Active" else panel.inactive_mods_list
+    )
+    search_filter = (
+        panel.active_mods_search_filter
+        if list_type == "Active"
+        else panel.inactive_mods_search_filter
+    )
+    matching_item = _add_mod_item(panel, list_type, matching_path)
+    other_item = _add_mod_item(panel, list_type, other_path)
+    mod_list.paths = [matching_path, other_path]
+    mod_list.check_widgets_visible = MagicMock()  # type: ignore[method-assign]
+    search_filter.setCurrentText(panel.tr("Author(s)"))
+
+    panel.signal_search_and_filters(list_type, "jAnE")
+
+    assert not matching_item.isHidden()
+    assert other_item.isHidden()
+
+
+@pytest.mark.parametrize(
+    "mod",
+    [
+        AboutXmlMod(
+            name="No Author Mod",
+            package_id=CaseInsensitiveStr("example.noauthor"),
+        ),
+        ListedMod(name="Invalid Mod"),
+    ],
+)
+def test_author_search_filters_mods_without_authors(
+    qtbot: object, mod: AboutXmlMod | ListedMod
+) -> None:
+    settings = Settings()
+    path = "/mods/no-author"
+    metadata = MagicMock()
+    metadata.mods_metadata = {path: mod}
+    metadata.get_mod.side_effect = metadata.mods_metadata.get
+
+    panel = ModsPanel(settings, metadata)
+    qtbot.addWidget(panel)  # type: ignore[attr-defined]
+    item = _add_mod_item(panel, "Active", path)
+    panel.active_mods_list.paths = [path]
+    panel.active_mods_list.check_widgets_visible = MagicMock()  # type: ignore[method-assign]
+    panel.active_mods_search_filter.setCurrentText(panel.tr("Author(s)"))
+
+    panel.signal_search_and_filters("Active", "author")
+
+    assert item.isHidden()


### PR DESCRIPTION
Fixes #2313.

The search selector mapped `Author(s)` to an `authors` filter, but the filtering chain never handled that value. Author searches therefore left every mod visible.

This adds case-insensitive partial matching across `AboutXmlMod.authors`. Mods without author metadata are hidden while an author query is active, consistently in the Active and Inactive lists.

Validation:

- Three focused cases fail against unchanged `main` because nonmatching rows remain visible.
- Author-search tests: 4 passed.
- Relevant views tests: 14 passed.
- Full suite: 1,379 passed, 1 skipped.
- Ruff, formatting, mypy, Pyright, deferred-import, duplicate, and diff checks passed.

No documentation change is needed because this makes the existing Author(s) search option functional.

## Agent Disclosure

This PR was generated by OpenAI Codex. The submitting account is operated by be-student (eunwoo song).
Human review of this PR: no — fully automated. Maintainer review is requested.
